### PR TITLE
feat(memory): insights on the main Memory page

### DIFF
--- a/apps/web/src/domains/memories/memories.collection.ts
+++ b/apps/web/src/domains/memories/memories.collection.ts
@@ -3,6 +3,8 @@ import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-qu
 import { useMemo } from "react"
 import { projectScopeData, projectScopeKey, useProjectScope } from "../projects/project-scope.tsx"
 import {
+  getMemoryActivityHistogram,
+  getMemoryAnalyticsOverview,
   getMemoryRecord,
   getMemoryRecordChangeDiff,
   getMemoryRecordReads,
@@ -10,15 +12,25 @@ import {
   getSessionMemoryDiff,
   getSessionMemorySummary,
   listMemoryRecordUsers,
-  listMemoryStores,
+  listMemoryStoresWithMetrics,
   listMemoryStoreUsers,
-  listUserMemoryStores,
-  type MemoryStoreRecord,
+  listMemoryZeroHitQueries,
+  type MemoryStoreMetricsRecord,
   type SessionMemoryDiffRecord,
   type SessionMemorySummaryRecord,
+  listUserMemoryStores,
 } from "./memories.functions.ts"
 
-type MemoryStoreSortField = "lastUpdated" | "lastRead" | "records" | "tokens" | "sessions" | "users"
+type MemoryStoreMetricsSortField =
+  | "lastUpdated"
+  | "lastRead"
+  | "records"
+  | "tokens"
+  | "sessions"
+  | "users"
+  | "reads"
+  | "yield"
+  | "netGrowth"
 
 /**
  * Memory footprint for a session's summary chip; pass `traceId` to restrict it
@@ -76,45 +88,6 @@ export function useSessionMemoryDiff({
     staleTime: 30_000,
     enabled: enabled && projectId.length > 0 && sessionId.length > 0,
   })
-}
-
-/** The project's memory stores, server-sorted and paginated for the store-list table. */
-export function useMemoryStores({
-  projectId,
-  sort,
-  direction,
-  limit = 50,
-  enabled = true,
-}: {
-  readonly projectId: string
-  readonly sort: MemoryStoreSortField
-  readonly direction: "asc" | "desc"
-  readonly limit?: number
-  readonly enabled?: boolean
-}) {
-  const scope = useProjectScope()
-  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
-    queryKey: [...projectScopeKey(scope), "memory-stores", projectId, sort, direction, limit],
-    queryFn: ({ pageParam }) =>
-      listMemoryStores({ data: { ...projectScopeData(scope), projectId, sort, direction, limit, offset: pageParam } }),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined),
-    placeholderData: keepPreviousData,
-    enabled: enabled && projectId.length > 0,
-  })
-
-  const infiniteScroll: InfiniteTableInfiniteScroll = useMemo(
-    () => ({ hasMore: hasNextPage ?? false, isLoadingMore: isFetchingNextPage, onLoadMore: fetchNextPage }),
-    [hasNextPage, isFetchingNextPage, fetchNextPage],
-  )
-  const stores = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data])
-
-  return {
-    stores: stores as readonly MemoryStoreRecord[],
-    totalCount: data?.pages[0]?.totalCount ?? 0,
-    isLoading,
-    infiniteScroll,
-  }
 }
 
 /** One store's current record ids for the detail filetree. */
@@ -259,5 +232,172 @@ export function useUserMemoryStores({
     queryFn: () => listUserMemoryStores({ data: { ...projectScopeData(scope), projectId, userId } }),
     staleTime: 30_000,
     enabled: enabled && projectId.length > 0 && userId.length > 0,
+  })
+}
+
+interface MemoryAnalyticsRange {
+  readonly fromIso: string
+  readonly toIso: string
+}
+
+/** The Memory-page (or store-scoped) analytics tile roll-up. */
+export function useMemoryAnalyticsOverview({
+  projectId,
+  storeId,
+  range,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly storeId?: string
+  readonly range: MemoryAnalyticsRange
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "memory-overview", projectId, storeId ?? "", range.fromIso, range.toIso],
+    queryFn: () =>
+      getMemoryAnalyticsOverview({
+        data: { ...projectScopeData(scope), projectId, ...(storeId !== undefined ? { storeId } : {}), ...range },
+      }),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0,
+  })
+}
+
+/** Bucketed mutation/read activity for the Memory analytics chart. */
+export function useMemoryActivityHistogram({
+  projectId,
+  storeId,
+  range,
+  bucketSeconds,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly storeId?: string
+  readonly range: MemoryAnalyticsRange
+  readonly bucketSeconds: number
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [
+      ...projectScopeKey(scope),
+      "memory-activity",
+      projectId,
+      storeId ?? "",
+      range.fromIso,
+      range.toIso,
+      bucketSeconds,
+    ],
+    queryFn: () =>
+      getMemoryActivityHistogram({
+        data: {
+          ...projectScopeData(scope),
+          projectId,
+          ...(storeId !== undefined ? { storeId } : {}),
+          ...range,
+          bucketSeconds,
+        },
+      }),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0,
+  })
+}
+
+/** The project's memory stores with range-scoped insight metrics, sorted and paginated. */
+export function useMemoryStoresWithMetrics({
+  projectId,
+  range,
+  sort,
+  direction,
+  trendBucketSeconds,
+  limit = 50,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly range: MemoryAnalyticsRange
+  readonly sort: MemoryStoreMetricsSortField
+  readonly direction: "asc" | "desc"
+  readonly trendBucketSeconds: number
+  readonly limit?: number
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey: [
+      ...projectScopeKey(scope),
+      "memory-stores-metrics",
+      projectId,
+      range.fromIso,
+      range.toIso,
+      sort,
+      direction,
+      trendBucketSeconds,
+      limit,
+    ],
+    queryFn: ({ pageParam }) =>
+      listMemoryStoresWithMetrics({
+        data: {
+          ...projectScopeData(scope),
+          projectId,
+          ...range,
+          sort,
+          direction,
+          trendBucketSeconds,
+          limit,
+          offset: pageParam,
+        },
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined),
+    placeholderData: keepPreviousData,
+    enabled: enabled && projectId.length > 0,
+  })
+
+  const infiniteScroll: InfiniteTableInfiniteScroll = useMemo(
+    () => ({ hasMore: hasNextPage ?? false, isLoadingMore: isFetchingNextPage, onLoadMore: fetchNextPage }),
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
+  )
+  const stores = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data])
+
+  return {
+    stores: stores as readonly MemoryStoreMetricsRecord[],
+    totalCount: data?.pages[0]?.totalCount ?? 0,
+    isLoading,
+    infiniteScroll,
+  }
+}
+
+/** Zero-hit searches grouped by query text; gate with `enabled` so it loads on demand. */
+export function useMemoryZeroHitQueries({
+  projectId,
+  storeId,
+  range,
+  limit,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly storeId?: string
+  readonly range: MemoryAnalyticsRange
+  readonly limit?: number
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "memory-zero-hit", projectId, storeId ?? "", range.fromIso, range.toIso],
+    queryFn: () =>
+      listMemoryZeroHitQueries({
+        data: {
+          ...projectScopeData(scope),
+          projectId,
+          ...(storeId !== undefined ? { storeId } : {}),
+          ...range,
+          ...(limit !== undefined ? { limit } : {}),
+        },
+      }),
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0,
   })
 }

--- a/apps/web/src/domains/memories/memories.functions.ts
+++ b/apps/web/src/domains/memories/memories.functions.ts
@@ -3,11 +3,16 @@ import {
   computeRecordHistoryUseCase,
   computeSessionMemoryDiffUseCase,
   computeSessionMemorySummaryUseCase,
-  listMemoryStoresUseCase,
+  getMemoryActivityHistogramUseCase,
+  getMemoryAnalyticsOverviewUseCase,
+  isMemoryStoreMetricsSortField,
   listRecordUsersUseCase,
+  listStoresWithMetricsUseCase,
   listStoreUsersUseCase,
   listUserStoresUseCase,
+  listZeroHitQueriesUseCase,
   type MemoryChangeKind,
+  type MemoryStoreMetricsSortField,
   type RecordChangeDiff,
   readRecordReadsUseCase,
   reconstructSnapshotUseCase,
@@ -15,7 +20,7 @@ import {
   type SessionMemorySummary,
 } from "@domain/memories"
 import { ExternalUserId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
-import { MemoryRepositoryLive } from "@platform/db-clickhouse"
+import { MemoryAnalyticsRepositoryLive, MemoryRepositoryLive } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
@@ -38,12 +43,51 @@ export interface MemoryStoreRecord {
   readonly userCount: number
 }
 
-interface MemoryStoresPageRecord {
-  readonly items: readonly MemoryStoreRecord[]
+export interface MemoryAnalyticsOverviewRecord {
+  readonly liveRecords: number
+  readonly liveTokens: number
+  readonly neverReadLiveTokens: number
+  readonly readSessions: number
+  readonly retrievedTokens: number
+  readonly searchCount: number
+  readonly zeroHitSearchCount: number
+  readonly contentWrites: number
+  readonly noopWrites: number
+  readonly completedVersions: number
+  readonly consumedVersions: number
+}
+
+export interface MemoryActivityBucketRecord {
+  readonly bucketStart: string
+  readonly adds: number
+  readonly updates: number
+  readonly removes: number
+  readonly reads: number
+}
+
+export interface MemoryStoreMetricsRecord extends MemoryStoreRecord {
+  readonly readSessions: number
+  readonly contentWrites: number
+  readonly completedVersions: number
+  readonly consumedVersions: number
+  readonly netTokenGrowth: number
+  readonly trend: readonly { readonly bucketStart: string; readonly writes: number; readonly reads: number }[]
+}
+
+interface MemoryStoreMetricsPageRecord {
+  readonly items: readonly MemoryStoreMetricsRecord[]
   readonly totalCount: number
   readonly hasMore: boolean
   readonly limit: number
   readonly offset: number
+}
+
+export interface MemoryZeroHitQueryRecord {
+  readonly queryText: string
+  readonly searchCount: number
+  readonly storeCount: number
+  readonly anyStoreId: string
+  readonly lastSeenAt: string
 }
 
 export interface MemoryStoreSnapshotRecord {
@@ -137,49 +181,6 @@ export const getSessionMemoryDiff = createServerFn({ method: "GET" })
         sessionId: SessionId(data.sessionId),
         ...(data.traceId ? { traceId: TraceId(data.traceId) } : {}),
       }).pipe(withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId), withTracing),
-    )
-  })
-
-/** The project's memory stores, one roll-up row each, server-sorted and paginated. */
-export const listMemoryStores = createServerFn({ method: "GET" })
-  .inputValidator(
-    z.object({
-      projectId: z.string(),
-      sort: z.enum(["lastUpdated", "lastRead", "records", "tokens", "sessions", "users"]).default("lastUpdated"),
-      direction: z.enum(["asc", "desc"]).default("desc"),
-      limit: z.number().int().min(1).max(200).default(50),
-      offset: z.number().int().min(0).default(0),
-    }),
-  )
-  .handler(async ({ data, context }): Promise<MemoryStoresPageRecord> => {
-    const orgId = await resolveOrgScope(context)
-
-    return Effect.runPromise(
-      listMemoryStoresUseCase({
-        organizationId: orgId,
-        projectId: ProjectId(data.projectId),
-        options: { sortBy: data.sort, sortDirection: data.direction, limit: data.limit, offset: data.offset },
-      }).pipe(
-        Effect.map(
-          (page): MemoryStoresPageRecord => ({
-            items: page.items.map((store) => ({
-              storeId: store.storeId,
-              recordCount: store.recordCount,
-              tokenCount: store.tokenCount,
-              lastUpdatedAt: store.lastUpdatedAt.toISOString(),
-              lastReadAt: store.lastReadAt ? store.lastReadAt.toISOString() : null,
-              sessionCount: store.sessionCount,
-              userCount: store.userCount,
-            })),
-            totalCount: page.totalCount,
-            hasMore: page.hasMore,
-            limit: page.limit,
-            offset: page.offset,
-          }),
-        ),
-        withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId),
-        withTracing,
-      ),
     )
   })
 
@@ -371,6 +372,153 @@ export const listUserMemoryStores = createServerFn({ method: "GET" })
           ),
         ),
         withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
+    )
+  })
+
+const analyticsScopeSchema = z.object({
+  projectId: z.string(),
+  storeId: z.string().optional(),
+  fromIso: z.string().datetime(),
+  toIso: z.string().datetime(),
+})
+
+const MAX_BUCKET_SECONDS = 90 * 24 * 60 * 60
+
+/** The Memory-page (or store-scoped) analytics tile roll-up over the ledger. */
+export const getMemoryAnalyticsOverview = createServerFn({ method: "GET" })
+  .inputValidator(analyticsScopeSchema)
+  .handler(async ({ data, context }): Promise<MemoryAnalyticsOverviewRecord> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      getMemoryAnalyticsOverviewUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        ...(data.storeId !== undefined ? { storeId: data.storeId } : {}),
+        range: { from: new Date(data.fromIso), to: new Date(data.toIso) },
+      }).pipe(withScopedClickHouse(MemoryAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+  })
+
+/** Bucketed mutation/read activity for the Memory analytics chart. */
+export const getMemoryActivityHistogram = createServerFn({ method: "GET" })
+  .inputValidator(analyticsScopeSchema.extend({ bucketSeconds: z.number().int().positive().max(MAX_BUCKET_SECONDS) }))
+  .handler(async ({ data, context }): Promise<readonly MemoryActivityBucketRecord[]> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      getMemoryActivityHistogramUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        ...(data.storeId !== undefined ? { storeId: data.storeId } : {}),
+        range: { from: new Date(data.fromIso), to: new Date(data.toIso) },
+        bucketSeconds: data.bucketSeconds,
+      }).pipe(
+        Effect.map((buckets) =>
+          buckets.map(
+            (bucket): MemoryActivityBucketRecord => ({
+              bucketStart: bucket.bucketStart.toISOString(),
+              adds: bucket.adds,
+              updates: bucket.updates,
+              removes: bucket.removes,
+              reads: bucket.reads,
+            }),
+          ),
+        ),
+        withScopedClickHouse(MemoryAnalyticsRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
+    )
+  })
+
+/** The project's memory stores with range-scoped insight metrics and trend sparklines. */
+export const listMemoryStoresWithMetrics = createServerFn({ method: "GET" })
+  .inputValidator(
+    analyticsScopeSchema.extend({
+      sort: z.string().default("lastUpdated"),
+      direction: z.enum(["asc", "desc"]).default("desc"),
+      limit: z.number().int().min(1).max(200).default(50),
+      offset: z.number().int().min(0).default(0),
+      trendBucketSeconds: z.number().int().positive().max(MAX_BUCKET_SECONDS),
+    }),
+  )
+  .handler(async ({ data, context }): Promise<MemoryStoreMetricsPageRecord> => {
+    const orgId = await resolveOrgScope(context)
+    const sortBy: MemoryStoreMetricsSortField = isMemoryStoreMetricsSortField(data.sort) ? data.sort : "lastUpdated"
+
+    return Effect.runPromise(
+      listStoresWithMetricsUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        range: { from: new Date(data.fromIso), to: new Date(data.toIso) },
+        options: { sortBy, sortDirection: data.direction, limit: data.limit, offset: data.offset },
+        trendBucketSeconds: data.trendBucketSeconds,
+      }).pipe(
+        Effect.map(({ page, trends }): MemoryStoreMetricsPageRecord => {
+          const trendByStore = new Map<string, { bucketStart: string; writes: number; reads: number }[]>()
+          for (const bucket of trends) {
+            const list = trendByStore.get(bucket.storeId) ?? []
+            list.push({ bucketStart: bucket.bucketStart.toISOString(), writes: bucket.writes, reads: bucket.reads })
+            trendByStore.set(bucket.storeId, list)
+          }
+          return {
+            items: page.items.map(
+              (store): MemoryStoreMetricsRecord => ({
+                storeId: store.storeId,
+                recordCount: store.recordCount,
+                tokenCount: store.tokenCount,
+                lastUpdatedAt: store.lastUpdatedAt.toISOString(),
+                lastReadAt: store.lastReadAt ? store.lastReadAt.toISOString() : null,
+                sessionCount: store.sessionCount,
+                userCount: store.userCount,
+                readSessions: store.readSessions,
+                contentWrites: store.contentWrites,
+                completedVersions: store.completedVersions,
+                consumedVersions: store.consumedVersions,
+                netTokenGrowth: store.netTokenGrowth,
+                trend: trendByStore.get(store.storeId) ?? [],
+              }),
+            ),
+            totalCount: page.totalCount,
+            hasMore: page.hasMore,
+            limit: page.limit,
+            offset: page.offset,
+          }
+        }),
+        withScopedClickHouse(MemoryAnalyticsRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
+    )
+  })
+
+/** Searches that returned nothing, grouped by query text — the "what to add" report. */
+export const listMemoryZeroHitQueries = createServerFn({ method: "GET" })
+  .inputValidator(analyticsScopeSchema.extend({ limit: z.number().int().min(1).max(100).optional() }))
+  .handler(async ({ data, context }): Promise<readonly MemoryZeroHitQueryRecord[]> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      listZeroHitQueriesUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        ...(data.storeId !== undefined ? { storeId: data.storeId } : {}),
+        range: { from: new Date(data.fromIso), to: new Date(data.toIso) },
+        ...(data.limit !== undefined ? { limit: data.limit } : {}),
+      }).pipe(
+        Effect.map((groups) =>
+          groups.map(
+            (group): MemoryZeroHitQueryRecord => ({
+              queryText: group.queryText,
+              searchCount: group.searchCount,
+              storeCount: group.storeCount,
+              anyStoreId: group.anyStoreId,
+              lastSeenAt: group.lastSeenAt.toISOString(),
+            }),
+          ),
+        ),
+        withScopedClickHouse(MemoryAnalyticsRepositoryLive, getClickhouseClient(), orgId),
         withTracing,
       ),
     )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-analytics-panel.tsx
@@ -1,0 +1,199 @@
+import { Button, Chart, type ChartSeries, HistogramSkeleton, Icon, Skeleton, Text } from "@repo/ui"
+import { formatCount } from "@repo/utils"
+import { BarChart2, ChevronDown, ChevronUp } from "lucide-react"
+import { useMemo, useState } from "react"
+import type {
+  MemoryActivityBucketRecord,
+  MemoryAnalyticsOverviewRecord,
+} from "../../../../../../domains/memories/memories.functions.ts"
+import { ChartHeader } from "../../-components/chart-header.tsx"
+import { formatBucketLabel, formatPercent, formatWriteYield } from "./memory-formatters.ts"
+
+// Adds/updates/removes follow the record-diff colors used elsewhere; reads ride
+// the right axis as a line so retrieval volume reads against write volume.
+const ADD_COLOR = "hsl(142 71% 45%)"
+const UPDATE_COLOR = "hsl(217 91% 60%)"
+const REMOVE_COLOR = "hsl(0 70% 55%)"
+const READS_COLOR = "hsl(199 89% 48%)"
+
+function MemoryAggregationItem({
+  label,
+  value,
+  subtext,
+  isLoading,
+  skeletonWidthClassName = "w-16",
+}: {
+  readonly label: string
+  readonly value: string
+  readonly subtext?: string | undefined
+  readonly isLoading?: boolean
+  readonly skeletonWidthClassName?: string
+}) {
+  return (
+    <div className="flex basis-[176px] min-w-[176px] shrink-0 flex-col gap-2">
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
+      {isLoading ? (
+        <Skeleton className={`h-5 ${skeletonWidthClassName}`} />
+      ) : (
+        <div className="flex flex-col gap-0.5">
+          <Text.H5 color="foreground" className="tabular-nums">
+            {value}
+          </Text.H5>
+          {subtext ? (
+            <Text.H6 color="foregroundMuted" className="tabular-nums">
+              {subtext}
+            </Text.H6>
+          ) : null}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface MemoryTile {
+  readonly key: string
+  readonly label: string
+  readonly value: string
+  readonly subtext?: string
+}
+
+function memoryOverviewTiles(overview: MemoryAnalyticsOverviewRecord | undefined): readonly MemoryTile[] {
+  const o = overview
+  const neverReadShare = o && o.liveTokens > 0 ? o.neverReadLiveTokens / o.liveTokens : 0
+  const supersededUnread = o ? Math.max(0, o.completedVersions - o.consumedVersions) : 0
+  return [
+    { key: "records", label: "Records", value: formatCount(o?.liveRecords ?? 0) },
+    {
+      key: "tokens",
+      label: "Live tokens",
+      value: formatCount(o?.liveTokens ?? 0),
+      ...(o ? { subtext: `${formatPercent(neverReadShare)} never read` } : {}),
+    },
+    { key: "readSessions", label: "Read sessions", value: formatCount(o?.readSessions ?? 0) },
+    { key: "retrieved", label: "Retrieved tokens", value: formatCount(o?.retrievedTokens ?? 0) },
+    {
+      key: "writes",
+      label: "Writes",
+      value: formatCount(o?.contentWrites ?? 0),
+      ...(o ? { subtext: `${formatCount(o.noopWrites)} no-ops` } : {}),
+    },
+    {
+      key: "yield",
+      label: "Write yield",
+      value: formatWriteYield(o?.consumedVersions ?? 0, o?.completedVersions ?? 0),
+      ...(o ? { subtext: `${formatCount(supersededUnread)} unread` } : {}),
+    },
+  ]
+}
+
+export function MemoryAnalyticsPanel({
+  overview,
+  histogram,
+  bucketSeconds,
+  rangeFromIso,
+  rangeToIso,
+  isAllTime,
+  isLoading,
+}: {
+  readonly overview: MemoryAnalyticsOverviewRecord | undefined
+  readonly histogram: readonly MemoryActivityBucketRecord[]
+  readonly bucketSeconds: number
+  readonly rangeFromIso: string
+  readonly rangeToIso: string
+  readonly isAllTime: boolean
+  readonly isLoading: boolean
+}) {
+  const [collapsed, setCollapsed] = useState(false)
+  const [showLeftFade, setShowLeftFade] = useState(false)
+
+  const tiles = useMemo(() => memoryOverviewTiles(overview), [overview])
+
+  const categories = useMemo(
+    () => histogram.map((bucket) => formatBucketLabel(bucket.bucketStart, bucketSeconds)),
+    [histogram, bucketSeconds],
+  )
+
+  const series = useMemo<readonly ChartSeries[]>(
+    () => [
+      { kind: "bar", name: "Removed", values: histogram.map((b) => b.removes), color: REMOVE_COLOR, axis: "left", stack: "writes" },
+      { kind: "bar", name: "Updated", values: histogram.map((b) => b.updates), color: UPDATE_COLOR, axis: "left", stack: "writes" },
+      { kind: "bar", name: "Added", values: histogram.map((b) => b.adds), color: ADD_COLOR, axis: "left", stack: "writes" },
+      { kind: "line", name: "Reads", values: histogram.map((b) => b.reads), color: READS_COLOR, axis: "right", smooth: true },
+    ],
+    [histogram],
+  )
+
+  const isEmpty = histogram.length === 0 || histogram.every((b) => b.adds + b.updates + b.removes + b.reads === 0)
+
+  if (collapsed) {
+    return (
+      <div className="flex flex-col rounded-lg bg-secondary">
+        <div className="flex items-center justify-between px-4 py-2">
+          <div className="flex items-center gap-1.5">
+            <Icon icon={BarChart2} size="sm" color="foregroundMuted" />
+            <Text.H6 color="foregroundMuted">Memory statistics</Text.H6>
+          </div>
+          <Button variant="ghost" size="icon" onClick={() => setCollapsed(false)} aria-label="Expand statistics">
+            <Icon icon={ChevronDown} size="sm" />
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col rounded-lg bg-secondary">
+      <div className="p-2">
+        <div className="flex items-start gap-1 pr-2">
+          <div className="relative min-w-0 flex-1">
+            <div
+              className="flex flex-row gap-3 overflow-x-auto p-4"
+              onScroll={(e) => setShowLeftFade(e.currentTarget.scrollLeft > 0)}
+            >
+              {tiles.map((tile) => (
+                <MemoryAggregationItem
+                  key={tile.key}
+                  label={tile.label}
+                  value={tile.value}
+                  subtext={tile.subtext}
+                  isLoading={isLoading}
+                  skeletonWidthClassName={tile.key === "retrieved" || tile.key === "readSessions" ? "w-20" : "w-16"}
+                />
+              ))}
+            </div>
+            {showLeftFade && (
+              <div className="pointer-events-none absolute inset-y-0 left-0 w-10 bg-gradient-to-r from-secondary to-transparent" />
+            )}
+            <div className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-secondary to-transparent" />
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setCollapsed(true)}
+            aria-label="Collapse statistics"
+            className="shrink-0"
+          >
+            <Icon icon={ChevronUp} size="sm" />
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <div className="px-4 py-3">
+            <HistogramSkeleton height={160} />
+          </div>
+        ) : isEmpty ? (
+          <div className="flex w-full min-h-[80px] items-center justify-center px-4 py-3">
+            <Text.H6 color="foregroundMuted">No memory activity in this time window</Text.H6>
+          </div>
+        ) : (
+          <>
+            <ChartHeader title="Memory activity over time" fromIso={rangeFromIso} toIso={rangeToIso} isAllTime={isAllTime} />
+            <div className="px-4 py-3">
+              <Chart categories={categories} series={series} height={160} xAxisLabelFontSize={10} ariaLabel="Memory activity over time" />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-formatters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-formatters.ts
@@ -1,0 +1,49 @@
+const TARGET_TREND_BUCKETS = 30
+const HOUR_SECONDS = 60 * 60
+const DAY_SECONDS = 24 * HOUR_SECONDS
+
+/** 0..1 fraction → "12%", keeping sub-1% values visible as "<1%". */
+export function formatPercent(rate: number): string {
+  if (rate <= 0) return "0%"
+  const percent = rate * 100
+  if (percent < 1) return "<1%"
+  if (percent < 10) return `${percent.toFixed(1).replace(/\.0$/, "")}%`
+  return `${Math.round(percent)}%`
+}
+
+/** Completed→consumed ratio as a percent, or "-" when nothing has completed yet. */
+export function formatWriteYield(consumed: number, completed: number): string {
+  if (completed <= 0) return "-"
+  return formatPercent(consumed / completed)
+}
+
+/** Signed token delta for the net-growth column, e.g. "+1.2k" / "−340" / "0". */
+export function formatSignedCount(value: number): string {
+  if (value === 0) return "0"
+  const sign = value > 0 ? "+" : "−"
+  return `${sign}${compactCount(Math.abs(value))}`
+}
+
+function compactCount(value: number): string {
+  if (value < 1000) return String(value)
+  if (value < 1_000_000) return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`
+  return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`
+}
+
+// Mirrors the tools bucket picker: day buckets round to the nearest day so the
+// default 30-day window gets daily buckets rather than rounding up.
+export function pickMemoryTrendBucketSeconds(rangeMs: number): number {
+  const rawSeconds = Math.max(1, Math.floor(rangeMs / 1000 / TARGET_TREND_BUCKETS))
+  if (rawSeconds <= HOUR_SECONDS) return HOUR_SECONDS
+  if (rawSeconds <= DAY_SECONDS) return Math.ceil(rawSeconds / HOUR_SECONDS) * HOUR_SECONDS
+  return Math.max(1, Math.round(rawSeconds / DAY_SECONDS)) * DAY_SECONDS
+}
+
+export function formatBucketLabel(bucketStartIso: string, bucketSeconds: number): string {
+  const date = new Date(bucketStartIso)
+  if (Number.isNaN(date.getTime())) return bucketStartIso
+  if (bucketSeconds < DAY_SECONDS) {
+    return date.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+  }
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" })
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-stores-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-stores-view.tsx
@@ -2,15 +2,34 @@ import { cn, InfiniteTable, type InfiniteTableColumn, type InfiniteTableInfinite
 import { formatCount, relativeTime } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import { DatabaseIcon } from "lucide-react"
-import type { MemoryStoreRecord } from "../../../../../../domains/memories/memories.functions.ts"
+import type { MemoryStoreMetricsRecord } from "../../../../../../domains/memories/memories.functions.ts"
 import {
   ListingLayout as Layout,
   listingLayoutIntrinsicScroll,
 } from "../../../../../../layouts/ListingLayout/index.tsx"
+import type { TableColumnOption } from "../../-components/columns-selector.tsx"
+import { formatSignedCount, formatWriteYield } from "./memory-formatters.ts"
+import { MemoryTrendBar } from "./memory-trend-bar.tsx"
 import { encodeStoreSegment, storeDisplayLabel } from "./store-encoding.ts"
 
+export const MEMORY_STORE_COLUMN_OPTIONS = [
+  { id: "store", label: "Store", required: true },
+  { id: "trend", label: "Trend" },
+  { id: "records", label: "Records" },
+  { id: "tokens", label: "Tokens" },
+  { id: "reads", label: "Reads" },
+  { id: "yield", label: "Write yield" },
+  { id: "netGrowth", label: "Net growth" },
+  { id: "lastUpdated", label: "Last updated" },
+  { id: "lastRead", label: "Last read" },
+  { id: "sessions", label: "Sessions", defaultHidden: true },
+  { id: "users", label: "Users", defaultHidden: true },
+] as const satisfies readonly TableColumnOption[]
+
+export type MemoryStoreColumnId = (typeof MEMORY_STORE_COLUMN_OPTIONS)[number]["id"]
+
 export interface MemoryStoresSorting {
-  readonly column: "lastUpdated" | "lastRead" | "records" | "tokens" | "sessions" | "users"
+  readonly column: "lastUpdated" | "lastRead" | "records" | "tokens" | "sessions" | "users" | "reads" | "yield" | "netGrowth"
   readonly direction: "asc" | "desc"
 }
 
@@ -23,20 +42,28 @@ export function MemoryStoresView({
   onSortChange,
   infiniteScroll,
   projectSlug,
+  visibleColumnIds,
+  rangeFromIso,
+  rangeToIso,
+  trendBucketSeconds,
 }: {
-  readonly stores: readonly MemoryStoreRecord[]
+  readonly stores: readonly MemoryStoreMetricsRecord[]
   readonly isLoading: boolean
   readonly sorting: MemoryStoresSorting
   readonly onSortChange: (sorting: MemoryStoresSorting) => void
   readonly infiniteScroll: InfiniteTableInfiniteScroll
   readonly projectSlug: string
+  readonly visibleColumnIds: readonly MemoryStoreColumnId[]
+  readonly rangeFromIso: string
+  readonly rangeToIso: string
+  readonly trendBucketSeconds: number
 }) {
-  const columns: InfiniteTableColumn<MemoryStoreRecord>[] = [
-    {
+  const allColumns: Record<MemoryStoreColumnId, InfiniteTableColumn<MemoryStoreMetricsRecord>> = {
+    store: {
       key: "store",
       header: "Store",
-      width: 320,
-      minWidth: 220,
+      width: 300,
+      minWidth: 200,
       render: (store) => (
         <div className="flex min-w-0 items-center gap-2">
           <DatabaseIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
@@ -52,53 +79,48 @@ export function MemoryStoresView({
         </div>
       ),
     },
-    {
-      key: "records",
-      header: "Records",
-      width: 96,
-      align: "end",
-      sortKey: "records",
-      render: (store) => formatCount(store.recordCount),
-    },
-    {
-      key: "tokens",
-      header: "Tokens",
-      width: 110,
-      align: "end",
-      sortKey: "tokens",
-      render: (store) => formatCount(store.tokenCount),
-    },
-    {
-      key: "lastUpdated",
-      header: "Last updated",
+    trend: {
+      key: "trend",
+      header: "Trend",
       width: 130,
-      sortKey: "lastUpdated",
-      render: (store) => relativeTime(new Date(store.lastUpdatedAt)),
+      render: (store) => (
+        <MemoryTrendBar
+          points={store.trend}
+          fromIso={rangeFromIso}
+          toIso={rangeToIso}
+          bucketSeconds={trendBucketSeconds}
+        />
+      ),
     },
-    {
-      key: "lastRead",
-      header: "Last read",
-      width: 130,
-      sortKey: "lastRead",
-      render: (store) => (store.lastReadAt ? relativeTime(new Date(store.lastReadAt)) : "-"),
-    },
-    {
-      key: "sessions",
-      header: "Sessions",
-      width: 96,
+    records: { key: "records", header: "Records", width: 92, align: "end", sortKey: "records", render: (store) => formatCount(store.recordCount) },
+    tokens: { key: "tokens", header: "Tokens", width: 100, align: "end", sortKey: "tokens", render: (store) => formatCount(store.tokenCount) },
+    reads: { key: "reads", header: "Reads", width: 92, align: "end", sortKey: "reads", render: (store) => formatCount(store.readSessions) },
+    yield: {
+      key: "yield",
+      header: "Write yield",
+      width: 100,
       align: "end",
-      sortKey: "sessions",
-      render: (store) => formatCount(store.sessionCount),
+      sortKey: "yield",
+      render: (store) => formatWriteYield(store.consumedVersions, store.completedVersions),
     },
-    {
-      key: "users",
-      header: "Users",
-      width: 90,
+    netGrowth: {
+      key: "netGrowth",
+      header: "Net growth",
+      width: 100,
       align: "end",
-      sortKey: "users",
-      render: (store) => formatCount(store.userCount),
+      sortKey: "netGrowth",
+      render: (store) => formatSignedCount(store.netTokenGrowth),
     },
-  ]
+    lastUpdated: { key: "lastUpdated", header: "Last updated", width: 124, sortKey: "lastUpdated", render: (store) => relativeTime(new Date(store.lastUpdatedAt)) },
+    lastRead: { key: "lastRead", header: "Last read", width: 124, sortKey: "lastRead", render: (store) => (store.lastReadAt ? relativeTime(new Date(store.lastReadAt)) : "-") },
+    sessions: { key: "sessions", header: "Sessions", width: 92, align: "end", sortKey: "sessions", render: (store) => formatCount(store.sessionCount) },
+    users: { key: "users", header: "Users", width: 84, align: "end", sortKey: "users", render: (store) => formatCount(store.userCount) },
+  }
+
+  const columns = visibleColumnIds.flatMap((columnId) => {
+    const column = allColumns[columnId]
+    return column ? [column] : []
+  })
 
   return (
     <Layout.Body>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-trend-bar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-trend-bar.tsx
@@ -1,0 +1,105 @@
+import { Text, TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from "@repo/ui"
+import { formatCount } from "@repo/utils"
+import { useMemo } from "react"
+import { formatBucketLabel } from "./memory-formatters.ts"
+
+export interface MemoryTrendPoint {
+  readonly bucketStart: string
+  readonly writes: number
+  readonly reads: number
+}
+
+const WRITE_BAR_CLASSES = "bg-muted-foreground/60 dark:bg-muted-foreground/70"
+const READ_BAR_CLASSES = "bg-sky-500/70 dark:bg-sky-400/80"
+const MIN_VISIBLE_HEIGHT_PERCENT = 6
+
+// Fills quiet periods with empty buckets so gaps render as gaps, not compression.
+function denseBuckets(
+  points: readonly MemoryTrendPoint[],
+  fromMs: number,
+  toMs: number,
+  bucketSeconds: number,
+): readonly MemoryTrendPoint[] {
+  const bucketMs = bucketSeconds * 1000
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs) || toMs <= fromMs) return points
+  const byStart = new Map(points.map((point) => [Date.parse(point.bucketStart), point]))
+  const firstBucketMs = Math.floor(fromMs / bucketMs) * bucketMs
+  const result: MemoryTrendPoint[] = []
+  for (let startMs = firstBucketMs; startMs <= toMs; startMs += bucketMs) {
+    result.push(byStart.get(startMs) ?? { bucketStart: new Date(startMs).toISOString(), writes: 0, reads: 0 })
+  }
+  return result
+}
+
+// Pure-div sparkline (one per store row) — writes and reads stacked per bucket.
+export function MemoryTrendBar({
+  points,
+  fromIso,
+  toIso,
+  bucketSeconds,
+  height = 36,
+}: {
+  readonly points: readonly MemoryTrendPoint[]
+  readonly fromIso: string
+  readonly toIso: string
+  readonly bucketSeconds: number
+  readonly height?: number
+}) {
+  const visualBuckets = useMemo(
+    () => denseBuckets(points, Date.parse(fromIso), Date.parse(toIso), bucketSeconds),
+    [points, fromIso, toIso, bucketSeconds],
+  )
+  const maxTotal = useMemo(
+    () => Math.max(1, ...visualBuckets.map((bucket) => bucket.writes + bucket.reads)),
+    [visualBuckets],
+  )
+
+  if (points.length === 0 || points.every((point) => point.writes === 0 && point.reads === 0)) {
+    return (
+      <div className="flex min-h-9 items-center">
+        <Text.H6 color="foregroundMuted">-</Text.H6>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col" style={{ height }} role="img" aria-label="Memory activity trend">
+      <TooltipProvider>
+        <div className="flex h-full items-end gap-px">
+          {visualBuckets.map((bucket) => {
+            const total = bucket.writes + bucket.reads
+            const totalPercent =
+              total === 0 ? 0 : Math.max(MIN_VISIBLE_HEIGHT_PERCENT, Math.round((total / maxTotal) * 100))
+            const readShare = total === 0 ? 0 : bucket.reads / total
+            return (
+              <TooltipRoot key={bucket.bucketStart} delayDuration={100}>
+                <TooltipTrigger asChild>
+                  <span className="group/bucket relative flex h-full min-w-0 flex-1 items-end">
+                    <span
+                      className="pointer-events-none absolute inset-0 rounded-[2px] bg-foreground/[0.06] opacity-0 transition-opacity group-hover/bucket:opacity-100"
+                      aria-hidden
+                    />
+                    <span
+                      className="relative flex w-full flex-col justify-end overflow-hidden rounded-t-[2px]"
+                      style={{ height: `${totalPercent}%` }}
+                    >
+                      <span className={READ_BAR_CLASSES} style={{ height: `${Math.round(readShare * 100)}%` }} />
+                      <span className={WRITE_BAR_CLASSES} style={{ height: `${Math.round((1 - readShare) * 100)}%` }} />
+                    </span>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={6}>
+                  <div className="flex flex-col gap-0.5">
+                    <Text.H6>{formatBucketLabel(bucket.bucketStart, bucketSeconds)}</Text.H6>
+                    <Text.H6B>{formatCount(bucket.writes)} writes</Text.H6B>
+                    <Text.H6 color="foregroundMuted">{formatCount(bucket.reads)} reads</Text.H6>
+                  </div>
+                </TooltipContent>
+              </TooltipRoot>
+            )
+          })}
+        </div>
+      </TooltipProvider>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/unanswered-searches-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/unanswered-searches-card.tsx
@@ -1,0 +1,47 @@
+import { cn, Text } from "@repo/ui"
+import { formatCount, relativeTime } from "@repo/utils"
+import { SearchXIcon } from "lucide-react"
+import type { MemoryZeroHitQueryRecord } from "../../../../../../domains/memories/memories.functions.ts"
+
+const ROW_CLASS = "flex h-8 w-full items-center gap-2 rounded px-2 text-left"
+
+/**
+ * Zero-hit searches grouped by query — the "what to add to memory" report.
+ * Rendered only when there is at least one zero-hit search in the window.
+ */
+export function UnansweredSearchesCard({ queries }: { readonly queries: readonly MemoryZeroHitQueryRecord[] }) {
+  if (queries.length === 0) return null
+  return (
+    <div className="flex flex-col rounded-lg border">
+      <div className="flex items-center gap-1.5 border-b px-4 py-2.5">
+        <SearchXIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <Text.H6M>Unanswered searches</Text.H6M>
+        <Text.H6 color="foregroundMuted">— searches that returned no records</Text.H6>
+      </div>
+      <div className="flex flex-col p-1">
+        {queries.map((query) => (
+          <div key={query.queryText} className={ROW_CLASS}>
+            {query.queryText ? (
+              <Text.H6 className="min-w-0 flex-1 truncate">
+                <span title={query.queryText}>{query.queryText}</span>
+              </Text.H6>
+            ) : (
+              <Text.H6 color="foregroundMuted" className="min-w-0 flex-1 truncate italic">
+                query not captured
+              </Text.H6>
+            )}
+            <Text.H6 color="foregroundMuted" className="shrink-0 whitespace-nowrap tabular-nums">
+              {formatCount(query.searchCount)} {query.searchCount === 1 ? "search" : "searches"}
+            </Text.H6>
+            <span aria-hidden className="shrink-0 text-muted-foreground/40">
+              ·
+            </span>
+            <Text.H6 color="foregroundMuted" className={cn("shrink-0 whitespace-nowrap tabular-nums")}>
+              {relativeTime(new Date(query.lastSeenAt))}
+            </Text.H6>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/index.tsx
@@ -1,16 +1,31 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { useCallback, useMemo } from "react"
-import { useMemoryStores } from "../../../../../domains/memories/memories.collection.ts"
+import {
+  useMemoryActivityHistogram,
+  useMemoryAnalyticsOverview,
+  useMemoryStoresWithMetrics,
+  useMemoryZeroHitQueries,
+} from "../../../../../domains/memories/memories.collection.ts"
+import { useAnalyticsTimeWindow } from "../../../../../domains/projects/use-analytics-time-window.ts"
+import { useProjectFirstTraceAt, useProjectLastTraceAt } from "../../../../../domains/traces/traces.collection.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { BreadcrumbText } from "../../../-components/breadcrumb-ui.tsx"
+import { ColumnsSelector } from "../-components/columns-selector.tsx"
+import { useTableColumnSettings } from "../-components/table-column-settings.ts"
+import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
 import { useRouteProject } from "../-route-data.ts"
+import { MemoryAnalyticsPanel } from "./-components/memory-analytics-panel.tsx"
 import { MemoryEmptyState } from "./-components/memory-empty-state.tsx"
+import { pickMemoryTrendBucketSeconds } from "./-components/memory-formatters.ts"
 import {
   DEFAULT_MEMORY_SORTING,
+  MEMORY_STORE_COLUMN_OPTIONS,
+  type MemoryStoreColumnId,
   type MemoryStoresSorting,
   MemoryStoresView,
 } from "./-components/memory-stores-view.tsx"
+import { UnansweredSearchesCard } from "./-components/unanswered-searches-card.tsx"
 
 const SORT_COLUMNS = [
   "lastUpdated",
@@ -19,9 +34,12 @@ const SORT_COLUMNS = [
   "tokens",
   "sessions",
   "users",
+  "reads",
+  "yield",
+  "netGrowth",
 ] as const satisfies readonly MemoryStoresSorting["column"][]
 const SORT_DIRECTIONS = ["asc", "desc"] as const satisfies readonly MemoryStoresSorting["direction"][]
-const SORT_PARAM_PATTERN = /^(lastUpdated|lastRead|records|tokens|sessions|users):(asc|desc)$/
+const SORT_PARAM_PATTERN = /^(lastUpdated|lastRead|records|tokens|sessions|users|reads|yield|netGrowth):(asc|desc)$/
 
 function serializeSorting(sorting: MemoryStoresSorting): string {
   return `${sorting.column}:${sorting.direction}`
@@ -50,33 +68,110 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/memo
 function MemoryPage() {
   const project = useRouteProject()
   const { projectSlug } = Route.useParams()
+  const { firstTraceAt } = useProjectFirstTraceAt({ projectId: project.id })
+  const { lastTraceAt } = useProjectLastTraceAt({ projectId: project.id })
+  const tw = useAnalyticsTimeWindow({
+    project,
+    fromKey: "memoryTimeFrom",
+    toKey: "memoryTimeTo",
+    allTimeLowerBoundIso: firstTraceAt,
+    lastActivityIso: lastTraceAt,
+  })
+
   const [rawSorting, setRawSorting] = useParamState("memorySort", serializeSorting(DEFAULT_MEMORY_SORTING), {
     validate: (value): value is string => SORT_PARAM_PATTERN.test(value),
   })
   const sorting = useMemo(() => parseSorting(rawSorting), [rawSorting])
   const setSorting = useCallback((next: MemoryStoresSorting) => setRawSorting(serializeSorting(next)), [setRawSorting])
-
-  const { stores, isLoading, infiniteScroll } = useMemoryStores({
-    projectId: project.id,
-    sort: sorting.column,
-    direction: sorting.direction,
+  const columnSettings = useTableColumnSettings<MemoryStoreColumnId>({
+    storageKey: "projects.memory.columns.v1",
+    columns: MEMORY_STORE_COLUMN_OPTIONS,
   })
 
-  const showEmptyState = !isLoading && stores.length === 0
+  // Event-scoped reads need a concrete lower bound; "All time" resolves to the
+  // project's earliest activity (falling back to the trend window's start).
+  const range = useMemo(
+    () => ({ fromIso: tw.listRange.fromIso ?? tw.trendRange.fromIso, toIso: tw.listRange.toIso }),
+    [tw.listRange, tw.trendRange],
+  )
+  const trendBucketSeconds = useMemo(
+    () => pickMemoryTrendBucketSeconds(Date.parse(range.toIso) - Date.parse(range.fromIso)),
+    [range],
+  )
+  // Chart clamps to the anchored window under All time so it never scans full history per bucket.
+  const histogramRange = useMemo(() => (tw.isAllTime ? tw.trendRange : range), [tw.isAllTime, tw.trendRange, range])
+  const histogramBucketSeconds = useMemo(
+    () => pickMemoryTrendBucketSeconds(Date.parse(histogramRange.toIso) - Date.parse(histogramRange.fromIso)),
+    [histogramRange],
+  )
+
+  const overview = useMemoryAnalyticsOverview({ projectId: project.id, range })
+  const histogram = useMemoryActivityHistogram({
+    projectId: project.id,
+    range: histogramRange,
+    bucketSeconds: histogramBucketSeconds,
+  })
+  const zeroHit = useMemoryZeroHitQueries({ projectId: project.id, range })
+  const { stores, isLoading, infiniteScroll } = useMemoryStoresWithMetrics({
+    projectId: project.id,
+    range,
+    sort: sorting.column,
+    direction: sorting.direction,
+    trendBucketSeconds,
+  })
+
+  const showEmptyState = !isLoading && stores.length === 0 && (overview.data?.liveRecords ?? 0) === 0
 
   return (
     <Layout>
       {showEmptyState ? (
         <MemoryEmptyState />
       ) : (
-        <MemoryStoresView
-          stores={stores}
-          isLoading={isLoading}
-          sorting={sorting}
-          onSortChange={setSorting}
-          infiniteScroll={infiniteScroll}
-          projectSlug={projectSlug}
-        />
+        <>
+          <Layout.Actions>
+            <Layout.ActionsRow>
+              <Layout.ActionRowItem>
+                <TimeFilterDropdown
+                  {...(tw.pickerStartFrom ? { startTimeFrom: tw.pickerStartFrom } : {})}
+                  {...(tw.pickerStartTo ? { startTimeTo: tw.pickerStartTo } : {})}
+                  onChange={tw.onTimeChange}
+                />
+              </Layout.ActionRowItem>
+              <Layout.ActionRowItem>
+                <ColumnsSelector
+                  columns={MEMORY_STORE_COLUMN_OPTIONS}
+                  selectedColumnIds={columnSettings.visibleColumnIds}
+                  onChange={(ids) => columnSettings.setVisibleColumnIds(ids as MemoryStoreColumnId[])}
+                  onOrderChange={(ids) => columnSettings.setColumnIds(ids as MemoryStoreColumnId[])}
+                />
+              </Layout.ActionRowItem>
+            </Layout.ActionsRow>
+          </Layout.Actions>
+          <div className="flex flex-col gap-4 px-6">
+            <MemoryAnalyticsPanel
+              overview={overview.data}
+              histogram={histogram.data ?? []}
+              bucketSeconds={histogramBucketSeconds}
+              rangeFromIso={histogramRange.fromIso}
+              rangeToIso={histogramRange.toIso}
+              isAllTime={tw.isAllTime}
+              isLoading={overview.isLoading || histogram.isLoading}
+            />
+            <UnansweredSearchesCard queries={zeroHit.data ?? []} />
+          </div>
+          <MemoryStoresView
+            stores={stores}
+            isLoading={isLoading}
+            sorting={sorting}
+            onSortChange={setSorting}
+            infiniteScroll={infiniteScroll}
+            projectSlug={projectSlug}
+            visibleColumnIds={columnSettings.visibleColumnIds}
+            rangeFromIso={range.fromIso}
+            rangeToIso={range.toIso}
+            trendBucketSeconds={trendBucketSeconds}
+          />
+        </>
       )}
     </Layout>
   )

--- a/packages/domain/memories/src/entities/memory-analytics.ts
+++ b/packages/domain/memories/src/entities/memory-analytics.ts
@@ -1,0 +1,81 @@
+import { MEMORY_STORE_SORT_FIELDS, type MemoryStoreListItem } from "./memory-store.ts"
+
+/** Concrete window for event-scoped analytics; "All time" resolves at the boundary. */
+export interface MemoryAnalyticsRange {
+  readonly from: Date
+  readonly to: Date
+}
+
+/**
+ * Roll-up for the analytics tiles. Live-state numbers (`live*`, `neverRead*`)
+ * come from `memory_current` and ignore the range; event-derived numbers are
+ * range-scoped. A version is *completed* once a later mutation supersedes it,
+ * and *consumed* when read at least once before that — write yield is
+ * `consumedVersions / completedVersions`, superseded-unread the difference.
+ */
+export interface MemoryAnalyticsOverview {
+  readonly liveRecords: number
+  readonly liveTokens: number
+  readonly neverReadLiveTokens: number
+  readonly readSessions: number
+  readonly retrievedTokens: number
+  readonly searchCount: number
+  readonly zeroHitSearchCount: number
+  readonly contentWrites: number
+  readonly noopWrites: number
+  readonly completedVersions: number
+  readonly consumedVersions: number
+}
+
+export interface MemoryActivityBucket {
+  readonly bucketStart: Date
+  readonly adds: number
+  readonly updates: number
+  readonly removes: number
+  readonly reads: number
+}
+
+export interface MemoryStoreTrendBucket {
+  readonly storeId: string
+  readonly bucketStart: Date
+  readonly writes: number
+  readonly reads: number
+}
+
+/** One store row with range-scoped insight metrics layered onto the base roll-up. */
+export interface MemoryStoreMetricsItem extends MemoryStoreListItem {
+  readonly readSessions: number
+  readonly contentWrites: number
+  readonly completedVersions: number
+  readonly consumedVersions: number
+  readonly netTokenGrowth: number
+}
+
+export const MEMORY_STORE_METRIC_SORT_FIELDS = [...MEMORY_STORE_SORT_FIELDS, "reads", "yield", "netGrowth"] as const
+export type MemoryStoreMetricsSortField = (typeof MEMORY_STORE_METRIC_SORT_FIELDS)[number]
+export const isMemoryStoreMetricsSortField = (value: string): value is MemoryStoreMetricsSortField =>
+  (MEMORY_STORE_METRIC_SORT_FIELDS as readonly string[]).includes(value)
+
+export interface MemoryStoreMetricsOptions {
+  readonly limit?: number
+  readonly offset?: number
+  readonly sortBy?: MemoryStoreMetricsSortField
+  readonly sortDirection?: "asc" | "desc"
+}
+
+export interface MemoryStoreMetricsPage {
+  readonly items: readonly MemoryStoreMetricsItem[]
+  readonly totalCount: number
+  readonly hasMore: boolean
+  readonly limit: number
+  readonly offset: number
+}
+
+/** Zero-hit searches grouped by query; `queryText` is `""` when not captured. */
+export interface MemoryZeroHitQueryGroup {
+  readonly queryText: string
+  readonly searchCount: number
+  readonly storeCount: number
+  readonly anyStoreId: string
+  readonly lastSeenAt: Date
+}

--- a/packages/domain/memories/src/index.ts
+++ b/packages/domain/memories/src/index.ts
@@ -88,6 +88,13 @@ export {
   type SessionMemoryRecordDiff,
 } from "./use-cases/compute-session-memory-diff.ts"
 export {
+  type ComputeSessionMemorySummaryInput,
+  computeSessionMemorySummaryUseCase,
+  type MemoryRecordSummary,
+  type MemorySummaryTotals,
+  type SessionMemorySummary,
+} from "./use-cases/compute-session-memory-summary.ts"
+export {
   type GetMemoryActivityHistogramInput,
   getMemoryActivityHistogramUseCase,
 } from "./use-cases/get-memory-activity-histogram.ts"
@@ -95,21 +102,6 @@ export {
   type GetMemoryAnalyticsOverviewInput,
   getMemoryAnalyticsOverviewUseCase,
 } from "./use-cases/get-memory-analytics-overview.ts"
-export {
-  type ListStoresWithMetricsInput,
-  listStoresWithMetricsUseCase,
-} from "./use-cases/list-stores-with-metrics.ts"
-export {
-  type ListZeroHitQueriesInput,
-  listZeroHitQueriesUseCase,
-} from "./use-cases/list-zero-hit-queries.ts"
-export {
-  type ComputeSessionMemorySummaryInput,
-  computeSessionMemorySummaryUseCase,
-  type MemoryRecordSummary,
-  type MemorySummaryTotals,
-  type SessionMemorySummary,
-} from "./use-cases/compute-session-memory-summary.ts"
 export {
   type ListMemoryStoresInput,
   listMemoryStoresUseCase,
@@ -123,9 +115,17 @@ export {
   listStoreUsersUseCase,
 } from "./use-cases/list-store-users.ts"
 export {
+  type ListStoresWithMetricsInput,
+  listStoresWithMetricsUseCase,
+} from "./use-cases/list-stores-with-metrics.ts"
+export {
   type ListUserStoresInput,
   listUserStoresUseCase,
 } from "./use-cases/list-user-stores.ts"
+export {
+  type ListZeroHitQueriesInput,
+  listZeroHitQueriesUseCase,
+} from "./use-cases/list-zero-hit-queries.ts"
 export {
   type MaterializeTraceMemoryInput,
   type MaterializeTraceMemoryResult,

--- a/packages/domain/memories/src/index.ts
+++ b/packages/domain/memories/src/index.ts
@@ -1,3 +1,18 @@
+export type {
+  MemoryActivityBucket,
+  MemoryAnalyticsOverview,
+  MemoryAnalyticsRange,
+  MemoryStoreMetricsItem,
+  MemoryStoreMetricsOptions,
+  MemoryStoreMetricsPage,
+  MemoryStoreMetricsSortField,
+  MemoryStoreTrendBucket,
+  MemoryZeroHitQueryGroup,
+} from "./entities/memory-analytics.ts"
+export {
+  isMemoryStoreMetricsSortField,
+  MEMORY_STORE_METRIC_SORT_FIELDS,
+} from "./entities/memory-analytics.ts"
 export {
   type MemoryBlob,
   memoryBlobSchema,
@@ -44,6 +59,10 @@ export {
   type MemoryUserStore,
 } from "./entities/memory-store.ts"
 export {
+  MemoryAnalyticsRepository,
+  type MemoryAnalyticsRepositoryShape,
+} from "./ports/memory-analytics-repository.ts"
+export {
   MemoryRepository,
   type MemoryRepositoryShape,
 } from "./ports/memory-repository.ts"
@@ -68,6 +87,22 @@ export {
   type SessionMemoryDiff,
   type SessionMemoryRecordDiff,
 } from "./use-cases/compute-session-memory-diff.ts"
+export {
+  type GetMemoryActivityHistogramInput,
+  getMemoryActivityHistogramUseCase,
+} from "./use-cases/get-memory-activity-histogram.ts"
+export {
+  type GetMemoryAnalyticsOverviewInput,
+  getMemoryAnalyticsOverviewUseCase,
+} from "./use-cases/get-memory-analytics-overview.ts"
+export {
+  type ListStoresWithMetricsInput,
+  listStoresWithMetricsUseCase,
+} from "./use-cases/list-stores-with-metrics.ts"
+export {
+  type ListZeroHitQueriesInput,
+  listZeroHitQueriesUseCase,
+} from "./use-cases/list-zero-hit-queries.ts"
 export {
   type ComputeSessionMemorySummaryInput,
   computeSessionMemorySummaryUseCase,

--- a/packages/domain/memories/src/ports/memory-analytics-repository.ts
+++ b/packages/domain/memories/src/ports/memory-analytics-repository.ts
@@ -1,0 +1,67 @@
+import type { ChSqlClient, OrganizationId, ProjectId, RepositoryError } from "@domain/shared"
+import { Context, type Effect } from "effect"
+import type {
+  MemoryActivityBucket,
+  MemoryAnalyticsOverview,
+  MemoryAnalyticsRange,
+  MemoryStoreMetricsOptions,
+  MemoryStoreMetricsPage,
+  MemoryStoreTrendBucket,
+  MemoryZeroHitQueryGroup,
+} from "../entities/memory-analytics.ts"
+
+/**
+ * Read-only analytics over the memory ledger (ClickHouse), backing the Memory
+ * insights surfaces. Like `MemoryRepository`, the `ChSqlClient` requirement is
+ * intentionally leaked (per-request org scope). Methods taking an optional
+ * `storeId` serve both the project-wide Memory page and the store overview.
+ */
+export interface MemoryAnalyticsRepositoryShape {
+  /** Tile roll-up: live footprint plus range-scoped read/write/version-outcome counts. */
+  getOverview(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly storeId?: string
+    readonly range: MemoryAnalyticsRange
+  }): Effect.Effect<MemoryAnalyticsOverview, RepositoryError, ChSqlClient>
+
+  /** Bucketed mutation/read activity for the analytics chart. */
+  getActivityHistogram(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly storeId?: string
+    readonly range: MemoryAnalyticsRange
+    readonly bucketSeconds: number
+  }): Effect.Effect<readonly MemoryActivityBucket[], RepositoryError, ChSqlClient>
+
+  /** The store list roll-up plus range-scoped metrics, server-sorted and paginated. */
+  listStoresWithMetrics(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly range: MemoryAnalyticsRange
+    readonly options?: MemoryStoreMetricsOptions
+  }): Effect.Effect<MemoryStoreMetricsPage, RepositoryError, ChSqlClient>
+
+  /** Bucketed writes/reads for the given stores' trend sparklines (one page's ids). */
+  getStoreTrendBuckets(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly storeIds: readonly string[]
+    readonly range: MemoryAnalyticsRange
+    readonly bucketSeconds: number
+  }): Effect.Effect<readonly MemoryStoreTrendBucket[], RepositoryError, ChSqlClient>
+
+  /** Zero-hit searches grouped by query text, most frequent first. */
+  listZeroHitQueries(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly storeId?: string
+    readonly range: MemoryAnalyticsRange
+    readonly limit?: number
+  }): Effect.Effect<readonly MemoryZeroHitQueryGroup[], RepositoryError, ChSqlClient>
+}
+
+export class MemoryAnalyticsRepository extends Context.Service<
+  MemoryAnalyticsRepository,
+  MemoryAnalyticsRepositoryShape
+>()("@domain/memories/MemoryAnalyticsRepository") {}

--- a/packages/domain/memories/src/use-cases/get-memory-activity-histogram.ts
+++ b/packages/domain/memories/src/use-cases/get-memory-activity-histogram.ts
@@ -1,0 +1,22 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import type { MemoryAnalyticsRange } from "../entities/memory-analytics.ts"
+import { MemoryAnalyticsRepository } from "../ports/memory-analytics-repository.ts"
+
+export interface GetMemoryActivityHistogramInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly storeId?: string
+  readonly range: MemoryAnalyticsRange
+  readonly bucketSeconds: number
+}
+
+/** Bucketed mutation/read activity for the Memory analytics chart. */
+export const getMemoryActivityHistogramUseCase = Effect.fn("memories.getMemoryActivityHistogram")(function* (
+  input: GetMemoryActivityHistogramInput,
+) {
+  yield* Effect.annotateCurrentSpan("memory.projectId", input.projectId)
+  if (input.storeId !== undefined) yield* Effect.annotateCurrentSpan("memory.storeId", input.storeId)
+  const repository = yield* MemoryAnalyticsRepository
+  return yield* repository.getActivityHistogram(input)
+})

--- a/packages/domain/memories/src/use-cases/get-memory-analytics-overview.ts
+++ b/packages/domain/memories/src/use-cases/get-memory-analytics-overview.ts
@@ -1,0 +1,21 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import type { MemoryAnalyticsRange } from "../entities/memory-analytics.ts"
+import { MemoryAnalyticsRepository } from "../ports/memory-analytics-repository.ts"
+
+export interface GetMemoryAnalyticsOverviewInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly storeId?: string
+  readonly range: MemoryAnalyticsRange
+}
+
+/** The Memory-page (or store-overview) tile roll-up over the ledger. */
+export const getMemoryAnalyticsOverviewUseCase = Effect.fn("memories.getMemoryAnalyticsOverview")(function* (
+  input: GetMemoryAnalyticsOverviewInput,
+) {
+  yield* Effect.annotateCurrentSpan("memory.projectId", input.projectId)
+  if (input.storeId !== undefined) yield* Effect.annotateCurrentSpan("memory.storeId", input.storeId)
+  const repository = yield* MemoryAnalyticsRepository
+  return yield* repository.getOverview(input)
+})

--- a/packages/domain/memories/src/use-cases/list-stores-with-metrics.ts
+++ b/packages/domain/memories/src/use-cases/list-stores-with-metrics.ts
@@ -1,0 +1,46 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import type { MemoryAnalyticsRange, MemoryStoreMetricsOptions } from "../entities/memory-analytics.ts"
+import { MemoryAnalyticsRepository } from "../ports/memory-analytics-repository.ts"
+
+export interface ListStoresWithMetricsInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly range: MemoryAnalyticsRange
+  readonly options?: MemoryStoreMetricsOptions
+  /** When set, buckets for each returned store's trend sparkline are fetched and zipped in. */
+  readonly trendBucketSeconds?: number
+}
+
+/**
+ * The project's memory stores with range-scoped insight metrics, plus (when
+ * `trendBucketSeconds` is set) each store's write/read trend buckets keyed by
+ * store id for the sparkline column.
+ */
+export const listStoresWithMetricsUseCase = Effect.fn("memories.listStoresWithMetrics")(function* (
+  input: ListStoresWithMetricsInput,
+) {
+  yield* Effect.annotateCurrentSpan("memory.projectId", input.projectId)
+  const repository = yield* MemoryAnalyticsRepository
+
+  const page = yield* repository.listStoresWithMetrics({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    range: input.range,
+    ...(input.options ? { options: input.options } : {}),
+  })
+
+  if (input.trendBucketSeconds === undefined || page.items.length === 0) {
+    return { page, trends: [] as const }
+  }
+
+  const trends = yield* repository.getStoreTrendBuckets({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    storeIds: page.items.map((item) => item.storeId),
+    range: input.range,
+    bucketSeconds: input.trendBucketSeconds,
+  })
+
+  return { page, trends }
+})

--- a/packages/domain/memories/src/use-cases/list-zero-hit-queries.ts
+++ b/packages/domain/memories/src/use-cases/list-zero-hit-queries.ts
@@ -1,0 +1,22 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import type { MemoryAnalyticsRange } from "../entities/memory-analytics.ts"
+import { MemoryAnalyticsRepository } from "../ports/memory-analytics-repository.ts"
+
+export interface ListZeroHitQueriesInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly storeId?: string
+  readonly range: MemoryAnalyticsRange
+  readonly limit?: number
+}
+
+/** Searches that returned nothing, grouped by query text — the "what to add" report. */
+export const listZeroHitQueriesUseCase = Effect.fn("memories.listZeroHitQueries")(function* (
+  input: ListZeroHitQueriesInput,
+) {
+  yield* Effect.annotateCurrentSpan("memory.projectId", input.projectId)
+  if (input.storeId !== undefined) yield* Effect.annotateCurrentSpan("memory.storeId", input.storeId)
+  const repository = yield* MemoryAnalyticsRepository
+  return yield* repository.listZeroHitQueries(input)
+})

--- a/packages/domain/memories/src/use-cases/materialize-trace-memory.test.ts
+++ b/packages/domain/memories/src/use-cases/materialize-trace-memory.test.ts
@@ -130,6 +130,39 @@ describe("materializeTraceMemory", () => {
     expect(reads.map((event) => event.recordId).sort()).toEqual(["", "rec1"])
   })
 
+  it("stamps the returned body's hash on read events; zero-hit reads stay hash-less", async () => {
+    const memory = createFakeMemoryRepository()
+    await materialize(
+      [
+        makeSpan({ operation: "create_memory", recordsRaw: records({ id: "r1", content: "alpha" }), endTime: at(0) }),
+        makeSpan({
+          spanId: spanId("r"),
+          operation: "search_memory",
+          recordCount: 1,
+          queryText: "q",
+          recordsRaw: records({ id: "r1", content: "alpha", score: 0.9 }),
+          endTime: at(1),
+        }),
+        makeSpan({
+          spanId: spanId("z"),
+          operation: "search_memory",
+          recordCount: 0,
+          queryText: "miss",
+          endTime: at(2),
+        }),
+      ],
+      memory,
+    )
+
+    const add = memory.events.find((event) => event.changeKind === "add")
+    const reads = memory.events.filter((event) => event.changeKind === "read")
+    const hit = reads.find((event) => event.recordId === "r1")
+    const miss = reads.find((event) => event.recordCount === 0)
+    expect(hit?.contentHash).not.toBe("")
+    expect(hit?.contentHash).toBe(add?.contentHash)
+    expect(miss?.contentHash).toBe("")
+  })
+
   it("resolves upsert to update for existing records and add for new ones", async () => {
     const memory = createFakeMemoryRepository()
     await materialize(

--- a/packages/domain/memories/src/use-cases/materialize-trace-memory.ts
+++ b/packages/domain/memories/src/use-cases/materialize-trace-memory.ts
@@ -90,7 +90,12 @@ export const materializeTraceMemoryUseCase = Effect.fn("memories.materializeTrac
   const pushSpanEvent = (
     span: MemoryOperationSpan,
     changeKind: MemoryChangeKind,
-    extra: { readonly recordId?: string; readonly tokenCount?: number; readonly queryText?: string } = {},
+    extra: {
+      readonly recordId?: string
+      readonly tokenCount?: number
+      readonly queryText?: string
+      readonly contentHash?: string
+    } = {},
   ) => {
     events.push({
       organizationId,
@@ -99,7 +104,7 @@ export const materializeTraceMemoryUseCase = Effect.fn("memories.materializeTrac
       recordId: extra.recordId ?? "",
       operation: span.operation,
       changeKind,
-      contentHash: "",
+      contentHash: extra.contentHash ?? "",
       tokenCount: extra.tokenCount ?? 0,
       recordCount: span.recordCount,
       queryText: extra.queryText ?? "",
@@ -206,14 +211,18 @@ export const materializeTraceMemoryUseCase = Effect.fn("memories.materializeTrac
       case "search_memory": {
         // One read event per returned record, keyed on the record's own id so
         // the read attributes to that record; id-less hits fall back to the
-        // span's (usually empty) record id and bucket together.
+        // span's (usually empty) record id and bucket together. The returned
+        // body's hash rides the event for read→version attribution — no blob
+        // is stored for reads.
         const records = parseMemoryRecords(span.recordsRaw)
         if (records && records.length > 0) {
           for (const record of records) {
+            const body = memoryRecordBody(record)
             pushSpanEvent(span, "read", {
               recordId: record.id ?? span.recordId,
-              tokenCount: countTokens(memoryRecordBody(record)),
+              tokenCount: countTokens(body),
               queryText: span.queryText,
+              ...(body ? { contentHash: sha256Hex(body) } : {}),
             })
           }
         } else {

--- a/packages/platform/db-clickhouse/src/index.ts
+++ b/packages/platform/db-clickhouse/src/index.ts
@@ -17,6 +17,7 @@ export { AnalyticsQueryReaderLive } from "./repositories/analytics-query-reposit
 export { ClaudeCodeSpanReaderLive } from "./repositories/claude-code-span-reader.ts"
 export { DatasetRowRepositoryLive } from "./repositories/dataset-row-repository.ts"
 export { FacetProjectionRepositoryLive } from "./repositories/facet-projection-repository.ts"
+export { MemoryAnalyticsRepositoryLive } from "./repositories/memory-analytics-repository.ts"
 export { MemoryRepositoryLive } from "./repositories/memory-repository.ts"
 export { MessageEmbeddingRepositoryLive } from "./repositories/message-embedding-repository.ts"
 export { MetricSeriesReaderLive } from "./repositories/metric-series-reader.ts"

--- a/packages/platform/db-clickhouse/src/repositories/memory-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/memory-analytics-repository.test.ts
@@ -14,8 +14,8 @@ import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
 import { beforeEach, describe, expect, it } from "vitest"
 import { withClickHouse } from "../with-clickhouse.ts"
-import { MemoryRepositoryLive } from "./memory-repository.ts"
 import { MemoryAnalyticsRepositoryLive } from "./memory-analytics-repository.ts"
+import { MemoryRepositoryLive } from "./memory-repository.ts"
 
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
@@ -115,9 +115,31 @@ describe("MemoryAnalyticsRepository", () => {
     it("counts searches and zero-hit searches distinctly, summing retrieved tokens", async () => {
       await seedEvents([
         // one search returning two records (shared span) + one zero-hit search
-        makeEvent({ changeKind: "read", recordId: "rec1", recordCount: 2, tokenCount: 10, spanId: spanN(100), endTime: at(2) }),
-        makeEvent({ changeKind: "read", recordId: "rec2", recordCount: 2, tokenCount: 15, spanId: spanN(100), endTime: at(2) }),
-        makeEvent({ changeKind: "read", recordId: "", recordCount: 0, tokenCount: 0, spanId: spanN(101), queryText: "missing", endTime: at(3) }),
+        makeEvent({
+          changeKind: "read",
+          recordId: "rec1",
+          recordCount: 2,
+          tokenCount: 10,
+          spanId: spanN(100),
+          endTime: at(2),
+        }),
+        makeEvent({
+          changeKind: "read",
+          recordId: "rec2",
+          recordCount: 2,
+          tokenCount: 15,
+          spanId: spanN(100),
+          endTime: at(2),
+        }),
+        makeEvent({
+          changeKind: "read",
+          recordId: "",
+          recordCount: 0,
+          tokenCount: 0,
+          spanId: spanN(101),
+          queryText: "missing",
+          endTime: at(3),
+        }),
       ])
 
       const overview = await withRepo((repo) => repo.getOverview({ organizationId, projectId, range }))
@@ -158,7 +180,15 @@ describe("MemoryAnalyticsRepository", () => {
     })
 
     it("dedups retried projection rows in additive aggregates", async () => {
-      const dup = makeEvent({ changeKind: "read", recordId: "rec1", recordCount: 1, tokenCount: 10, spanId: spanN(200), traceId: traceN(200), endTime: at(2) })
+      const dup = makeEvent({
+        changeKind: "read",
+        recordId: "rec1",
+        recordCount: 1,
+        tokenCount: 10,
+        spanId: spanN(200),
+        traceId: traceN(200),
+        endTime: at(2),
+      })
       await seedEvents([dup, { ...dup }, { ...dup }])
 
       const overview = await withRepo((repo) => repo.getOverview({ organizationId, projectId, range }))
@@ -201,11 +231,40 @@ describe("MemoryAnalyticsRepository", () => {
       ])
       await seedEvents([
         // alpha: add@0 (10 tok) → update@4 (40 tok); the add is completed, read@1 → consumed
-        makeEvent({ storeId: "alpha", recordId: "r1", changeKind: "add", contentHash: "a0", tokenCount: 10, endTime: at(0) }),
-        makeEvent({ storeId: "alpha", recordId: "r1", changeKind: "read", contentHash: "a0", tokenCount: 10, sessionId: SessionId("sA"), endTime: at(1) }),
-        makeEvent({ storeId: "alpha", recordId: "r1", changeKind: "update", contentHash: "a1", tokenCount: 40, endTime: at(4) }),
+        makeEvent({
+          storeId: "alpha",
+          recordId: "r1",
+          changeKind: "add",
+          contentHash: "a0",
+          tokenCount: 10,
+          endTime: at(0),
+        }),
+        makeEvent({
+          storeId: "alpha",
+          recordId: "r1",
+          changeKind: "read",
+          contentHash: "a0",
+          tokenCount: 10,
+          sessionId: SessionId("sA"),
+          endTime: at(1),
+        }),
+        makeEvent({
+          storeId: "alpha",
+          recordId: "r1",
+          changeKind: "update",
+          contentHash: "a1",
+          tokenCount: 40,
+          endTime: at(4),
+        }),
         // beta: single add, pending (no successor), 10 tok
-        makeEvent({ storeId: "beta", recordId: "r1", changeKind: "add", contentHash: "b0", tokenCount: 10, endTime: at(2) }),
+        makeEvent({
+          storeId: "beta",
+          recordId: "r1",
+          changeKind: "add",
+          contentHash: "b0",
+          tokenCount: 10,
+          endTime: at(2),
+        }),
       ])
 
       const page = await withRepo((repo) =>
@@ -247,11 +306,40 @@ describe("MemoryAnalyticsRepository", () => {
   describe("listZeroHitQueries", () => {
     it("groups zero-hit searches by query text, most frequent first", async () => {
       await seedEvents([
-        makeEvent({ changeKind: "read", recordId: "", recordCount: 0, queryText: "how to X", spanId: spanN(1), endTime: at(1) }),
-        makeEvent({ changeKind: "read", recordId: "", recordCount: 0, queryText: "how to X", spanId: spanN(2), endTime: at(2) }),
-        makeEvent({ changeKind: "read", recordId: "", recordCount: 0, queryText: "rare", spanId: spanN(3), endTime: at(3) }),
+        makeEvent({
+          changeKind: "read",
+          recordId: "",
+          recordCount: 0,
+          queryText: "how to X",
+          spanId: spanN(1),
+          endTime: at(1),
+        }),
+        makeEvent({
+          changeKind: "read",
+          recordId: "",
+          recordCount: 0,
+          queryText: "how to X",
+          spanId: spanN(2),
+          endTime: at(2),
+        }),
+        makeEvent({
+          changeKind: "read",
+          recordId: "",
+          recordCount: 0,
+          queryText: "rare",
+          spanId: spanN(3),
+          endTime: at(3),
+        }),
         // a hit search must NOT appear
-        makeEvent({ changeKind: "read", recordId: "rec1", recordCount: 1, queryText: "found", tokenCount: 5, spanId: spanN(4), endTime: at(4) }),
+        makeEvent({
+          changeKind: "read",
+          recordId: "rec1",
+          recordCount: 1,
+          queryText: "found",
+          tokenCount: 5,
+          spanId: spanN(4),
+          endTime: at(4),
+        }),
       ])
       const groups = await withRepo((repo) => repo.listZeroHitQueries({ organizationId, projectId, range }))
       expect(groups.map((g) => [g.queryText, g.searchCount])).toEqual([

--- a/packages/platform/db-clickhouse/src/repositories/memory-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/memory-analytics-repository.test.ts
@@ -1,0 +1,263 @@
+import type { MemoryAnalyticsRepositoryShape, MemoryCurrentEntry, MemoryEvent } from "@domain/memories"
+import { MemoryAnalyticsRepository, MemoryRepository } from "@domain/memories"
+import {
+  type ChSqlClient,
+  ExternalUserId,
+  OrganizationId,
+  ProjectId,
+  type RepositoryError,
+  SessionId,
+  SpanId,
+  TraceId,
+} from "@domain/shared"
+import { setupTestClickHouse } from "@platform/testkit"
+import { Effect } from "effect"
+import { beforeEach, describe, expect, it } from "vitest"
+import { withClickHouse } from "../with-clickhouse.ts"
+import { MemoryRepositoryLive } from "./memory-repository.ts"
+import { MemoryAnalyticsRepositoryLive } from "./memory-analytics-repository.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const base = new Date("2026-06-01T12:00:00.000Z").getTime()
+const at = (seconds: number) => new Date(base + seconds * 1000)
+const range = { from: at(-1000), to: at(1000) }
+const spanN = (n: number) => SpanId(String(n).padStart(16, "0"))
+const traceN = (n: number) => TraceId(String(n).padStart(32, "0"))
+
+const ch = setupTestClickHouse()
+
+let seq = 0
+const makeEvent = (o: Partial<MemoryEvent> = {}): MemoryEvent => {
+  const n = seq++
+  return {
+    organizationId,
+    projectId,
+    storeId: "store1",
+    recordId: "rec1",
+    operation: "create_memory",
+    changeKind: "add",
+    contentHash: "hash-a",
+    tokenCount: 10,
+    recordCount: 1,
+    queryText: "",
+    spanId: spanN(n),
+    traceId: traceN(n),
+    sessionId: SessionId("sess1"),
+    userId: ExternalUserId("user1"),
+    startTime: at(0),
+    endTime: at(0),
+    source: "otlp",
+    ...o,
+  }
+}
+
+const makeCurrent = (o: Partial<MemoryCurrentEntry> = {}): MemoryCurrentEntry => ({
+  organizationId,
+  projectId,
+  storeId: "store1",
+  recordId: "rec1",
+  contentHash: "hash-a",
+  changeKind: "add",
+  tokenCount: 10,
+  spanId: spanN(seq++),
+  traceId: traceN(0),
+  sessionId: SessionId("sess1"),
+  endTime: at(0),
+  ...o,
+})
+
+const withRepo = <A>(f: (repo: MemoryAnalyticsRepositoryShape) => Effect.Effect<A, RepositoryError, ChSqlClient>) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const repo = yield* MemoryAnalyticsRepository
+      return yield* f(repo)
+    }).pipe(withClickHouse(MemoryAnalyticsRepositoryLive, ch.client, organizationId)),
+  )
+
+const seedEvents = (events: readonly MemoryEvent[]) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const repo = yield* MemoryRepository
+      yield* repo.insertEvents(events)
+    }).pipe(withClickHouse(MemoryRepositoryLive, ch.client, organizationId)),
+  )
+
+const seedCurrent = (entries: readonly MemoryCurrentEntry[]) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const repo = yield* MemoryRepository
+      yield* repo.upsertCurrent(entries)
+    }).pipe(withClickHouse(MemoryRepositoryLive, ch.client, organizationId)),
+  )
+
+beforeEach(() => {
+  seq = 0
+})
+
+describe("MemoryAnalyticsRepository", () => {
+  describe("getOverview", () => {
+    it("reports live footprint with the never-read token share", async () => {
+      await seedCurrent([
+        makeCurrent({ recordId: "rec1", tokenCount: 30, endTime: at(0) }),
+        makeCurrent({ recordId: "rec2", tokenCount: 70, endTime: at(0) }),
+        makeCurrent({ recordId: "gone", changeKind: "remove", tokenCount: 0, endTime: at(1) }),
+      ])
+      // rec1 has been read; rec2 never; the removed record is excluded entirely.
+      await seedEvents([makeEvent({ recordId: "rec1", changeKind: "read", tokenCount: 30, endTime: at(5) })])
+
+      const overview = await withRepo((repo) => repo.getOverview({ organizationId, projectId, range }))
+      expect(overview.liveRecords).toBe(2)
+      expect(overview.liveTokens).toBe(100)
+      expect(overview.neverReadLiveTokens).toBe(70)
+    })
+
+    it("counts searches and zero-hit searches distinctly, summing retrieved tokens", async () => {
+      await seedEvents([
+        // one search returning two records (shared span) + one zero-hit search
+        makeEvent({ changeKind: "read", recordId: "rec1", recordCount: 2, tokenCount: 10, spanId: spanN(100), endTime: at(2) }),
+        makeEvent({ changeKind: "read", recordId: "rec2", recordCount: 2, tokenCount: 15, spanId: spanN(100), endTime: at(2) }),
+        makeEvent({ changeKind: "read", recordId: "", recordCount: 0, tokenCount: 0, spanId: spanN(101), queryText: "missing", endTime: at(3) }),
+      ])
+
+      const overview = await withRepo((repo) => repo.getOverview({ organizationId, projectId, range }))
+      expect(overview.searchCount).toBe(2)
+      expect(overview.zeroHitSearchCount).toBe(1)
+      expect(overview.retrievedTokens).toBe(25)
+      expect(overview.readSessions).toBe(1)
+    })
+
+    it("computes write yield: completed versions consumed before being superseded", async () => {
+      // rec1: add@0 (read@1 → consumed), update@2 (read@6 after next? no successor → pending, excluded)
+      // rec2: add@0 (never read), update@4 (supersedes → rec2 add completed & unread)
+      await seedEvents([
+        makeEvent({ recordId: "rec1", changeKind: "add", contentHash: "a0", endTime: at(0) }),
+        makeEvent({ recordId: "rec1", changeKind: "read", contentHash: "a0", tokenCount: 5, endTime: at(1) }),
+        makeEvent({ recordId: "rec1", changeKind: "update", contentHash: "a1", endTime: at(2) }),
+        makeEvent({ recordId: "rec2", changeKind: "add", contentHash: "b0", endTime: at(0) }),
+        makeEvent({ recordId: "rec2", changeKind: "update", contentHash: "b1", endTime: at(4) }),
+      ])
+
+      const overview = await withRepo((repo) => repo.getOverview({ organizationId, projectId, range }))
+      // completed = rec1.add (superseded@2) + rec2.add (superseded@4) = 2; rec1.update & rec2.update are pending
+      expect(overview.completedVersions).toBe(2)
+      // consumed = rec1.add only (read@1 in [0,2)); rec2.add never read
+      expect(overview.consumedVersions).toBe(1)
+    })
+
+    it("classifies no-op writes (same hash as predecessor) apart from content writes", async () => {
+      await seedEvents([
+        makeEvent({ recordId: "rec1", changeKind: "add", contentHash: "a0", endTime: at(0) }),
+        makeEvent({ recordId: "rec1", changeKind: "update", contentHash: "a0", endTime: at(2) }), // no-op
+        makeEvent({ recordId: "rec1", changeKind: "update", contentHash: "a1", endTime: at(4) }), // content change
+      ])
+
+      const overview = await withRepo((repo) => repo.getOverview({ organizationId, projectId, range }))
+      expect(overview.noopWrites).toBe(1)
+      expect(overview.contentWrites).toBe(2)
+    })
+
+    it("dedups retried projection rows in additive aggregates", async () => {
+      const dup = makeEvent({ changeKind: "read", recordId: "rec1", recordCount: 1, tokenCount: 10, spanId: spanN(200), traceId: traceN(200), endTime: at(2) })
+      await seedEvents([dup, { ...dup }, { ...dup }])
+
+      const overview = await withRepo((repo) => repo.getOverview({ organizationId, projectId, range }))
+      expect(overview.retrievedTokens).toBe(10)
+      expect(overview.searchCount).toBe(1)
+    })
+  })
+
+  describe("getActivityHistogram", () => {
+    it("buckets mutations and reads by kind", async () => {
+      await seedEvents([
+        makeEvent({ recordId: "rec1", changeKind: "add", endTime: at(0) }),
+        makeEvent({ recordId: "rec2", changeKind: "add", endTime: at(1) }),
+        makeEvent({ recordId: "rec1", changeKind: "update", endTime: at(2) }),
+        makeEvent({ recordId: "rec2", changeKind: "remove", contentHash: "", endTime: at(3) }),
+        makeEvent({ changeKind: "read", recordId: "rec1", tokenCount: 5, endTime: at(4) }),
+      ])
+
+      const buckets = await withRepo((repo) =>
+        repo.getActivityHistogram({ organizationId, projectId, range, bucketSeconds: 3600 }),
+      )
+      const totals = buckets.reduce(
+        (acc, b) => ({
+          adds: acc.adds + b.adds,
+          updates: acc.updates + b.updates,
+          removes: acc.removes + b.removes,
+          reads: acc.reads + b.reads,
+        }),
+        { adds: 0, updates: 0, removes: 0, reads: 0 },
+      )
+      expect(totals).toEqual({ adds: 2, updates: 1, removes: 1, reads: 1 })
+    })
+  })
+
+  describe("listStoresWithMetrics", () => {
+    it("returns per-store metrics with write yield and net token growth, sorted", async () => {
+      await seedCurrent([
+        makeCurrent({ storeId: "alpha", recordId: "r1", tokenCount: 40, endTime: at(4) }),
+        makeCurrent({ storeId: "beta", recordId: "r1", tokenCount: 10, endTime: at(2) }),
+      ])
+      await seedEvents([
+        // alpha: add@0 (10 tok) → update@4 (40 tok); the add is completed, read@1 → consumed
+        makeEvent({ storeId: "alpha", recordId: "r1", changeKind: "add", contentHash: "a0", tokenCount: 10, endTime: at(0) }),
+        makeEvent({ storeId: "alpha", recordId: "r1", changeKind: "read", contentHash: "a0", tokenCount: 10, sessionId: SessionId("sA"), endTime: at(1) }),
+        makeEvent({ storeId: "alpha", recordId: "r1", changeKind: "update", contentHash: "a1", tokenCount: 40, endTime: at(4) }),
+        // beta: single add, pending (no successor), 10 tok
+        makeEvent({ storeId: "beta", recordId: "r1", changeKind: "add", contentHash: "b0", tokenCount: 10, endTime: at(2) }),
+      ])
+
+      const page = await withRepo((repo) =>
+        repo.listStoresWithMetrics({
+          organizationId,
+          projectId,
+          range,
+          options: { sortBy: "tokens", sortDirection: "desc" },
+        }),
+      )
+      expect(page.items.map((i) => i.storeId)).toEqual(["alpha", "beta"])
+      const alpha = page.items[0]!
+      expect(alpha.completedVersions).toBe(1)
+      expect(alpha.consumedVersions).toBe(1)
+      expect(alpha.readSessions).toBe(1)
+      expect(alpha.netTokenGrowth).toBe(40) // 0 before window → 40 at end
+      const beta = page.items[1]!
+      expect(beta.completedVersions).toBe(0)
+      expect(beta.netTokenGrowth).toBe(10)
+    })
+  })
+
+  describe("getStoreTrendBuckets", () => {
+    it("buckets writes and reads per store", async () => {
+      await seedEvents([
+        makeEvent({ storeId: "alpha", recordId: "r1", changeKind: "add", endTime: at(0) }),
+        makeEvent({ storeId: "alpha", recordId: "r1", changeKind: "read", tokenCount: 3, endTime: at(1) }),
+      ])
+      const trend = await withRepo((repo) =>
+        repo.getStoreTrendBuckets({ organizationId, projectId, storeIds: ["alpha"], range, bucketSeconds: 3600 }),
+      )
+      const writes = trend.reduce((s, b) => s + b.writes, 0)
+      const reads = trend.reduce((s, b) => s + b.reads, 0)
+      expect(writes).toBe(1)
+      expect(reads).toBe(1)
+    })
+  })
+
+  describe("listZeroHitQueries", () => {
+    it("groups zero-hit searches by query text, most frequent first", async () => {
+      await seedEvents([
+        makeEvent({ changeKind: "read", recordId: "", recordCount: 0, queryText: "how to X", spanId: spanN(1), endTime: at(1) }),
+        makeEvent({ changeKind: "read", recordId: "", recordCount: 0, queryText: "how to X", spanId: spanN(2), endTime: at(2) }),
+        makeEvent({ changeKind: "read", recordId: "", recordCount: 0, queryText: "rare", spanId: spanN(3), endTime: at(3) }),
+        // a hit search must NOT appear
+        makeEvent({ changeKind: "read", recordId: "rec1", recordCount: 1, queryText: "found", tokenCount: 5, spanId: spanN(4), endTime: at(4) }),
+      ])
+      const groups = await withRepo((repo) => repo.listZeroHitQueries({ organizationId, projectId, range }))
+      expect(groups.map((g) => [g.queryText, g.searchCount])).toEqual([
+        ["how to X", 2],
+        ["rare", 1],
+      ])
+    })
+  })
+})

--- a/packages/platform/db-clickhouse/src/repositories/memory-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/memory-analytics-repository.ts
@@ -1,0 +1,637 @@
+import type { ClickHouseClient } from "@clickhouse/client"
+import type {
+  MemoryActivityBucket,
+  MemoryAnalyticsOverview,
+  MemoryAnalyticsRepositoryShape,
+  MemoryStoreMetricsItem,
+  MemoryStoreMetricsPage,
+  MemoryStoreMetricsSortField,
+  MemoryStoreTrendBucket,
+  MemoryZeroHitQueryGroup,
+} from "@domain/memories"
+import { MemoryAnalyticsRepository } from "@domain/memories"
+import {
+  ChSqlClient,
+  type ChSqlClientShape,
+  type OrganizationId,
+  type ProjectId,
+  toRepositoryError,
+} from "@domain/shared"
+import { formatCHDate, parseCHDate } from "@repo/utils"
+import { Effect, Layer } from "effect"
+
+const ZERO_HIT_QUERY_CAP = 50
+const STORE_METRICS_CAP = 200
+
+// Fixed map — never interpolate sort input into ORDER BY. Values are output
+// aliases of the store-metrics query.
+const STORE_METRIC_SORT_EXPRS: Record<MemoryStoreMetricsSortField, string> = {
+  lastUpdated: "last_updated_at",
+  lastRead: "last_read_at",
+  records: "record_count",
+  tokens: "token_count",
+  sessions: "session_count",
+  users: "user_count",
+  reads: "read_sessions",
+  yield: "write_yield",
+  netGrowth: "net_token_growth",
+}
+
+const num = (value: string | number | null | undefined): number => Number(value ?? 0)
+
+// Deduped mutating version chain over ALL time (retried projections collapse to
+// one row per (trace, span, store, record)). Consumers add their own filters.
+const mutationsSubquery = (storeFilter: string) => `
+  SELECT store_id, record_id, content_hash, change_kind, token_count, end_time
+  FROM (
+    SELECT store_id, record_id, content_hash, change_kind, token_count, end_time, trace_id, span_id, ingested_at
+    FROM memory_events
+    WHERE organization_id = {organizationId:String}
+      AND project_id = {projectId:String}
+      ${storeFilter}
+      AND change_kind IN ('add', 'update', 'remove')
+    ORDER BY trace_id, span_id, store_id, record_id, ingested_at DESC
+    LIMIT 1 BY trace_id, span_id, store_id, record_id
+  )
+`
+
+// Deduped read events over ALL time, one row per returned record.
+const readsSubquery = (storeFilter: string) => `
+  SELECT store_id, record_id, end_time AS read_time
+  FROM (
+    SELECT store_id, record_id, end_time, trace_id, span_id, ingested_at
+    FROM memory_events
+    WHERE organization_id = {organizationId:String}
+      AND project_id = {projectId:String}
+      ${storeFilter}
+      AND change_kind = 'read'
+    ORDER BY trace_id, span_id, store_id, record_id, ingested_at DESC
+    LIMIT 1 BY trace_id, span_id, store_id, record_id
+  )
+`
+
+// Per-version outcome flags: predecessor hash (no-op detection), whether a later
+// mutation supersedes it (completed), and whether it was read while active
+// (consumed). The ASOF join finds the first read at/after the version's write;
+// it lands inside the version's active window iff it precedes the successor.
+const versionOutcomeSubquery = (storeFilter: string) => `
+  SELECT
+    v.end_time                                                   AS end_time,
+    (v.content_hash != '' AND v.content_hash = v.prev_hash)      AS is_noop,
+    (v.rn < v.cnt)                                               AS has_successor,
+    (r.read_time >= v.end_time AND r.read_time < v.next_end)     AS consumed
+  FROM (
+    SELECT
+      store_id, record_id, end_time, content_hash,
+      lagInFrame(content_hash, 1, '') OVER w                                              AS prev_hash,
+      leadInFrame(end_time, 1, toDateTime64('2999-01-01 00:00:00', 6, 'UTC')) OVER w      AS next_end,
+      count() OVER w                                                                      AS cnt,
+      row_number() OVER w                                                                 AS rn
+    FROM ( ${mutationsSubquery(storeFilter)} )
+    WINDOW w AS (
+      PARTITION BY store_id, record_id ORDER BY end_time ASC
+      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+    )
+  ) AS v
+  ASOF LEFT JOIN ( ${readsSubquery(storeFilter)} ) AS r
+    ON v.store_id = r.store_id AND v.record_id = r.record_id AND v.end_time <= r.read_time
+`
+
+type OverviewLiveRow = {
+  readonly live_records: string | number
+  readonly live_tokens: string | number
+  readonly never_read_live_tokens: string | number
+}
+type OverviewReadRow = {
+  readonly read_sessions: string | number
+  readonly retrieved_tokens: string | number
+  readonly search_count: string | number
+  readonly zero_hit_search_count: string | number
+}
+type OverviewVersionRow = {
+  readonly content_writes: string | number
+  readonly noop_writes: string | number
+  readonly completed_versions: string | number
+  readonly consumed_versions: string | number
+}
+
+type ActivityRow = {
+  readonly bucket_start: string
+  readonly adds: string | number
+  readonly updates: string | number
+  readonly removes: string | number
+  readonly reads: string | number
+}
+
+type StoreMetricsRow = {
+  readonly store_id: string
+  readonly record_count: string | number
+  readonly token_count: string | number
+  readonly last_updated_at: string
+  readonly session_count: string | number
+  readonly user_count: string | number
+  readonly last_read_at: string
+  readonly read_sessions: string | number
+  readonly content_writes: string | number
+  readonly completed_versions: string | number
+  readonly consumed_versions: string | number
+  readonly net_token_growth: string | number
+}
+
+type StoreTrendRow = {
+  readonly store_id: string
+  readonly bucket_start: string
+  readonly writes: string | number
+  readonly reads: string | number
+}
+
+type ZeroHitRow = {
+  readonly query_text: string
+  readonly search_count: string | number
+  readonly store_count: string | number
+  readonly any_store_id: string
+  readonly last_seen_at: string
+}
+
+const rangeParams = (organizationId: OrganizationId, projectId: ProjectId, from: Date, to: Date) => ({
+  organizationId: organizationId as string,
+  projectId: projectId as string,
+  from: formatCHDate(from),
+  to: formatCHDate(to),
+})
+
+const RANGE_FILTER = "AND end_time >= {from:DateTime64(6, 'UTC')} AND end_time < {to:DateTime64(6, 'UTC')}"
+
+export const MemoryAnalyticsRepositoryLive = Layer.effect(
+  MemoryAnalyticsRepository,
+  Effect.gen(function* () {
+    const getOverview: MemoryAnalyticsRepositoryShape["getOverview"] = ({ organizationId, projectId, storeId, range }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        const storeFilter = storeId !== undefined ? "AND store_id = {storeId:String}" : ""
+        const scopeParams = {
+          organizationId: organizationId as string,
+          projectId: projectId as string,
+          ...(storeId !== undefined ? { storeId } : {}),
+        }
+        const withRange = { ...rangeParams(organizationId, projectId, range.from, range.to), ...scopeParams }
+
+        return yield* chSqlClient
+          .query(async (client) => {
+            const [liveResult, readResult, versionResult] = await Promise.all([
+              client.query({
+                query: `SELECT
+                          count()                              AS live_records,
+                          sum(token_count)                     AS live_tokens,
+                          sumIf(token_count, never_read)       AS never_read_live_tokens
+                        FROM (
+                          SELECT token_count,
+                                 (store_id, record_id) NOT IN (
+                                   SELECT store_id, record_id FROM memory_events
+                                   WHERE organization_id = {organizationId:String}
+                                     AND project_id = {projectId:String}
+                                     ${storeFilter}
+                                     AND change_kind = 'read'
+                                 ) AS never_read
+                          FROM (
+                            SELECT store_id, record_id, token_count, change_kind, end_time
+                            FROM memory_current
+                            WHERE organization_id = {organizationId:String}
+                              AND project_id = {projectId:String}
+                              ${storeFilter}
+                            ORDER BY store_id, record_id, end_time DESC
+                            LIMIT 1 BY store_id, record_id
+                          )
+                          WHERE change_kind != 'remove'
+                        )`,
+                query_params: scopeParams,
+                format: "JSONEachRow",
+              }),
+              client.query({
+                query: `SELECT
+                          uniqExactIf(session_id, session_id != '') AS read_sessions,
+                          sum(token_count)                          AS retrieved_tokens,
+                          uniqExact(span_id)                        AS search_count,
+                          uniqExactIf(span_id, record_count = 0)    AS zero_hit_search_count
+                        FROM (
+                          SELECT session_id, token_count, span_id, record_count
+                          FROM memory_events
+                          WHERE organization_id = {organizationId:String}
+                            AND project_id = {projectId:String}
+                            ${storeFilter}
+                            AND change_kind = 'read'
+                            ${RANGE_FILTER}
+                          ORDER BY trace_id, span_id, store_id, record_id, ingested_at DESC
+                          LIMIT 1 BY trace_id, span_id, store_id, record_id
+                        )`,
+                query_params: withRange,
+                format: "JSONEachRow",
+              }),
+              client.query({
+                query: `SELECT
+                          countIf(NOT is_noop)                 AS content_writes,
+                          countIf(is_noop)                     AS noop_writes,
+                          countIf(has_successor)               AS completed_versions,
+                          countIf(has_successor AND consumed)  AS consumed_versions
+                        FROM ( ${versionOutcomeSubquery(storeFilter)} )
+                        WHERE end_time >= {from:DateTime64(6, 'UTC')} AND end_time < {to:DateTime64(6, 'UTC')}`,
+                query_params: withRange,
+                format: "JSONEachRow",
+              }),
+            ])
+            const live = (await liveResult.json<OverviewLiveRow>())[0]
+            const read = (await readResult.json<OverviewReadRow>())[0]
+            const version = (await versionResult.json<OverviewVersionRow>())[0]
+            return { live, read, version }
+          })
+          .pipe(
+            Effect.map(
+              ({ live, read, version }): MemoryAnalyticsOverview => ({
+                liveRecords: num(live?.live_records),
+                liveTokens: num(live?.live_tokens),
+                neverReadLiveTokens: num(live?.never_read_live_tokens),
+                readSessions: num(read?.read_sessions),
+                retrievedTokens: num(read?.retrieved_tokens),
+                searchCount: num(read?.search_count),
+                zeroHitSearchCount: num(read?.zero_hit_search_count),
+                contentWrites: num(version?.content_writes),
+                noopWrites: num(version?.noop_writes),
+                completedVersions: num(version?.completed_versions),
+                consumedVersions: num(version?.consumed_versions),
+              }),
+            ),
+            Effect.mapError((error) => toRepositoryError(error, "MemoryAnalyticsRepository.getOverview")),
+          )
+      })
+
+    const getActivityHistogram: MemoryAnalyticsRepositoryShape["getActivityHistogram"] = ({
+      organizationId,
+      projectId,
+      storeId,
+      range,
+      bucketSeconds,
+    }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        const storeFilter = storeId !== undefined ? "AND store_id = {storeId:String}" : ""
+        return yield* chSqlClient
+          .query(async (client) => {
+            const result = await client.query({
+              query: `SELECT
+                        bucket_start,
+                        countIf(change_kind = 'add')    AS adds,
+                        countIf(change_kind = 'update')  AS updates,
+                        countIf(change_kind = 'remove')  AS removes,
+                        countIf(change_kind = 'read')    AS reads
+                      FROM (
+                        SELECT
+                          change_kind,
+                          toDateTime(
+                            intDiv(toUnixTimestamp(end_time), {bucketSeconds:UInt32}) * {bucketSeconds:UInt32},
+                            'UTC'
+                          ) AS bucket_start
+                        FROM memory_events
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          ${storeFilter}
+                          AND change_kind IN ('add', 'update', 'remove', 'read')
+                          ${RANGE_FILTER}
+                        ORDER BY trace_id, span_id, store_id, record_id, ingested_at DESC
+                        LIMIT 1 BY trace_id, span_id, store_id, record_id
+                      )
+                      GROUP BY bucket_start
+                      ORDER BY bucket_start ASC`,
+              query_params: {
+                ...rangeParams(organizationId, projectId, range.from, range.to),
+                ...(storeId !== undefined ? { storeId } : {}),
+                bucketSeconds,
+              },
+              format: "JSONEachRow",
+            })
+            return result.json<ActivityRow>()
+          })
+          .pipe(
+            Effect.map((rows) =>
+              rows.map(
+                (row): MemoryActivityBucket => ({
+                  bucketStart: parseCHDate(row.bucket_start),
+                  adds: num(row.adds),
+                  updates: num(row.updates),
+                  removes: num(row.removes),
+                  reads: num(row.reads),
+                }),
+              ),
+            ),
+            Effect.mapError((error) => toRepositoryError(error, "MemoryAnalyticsRepository.getActivityHistogram")),
+          )
+      })
+
+    const listStoresWithMetrics: MemoryAnalyticsRepositoryShape["listStoresWithMetrics"] = ({
+      organizationId,
+      projectId,
+      range,
+      options,
+    }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        const limit = Math.min(options?.limit ?? 50, STORE_METRICS_CAP)
+        const offset = options?.offset ?? 0
+        const sortExpr = STORE_METRIC_SORT_EXPRS[options?.sortBy ?? "lastUpdated"]
+        const orderDir = options?.sortDirection === "asc" ? "ASC" : "DESC"
+        const withRange = rangeParams(organizationId, projectId, range.from, range.to)
+
+        return yield* chSqlClient
+          .query(async (client) => {
+            const [pageResult, countResult] = await Promise.all([
+              client.query({
+                query: buildStoreMetricsQuery(sortExpr, orderDir),
+                query_params: { ...withRange, limit: limit + 1, offset },
+                format: "JSONEachRow",
+              }),
+              client.query({
+                query: `SELECT count() AS total FROM (
+                          SELECT store_id FROM memory_current
+                          WHERE organization_id = {organizationId:String}
+                            AND project_id = {projectId:String}
+                          GROUP BY store_id
+                        )`,
+                query_params: { organizationId: organizationId as string, projectId: projectId as string },
+                format: "JSONEachRow",
+              }),
+            ])
+            const rows = await pageResult.json<StoreMetricsRow>()
+            const total = num((await countResult.json<{ total: string | number }>())[0]?.total)
+            return { rows, total }
+          })
+          .pipe(
+            Effect.map(({ rows, total }): MemoryStoreMetricsPage => {
+              const hasMore = rows.length > limit
+              const pageRows = hasMore ? rows.slice(0, limit) : rows
+              return {
+                items: pageRows.map(toStoreMetricsItem),
+                totalCount: total,
+                hasMore,
+                limit,
+                offset,
+              }
+            }),
+            Effect.mapError((error) => toRepositoryError(error, "MemoryAnalyticsRepository.listStoresWithMetrics")),
+          )
+      })
+
+    const getStoreTrendBuckets: MemoryAnalyticsRepositoryShape["getStoreTrendBuckets"] = ({
+      organizationId,
+      projectId,
+      storeIds,
+      range,
+      bucketSeconds,
+    }) =>
+      Effect.gen(function* () {
+        if (storeIds.length === 0) return []
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        return yield* chSqlClient
+          .query(async (client) => {
+            const result = await client.query({
+              query: `SELECT
+                        store_id,
+                        bucket_start,
+                        countIf(change_kind IN ('add', 'update', 'remove')) AS writes,
+                        countIf(change_kind = 'read')                        AS reads
+                      FROM (
+                        SELECT
+                          store_id,
+                          change_kind,
+                          toDateTime(
+                            intDiv(toUnixTimestamp(end_time), {bucketSeconds:UInt32}) * {bucketSeconds:UInt32},
+                            'UTC'
+                          ) AS bucket_start
+                        FROM memory_events
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND store_id IN {storeIds:Array(String)}
+                          AND change_kind IN ('add', 'update', 'remove', 'read')
+                          ${RANGE_FILTER}
+                        ORDER BY trace_id, span_id, store_id, record_id, ingested_at DESC
+                        LIMIT 1 BY trace_id, span_id, store_id, record_id
+                      )
+                      GROUP BY store_id, bucket_start
+                      ORDER BY store_id ASC, bucket_start ASC`,
+              query_params: {
+                ...rangeParams(organizationId, projectId, range.from, range.to),
+                storeIds: [...storeIds],
+                bucketSeconds,
+              },
+              format: "JSONEachRow",
+            })
+            return result.json<StoreTrendRow>()
+          })
+          .pipe(
+            Effect.map((rows) =>
+              rows.map(
+                (row): MemoryStoreTrendBucket => ({
+                  storeId: row.store_id,
+                  bucketStart: parseCHDate(row.bucket_start),
+                  writes: num(row.writes),
+                  reads: num(row.reads),
+                }),
+              ),
+            ),
+            Effect.mapError((error) => toRepositoryError(error, "MemoryAnalyticsRepository.getStoreTrendBuckets")),
+          )
+      })
+
+    const listZeroHitQueries: MemoryAnalyticsRepositoryShape["listZeroHitQueries"] = ({
+      organizationId,
+      projectId,
+      storeId,
+      range,
+      limit,
+    }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        const storeFilter = storeId !== undefined ? "AND store_id = {storeId:String}" : ""
+        return yield* chSqlClient
+          .query(async (client) => {
+            const result = await client.query({
+              query: `SELECT
+                        query_text,
+                        count()                AS search_count,
+                        uniqExact(store_id)    AS store_count,
+                        any(store_id)          AS any_store_id,
+                        max(read_time)         AS last_seen_at
+                      FROM (
+                        SELECT query_text, store_id, span_id, end_time AS read_time
+                        FROM memory_events
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          ${storeFilter}
+                          AND change_kind = 'read'
+                          AND record_count = 0
+                          ${RANGE_FILTER}
+                        ORDER BY trace_id, span_id, store_id, record_id, ingested_at DESC
+                        LIMIT 1 BY trace_id, span_id, store_id, record_id
+                      )
+                      GROUP BY query_text
+                      ORDER BY search_count DESC, last_seen_at DESC
+                      LIMIT {limit:UInt32}`,
+              query_params: {
+                ...rangeParams(organizationId, projectId, range.from, range.to),
+                ...(storeId !== undefined ? { storeId } : {}),
+                limit: limit ?? ZERO_HIT_QUERY_CAP,
+              },
+              format: "JSONEachRow",
+            })
+            return result.json<ZeroHitRow>()
+          })
+          .pipe(
+            Effect.map((rows) =>
+              rows.map(
+                (row): MemoryZeroHitQueryGroup => ({
+                  queryText: row.query_text,
+                  searchCount: num(row.search_count),
+                  storeCount: num(row.store_count),
+                  anyStoreId: row.any_store_id,
+                  lastSeenAt: parseCHDate(row.last_seen_at),
+                }),
+              ),
+            ),
+            Effect.mapError((error) => toRepositoryError(error, "MemoryAnalyticsRepository.listZeroHitQueries")),
+          )
+      })
+
+    return {
+      getOverview,
+      getActivityHistogram,
+      listStoresWithMetrics,
+      getStoreTrendBuckets,
+      listZeroHitQueries,
+    }
+  }),
+)
+
+const toStoreMetricsItem = (row: StoreMetricsRow): MemoryStoreMetricsItem => {
+  const lastRead = parseCHDate(row.last_read_at)
+  return {
+    storeId: row.store_id,
+    recordCount: num(row.record_count),
+    tokenCount: num(row.token_count),
+    lastUpdatedAt: parseCHDate(row.last_updated_at),
+    sessionCount: num(row.session_count),
+    userCount: num(row.user_count),
+    lastReadAt: lastRead.getTime() > 0 ? lastRead : null,
+    readSessions: num(row.read_sessions),
+    contentWrites: num(row.content_writes),
+    completedVersions: num(row.completed_versions),
+    consumedVersions: num(row.consumed_versions),
+    netTokenGrowth: num(row.net_token_growth),
+  }
+}
+
+// The store list joins current-state footprint, all-time access stats, and
+// range-scoped read/write/version-outcome/net-growth metrics per store. Version
+// outcome is aggregated to the store here (the shared subquery emits per-version
+// rows, tagged with store_id for grouping).
+function buildStoreMetricsQuery(sortExpr: string, orderDir: string): string {
+  return `
+    SELECT
+      c.store_id                                            AS store_id,
+      c.record_count                                        AS record_count,
+      c.token_count                                         AS token_count,
+      c.last_updated_at                                     AS last_updated_at,
+      e.session_count                                       AS session_count,
+      e.user_count                                          AS user_count,
+      e.last_read_at                                        AS last_read_at,
+      r.read_sessions                                       AS read_sessions,
+      v.content_writes                                      AS content_writes,
+      v.completed_versions                                  AS completed_versions,
+      v.consumed_versions                                   AS consumed_versions,
+      (multiIf(v.completed_versions > 0, v.consumed_versions / v.completed_versions, 0)) AS write_yield,
+      g.net_token_growth                                    AS net_token_growth
+    FROM (
+      SELECT store_id, count() AS record_count, sum(token_count) AS token_count, max(end_time) AS last_updated_at
+      FROM (
+        SELECT store_id, record_id, token_count, change_kind, end_time
+        FROM memory_current
+        WHERE organization_id = {organizationId:String} AND project_id = {projectId:String}
+        ORDER BY store_id, record_id, end_time DESC
+        LIMIT 1 BY store_id, record_id
+      )
+      WHERE change_kind != 'remove'
+      GROUP BY store_id
+    ) AS c
+    LEFT JOIN (
+      SELECT store_id,
+             uniqExactIf(session_id, session_id != '')  AS session_count,
+             uniqExactIf(user_id, user_id != '')        AS user_count,
+             maxIf(end_time, change_kind = 'read')       AS last_read_at
+      FROM memory_events
+      WHERE organization_id = {organizationId:String} AND project_id = {projectId:String}
+      GROUP BY store_id
+    ) AS e ON c.store_id = e.store_id
+    LEFT JOIN (
+      SELECT store_id, uniqExactIf(session_id, session_id != '') AS read_sessions
+      FROM (
+        SELECT store_id, session_id
+        FROM memory_events
+        WHERE organization_id = {organizationId:String} AND project_id = {projectId:String}
+          AND change_kind = 'read' ${RANGE_FILTER}
+        ORDER BY trace_id, span_id, store_id, record_id, ingested_at DESC
+        LIMIT 1 BY trace_id, span_id, store_id, record_id
+      )
+      GROUP BY store_id
+    ) AS r ON c.store_id = r.store_id
+    LEFT JOIN (
+      SELECT store_id,
+             countIf(NOT is_noop)                AS content_writes,
+             countIf(has_successor)              AS completed_versions,
+             countIf(has_successor AND consumed) AS consumed_versions
+      FROM ( ${storeVersionOutcomeSubquery} )
+      WHERE end_time >= {from:DateTime64(6, 'UTC')} AND end_time < {to:DateTime64(6, 'UTC')}
+      GROUP BY store_id
+    ) AS v ON c.store_id = v.store_id
+    LEFT JOIN ( ${netGrowthSubquery} ) AS g ON c.store_id = g.store_id
+    ORDER BY ${sortExpr} ${orderDir}, store_id ASC
+    LIMIT {limit:UInt32} OFFSET {offset:UInt32}
+  `
+}
+
+// Store-tagged variant of the version-outcome subquery (project-wide, no store filter).
+const storeVersionOutcomeSubquery = `
+  SELECT
+    v.store_id                                                  AS store_id,
+    v.end_time                                                  AS end_time,
+    (v.content_hash != '' AND v.content_hash = v.prev_hash)     AS is_noop,
+    (v.rn < v.cnt)                                              AS has_successor,
+    (r.read_time >= v.end_time AND r.read_time < v.next_end)    AS consumed
+  FROM (
+    SELECT
+      store_id, record_id, end_time, content_hash,
+      lagInFrame(content_hash, 1, '') OVER w                                            AS prev_hash,
+      leadInFrame(end_time, 1, toDateTime64('2999-01-01 00:00:00', 6, 'UTC')) OVER w    AS next_end,
+      count() OVER w                                                                    AS cnt,
+      row_number() OVER w                                                               AS rn
+    FROM ( ${mutationsSubquery("")} )
+    WINDOW w AS (
+      PARTITION BY store_id, record_id ORDER BY end_time ASC
+      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+    )
+  ) AS v
+  ASOF LEFT JOIN ( ${readsSubquery("")} ) AS r
+    ON v.store_id = r.store_id AND v.record_id = r.record_id AND v.end_time <= r.read_time
+`
+
+// Per-store net token growth over the window: (tokens live at window end) −
+// (tokens live at window start), summed per record. Uses argMax over the deduped
+// mutation chain at each boundary; a `remove` contributes 0 tokens.
+const netGrowthSubquery = `
+  SELECT store_id, sum(end_tokens) - sum(start_tokens) AS net_token_growth
+  FROM (
+    SELECT
+      store_id, record_id,
+      argMaxIf(if(change_kind = 'remove', 0, token_count), end_time, end_time < {to:DateTime64(6, 'UTC')})    AS end_tokens,
+      argMaxIf(if(change_kind = 'remove', 0, token_count), end_time, end_time < {from:DateTime64(6, 'UTC')})  AS start_tokens
+    FROM ( ${mutationsSubquery("")} )
+    GROUP BY store_id, record_id
+  )
+  GROUP BY store_id
+`

--- a/packages/platform/db-clickhouse/src/repositories/memory-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/memory-analytics-repository.ts
@@ -165,7 +165,12 @@ const RANGE_FILTER = "AND end_time >= {from:DateTime64(6, 'UTC')} AND end_time <
 export const MemoryAnalyticsRepositoryLive = Layer.effect(
   MemoryAnalyticsRepository,
   Effect.gen(function* () {
-    const getOverview: MemoryAnalyticsRepositoryShape["getOverview"] = ({ organizationId, projectId, storeId, range }) =>
+    const getOverview: MemoryAnalyticsRepositoryShape["getOverview"] = ({
+      organizationId,
+      projectId,
+      storeId,
+      range,
+    }) =>
       Effect.gen(function* () {
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         const storeFilter = storeId !== undefined ? "AND store_id = {storeId:String}" : ""

--- a/specs/memory-insights.md
+++ b/specs/memory-insights.md
@@ -1,0 +1,101 @@
+# Memory Insights
+
+> Builds an aggregated-insight layer on top of [Memory Observability](./memory-observability.md). That spec ships the *forensic* surfaces (stores → record tree → record body, per-change diff, session/trace summary); this one adds the *analytics* that answer "what's interesting?" without browsing store by store, mirroring the Tools and Users pages. Read the observability spec's [Data model](./memory-observability.md#data-model) for the ledger — this spec does not restate it.
+>
+> **Linear**: follow-up to LAT-729.
+
+## Contents
+
+1. [Purpose](#purpose)
+2. [Model and vocabulary](#model-and-vocabulary)
+3. [Calculation rules](#calculation-rules)
+4. [Surfaces](#surfaces)
+5. [Data & code layout](#data--code-layout)
+6. [Decisions](#decisions)
+7. [Tasks](#tasks)
+
+---
+
+## Purpose
+
+Memory observability lets users *see* their agent's memory and how it evolves, but that is its only value today — finding anything interesting means opening every store and record by hand. Every other observe surface (Tools, Users) leads with analytics: stat tiles, a time-series chart, an enriched table. This adds the same to Memory: which memory is useful, wasteful, or unstable — surfaced, not hunted.
+
+## Model and vocabulary
+
+Four orthogonal axes keep the metrics from muddling (the key design cut):
+
+- **Hot / cold** describes a **record** — how much it's retrieved.
+- **Consumed / superseded-unread / pending** describes a **version** — whether it was read before being replaced.
+- **No-op / revert** describes a single **write**.
+- **Churn** describes **aggregate** writing behavior.
+
+The headline metric is **write yield**: of the versions the agent completed (wrote then later superseded), how many were read at least once before being replaced. It is memory's equivalent of an error rate — a single number that says whether the writing is worth anything — and it excludes the current pending version, which can't be judged yet.
+
+## Calculation rules
+
+All reads target the ledger alone (`memory_events` + `memory_current` + `memory_blobs`); the `spans` table is not involved (see [D-insights-1](#decisions)).
+
+- **Version chain** per `(store_id, record_id)`: deduped mutation events ordered by `end_time`. A version is *completed* once a later mutation supersedes it, else *pending*.
+- **Consumed**: ≥1 read of the record in `[version end, successor end)`. Attribution is time-based; the returned-body hash now stamped on read events (see below) enables an exact upgrade later.
+- **Write yield** = consumed ÷ completed; pending excluded; `-` when nothing has completed.
+- **No-op**: a version whose non-empty `content_hash` equals its predecessor's. Excluded from content-write counts and churn token sums.
+- **Revert**: a non-empty hash equal to an older, non-adjacent version's.
+- **Net token growth** (per store, per window): Σ over records of `(live tokens at window end) − (live tokens at window start)`, a `remove` counting 0.
+- **Never-read %**: over live (`memory_current`) records, those with no read event ever.
+- **Zero-hit search**: a `read` event with `record_count = 0`.
+- **Dedup**: the ledger is append-only with retry duplicates. Idempotent aggregates (`uniqExact*`, `max`, `argMax`) run raw; additive aggregates (`sum`, `count`) run over an inner `LIMIT 1 BY (span_id, store_id, record_id)`.
+- **Exclusions**: hash-less versions (content capture off) are excluded from no-op/revert detection; reads with `record_id = ''` count toward totals but attribute to no record.
+
+**Emit-side change**: `materializeTraceMemoryUseCase` now stamps the sha256 of the returned record body on `read` events (the body is already in hand for token counting). Zero-hit and content-off reads stay hash-less. No migration — `memory_events.content_hash` already exists on every row. This future-proofs exact read→version attribution; v1 analytics still attribute by time.
+
+## Surfaces
+
+**Main Memory page** — aggregates and store-level content only, never record-specific items ([D-insights-3](#decisions)):
+
+- Time filter (`useAnalyticsTimeWindow`) + a Tools/Users-style analytics panel: tiles (Records · Live tokens + never-read % · Read sessions · Retrieved tokens · Writes + no-ops · Write yield + superseded-unread) and an activity chart (stacked add/update/remove bars + reads line).
+- An "Unanswered searches" card (zero-hit queries grouped by text) — the *what to add to memory* report — shown only when there are zero-hit searches.
+- The store table gains a write/read trend sparkline and Reads, Write yield, Net growth columns, with column visibility + server-side sort.
+
+**Store page** (PR2) — an "Overview" entry pinned above the record tree, selected by default: store-scoped stat strip, activity + footprint charts, four ranked record cards (most retrieved / cold & large / wasteful writers / highest churn), a store-scoped search panel, and an events feed (wipes, blast-radius sessions).
+
+**Record section** (PR2) — Changes-tab rows gain a per-version consumption verdict ("Read by N sessions" / "Never read" / "No change" / "Revert of …"), and a new Insights tab (lifetime usage profile + top queries retrieving the record).
+
+## Data & code layout
+
+- **Port**: `packages/domain/memories/src/ports/memory-analytics-repository.ts` (`MemoryAnalyticsRepository`) — `ChSqlClient` leaked in `R`, methods org+project scoped, optional `storeId` on shared reads so the store page reuses them.
+- **Adapter**: `packages/platform/db-clickhouse/src/repositories/memory-analytics-repository.ts` — bucketed aggregations (bucketing + dedup per the Tools repo), a window-function version-outcome subquery (predecessor hash for no-ops, successor for completed, ASOF read join for consumed), and net-growth via `argMaxIf` at window boundaries. chdb integration tests colocated.
+- **Use-cases**: `get-memory-analytics-overview`, `get-memory-activity-histogram`, `list-stores-with-metrics` (list + trend zip), `list-zero-hit-queries`.
+- **Web**: server functions + hooks in `apps/web/src/domains/memories/`; UI under `apps/web/src/routes/_authenticated/projects/$projectSlug/memory/`.
+- **Operations/MCP/SDK exposure is deferred** to a follow-up ([D-insights-4](#decisions)); the domain use-cases are the shared seam so exposure needs no rework.
+
+## Decisions
+
+- **D-insights-1 — Ledger only; no error/latency insights.** Memory spans virtually never fail, and the failure story lives on the wrapping tool call (Tools page). Dropping errors/latency keeps every insight on `memory_events`/`memory_current`/`memory_blobs` — no `spans` join, one repository.
+- **D-insights-2 — No badges.** No status chips on stores/records/the tree. Ranked lists, sortable columns, and per-version verdict lines carry the signal instead.
+- **D-insights-3 — Main page is aggregates + store-level only.** Record-specific rankings live on the store page; the fleet page ranks and compares stores.
+- **D-insights-4 — Web-first, operations deferred.** These PRs ship web server functions over domain use-cases; API/MCP/SDK/CLI exposure follows in its own PR (precedent: the observability reads exposed after their UI).
+- **D-insights-5 — Time-based version consumption, hash stamped for later.** v1 attributes reads to the active version by time; read events now carry the returned body hash so an exact attribution (and the outcome-impact join) can follow without re-emitting.
+
+## Tasks
+
+### PR1 — Main Memory page analytics
+
+- [x] Stamp `content_hash` on read events in the materializer (+ tests).
+- [x] `MemoryAnalyticsRepository` port, entities, and four use-cases.
+- [x] ClickHouse adapter (overview, activity histogram, store metrics + trend, zero-hit queries) with chdb tests.
+- [x] Web server functions + hooks.
+- [x] Memory page: time filter, analytics panel, unanswered-searches card, store-table trend/metrics columns + column settings.
+
+### PR2 — Store Overview + record insights
+
+- [ ] Store Overview section (stat strip, activity + footprint charts, four ranked record cards, search panel, events feed) as the default store selection.
+- [ ] Record Changes-tab per-version consumption verdicts + diff-header echo.
+- [ ] Record Insights tab (usage profile, reads trend, top queries).
+- [ ] Repository/use-case additions: footprint series, record rankings, store events, record consumption + insights; extend `computeRecordHistory` with no-op/revert/pending flags.
+
+### Later (out of these PRs)
+
+- Operations/MCP/SDK/CLI exposure of the analytics reads.
+- Group-by-record-path rankings (the store-per-user fleet view).
+- Outcome / eval-score join (version impact on consuming sessions) — unblocked by the read-hash stamp.
+- Memory tax (retrieved tokens vs prompt spend; needs a span join), memory monitors stream, semantic hygiene detectors.


### PR DESCRIPTION
## What

Adds a Tools/Users-style analytics layer to the **main Memory page**, so users can see what memory is useful, wasteful, or unstable without opening every store by hand. Grounded in `specs/memory-insights.md`.

- **Time filter** (`useAnalyticsTimeWindow`, same as Tools/Users).
- **Analytics panel** — stat tiles (Records · Live tokens + never-read % · Read sessions · Retrieved tokens · Writes + no-ops · **Write yield** + superseded-unread) and an activity chart (stacked add/update/remove bars + a reads line).
- **Unanswered searches card** — zero-hit searches grouped by query text (the *what to add to memory* report), shown only when there are any.
- **Store table upgrade** — a write/read trend sparkline plus **Reads**, **Write yield**, and **Net growth** columns, with column visibility settings and server-side sort.

Everything reads the ledger alone (`memory_events` / `memory_current` / `memory_blobs`) — no `spans` join, one new repository.

## Key concept — write yield

Of the versions the agent completed (wrote, then later superseded), how many were read at least once before being replaced. It's memory's equivalent of an error rate; the current pending version is excluded because it can't be judged yet.

## Changes

- **Emit side**: `materializeTraceMemoryUseCase` now stamps the returned body's sha256 on `read` events (body already in hand for token counting; zero-hit/content-off reads stay hash-less). No migration — `content_hash` already exists on every row. Future-proofs exact read→version attribution; v1 attributes by time.
- **Domain**: `MemoryAnalyticsRepository` port + entities + four use-cases (overview, activity histogram, stores-with-metrics, zero-hit queries), with optional `storeId` on shared reads so the upcoming store page reuses them.
- **Platform**: ClickHouse adapter — bucketed aggregations, retry-dup dedup, a window-function version-outcome subquery (predecessor hash for no-ops, successor for completed, ASOF read join for consumed), net-growth via `argMaxIf` at window boundaries. Covered by chdb integration tests.
- **Web**: server functions + hooks + the Memory page UI.

## Decisions

- No error/latency insights (memory spans ~never fail; the wrapping tool call owns that story on the Tools page).
- No badges on stores/records/the tree.
- Main page carries only aggregates and store-level content — record-specific rankings land on the store page (next PR).
- Operations/MCP/SDK exposure deferred to a follow-up; the domain use-cases are the shared seam.

## Testing

- `@domain/memories` and `@platform/db-clickhouse` typecheck + tests green (incl. new `memory-analytics-repository.test.ts` chdb suite covering dedup, no-op/revert chains, write yield, zero-hit grouping, per-store metrics, net growth; `memory-projection.test.ts` extended for the read-hash stamp). `@app/web` typechecks.
- Not driven in the browser — please verify the page against a project with memory traffic: tiles/chart populate over the time window, the store table's new columns + trend render, and the unanswered-searches card appears when zero-hit searches exist.

## Follow-up

PR2 (stacked): store Overview section + record Insights tab + Changes-tab per-version consumption verdicts.