### PR TITLE
fix(ingest): bound trace payload memory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,10 +120,14 @@ LAT_API_PORT=3001
 # Change to "https://ingest.your-domain" for production
 LAT_INGEST_URL=http://localhost:3002
 LAT_INGEST_PORT=3002
-# Per project+API key trace ingest burst limits
+# Per organization+API key trace ingest burst limits
 # LAT_INGEST_TRACE_RATE_LIMIT_MAX_REQUESTS=1000
 # LAT_INGEST_TRACE_RATE_LIMIT_MAX_BYTES=67108864
 # LAT_INGEST_TRACE_RATE_LIMIT_WINDOW_SECONDS=60
+# Per-process trace payload memory protection
+# LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES=33554432
+# LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES=67108864
+# LAT_INGEST_TRACE_MAX_CONCURRENT_PAYLOADS=16
 # Dev/QA only: shrink the destinations sweep window-end safety lag (ms) so freshly
 # seeded spans become eligible in ~1 min instead of ~6. Ignored in production (5-min default).
 # LAT_DEV_DESTINATIONS_SAFETY_LAG_MS=30000

--- a/apps/ingest/src/routes/index.ts
+++ b/apps/ingest/src/routes/index.ts
@@ -1,13 +1,15 @@
 import type { Hono } from "hono"
+import type { TracePayloadProtection } from "../trace-payload.ts"
 import type { IngestEnv } from "../types.ts"
 import { registerHealthRoute } from "./health.ts"
 import { registerTracesRoute } from "./traces.ts"
 
 interface RoutesContext {
   app: Hono<IngestEnv>
+  tracePayloadProtection: TracePayloadProtection
 }
 
 export const registerRoutes = (context: RoutesContext) => {
-  registerHealthRoute(context)
+  registerHealthRoute({ app: context.app })
   registerTracesRoute(context)
 }

--- a/apps/ingest/src/routes/traces.ts
+++ b/apps/ingest/src/routes/traces.ts
@@ -16,15 +16,17 @@ import { QueuePublisherLive } from "@platform/queue-bullmq"
 import { StorageDiskLive } from "@platform/storage-object"
 import { withTracing } from "@repo/observability"
 import { Cause, Effect, Exit, Layer, Option } from "effect"
-import type { Hono } from "hono"
+import type { Handler, Hono } from "hono"
 import { getPostgresClient, getQueuePublisher, getRedisClient, getStorageDisk } from "../clients.ts"
 import { authMiddleware } from "../middleware/auth.ts"
 import { projectMiddleware } from "../middleware/project.ts"
 import { checkTraceIngestionRateLimit } from "../rate-limit/trace-ingestion.ts"
+import type { TracePayloadProtection } from "../trace-payload.ts"
 import type { IngestEnv } from "../types.ts"
 
 interface TracesRouteContext {
   app: Hono<IngestEnv>
+  tracePayloadProtection: TracePayloadProtection
 }
 
 const traceIngestionBillingLayers = Layer.mergeAll(
@@ -42,10 +44,9 @@ const buildRejectionMessage = (rejected: number): string =>
   "OTEL resource attribute, or the `X-Latitude-Project` export header. If you already set one, " +
   "check that the slug exists in this Latitude organization."
 
-export const registerTracesRoute = ({ app }: TracesRouteContext) => {
-  app.post("/v1/traces", authMiddleware, projectMiddleware, async (c) => {
-    const contentType = c.req.header("Content-Type") ?? "application/json"
-    const body = await c.req.arrayBuffer()
+export const registerTracesRoute = ({ app, tracePayloadProtection }: TracesRouteContext) => {
+  const handleTraceRequest: Handler<IngestEnv> = async (c) => {
+    const { payload: body, contentType } = c.get("tracePayload")
     if (!body.byteLength) return c.json({}, 202)
 
     const organizationId = c.get("organizationId")
@@ -86,7 +87,7 @@ export const registerTracesRoute = ({ app }: TracesRouteContext) => {
       organizationId: organization,
       apiKeyId,
       isSandbox,
-      payload: new Uint8Array(body),
+      payload: body,
       contentType,
       ...(defaultProjectSlug ? { defaultProjectSlug } : {}),
     }).pipe(
@@ -147,5 +148,14 @@ export const registerTracesRoute = ({ app }: TracesRouteContext) => {
     }
 
     return c.json({})
-  })
+  }
+
+  app.post(
+    "/v1/traces",
+    tracePayloadProtection.rejectOversizedHeaders,
+    authMiddleware,
+    projectMiddleware,
+    tracePayloadProtection.readPayload,
+    handleTraceRequest,
+  )
 }

--- a/apps/ingest/src/server.ts
+++ b/apps/ingest/src/server.ts
@@ -2,7 +2,7 @@ import { serve } from "@hono/node-server"
 import { httpInstrumentationMiddleware as otel } from "@hono/otel"
 import { waitForRedisClientReady } from "@platform/cache-redis"
 import { parseEnv } from "@platform/env"
-import { createLogger, initializeObservability, shutdownObservability, withTracing } from "@repo/observability"
+import { createLogger, initializeObservability, shutdownObservability, trace, withTracing } from "@repo/observability"
 import { isHttpError, LatitudeObservabilityTestError, toHttpResponse } from "@repo/utils"
 import { loadDevelopmentEnvironments } from "@repo/utils/env"
 import { Effect } from "effect"
@@ -11,6 +11,12 @@ import { getQueuePublisher, getRedisClient } from "./clients.ts"
 import { suppressHttpErrorTelemetry } from "./middleware/suppress-http-error-telemetry.ts"
 import { destroyTouchBuffer } from "./middleware/touch-buffer.ts"
 import { registerRoutes } from "./routes/index.ts"
+import {
+  createTracePayloadProtection,
+  createTracePayloadRuntime,
+  loadTracePayloadLimits,
+  TracePayloadAdmission,
+} from "./trace-payload.ts"
 import type { IngestEnv } from "./types.ts"
 
 loadDevelopmentEnvironments(import.meta.url)
@@ -23,6 +29,12 @@ const start = async () => {
   const app = new Hono<IngestEnv>()
   const port = Effect.runSync(parseEnv("LAT_INGEST_PORT", "number", 3002))
   const logger = createLogger("ingest")
+  const tracePayloadLimits = loadTracePayloadLimits()
+  const tracePayloadProtection = createTracePayloadProtection({
+    limits: tracePayloadLimits,
+    admission: new TracePayloadAdmission(tracePayloadLimits),
+    runtime: createTracePayloadRuntime(() => trace.getActiveSpan()),
+  })
 
   // Add Hono OpenTelemetry middleware
   app.use(otel())
@@ -42,7 +54,7 @@ const start = async () => {
     return c.json({ error: "Internal server error" }, 500)
   })
 
-  registerRoutes({ app })
+  registerRoutes({ app, tracePayloadProtection })
 
   await waitForRedisClientReady(getRedisClient())
   await getQueuePublisher()

--- a/apps/ingest/src/trace-payload.test.ts
+++ b/apps/ingest/src/trace-payload.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest"
 import {
   createTracePayloadProtection,
   DEFAULT_TRACE_PAYLOAD_LIMITS,
+  loadTracePayloadLimits,
   parseTraceContentLength,
   readTracePayload,
   TracePayloadAdmission,
@@ -37,6 +38,32 @@ const testLimits = {
   maxInFlightBytes: 16,
   maxConcurrentPayloads: 2,
 } as const
+
+describe("loadTracePayloadLimits", () => {
+  it("requires enough capacity to assemble a maximum-size chunked payload", () => {
+    const names = [
+      "LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES",
+      "LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES",
+      "LAT_INGEST_TRACE_MAX_CONCURRENT_PAYLOADS",
+    ] as const
+    const previous = Object.fromEntries(names.map((name) => [name, process.env[name]]))
+    process.env.LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES = "8"
+    process.env.LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES = "8"
+    process.env.LAT_INGEST_TRACE_MAX_CONCURRENT_PAYLOADS = "2"
+
+    try {
+      expect(loadTracePayloadLimits).toThrow(
+        "LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES must be at least twice LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES",
+      )
+    } finally {
+      for (const name of names) {
+        const value = previous[name]
+        if (value === undefined) delete process.env[name]
+        else process.env[name] = value
+      }
+    }
+  })
+})
 
 describe("parseTraceContentLength", () => {
   it.each(["-1", "1.5", "Infinity", "1, 2", "", "9007199254740992"])("rejects invalid Content-Length %s", (value) => {
@@ -72,7 +99,7 @@ describe("readTracePayload", () => {
     }
   })
 
-  it("uses one capped buffer for an unknown-length payload", async () => {
+  it("returns an exact-sized buffer for an unknown-length payload", async () => {
     const result = await readTracePayload({
       stream: streamFrom(["ok"]),
       maxPayloadBytes: 8,
@@ -81,7 +108,7 @@ describe("readTracePayload", () => {
     expect(result.kind).toBe("success")
     if (result.kind === "success") {
       expect(result.payload.byteLength).toBe(2)
-      expect(result.payload.buffer.byteLength).toBe(8)
+      expect(result.payload.buffer.byteLength).toBe(2)
     }
   })
 
@@ -138,6 +165,22 @@ describe("TracePayloadAdmission", () => {
     if (second.kind === "acquired") second.lease.release()
     expect(admission.usage()).toEqual({ activePayloads: 0, reservedBytes: 0 })
   })
+
+  it("adjusts a lease as an unknown-length payload grows", () => {
+    const admission = new TracePayloadAdmission(testLimits)
+    const acquired = admission.tryAcquire(0)
+    expect(acquired.kind).toBe("acquired")
+    if (acquired.kind !== "acquired") return
+
+    expect(acquired.lease.reserve(6)).toBe(true)
+    expect(acquired.lease.reserve(11)).toBe(false)
+    expect(admission.usage()).toEqual({ activePayloads: 1, reservedBytes: 6 })
+
+    acquired.lease.releaseReserved(2)
+    expect(acquired.lease.reserve(12)).toBe(true)
+    acquired.lease.release()
+    expect(admission.usage()).toEqual({ activePayloads: 0, reservedBytes: 0 })
+  })
 })
 
 describe("createTracePayloadProtection", () => {
@@ -163,6 +206,14 @@ describe("createTracePayloadProtection", () => {
     const response = await app.fetch(requestWithStream(streamFrom(["oversized"]), { "Content-Length": "9" }))
 
     expect(response.status).toBe(413)
+  })
+
+  it("rejects an invalid Content-Length in the header guard", async () => {
+    const { app } = createApp()
+
+    const response = await app.fetch(requestWithStream(streamFrom(["ok"]), { "Content-Length": "1, 2" }))
+
+    expect(response.status).toBe(400)
   })
 
   it("returns 413 and releases admission when a streamed payload crosses the limit", async () => {
@@ -197,6 +248,19 @@ describe("createTracePayloadProtection", () => {
     if (acquired.kind === "acquired") acquired.lease.release()
   })
 
+  it("returns 503 when a chunked payload cannot reserve assembly capacity", async () => {
+    const { admission, app } = createApp()
+    const existing = admission.tryAcquire(14)
+    expect(existing.kind).toBe("acquired")
+
+    const response = await app.fetch(requestWithStream(streamFrom(["ok"])))
+
+    expect(response.status).toBe(503)
+    expect(response.headers.get("Retry-After")).toBe("1")
+    expect(admission.usage()).toEqual({ activePayloads: 1, reservedBytes: 14 })
+    if (existing.kind === "acquired") existing.lease.release()
+  })
+
   it("releases admission when body reading fails", async () => {
     const { admission, app } = createApp()
     const stream = new ReadableStream<Uint8Array>({
@@ -211,13 +275,47 @@ describe("createTracePayloadProtection", () => {
     expect(admission.usage()).toEqual({ activePayloads: 0, reservedBytes: 0 })
   })
 
-  it("releases admission when downstream handling throws", async () => {
-    const { admission, app } = createApp({ handlerThrows: true })
+  it("releases admission when telemetry collection throws", async () => {
+    let memoryUsageCalls = 0
+    const runtime: TracePayloadRuntime = {
+      now: () => 0,
+      memoryUsage: () => {
+        memoryUsageCalls++
+        if (memoryUsageCalls === 2) throw new Error("telemetry failed")
+        return { rss: 100, arrayBuffers: 25 }
+      },
+      getActiveSpan: () => ({ setAttributes: () => undefined }),
+    }
+    const { admission, app } = createApp({ runtime })
 
     const response = await app.fetch(requestWithStream(streamFrom(["ok"]), { "Content-Length": "2" }))
 
     expect(response.status).toBe(500)
     expect(admission.usage()).toEqual({ activePayloads: 0, reservedBytes: 0 })
+  })
+
+  it("releases admission without overwriting telemetry when downstream handling throws", async () => {
+    const attributes: Record<string, unknown> = {}
+    const runtime: TracePayloadRuntime = {
+      now: (() => {
+        const values = [10, 15]
+        return () => values.shift() ?? 15
+      })(),
+      memoryUsage: () => ({ rss: 100, arrayBuffers: 25 }),
+      getActiveSpan: () => ({
+        setAttributes: (values) => Object.assign(attributes, values),
+      }),
+    }
+    const { admission, app } = createApp({ handlerThrows: true, runtime })
+
+    const response = await app.fetch(requestWithStream(streamFrom(["ok"]), { "Content-Length": "2" }))
+
+    expect(response.status).toBe(500)
+    expect(admission.usage()).toEqual({ activePayloads: 0, reservedBytes: 0 })
+    expect(attributes).toMatchObject({
+      "latitude.ingest.payload.outcome": "accepted",
+      "latitude.ingest.payload.size_bytes": 2,
+    })
   })
 
   it("records payload and memory attributes on the active request span", async () => {
@@ -272,6 +370,7 @@ describe("createTracePayloadProtection", () => {
       } as RequestInit & { duplex: "half" })
 
       expect(response.status).toBe(413)
+      await response.body?.cancel()
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()))

--- a/apps/ingest/src/trace-payload.test.ts
+++ b/apps/ingest/src/trace-payload.test.ts
@@ -1,0 +1,289 @@
+import { serve } from "@hono/node-server"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import {
+  createTracePayloadProtection,
+  DEFAULT_TRACE_PAYLOAD_LIMITS,
+  parseTraceContentLength,
+  readTracePayload,
+  TracePayloadAdmission,
+  type TracePayloadRuntime,
+} from "./trace-payload.ts"
+import type { IngestEnv } from "./types.ts"
+
+const textEncoder = new TextEncoder()
+
+const streamFrom = (chunks: string[], onCancel?: () => void): ReadableStream<Uint8Array> =>
+  new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(textEncoder.encode(chunk))
+      controller.close()
+    },
+    cancel() {
+      onCancel?.()
+    },
+  })
+
+const requestWithStream = (body: ReadableStream<Uint8Array>, headers?: HeadersInit): Request =>
+  new Request("http://localhost/v1/traces", {
+    method: "POST",
+    headers,
+    body,
+    duplex: "half",
+  } as RequestInit & { duplex: "half" })
+
+const testLimits = {
+  maxPayloadBytes: 8,
+  maxInFlightBytes: 16,
+  maxConcurrentPayloads: 2,
+} as const
+
+describe("parseTraceContentLength", () => {
+  it.each(["-1", "1.5", "Infinity", "1, 2", "", "9007199254740992"])("rejects invalid Content-Length %s", (value) => {
+    expect(parseTraceContentLength(value, testLimits.maxPayloadBytes)).toEqual({ kind: "invalid" })
+  })
+
+  it("rejects a declared payload above the request limit", () => {
+    expect(parseTraceContentLength("9", testLimits.maxPayloadBytes)).toEqual({
+      kind: "too_large",
+      declaredBytes: 9,
+    })
+  })
+
+  it("accepts a declared payload at the request limit", () => {
+    expect(parseTraceContentLength("8", testLimits.maxPayloadBytes)).toEqual({
+      kind: "valid",
+      declaredBytes: 8,
+    })
+  })
+})
+
+describe("readTracePayload", () => {
+  it("reads an exact-size declared payload across chunks", async () => {
+    const result = await readTracePayload({
+      stream: streamFrom(["abc", "defgh"]),
+      declaredBytes: 8,
+      maxPayloadBytes: 8,
+    })
+
+    expect(result.kind).toBe("success")
+    if (result.kind === "success") {
+      expect(new TextDecoder().decode(result.payload)).toBe("abcdefgh")
+    }
+  })
+
+  it("uses one capped buffer for an unknown-length payload", async () => {
+    const result = await readTracePayload({
+      stream: streamFrom(["ok"]),
+      maxPayloadBytes: 8,
+    })
+
+    expect(result.kind).toBe("success")
+    if (result.kind === "success") {
+      expect(result.payload.byteLength).toBe(2)
+      expect(result.payload.buffer.byteLength).toBe(8)
+    }
+  })
+
+  it("cancels an unknown-length stream when it crosses the limit", async () => {
+    let cancelled = false
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(textEncoder.encode("12345"))
+        controller.enqueue(textEncoder.encode("6789"))
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+
+    const result = await readTracePayload({ stream, maxPayloadBytes: 8 })
+
+    expect(result).toEqual({ kind: "too_large", observedBytes: 9 })
+    expect(cancelled).toBe(true)
+  })
+
+  it("rejects bodies that do not match their declared length", async () => {
+    await expect(
+      readTracePayload({
+        stream: streamFrom(["short"]),
+        declaredBytes: 8,
+        maxPayloadBytes: 8,
+      }),
+    ).resolves.toEqual({ kind: "length_mismatch", observedBytes: 5 })
+
+    await expect(
+      readTracePayload({
+        stream: streamFrom(["toolong"]),
+        declaredBytes: 4,
+        maxPayloadBytes: 8,
+      }),
+    ).resolves.toEqual({ kind: "length_mismatch", observedBytes: 7 })
+  })
+})
+
+describe("TracePayloadAdmission", () => {
+  it("enforces byte and concurrency limits and releases capacity", () => {
+    const admission = new TracePayloadAdmission(testLimits)
+    const first = admission.tryAcquire(8)
+    const second = admission.tryAcquire(8)
+
+    expect(first.kind).toBe("acquired")
+    expect(second.kind).toBe("acquired")
+    expect(admission.tryAcquire(1)).toEqual({ kind: "rejected", limitedBy: "concurrency" })
+
+    if (first.kind === "acquired") first.lease.release()
+    expect(admission.tryAcquire(9)).toEqual({ kind: "rejected", limitedBy: "bytes" })
+
+    if (second.kind === "acquired") second.lease.release()
+    expect(admission.usage()).toEqual({ activePayloads: 0, reservedBytes: 0 })
+  })
+})
+
+describe("createTracePayloadProtection", () => {
+  const createApp = (options?: { runtime?: TracePayloadRuntime; handlerThrows?: boolean }) => {
+    const admission = new TracePayloadAdmission(testLimits)
+    const protection = createTracePayloadProtection({
+      limits: testLimits,
+      admission,
+      runtime: options?.runtime,
+    })
+    const app = new Hono<IngestEnv>()
+    app.onError(() => new Response("error", { status: 500 }))
+    app.post("/v1/traces", protection.rejectOversizedHeaders, protection.readPayload, async (c) => {
+      if (options?.handlerThrows) throw new Error("boom")
+      return c.json({ size: c.get("tracePayload").payload.byteLength })
+    })
+    return { admission, app }
+  }
+
+  it("rejects a declared oversized body in the header guard", async () => {
+    const { app } = createApp()
+
+    const response = await app.fetch(requestWithStream(streamFrom(["oversized"]), { "Content-Length": "9" }))
+
+    expect(response.status).toBe(413)
+  })
+
+  it("returns 413 and releases admission when a streamed payload crosses the limit", async () => {
+    let cancelled = false
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(textEncoder.encode("12345"))
+        controller.enqueue(textEncoder.encode("6789"))
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+    const { admission, app } = createApp()
+
+    const response = await app.fetch(requestWithStream(stream))
+
+    expect(response.status).toBe(413)
+    expect(cancelled).toBe(true)
+    expect(admission.usage()).toEqual({ activePayloads: 0, reservedBytes: 0 })
+  })
+
+  it("returns 503 with Retry-After when admission is exhausted", async () => {
+    const { admission, app } = createApp()
+    const acquired = admission.tryAcquire(16)
+    expect(acquired.kind).toBe("acquired")
+
+    const response = await app.fetch(requestWithStream(streamFrom(["ok"]), { "Content-Length": "2" }))
+
+    expect(response.status).toBe(503)
+    expect(response.headers.get("Retry-After")).toBe("1")
+    if (acquired.kind === "acquired") acquired.lease.release()
+  })
+
+  it("releases admission when body reading fails", async () => {
+    const { admission, app } = createApp()
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(new Error("read failed"))
+      },
+    })
+
+    const response = await app.fetch(requestWithStream(stream))
+
+    expect(response.status).toBe(500)
+    expect(admission.usage()).toEqual({ activePayloads: 0, reservedBytes: 0 })
+  })
+
+  it("releases admission when downstream handling throws", async () => {
+    const { admission, app } = createApp({ handlerThrows: true })
+
+    const response = await app.fetch(requestWithStream(streamFrom(["ok"]), { "Content-Length": "2" }))
+
+    expect(response.status).toBe(500)
+    expect(admission.usage()).toEqual({ activePayloads: 0, reservedBytes: 0 })
+  })
+
+  it("records payload and memory attributes on the active request span", async () => {
+    const attributes: Record<string, unknown> = {}
+    const runtime: TracePayloadRuntime = {
+      now: (() => {
+        const values = [10, 15]
+        return () => values.shift() ?? 15
+      })(),
+      memoryUsage: () => ({ rss: 100, arrayBuffers: 25 }),
+      getActiveSpan: () => ({
+        setAttributes: (values) => Object.assign(attributes, values),
+      }),
+    }
+    const { app } = createApp({ runtime })
+
+    const response = await app.fetch(
+      requestWithStream(streamFrom(["okay"]), {
+        "Content-Length": "4",
+        "Content-Type": "application/json; charset=utf-8",
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(attributes).toMatchObject({
+      "latitude.ingest.payload.size_bytes": 4,
+      "latitude.ingest.payload.declared_size_bytes": 4,
+      "latitude.ingest.payload.content_type": "application/json",
+      "latitude.ingest.body_read.duration_ms": 5,
+      "latitude.ingest.memory.rss_bytes": 100,
+      "latitude.ingest.memory.array_buffers_bytes": 25,
+      "latitude.ingest.payload.outcome": "accepted",
+    })
+  })
+
+  it("returns 413 through the Node server adapter for a chunked oversized body", async () => {
+    const { app } = createApp()
+    const server = serve({ fetch: app.fetch, port: 0 })
+    await new Promise<void>((resolve, reject) => {
+      if (server.listening) return resolve()
+      server.once("listening", resolve)
+      server.once("error", reject)
+    })
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === "string") throw new Error("Expected a TCP server address")
+      const response = await fetch(`http://127.0.0.1:${address.port}/v1/traces`, {
+        method: "POST",
+        body: streamFrom(["12345", "6789"]),
+        duplex: "half",
+      } as RequestInit & { duplex: "half" })
+
+      expect(response.status).toBe(413)
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+
+  it("uses production-safe default limits", () => {
+    expect(DEFAULT_TRACE_PAYLOAD_LIMITS).toEqual({
+      maxPayloadBytes: 32 * 1024 * 1024,
+      maxInFlightBytes: 64 * 1024 * 1024,
+      maxConcurrentPayloads: 16,
+    })
+  })
+})

--- a/apps/ingest/src/trace-payload.ts
+++ b/apps/ingest/src/trace-payload.ts
@@ -1,0 +1,403 @@
+import { parseEnv } from "@platform/env"
+import { Effect } from "effect"
+import type { MiddlewareHandler } from "hono"
+import type { IngestEnv, TracePayload } from "./types.ts"
+
+interface TracePayloadLimits {
+  readonly maxPayloadBytes: number
+  readonly maxInFlightBytes: number
+  readonly maxConcurrentPayloads: number
+}
+
+export const DEFAULT_TRACE_PAYLOAD_LIMITS: TracePayloadLimits = {
+  maxPayloadBytes: 32 * 1024 * 1024,
+  maxInFlightBytes: 64 * 1024 * 1024,
+  maxConcurrentPayloads: 16,
+}
+
+interface TracePayloadSpan {
+  setAttributes(values: Record<string, string | number | boolean>): void
+}
+
+export interface TracePayloadRuntime {
+  readonly now: () => number
+  readonly memoryUsage: () => { readonly rss: number; readonly arrayBuffers: number }
+  readonly getActiveSpan: () => TracePayloadSpan | undefined
+}
+
+export const createTracePayloadRuntime = (
+  getActiveSpan: TracePayloadRuntime["getActiveSpan"] = () => undefined,
+): TracePayloadRuntime => ({
+  now: () => performance.now(),
+  memoryUsage: () => {
+    const memory = process.memoryUsage()
+    return { rss: memory.rss, arrayBuffers: memory.arrayBuffers }
+  },
+  getActiveSpan,
+})
+
+const defaultRuntime = createTracePayloadRuntime()
+
+const parsePositiveIntegerEnv = (name: string, fallback: number): number => {
+  const value = Effect.runSync(parseEnv(name, "number", fallback))
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return value
+}
+
+export const loadTracePayloadLimits = (): TracePayloadLimits => {
+  const limits = {
+    maxPayloadBytes: parsePositiveIntegerEnv(
+      "LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES",
+      DEFAULT_TRACE_PAYLOAD_LIMITS.maxPayloadBytes,
+    ),
+    maxInFlightBytes: parsePositiveIntegerEnv(
+      "LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES",
+      DEFAULT_TRACE_PAYLOAD_LIMITS.maxInFlightBytes,
+    ),
+    maxConcurrentPayloads: parsePositiveIntegerEnv(
+      "LAT_INGEST_TRACE_MAX_CONCURRENT_PAYLOADS",
+      DEFAULT_TRACE_PAYLOAD_LIMITS.maxConcurrentPayloads,
+    ),
+  }
+
+  if (limits.maxInFlightBytes < limits.maxPayloadBytes) {
+    throw new Error("LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES must be at least LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES")
+  }
+
+  return limits
+}
+
+type ParsedTraceContentLength =
+  | { readonly kind: "valid"; readonly declaredBytes?: number }
+  | { readonly kind: "invalid" }
+  | { readonly kind: "too_large"; readonly declaredBytes: number }
+
+export const parseTraceContentLength = (
+  value: string | undefined,
+  maxPayloadBytes: number,
+): ParsedTraceContentLength => {
+  if (value === undefined) return { kind: "valid" }
+  if (!/^\d+$/.test(value)) return { kind: "invalid" }
+
+  const declaredBytes = Number(value)
+  if (!Number.isSafeInteger(declaredBytes)) return { kind: "invalid" }
+  if (declaredBytes > maxPayloadBytes) return { kind: "too_large", declaredBytes }
+  return { kind: "valid", declaredBytes }
+}
+
+interface TracePayloadLease {
+  release(): void
+}
+
+type TracePayloadAdmissionResult =
+  | { readonly kind: "acquired"; readonly lease: TracePayloadLease }
+  | { readonly kind: "rejected"; readonly limitedBy: "bytes" | "concurrency" }
+
+export class TracePayloadAdmission {
+  private activePayloads = 0
+  private reservedBytes = 0
+
+  constructor(private readonly limits: TracePayloadLimits) {}
+
+  tryAcquire(bytes: number): TracePayloadAdmissionResult {
+    if (this.activePayloads >= this.limits.maxConcurrentPayloads) {
+      return { kind: "rejected", limitedBy: "concurrency" }
+    }
+    if (this.reservedBytes + bytes > this.limits.maxInFlightBytes) {
+      return { kind: "rejected", limitedBy: "bytes" }
+    }
+
+    this.activePayloads++
+    this.reservedBytes += bytes
+    let released = false
+
+    return {
+      kind: "acquired",
+      lease: {
+        release: () => {
+          if (released) return
+          released = true
+          this.activePayloads--
+          this.reservedBytes -= bytes
+        },
+      },
+    }
+  }
+
+  usage() {
+    return {
+      activePayloads: this.activePayloads,
+      reservedBytes: this.reservedBytes,
+    }
+  }
+}
+
+type ReadTracePayloadResult =
+  | { readonly kind: "success"; readonly payload: Uint8Array }
+  | { readonly kind: "too_large"; readonly observedBytes: number }
+  | { readonly kind: "length_mismatch"; readonly observedBytes: number }
+
+interface ReadTracePayloadInput {
+  readonly stream: ReadableStream<Uint8Array> | null
+  readonly declaredBytes?: number | undefined
+  readonly maxPayloadBytes: number
+}
+
+const cancelReader = async (reader: ReadableStreamDefaultReader<Uint8Array>) => {
+  try {
+    await reader.cancel()
+  } catch {}
+}
+
+export const readTracePayload = async ({
+  stream,
+  declaredBytes,
+  maxPayloadBytes,
+}: ReadTracePayloadInput): Promise<ReadTracePayloadResult> => {
+  if (!stream) {
+    if (declaredBytes !== undefined && declaredBytes !== 0) {
+      return { kind: "length_mismatch", observedBytes: 0 }
+    }
+    return { kind: "success", payload: new Uint8Array() }
+  }
+
+  const reader = stream.getReader()
+  const bufferSize = declaredBytes ?? maxPayloadBytes
+  let payloadBuffer = bufferSize === 0 ? new Uint8Array() : undefined
+  let observedBytes = 0
+
+  try {
+    while (true) {
+      const chunk = await reader.read()
+      if (chunk.done) break
+
+      observedBytes += chunk.value.byteLength
+      if (observedBytes > maxPayloadBytes) {
+        await cancelReader(reader)
+        return { kind: "too_large", observedBytes }
+      }
+      if (declaredBytes !== undefined && observedBytes > declaredBytes) {
+        await cancelReader(reader)
+        return { kind: "length_mismatch", observedBytes }
+      }
+
+      payloadBuffer ??= new Uint8Array(bufferSize)
+      payloadBuffer.set(chunk.value, observedBytes - chunk.value.byteLength)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  payloadBuffer ??= new Uint8Array()
+  if (declaredBytes !== undefined) {
+    if (observedBytes !== payloadBuffer.byteLength) return { kind: "length_mismatch", observedBytes }
+    return { kind: "success", payload: payloadBuffer }
+  }
+
+  return { kind: "success", payload: payloadBuffer.subarray(0, observedBytes) }
+}
+
+interface TracePayloadProtectionInput {
+  readonly limits: TracePayloadLimits
+  readonly admission: TracePayloadAdmission
+  readonly runtime?: TracePayloadRuntime | undefined
+}
+
+const normalizedContentType = (contentType: string): string => {
+  const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase()
+  if (mediaType === "application/x-protobuf") return mediaType
+  if (mediaType === "application/json") return mediaType
+  return "other"
+}
+
+const annotatePayloadSpan = ({
+  span,
+  runtime,
+  contentType,
+  outcome,
+  observedBytes,
+  declaredBytes,
+  bodyReadDurationMs,
+  admissionLimitedBy,
+}: {
+  span: TracePayloadSpan | undefined
+  runtime: TracePayloadRuntime
+  contentType: string
+  outcome: string
+  observedBytes: number
+  declaredBytes?: number | undefined
+  bodyReadDurationMs: number
+  admissionLimitedBy?: string | undefined
+}) => {
+  if (!span) return
+  const memory = runtime.memoryUsage()
+  const attributes: Record<string, string | number | boolean> = {
+    "latitude.ingest.payload.size_bytes": observedBytes,
+    "latitude.ingest.payload.content_type": normalizedContentType(contentType),
+    "latitude.ingest.payload.outcome": outcome,
+    "latitude.ingest.body_read.duration_ms": bodyReadDurationMs,
+    "latitude.ingest.memory.rss_bytes": memory.rss,
+    "latitude.ingest.memory.array_buffers_bytes": memory.arrayBuffers,
+  }
+  if (declaredBytes !== undefined) {
+    attributes["latitude.ingest.payload.declared_size_bytes"] = declaredBytes
+  }
+  if (admissionLimitedBy) {
+    attributes["latitude.ingest.payload.admission_limited_by"] = admissionLimitedBy
+  }
+  span.setAttributes(attributes)
+}
+
+const annotateProcessingMemory = (
+  span: TracePayloadSpan | undefined,
+  runtime: TracePayloadRuntime,
+  admission: TracePayloadAdmission,
+) => {
+  if (!span) return
+  const memory = runtime.memoryUsage()
+  const usage = admission.usage()
+  span.setAttributes({
+    "latitude.ingest.memory.after_processing.rss_bytes": memory.rss,
+    "latitude.ingest.memory.after_processing.array_buffers_bytes": memory.arrayBuffers,
+    "latitude.ingest.payload.active_count": usage.activePayloads,
+    "latitude.ingest.payload.reserved_bytes": usage.reservedBytes,
+  })
+}
+
+export interface TracePayloadProtection {
+  readonly rejectOversizedHeaders: MiddlewareHandler<IngestEnv>
+  readonly readPayload: MiddlewareHandler<IngestEnv>
+}
+
+export const createTracePayloadProtection = ({
+  limits,
+  admission,
+  runtime = defaultRuntime,
+}: TracePayloadProtectionInput): TracePayloadProtection => {
+  const rejectOversizedHeaders: MiddlewareHandler<IngestEnv> = async (c, next) => {
+    const contentType = c.req.header("Content-Type") ?? "application/json"
+    const parsed = parseTraceContentLength(c.req.header("Content-Length"), limits.maxPayloadBytes)
+
+    if (parsed.kind === "invalid") {
+      annotatePayloadSpan({
+        span: runtime.getActiveSpan(),
+        runtime,
+        contentType,
+        outcome: "invalid_content_length",
+        observedBytes: 0,
+        bodyReadDurationMs: 0,
+      })
+      return c.json({ error: "Invalid Content-Length header." }, 400)
+    }
+    if (parsed.kind === "too_large") {
+      annotatePayloadSpan({
+        span: runtime.getActiveSpan(),
+        runtime,
+        contentType,
+        outcome: "declared_too_large",
+        observedBytes: 0,
+        declaredBytes: parsed.declaredBytes,
+        bodyReadDurationMs: 0,
+      })
+      return c.json({ error: `Trace payload exceeds the ${limits.maxPayloadBytes}-byte limit.` }, 413)
+    }
+
+    await next()
+  }
+
+  const readPayload: MiddlewareHandler<IngestEnv> = async (c, next) => {
+    const contentType = c.req.header("Content-Type") ?? "application/json"
+    const parsed = parseTraceContentLength(c.req.header("Content-Length"), limits.maxPayloadBytes)
+    if (parsed.kind !== "valid") {
+      return c.json({ error: "Invalid trace payload length." }, parsed.kind === "too_large" ? 413 : 400)
+    }
+
+    const reservedBytes = parsed.declaredBytes ?? limits.maxPayloadBytes
+    const acquired = admission.tryAcquire(reservedBytes)
+    const span = runtime.getActiveSpan()
+    if (acquired.kind === "rejected") {
+      annotatePayloadSpan({
+        span,
+        runtime,
+        contentType,
+        outcome: "admission_rejected",
+        observedBytes: 0,
+        declaredBytes: parsed.declaredBytes,
+        bodyReadDurationMs: 0,
+        admissionLimitedBy: acquired.limitedBy,
+      })
+      return c.json({ error: "Trace ingestion is temporarily at capacity. Please retry later." }, 503, {
+        "Retry-After": "1",
+      })
+    }
+
+    const startedAt = runtime.now()
+    try {
+      const result = await readTracePayload({
+        stream: c.req.raw.body,
+        declaredBytes: parsed.declaredBytes,
+        maxPayloadBytes: limits.maxPayloadBytes,
+      })
+      const bodyReadDurationMs = runtime.now() - startedAt
+
+      if (result.kind === "too_large") {
+        annotatePayloadSpan({
+          span,
+          runtime,
+          contentType,
+          outcome: "streamed_too_large",
+          observedBytes: result.observedBytes,
+          declaredBytes: parsed.declaredBytes,
+          bodyReadDurationMs,
+        })
+        return c.json({ error: `Trace payload exceeds the ${limits.maxPayloadBytes}-byte limit.` }, 413)
+      }
+      if (result.kind === "length_mismatch") {
+        annotatePayloadSpan({
+          span,
+          runtime,
+          contentType,
+          outcome: "content_length_mismatch",
+          observedBytes: result.observedBytes,
+          declaredBytes: parsed.declaredBytes,
+          bodyReadDurationMs,
+        })
+        return c.json({ error: "Content-Length does not match the trace payload." }, 400)
+      }
+
+      const tracePayload: TracePayload = {
+        payload: result.payload,
+        contentType,
+      }
+      c.set("tracePayload", tracePayload)
+      annotatePayloadSpan({
+        span,
+        runtime,
+        contentType,
+        outcome: "accepted",
+        observedBytes: result.payload.byteLength,
+        declaredBytes: parsed.declaredBytes,
+        bodyReadDurationMs,
+      })
+      await next()
+    } catch (error) {
+      annotatePayloadSpan({
+        span,
+        runtime,
+        contentType,
+        outcome: "read_error",
+        observedBytes: 0,
+        declaredBytes: parsed.declaredBytes,
+        bodyReadDurationMs: runtime.now() - startedAt,
+      })
+      throw error
+    } finally {
+      annotateProcessingMemory(span, runtime, admission)
+      acquired.lease.release()
+    }
+  }
+
+  return { rejectOversizedHeaders, readPayload }
+}

--- a/apps/ingest/src/trace-payload.ts
+++ b/apps/ingest/src/trace-payload.ts
@@ -62,8 +62,9 @@ export const loadTracePayloadLimits = (): TracePayloadLimits => {
     ),
   }
 
-  if (limits.maxInFlightBytes < limits.maxPayloadBytes) {
-    throw new Error("LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES must be at least LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES")
+  const minimumInFlightBytes = limits.maxPayloadBytes * 2
+  if (!Number.isSafeInteger(minimumInFlightBytes) || limits.maxInFlightBytes < minimumInFlightBytes) {
+    throw new Error("LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES must be at least twice LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES")
   }
 
   return limits
@@ -88,6 +89,8 @@ export const parseTraceContentLength = (
 }
 
 interface TracePayloadLease {
+  reserve(bytes: number): boolean
+  releaseReserved(bytes: number): void
   release(): void
 }
 
@@ -111,16 +114,29 @@ export class TracePayloadAdmission {
 
     this.activePayloads++
     this.reservedBytes += bytes
+    let leaseBytes = bytes
     let released = false
 
     return {
       kind: "acquired",
       lease: {
+        reserve: (additionalBytes) => {
+          if (released || this.reservedBytes + additionalBytes > this.limits.maxInFlightBytes) return false
+          leaseBytes += additionalBytes
+          this.reservedBytes += additionalBytes
+          return true
+        },
+        releaseReserved: (releasedBytes) => {
+          if (released || releasedBytes > leaseBytes) return
+          leaseBytes -= releasedBytes
+          this.reservedBytes -= releasedBytes
+        },
         release: () => {
           if (released) return
           released = true
           this.activePayloads--
-          this.reservedBytes -= bytes
+          this.reservedBytes -= leaseBytes
+          leaseBytes = 0
         },
       },
     }
@@ -138,11 +154,13 @@ type ReadTracePayloadResult =
   | { readonly kind: "success"; readonly payload: Uint8Array }
   | { readonly kind: "too_large"; readonly observedBytes: number }
   | { readonly kind: "length_mismatch"; readonly observedBytes: number }
+  | { readonly kind: "capacity_exceeded"; readonly observedBytes: number }
 
 interface ReadTracePayloadInput {
   readonly stream: ReadableStream<Uint8Array> | null
   readonly declaredBytes?: number | undefined
   readonly maxPayloadBytes: number
+  readonly capacity?: Pick<TracePayloadLease, "reserve" | "releaseReserved"> | undefined
 }
 
 const cancelReader = async (reader: ReadableStreamDefaultReader<Uint8Array>) => {
@@ -155,6 +173,7 @@ export const readTracePayload = async ({
   stream,
   declaredBytes,
   maxPayloadBytes,
+  capacity,
 }: ReadTracePayloadInput): Promise<ReadTracePayloadResult> => {
   if (!stream) {
     if (declaredBytes !== undefined && declaredBytes !== 0) {
@@ -164,8 +183,8 @@ export const readTracePayload = async ({
   }
 
   const reader = stream.getReader()
-  const bufferSize = declaredBytes ?? maxPayloadBytes
-  let payloadBuffer = bufferSize === 0 ? new Uint8Array() : undefined
+  const declaredPayload = declaredBytes === undefined ? undefined : new Uint8Array(declaredBytes)
+  const chunks: Uint8Array[] = []
   let observedBytes = 0
 
   try {
@@ -183,20 +202,42 @@ export const readTracePayload = async ({
         return { kind: "length_mismatch", observedBytes }
       }
 
-      payloadBuffer ??= new Uint8Array(bufferSize)
-      payloadBuffer.set(chunk.value, observedBytes - chunk.value.byteLength)
+      if (declaredPayload !== undefined) {
+        declaredPayload.set(chunk.value, observedBytes - chunk.value.byteLength)
+      } else {
+        if (capacity && !capacity.reserve(chunk.value.byteLength)) {
+          await cancelReader(reader)
+          return { kind: "capacity_exceeded", observedBytes }
+        }
+        chunks.push(chunk.value)
+      }
     }
   } finally {
     reader.releaseLock()
   }
 
-  payloadBuffer ??= new Uint8Array()
-  if (declaredBytes !== undefined) {
-    if (observedBytes !== payloadBuffer.byteLength) return { kind: "length_mismatch", observedBytes }
-    return { kind: "success", payload: payloadBuffer }
+  if (declaredPayload !== undefined) {
+    if (observedBytes !== declaredPayload.byteLength) return { kind: "length_mismatch", observedBytes }
+    return { kind: "success", payload: declaredPayload }
   }
+  if (!observedBytes) return { kind: "success", payload: new Uint8Array() }
+  if (capacity && !capacity.reserve(observedBytes)) return { kind: "capacity_exceeded", observedBytes }
 
-  return { kind: "success", payload: payloadBuffer.subarray(0, observedBytes) }
+  let payload: Uint8Array
+  try {
+    payload = new Uint8Array(observedBytes)
+    let offset = 0
+    for (const chunk of chunks) {
+      payload.set(chunk, offset)
+      offset += chunk.byteLength
+    }
+  } catch (error) {
+    capacity?.releaseReserved(observedBytes)
+    throw error
+  }
+  chunks.length = 0
+  capacity?.releaseReserved(observedBytes)
+  return { kind: "success", payload }
 }
 
 interface TracePayloadProtectionInput {
@@ -314,9 +355,8 @@ export const createTracePayloadProtection = ({
       return c.json({ error: "Invalid trace payload length." }, parsed.kind === "too_large" ? 413 : 400)
     }
 
-    const reservedBytes = parsed.declaredBytes ?? limits.maxPayloadBytes
-    const acquired = admission.tryAcquire(reservedBytes)
     const span = runtime.getActiveSpan()
+    const acquired = admission.tryAcquire(parsed.declaredBytes ?? 0)
     if (acquired.kind === "rejected") {
       annotatePayloadSpan({
         span,
@@ -333,13 +373,29 @@ export const createTracePayloadProtection = ({
       })
     }
 
-    const startedAt = runtime.now()
+    let startedAt = 0
     try {
-      const result = await readTracePayload({
-        stream: c.req.raw.body,
-        declaredBytes: parsed.declaredBytes,
-        maxPayloadBytes: limits.maxPayloadBytes,
-      })
+      startedAt = runtime.now()
+      let result: ReadTracePayloadResult
+      try {
+        result = await readTracePayload({
+          stream: c.req.raw.body,
+          declaredBytes: parsed.declaredBytes,
+          maxPayloadBytes: limits.maxPayloadBytes,
+          capacity: acquired.lease,
+        })
+      } catch (error) {
+        annotatePayloadSpan({
+          span,
+          runtime,
+          contentType,
+          outcome: "read_error",
+          observedBytes: 0,
+          declaredBytes: parsed.declaredBytes,
+          bodyReadDurationMs: runtime.now() - startedAt,
+        })
+        throw error
+      }
       const bodyReadDurationMs = runtime.now() - startedAt
 
       if (result.kind === "too_large") {
@@ -366,6 +422,20 @@ export const createTracePayloadProtection = ({
         })
         return c.json({ error: "Content-Length does not match the trace payload." }, 400)
       }
+      if (result.kind === "capacity_exceeded") {
+        annotatePayloadSpan({
+          span,
+          runtime,
+          contentType,
+          outcome: "stream_admission_rejected",
+          observedBytes: result.observedBytes,
+          bodyReadDurationMs,
+          admissionLimitedBy: "bytes",
+        })
+        return c.json({ error: "Trace ingestion is temporarily at capacity. Please retry later." }, 503, {
+          "Retry-After": "1",
+        })
+      }
 
       const tracePayload: TracePayload = {
         payload: result.payload,
@@ -382,20 +452,12 @@ export const createTracePayloadProtection = ({
         bodyReadDurationMs,
       })
       await next()
-    } catch (error) {
-      annotatePayloadSpan({
-        span,
-        runtime,
-        contentType,
-        outcome: "read_error",
-        observedBytes: 0,
-        declaredBytes: parsed.declaredBytes,
-        bodyReadDurationMs: runtime.now() - startedAt,
-      })
-      throw error
     } finally {
-      annotateProcessingMemory(span, runtime, admission)
-      acquired.lease.release()
+      try {
+        annotateProcessingMemory(span, runtime, admission)
+      } finally {
+        acquired.lease.release()
+      }
     }
   }
 

--- a/apps/ingest/src/types.ts
+++ b/apps/ingest/src/types.ts
@@ -1,8 +1,14 @@
+export interface TracePayload {
+  readonly payload: Uint8Array
+  readonly contentType: string
+}
+
 export interface IngestEnv {
   Variables: {
     organizationId: string
     apiKeyId: string
     isSandbox: boolean
+    tracePayload: TracePayload
     /**
      * Optional default project slug from the `X-Latitude-Project` header. The middleware
      * is best-effort — it never fails if the header is missing or the slug doesn't resolve.

--- a/charts/latitude/templates/configmap.yaml
+++ b/charts/latitude/templates/configmap.yaml
@@ -20,6 +20,11 @@ data:
   LAT_WORKERS_HEALTH_PORT: "9090"
   LAT_WORKFLOWS_HEALTH_PORT: "9091"
 
+  # --- Ingest payload protection --------------------------------------------
+  LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES: {{ .Values.config.ingestTraceMaxPayloadBytes | quote }}
+  LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES: {{ .Values.config.ingestTraceMaxInFlightBytes | quote }}
+  LAT_INGEST_TRACE_MAX_CONCURRENT_PAYLOADS: {{ .Values.config.ingestTraceMaxConcurrentPayloads | quote }}
+
   # --- Postgres (bundled-container bootstrap; connection URLs live in the Secret)
   {{- if .Values.postgres.enabled }}
   POSTGRES_USER: {{ .Values.postgres.auth.username | quote }}

--- a/charts/latitude/values.yaml
+++ b/charts/latitude/values.yaml
@@ -33,6 +33,9 @@ config:
   ingestUrl: ""
   temporalTaskQueue: latitude-workflows
   temporalMaxConcurrentActivityTasks: ""
+  ingestTraceMaxPayloadBytes: 33554432
+  ingestTraceMaxInFlightBytes: 67108864
+  ingestTraceMaxConcurrentPayloads: 16
   # Extra non-secret environment for every app service and the migrations job —
   # email transport settings (LAT_SMTP_*/LAT_MAILGUN_*/LAT_SENDGRID_*), the
   # LAT_AI_* model selection, OAuth, integrations, etc. Standard EnvVar entries

--- a/dev-docs/spans.md
+++ b/dev-docs/spans.md
@@ -12,6 +12,17 @@ Today the repo already has:
 
 Reliability builds on top of that telemetry base rather than introducing a second trace store.
 
+## Ingest Admission And Memory Safety
+
+The ingest HTTP boundary protects each process before decoding OTLP payloads:
+
+- `Content-Length` is validated before authentication or body buffering; malformed values receive `400`, and declared payloads above `LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES` receive `413`
+- body streaming enforces the same payload cap for chunked requests and clients whose observed body does not match the declared length
+- a process-local admission controller limits both active payload count and reserved payload bytes; admission remains held through decoding, object-storage persistence, and queue publication because the raw payload stays live for that full path
+- admission exhaustion receives `503` with `Retry-After: 1`; this protects process memory and is independent from the authenticated organization/API-key rate limiter, which continues to return `429`
+
+The defaults are a 32 MiB request cap, a 64 MiB in-flight payload budget, and 16 concurrent payloads per ingest process. Operators can tune them with `LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES`, `LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES`, and `LAT_INGEST_TRACE_MAX_CONCURRENT_PAYLOADS`. The request span records observed and declared payload size, normalized content type, body-read duration, admission outcome, RSS, and ArrayBuffer memory before and after processing.
+
 ## Reliability Additions
 
 Reliability adds:

--- a/dev-docs/spans.md
+++ b/dev-docs/spans.md
@@ -21,7 +21,7 @@ The ingest HTTP boundary protects each process before decoding OTLP payloads:
 - a process-local admission controller limits both active payload count and reserved payload bytes; admission remains held through decoding, object-storage persistence, and queue publication because the raw payload stays live for that full path
 - admission exhaustion receives `503` with `Retry-After: 1`; this protects process memory and is independent from the authenticated organization/API-key rate limiter, which continues to return `429`
 
-The defaults are a 32 MiB request cap, a 64 MiB in-flight payload budget, and 16 concurrent payloads per ingest process. Operators can tune them with `LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES`, `LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES`, and `LAT_INGEST_TRACE_MAX_CONCURRENT_PAYLOADS`. The request span records observed and declared payload size, normalized content type, body-read duration, admission outcome, RSS, and ArrayBuffer memory before and after processing.
+The defaults are a 32 MiB request cap, a 64 MiB in-flight payload budget, and 16 concurrent payloads per ingest process. The in-flight budget must be at least twice the request cap because assembling a chunked body briefly retains its streamed chunks and exact-sized output buffer together. Operators can tune the limits with `LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES`, `LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES`, and `LAT_INGEST_TRACE_MAX_CONCURRENT_PAYLOADS`. The request span records observed and declared payload size, normalized content type, body-read duration, admission outcome, RSS, and ArrayBuffer memory before and after processing.
 
 ## Reliability Additions
 

--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -137,7 +137,7 @@ These wire Latitude to its datastores, depending on your chosen [deployment opti
 | `LAT_OSS_TELEMETRY_ENABLED` | Anonymous OSS deployment heartbeat sent to Latitude's PostHog project (default `true` in production, `false` in development). Set `false` to opt out. |
 | `LAT_EXPORT_RATE_LIMIT_*`, `LAT_INGEST_TRACE_RATE_LIMIT_*` | Rate-limit tuning for exports and per-organization/API-key trace ingestion. |
 | `LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES` | Maximum trace request body size in bytes (default `33554432`, or 32 MiB). Larger declared or streamed payloads receive `413`. |
-| `LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES` | Per-process budget for trace payloads being read or processed (default `67108864`, or 64 MiB). |
+| `LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES` | Per-process budget for trace payloads being read or processed (default `67108864`, or 64 MiB). This must be at least twice `LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES` to cover chunked-body assembly. |
 | `LAT_INGEST_TRACE_MAX_CONCURRENT_PAYLOADS` | Maximum trace payloads being read or processed concurrently per ingest process (default `16`). |
 
 ### Postgres

--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -135,7 +135,10 @@ These wire Latitude to its datastores, depending on your chosen [deployment opti
 | `LAT_WORKERS_HEALTH_PORT`, `LAT_WORKFLOWS_HEALTH_PORT` | Health-check ports for the background workers (default `9090` / `9091`). |
 | `LAT_IMAGE_TAG` | Image tag the stack pulls (default `latest`; pin `X.Y.Z` in production). |
 | `LAT_OSS_TELEMETRY_ENABLED` | Anonymous OSS deployment heartbeat sent to Latitude's PostHog project (default `true` in production, `false` in development). Set `false` to opt out. |
-| `LAT_EXPORT_RATE_LIMIT_*`, `LAT_INGEST_TRACE_RATE_LIMIT_*` | Rate-limit tuning for exports and trace ingestion. |
+| `LAT_EXPORT_RATE_LIMIT_*`, `LAT_INGEST_TRACE_RATE_LIMIT_*` | Rate-limit tuning for exports and per-organization/API-key trace ingestion. |
+| `LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES` | Maximum trace request body size in bytes (default `33554432`, or 32 MiB). Larger declared or streamed payloads receive `413`. |
+| `LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES` | Per-process budget for trace payloads being read or processed (default `67108864`, or 64 MiB). |
+| `LAT_INGEST_TRACE_MAX_CONCURRENT_PAYLOADS` | Maximum trace payloads being read or processed concurrently per ingest process (default `16`). |
 
 ### Postgres
 

--- a/infra/config.ts
+++ b/infra/config.ts
@@ -238,8 +238,8 @@ export const productionConfig: EnvironmentConfig = {
         memory: 1024,
         port: 8080,
         healthCheckPath: "/health",
-        desiredCount: 1,
-        minCount: 1,
+        desiredCount: 2,
+        minCount: 2,
         maxCount: 4,
       },
       {

--- a/infra/config.ts
+++ b/infra/config.ts
@@ -238,8 +238,8 @@ export const productionConfig: EnvironmentConfig = {
         memory: 1024,
         port: 8080,
         healthCheckPath: "/health",
-        desiredCount: 2,
-        minCount: 2,
+        desiredCount: 1,
+        minCount: 1,
         maxCount: 4,
       },
       {


### PR DESCRIPTION
Production ingest was OOM-killed after accepting jumbo OTLP JSON requests. The route buffered each complete body before rate limiting, and JSON decoding created additional copies while the raw payload stayed live through storage and queue publication.

## Ingest protection

- Validate `Content-Length` before reading the body and reject malformed values with `400` or oversized declarations with `413`.
- Enforce the same size limit while streaming chunked requests and cancel streams that exceed it.
- Hold process-local byte and concurrency admission through decoding, object storage, and queue publication. Saturated processes return `503` with `Retry-After: 1`; the existing organization and API-key rate limiter remains separate and continues to return `429`.
- Record request payload size, body-read duration, admission state, RSS, and ArrayBuffer memory on the request span.

The defaults are a 32 MiB request limit, a 64 MiB in-flight payload budget, and 16 concurrent payloads per process. The values are configurable through environment variables and Helm values.

## Validation

- `pnpm --filter @app/ingest check`
- `pnpm --filter @app/ingest typecheck`
- `pnpm --filter @app/ingest test` (32 tests)
- `pnpm --filter @app/ingest build`
- `pnpm --filter latitude-infra typecheck`
- `helm lint charts/latitude ...`
- repository pre-commit format and Knip checks
