### PR TITLE
chore: run README badge updates weekly

### DIFF
--- a/.github/workflows/readme-badges.yml
+++ b/.github/workflows/readme-badges.yml
@@ -2,7 +2,7 @@ name: Update README badges
 
 on:
   schedule:
-    - cron: "17 6 * * *"
+    - cron: "17 6 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `Update README badges` workflow was opening a PR every day for small npm/PyPI download and star count changes (e.g. #4196).

Changes the schedule from daily (`17 6 * * *`) to Mondays at 06:17 UTC (`17 6 * * 1`). Manual runs via `workflow_dispatch` are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a5ee674-1d6a-45a3-bec2-934be5398ccb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a5ee674-1d6a-45a3-bec2-934be5398ccb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

