### PR TITLE
feat(taxonomy): facets phase 3 — facet gardening + facet-aware naming (LAT-781)

### DIFF
--- a/apps/web/src/domains/taxonomy/custom-behaviors.functions.ts
+++ b/apps/web/src/domains/taxonomy/custom-behaviors.functions.ts
@@ -12,10 +12,10 @@ import {
   updateCustomBehavior,
 } from "@domain/taxonomy"
 import { TaxonomyObservationRepositoryLive } from "@platform/db-clickhouse"
-import { CustomBehaviorRepositoryLive } from "@platform/db-postgres"
+import { CustomBehaviorRepositoryLive, FacetRepositoryLive } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 import { z } from "zod"
 import { getClickhouseClient, getPostgresClient, getQueuePublisher } from "../../server/clients.ts"
 import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
@@ -100,7 +100,11 @@ export const createCustomBehaviorFn = createServerFn({ method: "POST" })
         filterSet: data.filterSet,
       }).pipe(
         Effect.provideService(QueuePublisher, publisher),
-        withScopedPostgres(CustomBehaviorRepositoryLive, getPostgresClient(), orgId),
+        withScopedPostgres(
+          Layer.mergeAll(CustomBehaviorRepositoryLive, FacetRepositoryLive),
+          getPostgresClient(),
+          orgId,
+        ),
         withTracing,
       ),
     )

--- a/apps/workers/src/workers/taxonomy-read-use-cases.test.ts
+++ b/apps/workers/src/workers/taxonomy-read-use-cases.test.ts
@@ -67,6 +67,7 @@ const cluster: TaxonomyCluster = {
   organizationId,
   projectId,
   customBehaviorId: null,
+  facetId: null,
   dimension: "topic",
   parentClusterId: null,
   depth: 0,

--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -15,12 +15,10 @@ import {
   CustomBehaviorStatus,
   customBehaviorFilterSetHasConditions,
   emitLineageUseCase,
-  extractFacetProjectionsUseCase,
-  type FacetExtractionSample,
-  FacetRepository,
   type HierarchicalTaxonomyPlan,
   isDisplayableTaxonomyName,
   parseTaxonomyAdaptiveModeBaseline,
+  planFacetGardenUseCase,
   planHierarchicalTaxonomyUseCase,
   type ReassignmentLeaf,
   type ReassignTaxonomyObservationByIdInput,
@@ -44,7 +42,6 @@ import {
   TaxonomyObservationRepository,
   type TaxonomyRun,
   TaxonomyRunRepository,
-  type TaxonomyScopedClusteringObservation,
   type TaxonomyViewAssignment,
   TaxonomyViewAssignmentRepository,
 } from "@domain/taxonomy"
@@ -716,58 +713,25 @@ const finalizeGardenPlan = (input: GardenTaxonomyStepInput, plan: HierarchicalTa
     } satisfies GardenTaxonomyBuildPlanResult
   })
 
-// Facet planning: gate-check, then sample sessions → extract facet projections
-// (Phase 2 cache) → cluster the non-unclear projection embeddings. Always the
-// off/static publish path — the facet clusters live in the projection embedding
-// space, so the adaptive full-window reassignment (which routes the observation
-// window) is meaningless here; `mode: "off"` keeps facets on the well-tested
-// sample-only view-slice write regardless of the org's adaptive rollout.
+// Facet planning: sample → extract projections → cluster the non-unclear ones,
+// all in `planFacetGardenUseCase` (tested with fakes). This activity only wires
+// the live layers and offloads the k-means build to the worker thread (like the
+// topic path) so a large facet sample never blocks the Temporal activity worker.
 const planFacetGarden = (input: GardenTaxonomyStepInput) =>
-  Effect.gen(function* () {
-    const facetId = FacetId(input.facetId as string)
-    const scoped = input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}
-    const filter = input.filterSet ? { filterSet: input.filterSet } : {}
-
-    const facets = yield* FacetRepository
-    const facet = yield* facets.findById(facetId)
-    const observations = yield* TaxonomyObservationRepository
-    const samples = yield* observations.listForFacetSample({
-      organizationId: OrganizationId(input.organizationId),
-      projectId: ProjectId(input.projectId),
-      since: gardeningLookbackStart(new Date(input.now)),
-      limit: TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX,
-      ...filter,
-    })
-    const extractionSamples: FacetExtractionSample[] = samples.map((sample) => ({
-      sessionObservationId: sample.sessionObservationId,
-      sessionId: sample.sessionId,
-      transcript: sample.transcript,
-      startTime: sample.startTime,
-    }))
-    const extraction = yield* extractFacetProjectionsUseCase({ facet, samples: extractionSamples })
-    // Unclear projections carry an empty extractedText + no embedding; exclude
-    // them from clustering (the noise path).
-    const lensObservations: readonly TaxonomyScopedClusteringObservation[] = extraction.projections
-      .filter((projection) => projection.extractedText.length > 0 && projection.embedding.length > 0)
-      .map((projection) => ({
-        observationId: projection.sessionObservationId,
-        sessionId: projection.sessionId,
-        startTime: projection.startTime,
-        embedding: projection.embedding,
-      }))
-
-    return yield* planHierarchicalTaxonomyUseCase({
-      organizationId: OrganizationId(input.organizationId),
-      projectId: ProjectId(input.projectId),
-      runId: TaxonomyRunId(input.runId),
-      dimension: input.dimension,
-      now: new Date(input.now),
-      mode: "off",
-      facetId,
-      ...scoped,
-      ...filter,
-      lensObservations,
-    })
+  planFacetGardenUseCase({
+    organizationId: OrganizationId(input.organizationId),
+    projectId: ProjectId(input.projectId),
+    runId: TaxonomyRunId(input.runId),
+    dimension: input.dimension,
+    now: new Date(input.now),
+    facetId: FacetId(input.facetId as string),
+    ...(input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}),
+    ...(input.filterSet ? { filterSet: input.filterSet } : {}),
+    clusterBuilder: (builderInput) =>
+      Effect.tryPromise({
+        try: () => buildHierarchicalClustersInWorker(builderInput),
+        catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+      }),
   }).pipe(
     (effect) => withFacetPostgres(effect, input.organizationId),
     (effect) => withFacetClickHouse(effect, input.organizationId),

--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -1,6 +1,7 @@
 import { hasFeatureFlagUseCase } from "@domain/feature-flags"
 import {
   CustomBehaviorId,
+  FacetId,
   type FilterSet,
   OrganizationId,
   ProjectId,
@@ -12,7 +13,11 @@ import {
   boundedPercentiles,
   CustomBehaviorRepository,
   CustomBehaviorStatus,
+  customBehaviorFilterSetHasConditions,
   emitLineageUseCase,
+  extractFacetProjectionsUseCase,
+  type FacetExtractionSample,
+  FacetRepository,
   type HierarchicalTaxonomyPlan,
   isDisplayableTaxonomyName,
   parseTaxonomyAdaptiveModeBaseline,
@@ -39,16 +44,20 @@ import {
   TaxonomyObservationRepository,
   type TaxonomyRun,
   TaxonomyRunRepository,
+  type TaxonomyScopedClusteringObservation,
   type TaxonomyViewAssignment,
   TaxonomyViewAssignmentRepository,
 } from "@domain/taxonomy"
+import { AIEmbedLive, AIGenerateLive, withAi } from "@platform/ai"
 import {
+  FacetProjectionRepositoryLive,
   TaxonomyObservationRepositoryLive,
   TaxonomyViewAssignmentRepositoryLive,
   withClickHouse,
 } from "@platform/db-clickhouse"
 import {
   CustomBehaviorRepositoryLive,
+  FacetRepositoryLive,
   FeatureFlagRepositoryLive,
   TaxonomyClusterRepositoryLive,
   TaxonomyLineageRepositoryLive,
@@ -97,8 +106,9 @@ export interface GardenTaxonomyActivityInput {
   readonly workflowRunId?: string
   readonly taxonomyRunId?: string
   /**
-   * Scope. Absent ⇒ global gardening (project-wide, byte-identical to the
-   * pre-unification workflow). Present ⇒ a custom behavior's scoped sub-tree.
+   * Scope. Absent ⇒ whole-project topic tree (byte-identical to the pre-facets
+   * workflow). Present ⇒ a custom behavior — the caller only knows its id; the
+   * behavior's lens (`facet_id`) + `filterSet` are loaded in the start activity.
    */
   readonly customBehaviorId?: string
 }
@@ -106,8 +116,10 @@ export interface GardenTaxonomyActivityInput {
 export interface GardenTaxonomyStepInput extends GardenTaxonomyActivityInput {
   readonly runId: string
   readonly now: string
-  /** Populated by the start step for the scoped path; the FilterSet the plan samples. */
+  /** Populated by the start step for a custom behavior; the FilterSet the plan samples (absent ⇒ whole-project). */
   readonly filterSet?: FilterSet
+  /** Populated by the start step from the behavior's `facet_id`; the lens this run gardens through. */
+  readonly facetId?: string
 }
 
 export interface GardenTaxonomyCompleteInput extends GardenTaxonomyStepInput {
@@ -163,10 +175,13 @@ export type GardenTaxonomyDeprecateClustersInput = GardenTaxonomyPlanReferenceIn
 interface StoredGardenTaxonomyPlan {
   readonly clusters: readonly TaxonomyCluster[]
   readonly observationAssignments: readonly ReassignTaxonomyObservationByIdInput[]
-  /** Scoped write target; empty on the global path. */
+  /** Scoped write target; empty on the whole-project topic path. */
   readonly customAssignments: readonly TaxonomyViewAssignment[]
-  /** Non-null ⇒ the plan is scoped to this custom behavior (drives the reassign write target). */
+  /** Non-null ⇒ the plan's scope is this cohort. */
   readonly customBehaviorId: string | null
+  /** Non-null ⇒ the plan's lens is this facet. A non-null customBehaviorId OR facetId
+   * routes the reassign to the view-assignment slice instead of the inline column. */
+  readonly facetId?: string | null
   readonly deprecatedClusterIds: readonly string[]
   /**
    * Rollout mode resolved at plan time. Downstream activities branch on THIS
@@ -373,6 +388,30 @@ const withScopedReassignClickHouse = <A, E, R>(effect: Effect.Effect<A, E, R>, o
     ),
   )
 
+const withFacetPostgres = <A, E, R>(effect: Effect.Effect<A, E, R>, organizationId: string) =>
+  effect.pipe(
+    withPostgres(
+      Layer.mergeAll(TaxonomyClusterRepositoryLive, FacetRepositoryLive),
+      getPostgresClient(),
+      OrganizationId(organizationId),
+    ),
+  )
+
+// Facet planning samples sessions + reads the projection cache (ClickHouse), and
+// extraction embeds/generates via AI; the plan use-case also needs the taxonomy
+// observation repo in context even though the facet path clusters projections.
+const withFacetClickHouse = <A, E, R>(effect: Effect.Effect<A, E, R>, organizationId: string) =>
+  effect.pipe(
+    withClickHouse(
+      Layer.mergeAll(TaxonomyObservationRepositoryLive, FacetProjectionRepositoryLive),
+      getClickhouseClient(),
+      OrganizationId(organizationId),
+    ),
+  )
+
+const withFacetAi = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(withAi(Layer.mergeAll(AIEmbedLive, AIGenerateLive), getRedisClient()))
+
 const runGardenStep = <A, E>(
   name: string,
   input: GardenTaxonomyStepInput | GardenTaxonomyActivityInput,
@@ -469,7 +508,10 @@ const startGlobalRun = (step: GardenTaxonomyStepInput) => {
 
 // Scoped start: mark the behavior Generating and stamp the cadence anchor at run
 // start (so the scoped sweep throttles on it and it survives a crash mid-run),
-// carrying the behavior's FilterSet into the step so the plan can sample it.
+// carrying the behavior's FilterSet AND its lens (`facet_id`) into the step so
+// the plan samples the right sessions and clusters through the right lens. A
+// facet-lens behavior with no filter is whole-project through that lens, so an
+// empty filter is threaded as absent.
 const startCustomBehaviorRun = (step: GardenTaxonomyStepInput) =>
   runGardenStep(
     "GardenTaxonomyWorkflow start run",
@@ -480,9 +522,11 @@ const startCustomBehaviorRun = (step: GardenTaxonomyStepInput) =>
       const startedAt = new Date(step.now)
       yield* behaviors.save({ ...behavior, status: CustomBehaviorStatus.Generating, updatedAt: startedAt })
       yield* behaviors.markGardened({ id: behavior.id, gardenedAt: startedAt })
+      const hasFilter = customBehaviorFilterSetHasConditions(behavior.filterSet)
       return {
         ...step,
-        filterSet: behavior.filterSet,
+        ...(hasFilter ? { filterSet: behavior.filterSet } : {}),
+        ...(behavior.facetId ? { facetId: behavior.facetId } : {}),
         observationsScanned: 0,
         observationsAvailable: 0,
         observationsSampled: 0,
@@ -637,61 +681,128 @@ const annotateAdaptiveTelemetrySpan = (input: GardenTaxonomyStepInput, plan: Hie
         }
       }).pipe(Effect.withSpan("taxonomy.gardenTaxonomyWorkflow.shadow"))
 
+// Telemetry + persist the staged plan artifact + shape the activity result. No
+// repository requirements (Redis + sync only), so both the topic and facet
+// planning paths reuse it after computing the plan under their own layers.
+const finalizeGardenPlan = (input: GardenTaxonomyStepInput, plan: HierarchicalTaxonomyPlan) =>
+  Effect.gen(function* () {
+    yield* Effect.sync(() => emitAdaptivePlanTelemetry(input, plan))
+    yield* annotateAdaptiveTelemetrySpan(input, plan)
+    const planKey = yield* storeGardenTaxonomyPlan(input, {
+      clusters: plan.clusters,
+      observationAssignments: plan.observationAssignments,
+      customAssignments: plan.customAssignments,
+      customBehaviorId: plan.customBehaviorId,
+      facetId: plan.facetId,
+      deprecatedClusterIds: plan.deprecatedClusterIds.map((clusterId) => clusterId as string),
+      mode: plan.mode,
+      fallbackReason: plan.fallbackReason,
+      leafClusters: plan.leafClusters,
+      supersededClusterIds: plan.supersededClusterIds.map((clusterId) => clusterId as string),
+    })
+    return {
+      observationsScanned: plan.observationsScanned,
+      observationsAvailable: plan.observationsAvailable,
+      observationsSampled: plan.observationsSampled,
+      sampleStrategy: plan.sampleStrategy,
+      sampleCap: plan.sampleCap,
+      clustersBorn: plan.clustersBorn,
+      clustersContinued: plan.clustersContinued,
+      clustersDeprecated: plan.clustersDeprecated,
+      leavesAssigned: plan.leavesAssigned,
+      maxDepthReached: plan.maxDepthReached,
+      lineage: plan.lineage,
+      planKey,
+    } satisfies GardenTaxonomyBuildPlanResult
+  })
+
+// Facet planning: gate-check, then sample sessions → extract facet projections
+// (Phase 2 cache) → cluster the non-unclear projection embeddings. Always the
+// off/static publish path — the facet clusters live in the projection embedding
+// space, so the adaptive full-window reassignment (which routes the observation
+// window) is meaningless here; `mode: "off"` keeps facets on the well-tested
+// sample-only view-slice write regardless of the org's adaptive rollout.
+const planFacetGarden = (input: GardenTaxonomyStepInput) =>
+  Effect.gen(function* () {
+    const facetId = FacetId(input.facetId as string)
+    const scoped = input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}
+    const filter = input.filterSet ? { filterSet: input.filterSet } : {}
+
+    const facets = yield* FacetRepository
+    const facet = yield* facets.findById(facetId)
+    const observations = yield* TaxonomyObservationRepository
+    const samples = yield* observations.listForFacetSample({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: ProjectId(input.projectId),
+      since: gardeningLookbackStart(new Date(input.now)),
+      limit: TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX,
+      ...filter,
+    })
+    const extractionSamples: FacetExtractionSample[] = samples.map((sample) => ({
+      sessionObservationId: sample.sessionObservationId,
+      sessionId: sample.sessionId,
+      transcript: sample.transcript,
+      startTime: sample.startTime,
+    }))
+    const extraction = yield* extractFacetProjectionsUseCase({ facet, samples: extractionSamples })
+    // Unclear projections carry an empty extractedText + no embedding; exclude
+    // them from clustering (the noise path).
+    const lensObservations: readonly TaxonomyScopedClusteringObservation[] = extraction.projections
+      .filter((projection) => projection.extractedText.length > 0 && projection.embedding.length > 0)
+      .map((projection) => ({
+        observationId: projection.sessionObservationId,
+        sessionId: projection.sessionId,
+        startTime: projection.startTime,
+        embedding: projection.embedding,
+      }))
+
+    return yield* planHierarchicalTaxonomyUseCase({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: ProjectId(input.projectId),
+      runId: TaxonomyRunId(input.runId),
+      dimension: input.dimension,
+      now: new Date(input.now),
+      mode: "off",
+      facetId,
+      ...scoped,
+      ...filter,
+      lensObservations,
+    })
+  }).pipe(
+    (effect) => withFacetPostgres(effect, input.organizationId),
+    (effect) => withFacetClickHouse(effect, input.organizationId),
+    withFacetAi,
+  )
+
+const planTopicGarden = (input: GardenTaxonomyStepInput) =>
+  Effect.gen(function* () {
+    const mode = yield* resolveAdaptiveMode(input.organizationId)
+    return yield* planHierarchicalTaxonomyUseCase({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: ProjectId(input.projectId),
+      runId: TaxonomyRunId(input.runId),
+      dimension: input.dimension,
+      now: new Date(input.now),
+      mode,
+      clusterBuilder: (builderInput) =>
+        Effect.tryPromise({
+          try: () => buildHierarchicalClustersInWorker(builderInput),
+          catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+        }),
+      ...(input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}),
+      ...(input.filterSet ? { filterSet: input.filterSet } : {}),
+    })
+  }).pipe(
+    (effect) => withTaxonomyPostgres(effect, input.organizationId),
+    (effect) => withTaxonomyClickHouse(effect, input.organizationId),
+  )
+
 export const planHierarchicalGardenTaxonomyActivity = (input: GardenTaxonomyStepInput) =>
   runGardenStep(
     "GardenTaxonomyWorkflow plan hierarchical tree",
     input,
-    Effect.gen(function* () {
-      const mode = yield* resolveAdaptiveMode(input.organizationId)
-      return yield* planHierarchicalTaxonomyUseCase({
-        organizationId: OrganizationId(input.organizationId),
-        projectId: ProjectId(input.projectId),
-        runId: TaxonomyRunId(input.runId),
-        dimension: input.dimension,
-        now: new Date(input.now),
-        mode,
-        clusterBuilder: (builderInput) =>
-          Effect.tryPromise({
-            try: () => buildHierarchicalClustersInWorker(builderInput),
-            catch: (error) => (error instanceof Error ? error : new Error(String(error))),
-          }),
-        ...(input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}),
-        ...(input.filterSet ? { filterSet: input.filterSet } : {}),
-      })
-    }).pipe(
-      Effect.flatMap((plan) =>
-        Effect.gen(function* () {
-          yield* Effect.sync(() => emitAdaptivePlanTelemetry(input, plan))
-          yield* annotateAdaptiveTelemetrySpan(input, plan)
-          const planKey = yield* storeGardenTaxonomyPlan(input, {
-            clusters: plan.clusters,
-            observationAssignments: plan.observationAssignments,
-            customAssignments: plan.customAssignments,
-            customBehaviorId: plan.customBehaviorId,
-            deprecatedClusterIds: plan.deprecatedClusterIds.map((clusterId) => clusterId as string),
-            mode: plan.mode,
-            fallbackReason: plan.fallbackReason,
-            leafClusters: plan.leafClusters,
-            supersededClusterIds: plan.supersededClusterIds.map((clusterId) => clusterId as string),
-          })
-          return {
-            observationsScanned: plan.observationsScanned,
-            observationsAvailable: plan.observationsAvailable,
-            observationsSampled: plan.observationsSampled,
-            sampleStrategy: plan.sampleStrategy,
-            sampleCap: plan.sampleCap,
-            clustersBorn: plan.clustersBorn,
-            clustersContinued: plan.clustersContinued,
-            clustersDeprecated: plan.clustersDeprecated,
-            leavesAssigned: plan.leavesAssigned,
-            maxDepthReached: plan.maxDepthReached,
-            lineage: plan.lineage,
-            planKey,
-          } satisfies GardenTaxonomyBuildPlanResult
-        }),
-      ),
-      (effect) => withTaxonomyPostgres(effect, input.organizationId),
-      (effect) => withTaxonomyClickHouse(effect, input.organizationId),
+    (input.facetId ? planFacetGarden(input) : planTopicGarden(input)).pipe(
+      Effect.flatMap((plan) => finalizeGardenPlan(input, plan)),
     ),
   )
 
@@ -841,14 +952,16 @@ export const reassignGardenTaxonomyObservationsActivity = (input: GardenTaxonomy
     // full bounded live window to the staging leaves.
     Effect.gen(function* () {
       const plan = yield* loadGardenTaxonomyPlan(input)
+      // Any view (a cohort OR a facet lens) writes the view-assignment slice; only
+      // the whole-project topic tree reassigns the inline column. Facet plans are
+      // always off-mode (no staging leaves), so they take the sample-only branch.
+      const isView = plan.customBehaviorId != null || plan.facetId != null
       if (planPersistsAdaptive(plan)) {
         return yield* plan.customBehaviorId
           ? reassignFullWindowScoped(input, plan)
           : reassignFullWindowGlobal(input, plan)
       }
-      return yield* plan.customBehaviorId
-        ? reassignScopedAssignments(input, plan)
-        : reassignGlobalObservations(input, plan)
+      return yield* isView ? reassignScopedAssignments(input, plan) : reassignGlobalObservations(input, plan)
     }),
   )
 
@@ -943,6 +1056,7 @@ export const assertGardenTaxonomyQualityActivity = (input: GardenTaxonomyStepInp
       projectId: ProjectId(input.projectId),
       dimension: input.dimension,
       ...(input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}),
+      ...(input.facetId ? { facetId: FacetId(input.facetId) } : {}),
     }).pipe(
       (effect) => withTaxonomyPostgres(effect, input.organizationId),
       (effect) => withTaxonomyClickHouse(effect, input.organizationId),
@@ -967,6 +1081,7 @@ export const planGardenTaxonomyNamingActivity = (input: GardenTaxonomyStepInput 
         projectId,
         dimension: input.dimension,
         ...(input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}),
+        ...(input.facetId ? { facetId: FacetId(input.facetId) } : {}),
       })
       // Name deepest clusters first. Interior naming falls back to its
       // children's already-assigned names; if we name top-down the interior

--- a/apps/workflows/src/activities/taxonomy-naming-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-naming-activities.ts
@@ -1,5 +1,10 @@
-import { CustomBehaviorId, OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
-import { nameClusterUseCase, nameCustomBehaviorClusterUseCase } from "@domain/taxonomy"
+import { CustomBehaviorId, FacetId, OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
+import {
+  FacetRepository,
+  nameClusterUseCase,
+  nameCustomBehaviorClusterUseCase,
+  nameFacetClusterUseCase,
+} from "@domain/taxonomy"
 import { AIEmbedLive, AIGenerateLive, withAi } from "@platform/ai"
 import { RedisCacheStoreLive, RedisDistributedLockRepositoryLive } from "@platform/cache-redis"
 import {
@@ -7,7 +12,7 @@ import {
   TaxonomyViewAssignmentRepositoryLive,
   withClickHouse,
 } from "@platform/db-clickhouse"
-import { TaxonomyClusterRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { FacetRepositoryLive, TaxonomyClusterRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
 
@@ -15,8 +20,10 @@ export interface NameTaxonomyClusterActivityInput {
   readonly organizationId: string
   readonly projectId: string
   readonly clusterId: string
-  /** Present ⇒ name within a custom behavior's scoped member source; absent ⇒ the global tree. */
+  /** Present ⇒ name within a custom behavior's scoped member source; absent ⇒ the whole-project tree. */
   readonly customBehaviorId?: string
+  /** Present ⇒ a facet lens: read members from `taxonomy_facet_projections` and name in the facet's voice. */
+  readonly facetId?: string
 }
 
 export const nameTaxonomyClusterActivity = (input: NameTaxonomyClusterActivityInput) => {
@@ -28,6 +35,35 @@ export const nameTaxonomyClusterActivity = (input: NameTaxonomyClusterActivityIn
     RedisCacheStoreLive(getRedisClient()),
     RedisDistributedLockRepositoryLive(getRedisClient()),
   )
+
+  if (input.facetId) {
+    // Resolve the per-tree naming policy from the facet: load its instructions +
+    // name (Postgres), then name the cluster from its extracted facet projections.
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const facets = yield* FacetRepository
+        const facet = yield* facets.findById(FacetId(input.facetId as string))
+        // Every facet view is behavior-wrapped, so customBehaviorId is always present here.
+        return yield* nameFacetClusterUseCase({
+          organizationId,
+          projectId,
+          facet,
+          clusterId,
+          customBehaviorId: CustomBehaviorId(input.customBehaviorId as string),
+        })
+      }).pipe(
+        Effect.asVoid,
+        withPostgres(
+          Layer.mergeAll(TaxonomyClusterRepositoryLive, FacetRepositoryLive),
+          getPostgresClient(),
+          organizationId,
+        ),
+        withClickHouse(clickHouse, getClickhouseClient(), organizationId),
+        withAi(Layer.mergeAll(AIEmbedLive, AIGenerateLive), getRedisClient()),
+        Effect.provide(cache),
+      ),
+    )
+  }
 
   if (input.customBehaviorId) {
     return Effect.runPromise(

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
@@ -132,6 +132,7 @@ export const gardenTaxonomyWorkflow = async (
           projectId: started.projectId,
           clusterId,
           ...(started.customBehaviorId ? { customBehaviorId: started.customBehaviorId } : {}),
+          ...(started.facetId ? { facetId: started.facetId } : {}),
         }),
       )
     }

--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
@@ -214,6 +214,7 @@ const makeCluster = (overrides: Partial<TaxonomyCluster> = {}): TaxonomyCluster 
   organizationId,
   projectId,
   customBehaviorId: null,
+  facetId: null,
   dimension: "topic",
   parentClusterId: null,
   depth: 0,

--- a/packages/domain/taxonomy/src/constants.ts
+++ b/packages/domain/taxonomy/src/constants.ts
@@ -126,8 +126,6 @@ export const FACET_DESCRIPTION_MAX_LENGTH = 300
  */
 export const FACET_INSTRUCTIONS_MAX_LENGTH = 4_000
 
-export const FACET_STATUSES = ["pending", "generating", "ready", "failed"] as const
-
 /**
  * Per-project cap on facets, enforced in the create use-case. Each facet spawns
  * its own `taxonomy_facet_projections` slice (one extraction + embedding per
@@ -171,16 +169,6 @@ export const TAXONOMY_DEFAULT_FACET_EXTRACTION_MODEL = {
 
 /** Bounded concurrency for the per-session extraction fan-out (misses only). */
 export const FACET_EXTRACTION_CONCURRENCY = 8
-
-/**
- * Facet-gardening sweep: the periodic enqueue that keeps every created facet
- * view a living taxonomy, the facet analogue of `gardenCustomBehaviorSweep`.
- * Same 6h cadence; a facet gardened within `FACET_GARDENING_MIN_INTERVAL_MS` is
- * skipped so a create-time run or a prior sweep isn't redone every tick.
- */
-export const FACET_GARDENING_CRON_KEY = "taxonomy:garden-facet-sweep"
-export const FACET_GARDENING_CRON_PATTERN = "0 */6 * * *"
-export const FACET_GARDENING_MIN_INTERVAL_MS = 5 * 60 * 60_000
 
 // ---------------------------------------------------------------------------
 // Embedding + summary

--- a/packages/domain/taxonomy/src/entities/cluster.ts
+++ b/packages/domain/taxonomy/src/entities/cluster.ts
@@ -1,4 +1,4 @@
-import { cuidSchema, customBehaviorIdSchema, taxonomyClusterIdSchema } from "@domain/shared"
+import { cuidSchema, customBehaviorIdSchema, facetIdSchema, taxonomyClusterIdSchema } from "@domain/shared"
 import { z } from "zod"
 import {
   TAXONOMY_CLUSTER_DESCRIPTION_MAX_LENGTH,
@@ -48,8 +48,11 @@ export const taxonomyClusterSchema = z.object({
   id: taxonomyClusterIdSchema,
   organizationId: cuidSchema,
   projectId: cuidSchema,
-  // NULL = global taxonomy; non-null scopes the row to a custom behavior's sub-tree.
+  // A view is (scope × facet). `customBehaviorId` names the scope (NULL =
+  // whole-project); `facetId` names the lens (NULL = topic). (NULL, NULL) is the
+  // one online-routed whole-project topic tree.
   customBehaviorId: customBehaviorIdSchema.nullable().default(null),
+  facetId: facetIdSchema.nullable().default(null),
   dimension: taxonomyDimensionSchema,
   /** Tree parent. Null = root node (the coarsest density level). */
   parentClusterId: taxonomyClusterIdSchema.nullable(),

--- a/packages/domain/taxonomy/src/entities/custom-behavior.ts
+++ b/packages/domain/taxonomy/src/entities/custom-behavior.ts
@@ -79,14 +79,7 @@ export const customBehaviorFilterSetHasConditions = (filterSet: FilterSet): bool
 // CustomBehavior
 // ---------------------------------------------------------------------------
 
-/**
- * A named, project-scoped view = (lens × filterSet). `filterSet` selects the
- * sessions the workflow samples; `facetId` picks the lens: NULL = topic (cluster
- * observation embeddings), non-null = a facet (cluster its extracted
- * projections). Both are mirrored by `custom_behavior_id`/`facet_id`-tagged rows
- * in Postgres and the ClickHouse `taxonomy_view_assignments` slice. The only
- * invalid shape is a topic lens with an empty filter (that's the live global tree).
- */
+/** A named, project-scoped view = (lens × filterSet); `facetId` null = topic lens, set = a facet lens. */
 export const customBehaviorSchema = z.object({
   id: customBehaviorIdSchema,
   organizationId: organizationIdSchema,

--- a/packages/domain/taxonomy/src/entities/custom-behavior.ts
+++ b/packages/domain/taxonomy/src/entities/custom-behavior.ts
@@ -1,6 +1,7 @@
 import {
   customBehaviorIdSchema,
   type FilterSet,
+  facetIdSchema,
   filterSetSchema,
   organizationIdSchema,
   projectIdSchema,
@@ -79,10 +80,12 @@ export const customBehaviorFilterSetHasConditions = (filterSet: FilterSet): bool
 // ---------------------------------------------------------------------------
 
 /**
- * A named, project-scoped exploration scope. Its `filterSet` selects the
- * sessions the Phase 2 workflow samples and clusters into a scoped behavior
- * sub-tree (mirrored by `custom_behavior_id`-tagged rows in Postgres and the
- * ClickHouse `taxonomy_view_assignments` slice).
+ * A named, project-scoped view = (lens × filterSet). `filterSet` selects the
+ * sessions the workflow samples; `facetId` picks the lens: NULL = topic (cluster
+ * observation embeddings), non-null = a facet (cluster its extracted
+ * projections). Both are mirrored by `custom_behavior_id`/`facet_id`-tagged rows
+ * in Postgres and the ClickHouse `taxonomy_view_assignments` slice. The only
+ * invalid shape is a topic lens with an empty filter (that's the live global tree).
  */
 export const customBehaviorSchema = z.object({
   id: customBehaviorIdSchema,
@@ -91,6 +94,7 @@ export const customBehaviorSchema = z.object({
   slug: z.string().min(1).max(SLUG_MAX_LENGTH),
   name: z.string().min(1).max(CUSTOM_BEHAVIOR_NAME_MAX_LENGTH),
   filterSet: customBehaviorFilterSetSchema,
+  facetId: facetIdSchema.nullable().default(null),
   status: customBehaviorStatusSchema,
   createdAt: z.date(),
   updatedAt: z.date(),

--- a/packages/domain/taxonomy/src/entities/facet.test.ts
+++ b/packages/domain/taxonomy/src/entities/facet.test.ts
@@ -29,7 +29,6 @@ const makeFacet = (overrides: Partial<TaxonomyFacet> = {}): TaxonomyFacet =>
     name: "Apparent user goal",
     description: "Clusters sessions by what the user was trying to accomplish, surfacing the top goals and unmet ones.",
     instructions: "In one sentence, what was the end user ultimately trying to accomplish? Ignore pleasantries.",
-    status: "pending",
     createdAt: now,
     updatedAt: now,
     ...overrides,

--- a/packages/domain/taxonomy/src/entities/facet.ts
+++ b/packages/domain/taxonomy/src/entities/facet.ts
@@ -1,25 +1,6 @@
 import { facetIdSchema, organizationIdSchema, projectIdSchema, SLUG_MAX_LENGTH } from "@domain/shared"
 import { z } from "zod"
-import {
-  FACET_DESCRIPTION_MAX_LENGTH,
-  FACET_INSTRUCTIONS_MAX_LENGTH,
-  FACET_NAME_MAX_LENGTH,
-  FACET_STATUSES,
-} from "../constants.ts"
-
-// ---------------------------------------------------------------------------
-// FacetStatus
-// ---------------------------------------------------------------------------
-
-export const facetStatusSchema = z.enum(FACET_STATUSES)
-export type FacetStatus = z.infer<typeof facetStatusSchema>
-
-export const FacetStatus = {
-  Pending: "pending",
-  Generating: "generating",
-  Ready: "ready",
-  Failed: "failed",
-} as const satisfies Record<string, FacetStatus>
+import { FACET_DESCRIPTION_MAX_LENGTH, FACET_INSTRUCTIONS_MAX_LENGTH, FACET_NAME_MAX_LENGTH } from "../constants.ts"
 
 // ---------------------------------------------------------------------------
 // TaxonomyFacet
@@ -46,7 +27,6 @@ export const taxonomyFacetSchema = z.object({
   name: z.string().trim().min(1).max(FACET_NAME_MAX_LENGTH),
   description: z.string().trim().min(1).max(FACET_DESCRIPTION_MAX_LENGTH),
   instructions: z.string().trim().min(1).max(FACET_INSTRUCTIONS_MAX_LENGTH),
-  status: facetStatusSchema,
   createdAt: z.date(),
   updatedAt: z.date(),
 })

--- a/packages/domain/taxonomy/src/entities/taxonomy-view-assignment.ts
+++ b/packages/domain/taxonomy/src/entities/taxonomy-view-assignment.ts
@@ -17,9 +17,9 @@ import { taxonomyObservationAssignmentMethodSchema } from "./observation.ts"
  * every non-online tree's memberships, so a scoped tree never mutates the global
  * `taxonomy_observations.assigned_cluster_id`.
  *
- * `customBehaviorId` names the scope (a cohort); `facetId` names the lens.
- * `facetId = null` = the topic lens, whose edges resolve against
- * `taxonomy_observations`; a set `facetId` resolves against
+ * Every view is a custom behavior, so `customBehaviorId` always names the scope;
+ * `facetId` names the lens. `facetId = null` = the topic lens, whose edges
+ * resolve against `taxonomy_observations`; a set `facetId` resolves against
  * `taxonomy_facet_projections`.
  */
 export const taxonomyViewAssignmentSchema = z.object({

--- a/packages/domain/taxonomy/src/entities/taxonomy-view-assignment.ts
+++ b/packages/domain/taxonomy/src/entities/taxonomy-view-assignment.ts
@@ -12,14 +12,10 @@ import { z } from "zod"
 import { taxonomyObservationAssignmentMethodSchema } from "./observation.ts"
 
 /**
- * One session's edge to a cluster within a single analysis view — a
- * `(scope, facet)` pair. The ClickHouse `taxonomy_view_assignments` slice holds
- * every non-online tree's memberships, so a scoped tree never mutates the global
- * `taxonomy_observations.assigned_cluster_id`.
- *
- * Every view is a custom behavior, so `customBehaviorId` always names the scope;
- * `facetId` names the lens. `facetId = null` = the topic lens, whose edges
- * resolve against `taxonomy_observations`; a set `facetId` resolves against
+ * One session's edge to a cluster within a `(customBehaviorId × facetId)` view —
+ * the `taxonomy_view_assignments` slice for every non-online tree, so a scoped
+ * tree never mutates `taxonomy_observations.assigned_cluster_id`. `facetId = null`
+ * resolves edges against `taxonomy_observations`; a set `facetId` against
  * `taxonomy_facet_projections`.
  */
 export const taxonomyViewAssignmentSchema = z.object({

--- a/packages/domain/taxonomy/src/errors.ts
+++ b/packages/domain/taxonomy/src/errors.ts
@@ -50,3 +50,23 @@ export class CustomBehaviorLimitReachedError extends Data.TaggedError("CustomBeh
     return `This project already has the maximum of ${this.limit} custom behaviors`
   }
 }
+
+export class FacetInvalidError extends Data.TaggedError("FacetInvalidError")<{
+  readonly field: string
+  readonly message: string
+}> {
+  readonly httpStatus = 400
+  get httpMessage() {
+    return this.message
+  }
+}
+
+export class FacetLimitReachedError extends Data.TaggedError("FacetLimitReachedError")<{
+  readonly projectId: string
+  readonly limit: number
+}> {
+  readonly httpStatus = 422
+  get httpMessage() {
+    return `This project already has the maximum of ${this.limit} facets`
+  }
+}

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -374,6 +374,7 @@ export {
   nameClusterUseCase,
   TOPIC_NAMING_POLICY,
 } from "./use-cases/name-taxonomy.ts"
+export { type PlanFacetGardenInput, planFacetGardenUseCase } from "./use-cases/plan-facet-garden.ts"
 export {
   type PreviewCustomBehaviorSampleInput,
   type PreviewCustomBehaviorSampleResult,

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -28,13 +28,9 @@ export {
   FACET_DESCRIPTION_MAX_LENGTH,
   FACET_EXTRACTION_CONCURRENCY,
   FACET_EXTRACTION_INPUT_CHAR_CAP,
-  FACET_GARDENING_CRON_KEY,
-  FACET_GARDENING_CRON_PATTERN,
-  FACET_GARDENING_MIN_INTERVAL_MS,
   FACET_INSTRUCTIONS_MAX_LENGTH,
   FACET_NAME_MAX_LENGTH,
   FACET_PROJECTION_TEXT_MAX_LENGTH,
-  FACET_STATUSES,
   MAX_CUSTOM_BEHAVIORS_PER_PROJECT,
   MAX_FACETS_PER_PROJECT,
   TAXONOMY_ADAPTIVE_CLUSTERING_MODE_ENV,
@@ -113,8 +109,6 @@ export {
 } from "./entities/custom-behavior.ts"
 export { TaxonomyDimension, taxonomyDimensionSchema } from "./entities/dimension.ts"
 export {
-  FacetStatus,
-  facetStatusSchema,
   type TaxonomyFacet,
   taxonomyFacetSchema,
 } from "./entities/facet.ts"
@@ -150,6 +144,8 @@ export {
   CustomBehaviorFilterInvalidError,
   CustomBehaviorLimitReachedError,
   CustomBehaviorNameInvalidError,
+  FacetInvalidError,
+  FacetLimitReachedError,
   TaxonomyClusterLockUnavailableError,
   TaxonomyClusterNotFoundError,
   TaxonomyQualityGateError,
@@ -223,6 +219,7 @@ export {
   type ReassignTaxonomyObservationByIdInput,
   type ReassignTaxonomyObservationInput,
   type TaxonomyClusteringObservation,
+  type TaxonomyFacetSample,
   type TaxonomyObservationClusterAssignmentCount,
   type TaxonomyObservationClusterOccurrence,
   type TaxonomyObservationClusterTrendCounts,
@@ -237,7 +234,9 @@ export {
   type TaxonomyRunRepositoryShape,
 } from "./ports/taxonomy-run-repository.ts"
 export {
+  type TaxonomyClusterNamingMember,
   type TaxonomyViewAssignmentClusterCount,
+  type TaxonomyViewAssignmentClusterTrendCount,
   TaxonomyViewAssignmentRepository,
   type TaxonomyViewAssignmentRepositoryShape,
 } from "./ports/taxonomy-view-assignment-repository.ts"
@@ -297,6 +296,7 @@ export {
   type TaxonomyClusterBuildResult,
 } from "./use-cases/build-hierarchical-taxonomy.ts"
 export { type CreateCustomBehaviorInput, createCustomBehavior } from "./use-cases/create-custom-behavior.ts"
+export { type CreateFacetInput, createFacet } from "./use-cases/create-facet.ts"
 export {
   type ClusterAssignmentDecision,
   decideClusterAssignment,
@@ -365,10 +365,14 @@ export {
   type NameCustomBehaviorClusterInput,
   nameCustomBehaviorClusterUseCase,
 } from "./use-cases/name-custom-behavior-cluster.ts"
+export { type NameFacetClusterInput, nameFacetClusterUseCase } from "./use-cases/name-facet-cluster.ts"
 export {
+  type ClusterNamingPolicy,
+  facetNamingPolicy,
   type NameClusterInput,
   type NameTaxonomyResult,
   nameClusterUseCase,
+  TOPIC_NAMING_POLICY,
 } from "./use-cases/name-taxonomy.ts"
 export {
   type PreviewCustomBehaviorSampleInput,

--- a/packages/domain/taxonomy/src/ports/taxonomy-cluster-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-cluster-repository.ts
@@ -75,6 +75,12 @@ export interface TaxonomyClusterRepositoryShape {
     readonly facetId?: FacetId | null
   }): Effect.Effect<readonly TaxonomyClusterId[], RepositoryError, SqlClient>
   /**
+   * WHOLE-PROJECT TOPIC TREE ONLY (`custom_behavior_id IS NULL AND facet_id IS
+   * NULL`). This is the online router's read: only that one tree is
+   * live-assigned, so it must never return a cohort or facet cluster — those are
+   * gardening-only and their membership is written to `taxonomy_view_assignments`
+   * at garden time, never by online routing.
+   *
    * Exact pgvector cosine over `(organization_id, project_id)` for state =
    * 'active' clusters with a non-null `centroid_embedding`. Sub-ms at the
    * cluster counts this product runs at (hundreds to low-thousands per
@@ -89,6 +95,11 @@ export interface TaxonomyClusterRepositoryShape {
     /** Omit for all nodes; null for roots; an id for that node's children. */
     readonly parentClusterId?: TaxonomyClusterId | null
   }): Effect.Effect<readonly NearestClusterMatch[], RepositoryError, SqlClient>
+  /**
+   * WHOLE-PROJECT TOPIC TREE ONLY (`custom_behavior_id IS NULL AND facet_id IS
+   * NULL`) — cluster search over the online-routed tree. Cohort and facet trees
+   * are not searchable through this method; scope-aware browse goes through `list`.
+   */
   hybridSearch(input: {
     readonly projectId: ProjectId
     readonly dimension: TaxonomyDimension

--- a/packages/domain/taxonomy/src/ports/taxonomy-cluster-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-cluster-repository.ts
@@ -1,5 +1,6 @@
 import type {
   CustomBehaviorId,
+  FacetId,
   NotFoundError,
   ProjectId,
   RepositoryError,
@@ -32,8 +33,10 @@ export interface ListClustersInput {
   readonly sort?: TaxonomyClusterSort
   readonly limit: number
   readonly offset: number
-  /** Omit/null = global taxonomy (custom_behavior_id IS NULL); an id scopes to that behavior's sub-tree. */
+  /** Omit/null = whole-project scope (custom_behavior_id IS NULL); an id scopes to that behavior's sub-tree. */
   readonly customBehaviorId?: CustomBehaviorId | null
+  /** Omit/null = topic lens (facet_id IS NULL); an id scopes to that facet's tree. */
+  readonly facetId?: FacetId | null
 }
 
 export interface TaxonomyClusterListPage {
@@ -57,15 +60,19 @@ export interface TaxonomyClusterRepositoryShape {
     readonly dimension: TaxonomyDimension
     /** Omit for all nodes; null for roots; an id for that node's children. */
     readonly parentClusterId?: TaxonomyClusterId | null
-    /** Omit/null = global taxonomy (custom_behavior_id IS NULL); an id scopes to that behavior's sub-tree. */
+    /** Omit/null = whole-project scope (custom_behavior_id IS NULL); an id scopes to that behavior's sub-tree. */
     readonly customBehaviorId?: CustomBehaviorId | null
+    /** Omit/null = topic lens (facet_id IS NULL); an id scopes to that facet's tree. */
+    readonly facetId?: FacetId | null
   }): Effect.Effect<readonly TaxonomyCluster[], RepositoryError, SqlClient>
   /** Active ids of the node plus all its descendants (path prefix match). */
   listSubtreeIds(input: {
     readonly projectId: ProjectId
     readonly clusterId: TaxonomyClusterId
-    /** Omit/null = global taxonomy (custom_behavior_id IS NULL); an id scopes to that behavior's sub-tree. */
+    /** Omit/null = whole-project scope (custom_behavior_id IS NULL); an id scopes to that behavior's sub-tree. */
     readonly customBehaviorId?: CustomBehaviorId | null
+    /** Omit/null = topic lens (facet_id IS NULL); an id scopes to that facet's tree. */
+    readonly facetId?: FacetId | null
   }): Effect.Effect<readonly TaxonomyClusterId[], RepositoryError, SqlClient>
   /**
    * Exact pgvector cosine over `(organization_id, project_id)` for state =

--- a/packages/domain/taxonomy/src/ports/taxonomy-observation-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-observation-repository.ts
@@ -74,6 +74,20 @@ export interface TaxonomyScopedClusteringObservation extends TaxonomyClusteringO
   readonly sessionId: SessionId
 }
 
+/**
+ * One sampled session for facet extraction: the ids + start time the caller
+ * needs to build a `FacetExtractionSample`, plus the stored transcript summary
+ * (`projection_metadata.summary`) the extractor reads instead of refetching
+ * spans. `sessionObservationId` is the session's `taxonomy_observations`
+ * observation id — the facet-projection cache key.
+ */
+export interface TaxonomyFacetSample {
+  readonly sessionObservationId: string
+  readonly sessionId: SessionId
+  readonly startTime: Date
+  readonly transcript: string
+}
+
 export interface TaxonomyObservationCounts {
   readonly total: number
   readonly assigned: number
@@ -163,6 +177,20 @@ export interface TaxonomyObservationRepositoryShape {
     readonly limit: number
     readonly filterSet: FilterSet
   }) => Effect.Effect<readonly TaxonomyScopedClusteringObservation[], RepositoryError, ChSqlClient>
+  /**
+   * Facet-extraction sample over the same day-stratified `(since, limit)` window
+   * `listForCustomBehaviorSample` uses, returning each session's ids, start time,
+   * and stored transcript summary so the caller can build `FacetExtractionSample`
+   * records. An optional `filterSet` scopes it to a cohort's sessions; omit it for
+   * a whole-project facet. Reads global `taxonomy_observations`, never mutates it.
+   */
+  readonly listForFacetSample: (input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly since: Date
+    readonly limit: number
+    readonly filterSet?: FilterSet
+  }) => Effect.Effect<readonly TaxonomyFacetSample[], RepositoryError, ChSqlClient>
   /**
    * The complete bounded live window (newest ≤ `limit`, no day-stratified
    * sampling) as slim rows carrying the current assignment — the read the

--- a/packages/domain/taxonomy/src/ports/taxonomy-view-assignment-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-view-assignment-repository.ts
@@ -1,18 +1,32 @@
 import type {
   ChSqlClient,
   CustomBehaviorId,
+  FacetId,
   OrganizationId,
   ProjectId,
   RepositoryError,
   TaxonomyClusterId,
 } from "@domain/shared"
 import { Context, type Effect } from "effect"
-import type { TaxonomyMomentObservation } from "../entities/observation.ts"
 import type { TaxonomyViewAssignment } from "../entities/taxonomy-view-assignment.ts"
 
 export interface TaxonomyViewAssignmentClusterCount {
   readonly clusterId: TaxonomyClusterId
   readonly count: number
+}
+
+/**
+ * The slim member row cluster naming needs: an embedding for farthest-point
+ * sampling, a `startTime` for recency ranking, and the readable text in
+ * `projectionMetadata.summary`. Topic members carry the full transcript summary
+ * from `taxonomy_observations`; facet members carry the extracted one-sentence
+ * answer from `taxonomy_facet_projections`. `TaxonomyMomentObservation` is
+ * structurally assignable, so the topic read returns full rows unchanged.
+ */
+export interface TaxonomyClusterNamingMember {
+  readonly embedding: readonly number[]
+  readonly startTime: Date
+  readonly projectionMetadata: Readonly<Record<string, unknown>>
 }
 
 /**
@@ -69,22 +83,35 @@ export interface TaxonomyViewAssignmentRepositoryShape {
     readonly baselineDays: number
   }) => Effect.Effect<readonly TaxonomyViewAssignmentClusterTrendCount[], RepositoryError, ChSqlClient>
   /**
-   * Full observation rows assigned to one scoped cluster, resolved by joining
-   * the view's assignment slice back to global `taxonomy_observations` for the
-   * embeddings + summaries the naming step needs. Read-only on the global table.
+   * Member rows of one scoped cluster for the naming step, resolved by joining
+   * the view's assignment slice back to the projection source: the topic lens
+   * (`facetId` omitted/null) reads global `taxonomy_observations`; a facet lens
+   * reads `taxonomy_facet_projections`. Read-only on both source tables.
    */
   readonly listClusterMemberObservations: (input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
     readonly customBehaviorId: CustomBehaviorId
+    /** Omit/null = topic lens (members from `taxonomy_observations`); an id reads `taxonomy_facet_projections`. */
+    readonly facetId?: FacetId | null
     readonly clusterId: TaxonomyClusterId
     readonly limit: number
-  }) => Effect.Effect<readonly TaxonomyMomentObservation[], RepositoryError, ChSqlClient>
-  /** Purge a behavior's slice when the behavior is deleted (lightweight delete). */
+  }) => Effect.Effect<readonly TaxonomyClusterNamingMember[], RepositoryError, ChSqlClient>
+  /**
+   * Purge a scope's edges when the entity is deleted. `deleteByBehavior` drops
+   * every edge for a cohort across BOTH lenses — its topic slice AND each facet
+   * lens applied to it — so deleting a cohort never orphans facet-lens edges.
+   */
   readonly deleteByBehavior: (input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
     readonly customBehaviorId: CustomBehaviorId
+  }) => Effect.Effect<void, RepositoryError, ChSqlClient>
+  /** Purge a facet's edges across every scope when the facet is deleted. */
+  readonly deleteByFacet: (input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly facetId: FacetId
   }) => Effect.Effect<void, RepositoryError, ChSqlClient>
 }
 

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-cluster-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-cluster-repository.ts
@@ -24,13 +24,14 @@ export const createFakeTaxonomyClusterRepository = (
         ids.map((id) => clusters.get(id)).filter((cluster): cluster is TaxonomyCluster => cluster !== undefined),
       ),
 
-    listActiveByProject: ({ projectId, parentClusterId, customBehaviorId }) =>
+    listActiveByProject: ({ projectId, parentClusterId, customBehaviorId, facetId }) =>
       Effect.sync(() =>
         [...clusters.values()].filter(
           (cluster) =>
             cluster.projectId === projectId &&
             cluster.state === "active" &&
             (cluster.customBehaviorId ?? null) === (customBehaviorId ?? null) &&
+            (cluster.facetId ?? null) === (facetId ?? null) &&
             (parentClusterId === undefined || cluster.parentClusterId === parentClusterId),
         ),
       ),
@@ -86,13 +87,14 @@ export const createFakeTaxonomyClusterRepository = (
           })),
       ),
 
-    list: ({ projectId, state, sort, limit, offset, customBehaviorId }) =>
+    list: ({ projectId, state, sort, limit, offset, customBehaviorId, facetId }) =>
       Effect.sync(() => {
         const filtered = [...clusters.values()]
           .filter(
             (cluster) =>
               cluster.projectId === projectId &&
               (cluster.customBehaviorId ?? null) === (customBehaviorId ?? null) &&
+              (cluster.facetId ?? null) === (facetId ?? null) &&
               // `staging` is internal to the publish swap; never surface it unless
               // explicitly requested (mirrors the Live repository).
               (state ? cluster.state === state : cluster.state !== "staging"),

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-cluster-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-cluster-repository.ts
@@ -36,13 +36,15 @@ export const createFakeTaxonomyClusterRepository = (
         ),
       ),
 
-    listSubtreeIds: ({ projectId, clusterId }) =>
+    listSubtreeIds: ({ projectId, clusterId, customBehaviorId, facetId }) =>
       Effect.sync(() =>
         [...clusters.values()]
           .filter(
             (cluster) =>
               cluster.projectId === projectId &&
               cluster.state === "active" &&
+              (cluster.customBehaviorId ?? null) === (customBehaviorId ?? null) &&
+              (cluster.facetId ?? null) === (facetId ?? null) &&
               (cluster.id === clusterId || cluster.path.split("/").includes(clusterId as string)),
           )
           .map((cluster) => cluster.id),

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-observation-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-observation-repository.ts
@@ -246,6 +246,46 @@ export const createFakeTaxonomyObservationRepository = (
           }))
       }),
 
+    // Facet-extraction sample: same day-stratified window as
+    // listForCustomBehaviorSample, projecting each row's ids/startTime and the
+    // stored transcript summary. The fake does not compile `filterSet`.
+    listForFacetSample: ({ organizationId, projectId, since, limit }) =>
+      Effect.sync(() => {
+        const eligible = [...rows.values()].filter(
+          (observation) =>
+            observation.organizationId === organizationId &&
+            observation.projectId === projectId &&
+            observation.embedding.length > 0 &&
+            observation.startTime >= since,
+        )
+        const dayBuckets = new Map<string, TaxonomyMomentObservation[]>()
+        for (const observation of eligible) {
+          const day = observation.startTime.toISOString().slice(0, 10)
+          const bucket = dayBuckets.get(day) ?? []
+          bucket.push(observation)
+          dayBuckets.set(day, bucket)
+        }
+        const ranked = [...dayBuckets.values()].flatMap((bucket) =>
+          [...bucket]
+            .sort((a, b) => deterministicHash(a.observationId) - deterministicHash(b.observationId))
+            .map((observation, rank) => ({ observation, rank })),
+        )
+        return ranked
+          .sort((a, b) => a.rank - b.rank || a.observation.observationId.localeCompare(b.observation.observationId))
+          .slice(0, limit)
+          .map((entry) => entry.observation)
+          .sort(
+            (a, b) => b.startTime.getTime() - a.startTime.getTime() || a.observationId.localeCompare(b.observationId),
+          )
+          .map((observation) => ({
+            sessionObservationId: observation.observationId,
+            sessionId: observation.sessionId,
+            startTime: observation.startTime,
+            transcript:
+              typeof observation.projectionMetadata.summary === "string" ? observation.projectionMetadata.summary : "",
+          }))
+      }),
+
     // Like listForCustomBehaviorSample, the fake does not compile `filterSet`;
     // it returns the unsampled eligible totals over the window.
     countForCustomBehaviorSample: ({ organizationId, projectId, since }) =>

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-view-assignment-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-view-assignment-repository.ts
@@ -60,10 +60,19 @@ export const createFakeTaxonomyViewAssignmentRepository = (
     listClusterMemberObservations: ({ clusterId, limit }) =>
       Effect.sync(() => (members.get(clusterId as string) ?? []).slice(0, limit)),
 
+    // Purge across BOTH lenses (no facet_id filter): deleting a cohort drops its
+    // topic slice AND every facet-lens slice applied to it.
     deleteByBehavior: ({ customBehaviorId }) =>
       Effect.sync(() => {
         for (let index = assignments.length - 1; index >= 0; index--) {
           if (assignments[index]?.customBehaviorId === customBehaviorId) assignments.splice(index, 1)
+        }
+      }),
+
+    deleteByFacet: ({ facetId }) =>
+      Effect.sync(() => {
+        for (let index = assignments.length - 1; index >= 0; index--) {
+          if (assignments[index]?.facetId === facetId) assignments.splice(index, 1)
         }
       }),
 

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-view-assignment-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-view-assignment-repository.ts
@@ -60,8 +60,7 @@ export const createFakeTaxonomyViewAssignmentRepository = (
     listClusterMemberObservations: ({ clusterId, limit }) =>
       Effect.sync(() => (members.get(clusterId as string) ?? []).slice(0, limit)),
 
-    // Purge across BOTH lenses (no facet_id filter): deleting a cohort drops its
-    // topic slice AND every facet-lens slice applied to it.
+    // Purge across BOTH lenses (no facet_id filter), matching the real repo.
     deleteByBehavior: ({ customBehaviorId }) =>
       Effect.sync(() => {
         for (let index = assignments.length - 1; index >= 0; index--) {

--- a/packages/domain/taxonomy/src/use-cases/assert-taxonomy-quality.ts
+++ b/packages/domain/taxonomy/src/use-cases/assert-taxonomy-quality.ts
@@ -1,4 +1,4 @@
-import type { CustomBehaviorId, OrganizationId, ProjectId } from "@domain/shared"
+import type { CustomBehaviorId, FacetId, OrganizationId, ProjectId } from "@domain/shared"
 import { Effect } from "effect"
 import { TaxonomyDimension, type TaxonomyDimension as TaxonomyDimensionType } from "../entities/dimension.ts"
 import { TaxonomyQualityGateError } from "../errors.ts"
@@ -8,8 +8,10 @@ export interface AssertTaxonomyQualityInput {
   readonly organizationId?: OrganizationId
   readonly projectId: ProjectId
   readonly dimension?: TaxonomyDimensionType
-  /** Omit/null asserts the global tree; an id asserts that custom behavior's scoped tree. */
+  /** Omit/null asserts the whole-project tree; an id asserts that cohort's scoped tree. */
   readonly customBehaviorId?: CustomBehaviorId | null
+  /** Omit/null = topic lens; an id asserts that facet lens's tree. */
+  readonly facetId?: FacetId | null
 }
 
 export interface AssertTaxonomyQualityResult {
@@ -40,6 +42,7 @@ export const assertTaxonomyQualityUseCase = (input: AssertTaxonomyQualityInput) 
       projectId: input.projectId,
       dimension,
       customBehaviorId: input.customBehaviorId ?? null,
+      facetId: input.facetId ?? null,
     })
     const parentsWithChildren = new Set(
       active.flatMap((cluster) => (cluster.parentClusterId ? [cluster.parentClusterId] : [])),

--- a/packages/domain/taxonomy/src/use-cases/behaviour-reads.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/behaviour-reads.test.ts
@@ -23,8 +23,15 @@ const CUSTOM_BEHAVIOR_ID = CustomBehaviorId("b".repeat(24))
 
 // The fake cluster repo's listSubtreeIds keys off id / project / state / path
 // only, so a minimal cast is enough — these use-cases never touch the rest.
-const cluster = (id: string, path: string): TaxonomyCluster =>
-  ({ id: TaxonomyClusterId(id), projectId: PROJECT_ID, state: "active", path }) as unknown as TaxonomyCluster
+const cluster = (id: string, path: string, customBehaviorId: CustomBehaviorId | null = null): TaxonomyCluster =>
+  ({
+    id: TaxonomyClusterId(id),
+    projectId: PROJECT_ID,
+    state: "active",
+    path,
+    customBehaviorId,
+    facetId: null,
+  }) as unknown as TaxonomyCluster
 
 const trajectoryRow = (bucket: string, frequency: number): ClusterTrajectoryRow => ({
   bucket,
@@ -63,7 +70,10 @@ describe("listBehaviourSessionsUseCase", () => {
   const CHILD = "c".repeat(24)
 
   it("resolves the whole subtree and forwards it (plus filters + scope) to the intelligence repo", async () => {
-    const clusters = createFakeTaxonomyClusterRepository([cluster(ROOT, ""), cluster(CHILD, `${ROOT}/`)])
+    const clusters = createFakeTaxonomyClusterRepository([
+      cluster(ROOT, "", CUSTOM_BEHAVIOR_ID),
+      cluster(CHILD, `${ROOT}/`, CUSTOM_BEHAVIOR_ID),
+    ])
     const page: ClusterSessionsPage = {
       sessions: [
         {

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.test.ts
@@ -2,6 +2,7 @@ import { EMBEDDING_DIMENSIONS } from "@domain/ai"
 import {
   ChSqlClient,
   CustomBehaviorId,
+  FacetId,
   OrganizationId,
   ProjectId,
   SessionId,
@@ -101,6 +102,7 @@ const makeCluster = (overrides: Partial<TaxonomyCluster>): TaxonomyCluster => ({
   organizationId,
   projectId,
   customBehaviorId: null,
+  facetId: null,
   dimension: "topic",
   parentClusterId: null,
   depth: 0,
@@ -384,6 +386,121 @@ describe("planHierarchicalTaxonomyUseCase scoped to a custom behavior", () => {
     expect(plan.clustersContinued).toBe(0)
     expect(plan.clusters).toEqual([])
     expect(plan.customAssignments).toEqual([])
+    expect(plan.deprecatedClusterIds).toEqual([])
+  })
+})
+
+describe("planHierarchicalTaxonomyUseCase facet lens (scope × lens)", () => {
+  const customBehaviorId = CustomBehaviorId("b".repeat(24))
+  const facetId = FacetId("f".repeat(24))
+
+  const makeProjection = (index: number, embedding: readonly number[], at: Date) => ({
+    observationId: String(index).padStart(24, "o").slice(0, 24),
+    sessionId: SessionId(`session-${index}`),
+    startTime: new Date(at.getTime() + index * 1000),
+    embedding: [...embedding],
+  })
+
+  const runFacetPlan = (input: {
+    readonly lensObservations: ReadonlyArray<ReturnType<typeof makeProjection>>
+    readonly seededClusters?: readonly TaxonomyCluster[]
+    readonly customBehaviorId?: CustomBehaviorId
+    readonly filterSet?: Record<string, unknown>
+    readonly now: Date
+  }) => {
+    const clusters = createFakeTaxonomyClusterRepository(input.seededClusters ?? [])
+    // Facet clustering never reads the observation repo (the caller pre-extracts).
+    const observations = createFakeTaxonomyObservationRepository([])
+    return Effect.runPromise(
+      planHierarchicalTaxonomyUseCase({
+        organizationId,
+        projectId,
+        runId: TaxonomyRunId("r".repeat(24)),
+        dimension: "topic",
+        now: input.now,
+        facetId,
+        lensObservations: input.lensObservations,
+        ...(input.customBehaviorId ? { customBehaviorId: input.customBehaviorId } : {}),
+        ...(input.filterSet ? { filterSet: input.filterSet as never } : {}),
+      }).pipe(
+        Effect.provide(Layer.succeed(TaxonomyObservationRepository, observations.repository)),
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+        Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+      ),
+    )
+  }
+
+  it("cohort × facet: clusters the projections and keys clusters + edges by BOTH the cohort and the facet", async () => {
+    const now = new Date("2026-05-24T12:00:00.000Z")
+    const plan = await runFacetPlan({
+      lensObservations: Array.from({ length: 20 }, (_, index) => makeProjection(index, E1, now)),
+      customBehaviorId,
+      filterSet: { userId: [{ op: "in", value: ["usr-cohort"] }] },
+      now,
+    })
+
+    expect(plan.facetId).toBe(facetId)
+    expect(plan.customBehaviorId).toBe(customBehaviorId)
+    expect(plan.clustersBorn).toBe(1)
+    // Facet edges go to the view slice, never the inline global column.
+    expect(plan.observationAssignments).toEqual([])
+    expect(plan.customAssignments).toHaveLength(20)
+    expect(plan.customAssignments.every((a) => a.customBehaviorId === customBehaviorId && a.facetId === facetId)).toBe(
+      true,
+    )
+    expect(plan.customAssignments.every((a) => (a.sessionId as string).startsWith("session-"))).toBe(true)
+    expect(plan.clusters.every((c) => c.customBehaviorId === customBehaviorId && c.facetId === facetId)).toBe(true)
+  })
+
+  it("whole-project facet (behavior, no filter): still writes facet-keyed view edges, never the global column", async () => {
+    const now = new Date("2026-05-24T12:00:00.000Z")
+    const plan = await runFacetPlan({
+      lensObservations: Array.from({ length: 20 }, (_, index) => makeProjection(index, E1, now)),
+      customBehaviorId,
+      now,
+    })
+
+    expect(plan.facetId).toBe(facetId)
+    expect(plan.observationAssignments).toEqual([])
+    expect(plan.customAssignments).toHaveLength(20)
+    expect(plan.customAssignments.every((a) => a.customBehaviorId === customBehaviorId && a.facetId === facetId)).toBe(
+      true,
+    )
+  })
+
+  it("fails fast on a facet lens with no wrapping behavior (facet edges have nowhere to write)", async () => {
+    const now = new Date("2026-05-24T12:00:00.000Z")
+    await expect(
+      runFacetPlan({
+        lensObservations: Array.from({ length: 20 }, (_, index) => makeProjection(index, E1, now)),
+        now,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it("isolates the facet tree from a same-cohort TOPIC tree (facet run never sees topic clusters)", async () => {
+    const now = new Date("2026-05-24T12:00:00.000Z")
+    // A prior TOPIC cohort cluster (facetId null) on the SAME behavior, on a
+    // different topic (E1) than the facet projections (E2). A facet run must not
+    // treat it as prior-active, so it is neither continued nor deprecated.
+    const priorTopicCohort = makeCluster({
+      id: "a".repeat(24) as TaxonomyClusterId,
+      customBehaviorId,
+      facetId: null,
+      centroid: centroidFrom(E1, new Date("2026-01-01T00:00:00.000Z")),
+    })
+    const plan = await runFacetPlan({
+      lensObservations: Array.from({ length: 20 }, (_, index) => makeProjection(index, E2, now)),
+      customBehaviorId,
+      seededClusters: [priorTopicCohort],
+      now,
+    })
+
+    expect(plan.clustersBorn).toBe(1)
+    expect(plan.clustersContinued).toBe(0)
+    // The topic cohort cluster belongs to a different lens, so the facet run
+    // leaves it untouched (no cross-lens deprecation).
     expect(plan.deprecatedClusterIds).toEqual([])
   })
 })

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
@@ -49,6 +49,7 @@
 import { resolveEmbeddingConfig } from "@domain/ai"
 import {
   type CustomBehaviorId,
+  type FacetId,
   type FilterSet,
   generateId,
   type OrganizationId,
@@ -102,6 +103,7 @@ import { type LineageDecision, matchTaxonomyLineage } from "../lineage.ts"
 import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
 import {
   type ReassignTaxonomyObservationByIdInput,
+  type TaxonomyClusteringObservation,
   TaxonomyObservationRepository,
   type TaxonomyScopedClusteringObservation,
 } from "../ports/taxonomy-observation-repository.ts"
@@ -181,14 +183,32 @@ export const runTaxonomyClusterBuild = (input: TaxonomyClusterBuildRequest): Tax
 export interface PlanHierarchicalTaxonomyInput extends BuildHierarchicalTaxonomyInput {
   readonly clusterBuilder?: TaxonomyClusterBuilder
   /**
-   * Scope. Absent ⇒ global gardening (project-wide sample, membership written to
-   * `taxonomy_observations.assigned_cluster_id`). Present ⇒ a custom behavior's
-   * scoped sub-tree (FilterSet session slice, membership written to the
-   * `taxonomy_view_assignments` slice). Global callers omit both so their
-   * serialized payloads are byte-identical to the pre-unification workflow.
+   * A view is (scope × lens); scope and lens are resolved orthogonally.
+   *
+   * SCOPE — `customBehaviorId` absent ⇒ whole-project; present ⇒ a cohort's
+   * FilterSet session slice (requires a non-empty `filterSet` on the topic lens).
+   *
+   * LENS — `facetId` absent ⇒ the topic lens (cluster the sampled observation
+   * embeddings); present ⇒ a facet lens, where the caller has already sampled +
+   * extracted the facet projections and passes them as `lensObservations` (this
+   * use-case does not sample or extract on the facet path).
+   *
+   * WRITE TARGET — only (whole-project, topic) writes inline to
+   * `taxonomy_observations.assigned_cluster_id`; every other combination writes
+   * the `taxonomy_view_assignments` slice keyed by `(customBehaviorId, facetId)`.
+   * The (whole-project, topic) caller omits all three fields so its serialized
+   * payload stays byte-identical to the pre-facets workflow.
    */
   readonly customBehaviorId?: CustomBehaviorId
+  readonly facetId?: FacetId
   readonly filterSet?: FilterSet
+  /**
+   * Facet-lens embeddings to cluster: the non-unclear facet projections the
+   * caller extracted for the sampled sessions (each carries the session's
+   * `observationId`/`sessionId`/`startTime`). Required on the facet path, ignored
+   * on the topic path.
+   */
+  readonly lensObservations?: readonly TaxonomyScopedClusteringObservation[]
   /**
    * Rollout mode, resolved in the planning activity. `off` (default) is a
    * byte-identical no-op: static builder, sample-only reassignment, active
@@ -217,8 +237,11 @@ export interface HierarchicalTaxonomyPlan extends BuildHierarchicalTaxonomyResul
   readonly customAssignments: readonly TaxonomyViewAssignment[]
   /** Leaf id + centroid for adaptive full-window routing. Empty on the off path. */
   readonly leafClusters: readonly StagingLeafCluster[]
-  /** Non-null ⇒ the plan is scoped to this custom behavior (drives the write target). */
+  /** Non-null ⇒ the plan's scope is this cohort. */
   readonly customBehaviorId: CustomBehaviorId | null
+  /** Non-null ⇒ the plan's lens is this facet. Any non-null id here — or a non-null
+   * `customBehaviorId` — means the plan writes the `taxonomy_view_assignments` slice. */
+  readonly facetId: FacetId | null
   /**
    * Death lineage targets — previously-active clusters no node continued. On the
    * off path this is exactly what gets deprecated.
@@ -264,8 +287,10 @@ const buildPersistedCluster = (input: {
   readonly id: string
   readonly organizationId: OrganizationId
   readonly projectId: ProjectId
-  /** NULL = global taxonomy; non-null scopes the row to a custom behavior's sub-tree. */
+  /** NULL = whole-project scope; non-null scopes the row to a cohort's sub-tree. */
   readonly customBehaviorId?: CustomBehaviorId | null
+  /** NULL = topic lens; non-null scopes the row to a facet's tree. */
+  readonly facetId?: FacetId | null
   readonly dimension: TaxonomyDimensionType
   readonly parentId: string | null
   readonly path: string
@@ -313,6 +338,7 @@ const buildPersistedCluster = (input: {
     organizationId: input.organizationId,
     projectId: input.projectId,
     customBehaviorId: input.customBehaviorId ?? null,
+    facetId: input.facetId ?? null,
     dimension: input.dimension,
     parentClusterId: input.parentId === null ? null : TaxonomyClusterId(input.parentId),
     depth: input.depth,
@@ -493,31 +519,49 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
     const observationsRepo = yield* TaxonomyObservationRepository
     const clustersRepo = yield* TaxonomyClusterRepository
     const scopedBehaviorId = input.customBehaviorId ?? null
-    // A scoped run without a filter would sample the whole project yet tag the
-    // clusters/assignments to the behavior — silently wrong. Custom behaviors
-    // always carry a non-empty filter, so fail fast rather than fall back to `{}`.
-    if (scopedBehaviorId !== null && (!input.filterSet || Object.keys(input.filterSet).length === 0)) {
+    const facetLensId = input.facetId ?? null
+    const isFacetLens = facetLensId !== null
+    // Every view is a custom behavior, so a facet lens is always cohort-wrapped —
+    // its edges key on that behavior's id. A facet lens without a behavior would
+    // have nowhere to write (whole-project topic is the only behavior-less tree,
+    // and it is the inline online tree), so fail fast.
+    if (isFacetLens && scopedBehaviorId === null) {
+      return yield* Effect.die(
+        new Error(`planHierarchicalTaxonomy: facet lens ${facetLensId} requires a customBehaviorId`),
+      )
+    }
+    // A cohort on the TOPIC lens samples the observation window through its
+    // filter, so it needs a non-empty filter (sampling the whole project yet
+    // tagging the cohort would be silently wrong). A facet lens samples +
+    // extracts in the caller, so it needs no filter here even when cohort-scoped.
+    if (!isFacetLens && scopedBehaviorId !== null && (!input.filterSet || Object.keys(input.filterSet).length === 0)) {
       return yield* Effect.die(
         new Error(`planHierarchicalTaxonomy: scoped run for ${scopedBehaviorId} requires a non-empty filterSet`),
       )
     }
     const since = lookbackStart(now)
-    // Scoped gardening samples the behavior's FilterSet session slice (rows carry
-    // sessionId for the assignment write); global samples the project-wide window.
-    const observations = scopedBehaviorId
-      ? yield* observationsRepo.listForCustomBehaviorSample({
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-          since,
-          limit: TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX,
-          filterSet: input.filterSet ?? {},
-        })
-      : yield* observationsRepo.listForClusteringSample({
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-          since,
-          limit: TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX,
-        })
+    // Lens picks the embeddings to cluster: the facet lens clusters the
+    // caller-supplied facet projections; the topic lens samples observation
+    // embeddings — scoped to the cohort's FilterSet session slice, or the whole
+    // project window. Scoped/facet rows carry sessionId for the view-slice write.
+    const observations: readonly TaxonomyClusteringObservation[] = isFacetLens
+      ? (input.lensObservations ?? [])
+      : scopedBehaviorId
+        ? yield* observationsRepo.listForCustomBehaviorSample({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            since,
+            limit: TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX,
+            filterSet: input.filterSet ?? {},
+          })
+        : yield* observationsRepo.listForClusteringSample({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            since,
+            limit: TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX,
+          })
+    // Any view (cohort topic or facet, both behavior-wrapped) reports its own
+    // sample size; only the whole-project topic tree reads project-wide counts.
     const observationsAvailable = scopedBehaviorId
       ? observations.length
       : (yield* observationsRepo.getCounts({ organizationId: input.organizationId, projectId: input.projectId, since }))
@@ -545,6 +589,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
         customAssignments: [],
         leafClusters: [],
         customBehaviorId: scopedBehaviorId,
+        facetId: facetLensId,
         deprecatedClusterIds: [],
         supersededClusterIds: [],
         mode,
@@ -560,7 +605,11 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
     const clusterBuilder =
       input.clusterBuilder ??
       ((request: TaxonomyClusterBuildRequest) => Effect.sync(() => runTaxonomyClusterBuild(request)))
-    const seed = seedFromProjectId(scopedBehaviorId ? `${input.projectId}:${scopedBehaviorId}` : input.projectId)
+    // Seed is deterministic per view (project × scope × lens) so a pass replays
+    // identically under Temporal and different views never share a seed.
+    const seed = seedFromProjectId(
+      `${input.projectId}${scopedBehaviorId ? `:${scopedBehaviorId}` : ""}${facetLensId ? `:facet:${facetLensId}` : ""}`,
+    )
 
     // Static is always built: it is the tree we persist for off/shadow (and for an
     // enforced run that falls back), and the comparison baseline for shadow.
@@ -624,6 +673,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       projectId: input.projectId,
       dimension,
       ...(input.customBehaviorId ? { customBehaviorId: input.customBehaviorId } : {}),
+      ...(input.facetId ? { facetId: input.facetId } : {}),
     })
     const { oldById, decisionByTempId, finalIdByTempId, matchedOldIds } = resolveTaxonomyLineage({
       descriptors,
@@ -658,6 +708,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
         organizationId: input.organizationId,
         projectId: input.projectId,
         customBehaviorId: input.customBehaviorId ?? null,
+        facetId: input.facetId ?? null,
         dimension,
         parentId: parentFinalId,
         path,
@@ -730,9 +781,10 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       ? bornLeaves.map((leaf) => ({ clusterId: leaf.clusterId, centroid: [...leaf.centroid] }))
       : []
 
-    // Two write targets, picked by scope: global reassigns the observation's
-    // `assigned_cluster_id`; a scoped run writes the `taxonomy_view_assignments`
-    // slice (carrying sessionId + customBehaviorId), never the global column.
+    // Two write targets, picked by view: only the whole-project topic tree
+    // reassigns the observation's `assigned_cluster_id`; every behavior-wrapped
+    // view (cohort topic or facet) writes the `taxonomy_view_assignments` slice
+    // (keyed by customBehaviorId × facetId, carrying sessionId), never the column.
     const observationAssignments: ReassignTaxonomyObservationByIdInput[] =
       adaptive || scopedBehaviorId
         ? []
@@ -747,10 +799,9 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
     const customAssignments: TaxonomyViewAssignment[] =
       !adaptive && scopedBehaviorId
         ? leafMembers.flatMap(({ leaf, observation, confidence }) => {
-            // Scoped samples come from listForCustomBehaviorSample and carry a
-            // sessionId; guard at runtime (via a widening cast, not an unchecked
-            // one) so a non-scoped observation can never yield a `sessionId:
-            // undefined` assignment.
+            // Scoped/facet samples carry a sessionId; guard at runtime (via a
+            // widening cast, not an unchecked one) so a whole-project topic
+            // observation can never yield a `sessionId: undefined` assignment.
             const sessionId = (observation as Partial<TaxonomyScopedClusteringObservation>).sessionId
             if (sessionId === undefined) return []
             return [
@@ -758,7 +809,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
                 organizationId: input.organizationId,
                 projectId: input.projectId,
                 customBehaviorId: scopedBehaviorId,
-                facetId: null,
+                facetId: facetLensId,
                 observationId: observation.observationId,
                 sessionId,
                 assignedClusterId: leaf.clusterId,
@@ -807,6 +858,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       customAssignments,
       leafClusters,
       customBehaviorId: scopedBehaviorId,
+      facetId: facetLensId,
       deprecatedClusterIds,
       supersededClusterIds: adaptive ? previouslyActive.map((cluster) => cluster.id) : [],
       mode,

--- a/packages/domain/taxonomy/src/use-cases/create-custom-behavior.ts
+++ b/packages/domain/taxonomy/src/use-cases/create-custom-behavior.ts
@@ -21,8 +21,10 @@ import {
   CustomBehaviorFilterInvalidError,
   CustomBehaviorLimitReachedError,
   CustomBehaviorNameInvalidError,
+  FacetInvalidError,
 } from "../errors.ts"
 import { CustomBehaviorRepository } from "../ports/custom-behavior-repository.ts"
+import { FacetRepository } from "../ports/facet-repository.ts"
 import { generateCustomBehavior } from "./generate-custom-behavior.ts"
 
 export interface CreateCustomBehaviorInput {
@@ -30,11 +32,7 @@ export interface CreateCustomBehaviorInput {
   readonly projectId: ProjectId
   readonly name: string
   readonly filterSet: FilterSet
-  /**
-   * The lens. Omit/null = topic (clusters observation embeddings, requires a
-   * non-empty filter). An id = a facet lens (clusters that facet's extracted
-   * projections), which makes an empty filter valid (whole-project through the lens).
-   */
+  /** The lens: omit/null = topic (needs a filter); an id = a facet (empty filter allowed). */
   readonly facetId?: FacetId | null
 }
 
@@ -67,9 +65,7 @@ export const createCustomBehavior = Effect.fn("taxonomy.createCustomBehavior")(f
       message: parsedFilterSet.error.issues[0]?.message ?? "Invalid filter set",
     })
   }
-  // A facet lens makes an empty filter valid (whole-project through the lens). The
-  // only invalid shape is the topic lens with no filter — that's just the live
-  // global tree, not a distinct view.
+  // Only invalid shape is a topic lens with no filter (that's the live global tree).
   if (input.facetId == null && !customBehaviorFilterSetHasConditions(parsedFilterSet.data)) {
     return yield* new CustomBehaviorFilterInvalidError({ message: CUSTOM_BEHAVIOR_EMPTY_FILTER_MESSAGE })
   }
@@ -78,6 +74,18 @@ export const createCustomBehavior = Effect.fn("taxonomy.createCustomBehavior")(f
   const created = yield* sqlClient.transaction(
     Effect.gen(function* () {
       const repo = yield* CustomBehaviorRepository
+
+      // A facet-backed view must reference a lens that exists in THIS project, or its
+      // auto-started garden would fail at `FacetRepository.findById` and a same-org
+      // cross-project facet would garden under mismatched project ids. findById is
+      // org-scoped (RLS), so a missing/cross-org id already surfaces as null here.
+      if (input.facetId != null) {
+        const facets = yield* FacetRepository
+        const facet = yield* facets.findById(input.facetId).pipe(Effect.orElseSucceed(() => null))
+        if (facet === null || facet.projectId !== input.projectId) {
+          return yield* new FacetInvalidError({ field: "facetId", message: "Facet not found in this project" })
+        }
+      }
 
       // Soft cost guard (MVP): count-based, not locked, so concurrent creates may briefly overshoot by a few. Intentional — see LAT-748.
       const existing = yield* repo.countByProject({ projectId: input.projectId })

--- a/packages/domain/taxonomy/src/use-cases/create-custom-behavior.ts
+++ b/packages/domain/taxonomy/src/use-cases/create-custom-behavior.ts
@@ -1,5 +1,6 @@
 import {
   CustomBehaviorId,
+  type FacetId,
   type FilterSet,
   generateId,
   generateSlug,
@@ -29,6 +30,12 @@ export interface CreateCustomBehaviorInput {
   readonly projectId: ProjectId
   readonly name: string
   readonly filterSet: FilterSet
+  /**
+   * The lens. Omit/null = topic (clusters observation embeddings, requires a
+   * non-empty filter). An id = a facet lens (clusters that facet's extracted
+   * projections), which makes an empty filter valid (whole-project through the lens).
+   */
+  readonly facetId?: FacetId | null
 }
 
 export const createCustomBehavior = Effect.fn("taxonomy.createCustomBehavior")(function* (
@@ -60,7 +67,10 @@ export const createCustomBehavior = Effect.fn("taxonomy.createCustomBehavior")(f
       message: parsedFilterSet.error.issues[0]?.message ?? "Invalid filter set",
     })
   }
-  if (!customBehaviorFilterSetHasConditions(parsedFilterSet.data)) {
+  // A facet lens makes an empty filter valid (whole-project through the lens). The
+  // only invalid shape is the topic lens with no filter — that's just the live
+  // global tree, not a distinct view.
+  if (input.facetId == null && !customBehaviorFilterSetHasConditions(parsedFilterSet.data)) {
     return yield* new CustomBehaviorFilterInvalidError({ message: CUSTOM_BEHAVIOR_EMPTY_FILTER_MESSAGE })
   }
 
@@ -91,6 +101,7 @@ export const createCustomBehavior = Effect.fn("taxonomy.createCustomBehavior")(f
         slug,
         name: trimmedName,
         filterSet: parsedFilterSet.data,
+        facetId: input.facetId ?? null,
         status: CustomBehaviorStatus.Pending,
         createdAt: now,
         updatedAt: now,

--- a/packages/domain/taxonomy/src/use-cases/create-facet.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/create-facet.test.ts
@@ -1,0 +1,60 @@
+import { ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { MAX_FACETS_PER_PROJECT } from "../constants.ts"
+import { FacetInvalidError, FacetLimitReachedError } from "../errors.ts"
+import { FacetRepository } from "../ports/facet-repository.ts"
+import { createFakeFacetRepository } from "../testing/fake-facet-repository.ts"
+import { createFacet } from "./create-facet.ts"
+
+const PROJECT_ID = ProjectId("p".repeat(24))
+
+const makeLayer = () => {
+  const { repository, rows } = createFakeFacetRepository()
+  const layer = Layer.mergeAll(
+    Layer.succeed(FacetRepository, repository),
+    Layer.succeed(SqlClient, createFakeSqlClient()),
+  )
+  return { layer, rows }
+}
+
+const validInput = {
+  projectId: PROJECT_ID,
+  name: "Apparent user goal",
+  description: "What the user is ultimately trying to accomplish.",
+  instructions: "In one sentence, what was the user trying to accomplish?",
+}
+
+describe("createFacet", () => {
+  it("persists a lens definition with a slugified name and does not garden on its own", async () => {
+    const { layer, rows } = makeLayer()
+    const facet = await Effect.runPromise(createFacet(validInput).pipe(Effect.provide(layer)))
+
+    expect(facet.slug).toBe("apparent-user-goal")
+    expect(facet.name).toBe("Apparent user goal")
+    expect(facet.instructions).toBe(validInput.instructions)
+    expect(rows.get(facet.id)?.slug).toBe("apparent-user-goal")
+  })
+
+  it("rejects empty instructions (the write-once extraction target must exist)", async () => {
+    const { layer } = makeLayer()
+    await expect(
+      Effect.runPromise(createFacet({ ...validInput, instructions: "   " }).pipe(Effect.provide(layer))),
+    ).rejects.toBeInstanceOf(FacetInvalidError)
+  })
+
+  it("enforces the per-project facet cap", async () => {
+    const { layer } = makeLayer()
+    await expect(
+      Effect.runPromise(
+        Effect.gen(function* () {
+          for (let index = 0; index < MAX_FACETS_PER_PROJECT; index++) {
+            yield* createFacet({ ...validInput, name: `Lens ${index}` })
+          }
+          return yield* createFacet({ ...validInput, name: "One too many" })
+        }).pipe(Effect.provide(layer)),
+      ),
+    ).rejects.toBeInstanceOf(FacetLimitReachedError)
+  })
+})

--- a/packages/domain/taxonomy/src/use-cases/create-facet.ts
+++ b/packages/domain/taxonomy/src/use-cases/create-facet.ts
@@ -1,6 +1,11 @@
 import { FacetId, generateId, generateSlug, type ProjectId, SqlClient, toSlug } from "@domain/shared"
 import { Effect } from "effect"
-import { FACET_INSTRUCTIONS_MAX_LENGTH, FACET_NAME_MAX_LENGTH, MAX_FACETS_PER_PROJECT } from "../constants.ts"
+import {
+  FACET_DESCRIPTION_MAX_LENGTH,
+  FACET_INSTRUCTIONS_MAX_LENGTH,
+  FACET_NAME_MAX_LENGTH,
+  MAX_FACETS_PER_PROJECT,
+} from "../constants.ts"
 import type { TaxonomyFacet } from "../entities/facet.ts"
 import { FacetInvalidError, FacetLimitReachedError } from "../errors.ts"
 import { FacetRepository } from "../ports/facet-repository.ts"
@@ -14,12 +19,7 @@ export interface CreateFacetInput {
   readonly instructions: string
 }
 
-/**
- * Create a facet — a reusable, immutable lens DEFINITION (name, description,
- * write-once instructions). A facet does not garden on its own; a lens produces a
- * tree only when a custom behavior selects it (see `createCustomBehavior`'s
- * `facetId`), so this use-case just persists the definition.
- */
+/** Persist a facet — an immutable lens definition. It gardens only when a custom behavior selects it. */
 export const createFacet = Effect.fn("taxonomy.createFacet")(function* (input: CreateFacetInput) {
   yield* Effect.annotateCurrentSpan("projectId", input.projectId)
 
@@ -49,6 +49,12 @@ export const createFacet = Effect.fn("taxonomy.createFacet")(function* (input: C
   const trimmedDescription = input.description.trim()
   if (trimmedDescription.length === 0) {
     return yield* new FacetInvalidError({ field: "description", message: "Description cannot be empty" })
+  }
+  if (trimmedDescription.length > FACET_DESCRIPTION_MAX_LENGTH) {
+    return yield* new FacetInvalidError({
+      field: "description",
+      message: `Description exceeds ${FACET_DESCRIPTION_MAX_LENGTH} characters`,
+    })
   }
 
   const sqlClient = yield* SqlClient

--- a/packages/domain/taxonomy/src/use-cases/create-facet.ts
+++ b/packages/domain/taxonomy/src/use-cases/create-facet.ts
@@ -1,0 +1,89 @@
+import { FacetId, generateId, generateSlug, type ProjectId, SqlClient, toSlug } from "@domain/shared"
+import { Effect } from "effect"
+import { FACET_INSTRUCTIONS_MAX_LENGTH, FACET_NAME_MAX_LENGTH, MAX_FACETS_PER_PROJECT } from "../constants.ts"
+import type { TaxonomyFacet } from "../entities/facet.ts"
+import { FacetInvalidError, FacetLimitReachedError } from "../errors.ts"
+import { FacetRepository } from "../ports/facet-repository.ts"
+
+export interface CreateFacetInput {
+  readonly id?: FacetId
+  readonly projectId: ProjectId
+  readonly name: string
+  readonly description: string
+  /** Write-once free-text guidance compiled into the extraction prompt. */
+  readonly instructions: string
+}
+
+/**
+ * Create a facet — a reusable, immutable lens DEFINITION (name, description,
+ * write-once instructions). A facet does not garden on its own; a lens produces a
+ * tree only when a custom behavior selects it (see `createCustomBehavior`'s
+ * `facetId`), so this use-case just persists the definition.
+ */
+export const createFacet = Effect.fn("taxonomy.createFacet")(function* (input: CreateFacetInput) {
+  yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+
+  const trimmedName = input.name.trim()
+  if (trimmedName.length === 0) {
+    return yield* new FacetInvalidError({ field: "name", message: "Name cannot be empty" })
+  }
+  if (trimmedName.length > FACET_NAME_MAX_LENGTH) {
+    return yield* new FacetInvalidError({ field: "name", message: `Name exceeds ${FACET_NAME_MAX_LENGTH} characters` })
+  }
+  if (toSlug(trimmedName).length === 0) {
+    return yield* new FacetInvalidError({
+      field: "name",
+      message: "Name must contain at least one letter or number",
+    })
+  }
+  const trimmedInstructions = input.instructions.trim()
+  if (trimmedInstructions.length === 0) {
+    return yield* new FacetInvalidError({ field: "instructions", message: "Instructions cannot be empty" })
+  }
+  if (trimmedInstructions.length > FACET_INSTRUCTIONS_MAX_LENGTH) {
+    return yield* new FacetInvalidError({
+      field: "instructions",
+      message: `Instructions exceed ${FACET_INSTRUCTIONS_MAX_LENGTH} characters`,
+    })
+  }
+  const trimmedDescription = input.description.trim()
+  if (trimmedDescription.length === 0) {
+    return yield* new FacetInvalidError({ field: "description", message: "Description cannot be empty" })
+  }
+
+  const sqlClient = yield* SqlClient
+  const created = yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const repo = yield* FacetRepository
+
+      // Soft cost guard (count-based, not locked, so concurrent creates may briefly overshoot).
+      const existing = yield* repo.countByProject({ projectId: input.projectId })
+      if (existing >= MAX_FACETS_PER_PROJECT) {
+        return yield* new FacetLimitReachedError({ projectId: input.projectId, limit: MAX_FACETS_PER_PROJECT })
+      }
+
+      const slug = yield* generateSlug({
+        name: trimmedName,
+        count: (slug) => repo.countBySlug({ projectId: input.projectId, slug }),
+      })
+
+      const now = new Date()
+      const facet: TaxonomyFacet = {
+        id: input.id ?? FacetId(generateId()),
+        organizationId: sqlClient.organizationId,
+        projectId: input.projectId,
+        slug,
+        name: trimmedName,
+        description: trimmedDescription,
+        instructions: trimmedInstructions,
+        createdAt: now,
+        updatedAt: now,
+      }
+
+      yield* repo.save(facet)
+      return facet
+    }),
+  )
+
+  return created
+})

--- a/packages/domain/taxonomy/src/use-cases/custom-behavior-crud.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/custom-behavior-crud.test.ts
@@ -6,13 +6,17 @@ import { Effect, Exit, Layer } from "effect"
 import { describe, expect, it } from "vitest"
 import { CUSTOM_BEHAVIOR_GARDENING_MIN_INTERVAL_MS, MAX_CUSTOM_BEHAVIORS_PER_PROJECT } from "../constants.ts"
 import { type CustomBehavior, CustomBehaviorStatus } from "../entities/custom-behavior.ts"
+import type { TaxonomyFacet } from "../entities/facet.ts"
 import {
   CustomBehaviorFilterInvalidError,
   CustomBehaviorLimitReachedError,
   CustomBehaviorNameInvalidError,
+  FacetInvalidError,
 } from "../errors.ts"
 import { CustomBehaviorRepository } from "../ports/custom-behavior-repository.ts"
+import { FacetRepository } from "../ports/facet-repository.ts"
 import { createFakeCustomBehaviorRepository } from "../testing/fake-custom-behavior-repository.ts"
+import { createFakeFacetRepository } from "../testing/fake-facet-repository.ts"
 import { createCustomBehavior } from "./create-custom-behavior.ts"
 import { deleteCustomBehavior } from "./delete-custom-behavior.ts"
 import { generateCustomBehavior } from "./generate-custom-behavior.ts"
@@ -38,11 +42,13 @@ const makeBehavior = (overrides: Partial<CustomBehavior> = {}): CustomBehavior =
   ...overrides,
 })
 
-function makeLayer() {
+function makeLayer(facets: readonly TaxonomyFacet[] = []) {
   const { repository, rows } = createFakeCustomBehaviorRepository()
+  const facetRepo = createFakeFacetRepository(facets)
   const queue = createFakeQueuePublisher()
   const layer = Layer.mergeAll(
     Layer.succeed(CustomBehaviorRepository, repository),
+    Layer.succeed(FacetRepository, facetRepo.repository),
     Layer.succeed(QueuePublisher, queue.publisher),
     Layer.succeed(SqlClient, createFakeSqlClient()),
   )
@@ -100,9 +106,22 @@ describe("createCustomBehavior", () => {
     ).rejects.toBeInstanceOf(CustomBehaviorFilterInvalidError)
   })
 
+  const makeFacet = (overrides: Partial<TaxonomyFacet> = {}): TaxonomyFacet => ({
+    id: FacetId("f".repeat(24)),
+    organizationId: ORG_ID,
+    projectId: PROJECT_ID,
+    slug: "user-goal",
+    name: "User goal",
+    description: "What the user is trying to accomplish.",
+    instructions: "In one sentence, what was the user trying to accomplish?",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  })
+
   it("allows an empty filter when a facet lens is chosen (a whole-project facet view) and stores the lens", async () => {
-    const { layer, rows } = makeLayer()
     const facetId = FacetId("f".repeat(24))
+    const { layer, rows } = makeLayer([makeFacet({ id: facetId })])
     const result = await Effect.runPromise(
       createCustomBehavior({ projectId: PROJECT_ID, name: "User goal", filterSet: {}, facetId }).pipe(
         Effect.provide(layer),
@@ -112,6 +131,32 @@ describe("createCustomBehavior", () => {
     expect(rows.get(result.id)?.facetId).toBe(facetId)
     // Still auto-starts gardening — the lens gardens through the custom-behavior sweep.
     expect(result.status).toBe(CustomBehaviorStatus.Generating)
+  })
+
+  it("rejects a facetId that does not exist in the project", async () => {
+    const { layer } = makeLayer() // no facets seeded
+    await expect(
+      Effect.runPromise(
+        createCustomBehavior({
+          projectId: PROJECT_ID,
+          name: "Dangling lens",
+          filterSet: {},
+          facetId: FacetId("f".repeat(24)),
+        }).pipe(Effect.provide(layer)),
+      ),
+    ).rejects.toBeInstanceOf(FacetInvalidError)
+  })
+
+  it("rejects a facetId that belongs to another project (same org)", async () => {
+    const facetId = FacetId("f".repeat(24))
+    const { layer } = makeLayer([makeFacet({ id: facetId, projectId: OTHER_PROJECT_ID })])
+    await expect(
+      Effect.runPromise(
+        createCustomBehavior({ projectId: PROJECT_ID, name: "Cross-project lens", filterSet: {}, facetId }).pipe(
+          Effect.provide(layer),
+        ),
+      ),
+    ).rejects.toBeInstanceOf(FacetInvalidError)
   })
 
   it("rejects an empty name", async () => {

--- a/packages/domain/taxonomy/src/use-cases/custom-behavior-crud.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/custom-behavior-crud.test.ts
@@ -1,6 +1,6 @@
 import { QueuePublisher } from "@domain/queue"
 import { createFakeQueuePublisher } from "@domain/queue/testing"
-import { CustomBehaviorId, type FilterSet, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { CustomBehaviorId, FacetId, type FilterSet, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Exit, Layer } from "effect"
 import { describe, expect, it } from "vitest"
@@ -31,6 +31,7 @@ const makeBehavior = (overrides: Partial<CustomBehavior> = {}): CustomBehavior =
   slug: "refunds",
   name: "Refunds",
   filterSet: FILTER,
+  facetId: null,
   status: CustomBehaviorStatus.Pending,
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -97,6 +98,20 @@ describe("createCustomBehavior", () => {
         createCustomBehavior({ projectId: PROJECT_ID, name: "Everything", filterSet: {} }).pipe(Effect.provide(layer)),
       ),
     ).rejects.toBeInstanceOf(CustomBehaviorFilterInvalidError)
+  })
+
+  it("allows an empty filter when a facet lens is chosen (a whole-project facet view) and stores the lens", async () => {
+    const { layer, rows } = makeLayer()
+    const facetId = FacetId("f".repeat(24))
+    const result = await Effect.runPromise(
+      createCustomBehavior({ projectId: PROJECT_ID, name: "User goal", filterSet: {}, facetId }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+    expect(result.facetId).toBe(facetId)
+    expect(rows.get(result.id)?.facetId).toBe(facetId)
+    // Still auto-starts gardening — the lens gardens through the custom-behavior sweep.
+    expect(result.status).toBe(CustomBehaviorStatus.Generating)
   })
 
   it("rejects an empty name", async () => {

--- a/packages/domain/taxonomy/src/use-cases/extract-facet-projections.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/extract-facet-projections.test.ts
@@ -23,7 +23,6 @@ const facet = (overrides: Partial<TaxonomyFacet> = {}): TaxonomyFacet => ({
   name: "Apparent user goal",
   description: "What the user is ultimately trying to accomplish.",
   instructions: "Summarize, in one sentence, what the user is ultimately trying to accomplish.",
-  status: "ready",
   createdAt: now,
   updatedAt: now,
   ...overrides,

--- a/packages/domain/taxonomy/src/use-cases/gardening.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/gardening.test.ts
@@ -84,6 +84,7 @@ const makeCluster = (overrides: Partial<TaxonomyCluster> = {}): TaxonomyCluster 
   organizationId,
   projectId,
   customBehaviorId: null,
+  facetId: null,
   dimension: "topic",
   parentClusterId: null,
   depth: 0,

--- a/packages/domain/taxonomy/src/use-cases/name-custom-behavior-cluster.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-custom-behavior-cluster.test.ts
@@ -37,6 +37,7 @@ const cluster = (overrides: Partial<TaxonomyCluster> = {}): TaxonomyCluster => (
   organizationId,
   projectId,
   customBehaviorId,
+  facetId: null,
   dimension: "topic",
   parentClusterId: null,
   depth: 0,

--- a/packages/domain/taxonomy/src/use-cases/name-facet-cluster.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-facet-cluster.ts
@@ -1,0 +1,53 @@
+/**
+ * Names one cluster of a facet lens's scoped tree (whole-project or cohort×facet).
+ *
+ * Shares all naming logic (prompts, collision guard, deepest-first ordering)
+ * with the topic taxonomy via `nameClusterCore`; this wrapper only supplies the
+ * facet-scoped naming source: siblings/children from the `(customBehaviorId,
+ * facetId)`-scoped cluster tree, member summaries from the extracted answers in
+ * `taxonomy_facet_projections` (via the `taxonomy_view_assignments` slice), and
+ * the facet's own naming policy. It never reads or writes the topic tree.
+ */
+
+import type { CustomBehaviorId, FacetId, OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import type { TaxonomyCluster } from "../entities/cluster.ts"
+import type { TaxonomyFacet } from "../entities/facet.ts"
+import { TaxonomyViewAssignmentRepository } from "../ports/taxonomy-view-assignment-repository.ts"
+import { facetNamingPolicy, nameClusterCore } from "./name-taxonomy.ts"
+
+export interface NameFacetClusterInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  /** The lens; its `name` + `instructions` drive the per-tree naming policy. */
+  readonly facet: Pick<TaxonomyFacet, "id" | "name" | "instructions">
+  /** The wrapping behavior — every facet view is a custom behavior (whole-project or cohort). */
+  readonly customBehaviorId: CustomBehaviorId
+  readonly clusterId: TaxonomyCluster["id"]
+  readonly now?: Date
+}
+
+export const nameFacetClusterUseCase = (input: NameFacetClusterInput) =>
+  Effect.gen(function* () {
+    const assignments = yield* TaxonomyViewAssignmentRepository
+    const facetId: FacetId = input.facet.id
+    return yield* nameClusterCore(
+      {
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        clusterId: input.clusterId,
+        ...(input.now ? { now: input.now } : {}),
+      },
+      {
+        customBehaviorId: input.customBehaviorId,
+        facetId,
+        policy: facetNamingPolicy(input.facet),
+        listMembers: (params) =>
+          assignments.listClusterMemberObservations({
+            ...params,
+            customBehaviorId: input.customBehaviorId,
+            facetId,
+          }),
+      },
+    )
+  }).pipe(Effect.withSpan("taxonomy.nameFacetCluster"))

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
@@ -34,6 +34,7 @@ const cluster = (overrides: Partial<TaxonomyCluster> = {}): TaxonomyCluster => (
   organizationId,
   projectId,
   customBehaviorId: null,
+  facetId: null,
   dimension: "topic",
   parentClusterId: null,
   depth: 0,
@@ -150,5 +151,40 @@ describe("nameClusterUseCase", () => {
     expect(prompts.join("\n")).toContain(summary)
     expect(prompts.join("\n")).not.toContain(momentId)
     expect(clusters.clusters.get(clusterId)?.name).toBe("Roaming Troubleshooting")
+  })
+
+  // Golden guard: the per-tree naming-policy refactor must leave the TOPIC tree's
+  // prompts byte-identical (the default policy === the previously hard-coded
+  // strings). This is the always-on production naming path; any drift here changes
+  // live topic names. If the topic wording is intentionally changed, update these
+  // literals in the same commit.
+  it("emits byte-identical topic naming prompts under the default policy (golden)", async () => {
+    const systems: string[] = []
+    const summary = "Assistant: reset the roaming settings and explained the next step."
+    const { effect } = runNameCluster({
+      seedObservations: [observation({ projectionMetadata: { summary } })],
+      ai: {
+        generate: <T>(input: GenerateInput<T>) => {
+          systems.push(input.system ?? "")
+          const object = input.prompt.includes("Candidates:")
+            ? { name: "Order Status", description: "Users check on the status of an order they placed." }
+            : { candidates: [{ theme: "order status", examples: [0] }] }
+          return Effect.succeed({ object: object as T, tokens: 10, duration: 1 } satisfies GenerateResult<T>)
+        },
+        embed: () => Effect.die("embed not used"),
+        rerank: () => Effect.die("rerank not used"),
+      },
+    })
+
+    await Effect.runPromise(effect)
+
+    const TOPIC_POLICY =
+      "Conversation topic clusters describe what users come to do (e.g. 'Order Status', 'Returns and Refunds', 'Account Billing'). They are NOT conversational rituals (no 'user greets', 'user thanks', 'user says hello'), NOT model behaviours (no 'agent apologizes'), and NOT generic dispositions ('frustrated user'). If samples disagree, name the dominant topic of the conversation transcripts."
+    const leafModeContext = "These are raw conversation samples. Find the dominant topic across them."
+
+    expect(systems).toEqual([
+      `proposeCandidateThemes: propose concise candidate conversation TOPIC themes for this cluster. ${TOPIC_POLICY} ${leafModeContext} Return only schema-valid JSON.`,
+      `Collapse candidate themes into ONE conversation TOPIC name (2-5 words) and a one-sentence description of what the user is trying to do. ${TOPIC_POLICY} ${leafModeContext} The name MUST be clearly distinct from any forbidden names provided. Return only schema-valid JSON with BOTH required string keys: name and description.`,
+    ])
   })
 })

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
@@ -84,10 +84,11 @@ const observation = (overrides: Partial<TaxonomyMomentObservation> = {}): Taxono
 
 const runNameCluster = (input: {
   readonly seedCluster?: TaxonomyCluster
+  readonly seedClusters?: readonly TaxonomyCluster[]
   readonly seedObservations: readonly TaxonomyMomentObservation[]
   readonly ai: AIShape
 }) => {
-  const clusters = createFakeTaxonomyClusterRepository([input.seedCluster ?? cluster()])
+  const clusters = createFakeTaxonomyClusterRepository(input.seedClusters ?? [input.seedCluster ?? cluster()])
   const observations = createFakeTaxonomyObservationRepository(input.seedObservations)
   const effect = nameClusterUseCase({ organizationId, projectId, clusterId, now }).pipe(
     Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
@@ -185,6 +186,74 @@ describe("nameClusterUseCase", () => {
     expect(systems).toEqual([
       `proposeCandidateThemes: propose concise candidate conversation TOPIC themes for this cluster. ${TOPIC_POLICY} ${leafModeContext} Return only schema-valid JSON.`,
       `Collapse candidate themes into ONE conversation TOPIC name (2-5 words) and a one-sentence description of what the user is trying to do. ${TOPIC_POLICY} ${leafModeContext} The name MUST be clearly distinct from any forbidden names provided. Return only schema-valid JSON with BOTH required string keys: name and description.`,
+    ])
+  })
+
+  // Interior + root modes are named from already-named children (no direct
+  // members), and their modeContext is also parameterized/hardcoded — cover them
+  // too so an edit to the interior `umbrella` string or the root prompt can't
+  // silently change live topic naming.
+  const TOPIC_POLICY_TEXT =
+    "Conversation topic clusters describe what users come to do (e.g. 'Order Status', 'Returns and Refunds', 'Account Billing'). They are NOT conversational rituals (no 'user greets', 'user thanks', 'user says hello'), NOT model behaviours (no 'agent apologizes'), and NOT generic dispositions ('frustrated user'). If samples disagree, name the dominant topic of the conversation transcripts."
+
+  const namedChild = (id: string, parentClusterId: TaxonomyCluster["id"]): TaxonomyCluster =>
+    cluster({
+      id: TaxonomyClusterId(id.repeat(24).slice(0, 24)),
+      parentClusterId,
+      depth: 1,
+      path: `${clusterId}/`,
+      name: `Child ${id}`,
+      description: `Child topic ${id}.`,
+      observationCount: 5,
+    })
+
+  const captureInteriorSystems = async (
+    target: TaxonomyCluster,
+    extraClusters: readonly TaxonomyCluster[] = [],
+  ): Promise<string[]> => {
+    const systems: string[] = []
+    // No observations → members empty → the interior/root branch (name from children).
+    const { effect } = runNameCluster({
+      seedClusters: [target, namedChild("x", target.id), namedChild("y", target.id), ...extraClusters],
+      seedObservations: [],
+      ai: {
+        generate: <T>(input: GenerateInput<T>) => {
+          systems.push(input.system ?? "")
+          const object = input.prompt.includes("Candidates:")
+            ? { name: "Umbrella Label", description: "A broad umbrella over the child topics." }
+            : { candidates: [{ theme: "umbrella", examples: [0] }] }
+          return Effect.succeed({ object: object as T, tokens: 10, duration: 1 } satisfies GenerateResult<T>)
+        },
+        embed: () => Effect.die("embed not used"),
+        rerank: () => Effect.die("rerank not used"),
+      },
+    })
+    await Effect.runPromise(effect)
+    return systems
+  }
+
+  it("keeps interior-mode topic prompts byte-identical (umbrella TOPIC)", async () => {
+    const parentId = TaxonomyClusterId("e".repeat(24))
+    // Seed the named parent so the target resolves to interior mode (not root).
+    const parent = cluster({ id: parentId, name: "Parent Umbrella", description: "Parent.", observationCount: 20 })
+    const interior = cluster({ parentClusterId: parentId, depth: 1, path: `${parentId}/`, observationCount: 10 })
+    const systems = await captureInteriorSystems(interior, [parent])
+    const interiorModeContext =
+      "These are NOT raw conversation samples — they are the names and descriptions of THIS cluster's CHILD topics. Your job is to find a single short umbrella TOPIC that subsumes all of them and is BROADER than every child. The umbrella must not be identical or near-identical to any child."
+    expect(systems).toEqual([
+      `proposeCandidateThemes: propose concise candidate conversation TOPIC themes for this cluster. ${TOPIC_POLICY_TEXT} ${interiorModeContext} Return only schema-valid JSON.`,
+      `Collapse candidate themes into ONE conversation TOPIC name (2-5 words) and a one-sentence description of what the user is trying to do. ${TOPIC_POLICY_TEXT} ${interiorModeContext} The name MUST be clearly distinct from any forbidden names provided. Return only schema-valid JSON with BOTH required string keys: name and description.`,
+    ])
+  })
+
+  it("keeps root-mode topic prompts byte-identical", async () => {
+    const root = cluster({ parentClusterId: null, depth: 0, path: "", observationCount: 10 })
+    const systems = await captureInteriorSystems(root)
+    const rootModeContext =
+      "These are NOT raw conversation samples — they are the names and descriptions of the TOP-LEVEL categories in this entire project's taxonomy. Your job is to produce a SHORT umbrella label that captures the WHOLE project. It MUST cover EVERY listed top-level category — never name something that fits one branch but excludes the others. A correct label feels like 'Customer Support Conversations', 'Internal Helpdesk Tickets', or '<Company> Customer Interactions' — broad and category-neutral. The label must not be identical to or paraphrase any listed category."
+    expect(systems).toEqual([
+      `proposeCandidateThemes: propose concise candidate conversation TOPIC themes for this cluster. ${TOPIC_POLICY_TEXT} ${rootModeContext} Return only schema-valid JSON.`,
+      `Collapse candidate themes into ONE conversation TOPIC name (2-5 words) and a one-sentence description of what the user is trying to do. ${TOPIC_POLICY_TEXT} ${rootModeContext} The name MUST be clearly distinct from any forbidden names provided. Return only schema-valid JSON with BOTH required string keys: name and description.`,
     ])
   })
 })

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
@@ -8,6 +8,7 @@ import {
 import {
   type ChSqlClient,
   type CustomBehaviorId,
+  type FacetId,
   LATITUDE_TELEMETRY_PROJECT_SLUGS,
   type OrganizationId,
   type ProjectId,
@@ -24,11 +25,12 @@ import {
   TAXONOMY_NAMING_TIMEOUT_MS,
 } from "../constants.ts"
 import type { TaxonomyCluster } from "../entities/cluster.ts"
-import type { TaxonomyMomentObservation } from "../entities/observation.ts"
+import type { TaxonomyFacet } from "../entities/facet.ts"
 import { clamp, farthestPointSample } from "../helpers.ts"
 import { withTaxonomyClusterLock } from "../locks.ts"
 import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
 import { TaxonomyObservationRepository } from "../ports/taxonomy-observation-repository.ts"
+import type { TaxonomyClusterNamingMember } from "../ports/taxonomy-view-assignment-repository.ts"
 
 export interface NameClusterInput {
   readonly organizationId: OrganizationId
@@ -67,6 +69,47 @@ const TOPIC_POLICY =
   "Conversation topic clusters describe what users come to do (e.g. 'Order Status', 'Returns and Refunds', 'Account Billing'). They are NOT conversational rituals (no 'user greets', 'user thanks', 'user says hello'), NOT model behaviours (no 'agent apologizes'), and NOT generic dispositions ('frustrated user'). If samples disagree, name the dominant topic of the conversation transcripts."
 
 /**
+ * The per-tree naming policy — the wording that varies between the topic tree
+ * and each facet lens. Everything else about naming (prompts, collision guard,
+ * deepest-first ordering) is shared. `TOPIC_NAMING_POLICY` reproduces the
+ * previously hard-coded topic strings byte-for-byte, so a topic tree named
+ * without an explicit policy is unchanged.
+ */
+export interface ClusterNamingPolicy {
+  /** Domain guidance folded into both naming prompts (was the hard-coded `TOPIC_POLICY`). */
+  readonly guidance: string
+  /** Upper-cased noun used in "conversation X themes/name" and "umbrella X". */
+  readonly subjectLabel: string
+  /** Trailing clause after "a one-sentence description". */
+  readonly descriptionClause: string
+  /** Leaf-mode preamble telling the model what the raw samples are. */
+  readonly leafModeContext: string
+}
+
+export const TOPIC_NAMING_POLICY: ClusterNamingPolicy = {
+  guidance: TOPIC_POLICY,
+  subjectLabel: "TOPIC",
+  descriptionClause: "of what the user is trying to do",
+  leafModeContext: "These are raw conversation samples. Find the dominant topic across them.",
+}
+
+/**
+ * Naming policy for a facet lens: the clusters group one-sentence extracted
+ * statements (not raw transcripts), so the model is told to name the shared
+ * answer to the facet's question rather than a conversation topic.
+ */
+export const facetNamingPolicy = (facet: Pick<TaxonomyFacet, "name" | "instructions">): ClusterNamingPolicy => {
+  const lens = facet.name.trim()
+  const subject = lens.toLowerCase()
+  return {
+    guidance: `Each cluster groups one-sentence statements extracted from separate conversations through the "${lens}" lens: ${facet.instructions} Name each cluster by the shared ${subject} its statements express — a short label, never the lens name itself, never a conversational ritual or generic disposition. If samples disagree, name the dominant one.`,
+    subjectLabel: "THEME",
+    descriptionClause: `of the shared ${subject} these statements express`,
+    leafModeContext: `These are one-sentence statements extracted from separate conversations through the "${lens}" lens. Find the dominant ${subject} across them.`,
+  }
+}
+
+/**
  * Normalize a name so we can detect collisions ("Order Status" vs "order
  * status" vs "Order-Status" should all be treated as the same name).
  */
@@ -81,6 +124,7 @@ interface GenerateInput {
   readonly projectId: ProjectId
   readonly clusterId: TaxonomyCluster["id"]
   readonly mode: "leaf" | "interior" | "root"
+  readonly policy: ClusterNamingPolicy
   readonly samples: readonly string[]
   readonly parentName?: string
   readonly parentDescription?: string
@@ -112,8 +156,8 @@ const generateClusterName = (input: GenerateInput) =>
         input.mode === "root"
           ? "These are NOT raw conversation samples — they are the names and descriptions of the TOP-LEVEL categories in this entire project's taxonomy. Your job is to produce a SHORT umbrella label that captures the WHOLE project. It MUST cover EVERY listed top-level category — never name something that fits one branch but excludes the others. A correct label feels like 'Customer Support Conversations', 'Internal Helpdesk Tickets', or '<Company> Customer Interactions' — broad and category-neutral. The label must not be identical to or paraphrase any listed category."
           : input.mode === "interior"
-            ? "These are NOT raw conversation samples — they are the names and descriptions of THIS cluster's CHILD topics. Your job is to find a single short umbrella TOPIC that subsumes all of them and is BROADER than every child. The umbrella must not be identical or near-identical to any child."
-            : "These are raw conversation samples. Find the dominant topic across them."
+            ? `These are NOT raw conversation samples — they are the names and descriptions of THIS cluster's CHILD topics. Your job is to find a single short umbrella ${input.policy.subjectLabel} that subsumes all of them and is BROADER than every child. The umbrella must not be identical or near-identical to any child.`
+            : input.policy.leafModeContext
       const modelConfig = yield* resolveGenerationConfig("TAXONOMY_NAMING", TAXONOMY_DEFAULT_NAMING_MODEL)
       const map = yield* ai.generate({
         ...modelConfig,
@@ -126,7 +170,7 @@ const generateClusterName = (input: GenerateInput) =>
             { clusterId: input.clusterId, mode: input.mode },
           ),
         },
-        system: `proposeCandidateThemes: propose concise candidate conversation TOPIC themes for this cluster. ${TOPIC_POLICY} ${modeContext} Return only schema-valid JSON.`,
+        system: `proposeCandidateThemes: propose concise candidate conversation ${input.policy.subjectLabel} themes for this cluster. ${input.policy.guidance} ${modeContext} Return only schema-valid JSON.`,
         prompt: `${parentContext}${forbiddenContext}${retryContext}Samples:\n${sampleLines}`,
         schema: candidateThemesSchema,
       })
@@ -141,7 +185,7 @@ const generateClusterName = (input: GenerateInput) =>
             { clusterId: input.clusterId, mode: input.mode },
           ),
         },
-        system: `Collapse candidate themes into ONE conversation TOPIC name (2-5 words) and a one-sentence description of what the user is trying to do. ${TOPIC_POLICY} ${modeContext} The name MUST be clearly distinct from any forbidden names provided. Return only schema-valid JSON with BOTH required string keys: name and description.`,
+        system: `Collapse candidate themes into ONE conversation ${input.policy.subjectLabel} name (2-5 words) and a one-sentence description ${input.policy.descriptionClause}. ${input.policy.guidance} ${modeContext} The name MUST be clearly distinct from any forbidden names provided. Return only schema-valid JSON with BOTH required string keys: name and description.`,
         prompt: `${parentContext}${forbiddenContext}${retryContext}Samples:\n${sampleLines}\n\nCandidates:\n${JSON.stringify(map.object.candidates)}\n\nReturn JSON exactly like {"name":"Short topic label","description":"One sentence describing what these conversations are about."}`,
         schema: finalNameSchema,
       })
@@ -179,21 +223,26 @@ const generateWithCollisionGuard = (input: Omit<GenerateInput, "retryForbiddenNa
   })
 
 /**
- * The scope a cluster is named within. The global taxonomy and each custom
- * behavior share the same prompts, collision guard, and deepest-first ordering
- * and differ only here: which sub-tree the siblings/children come from
- * (`customBehaviorId`), and where the member embeddings/summaries are read from
- * (`listMembers`). `nameClusterCore` owns everything else.
+ * The view a cluster is named within. Every tree (global topic, cohort topic,
+ * and each facet lens) shares the same prompts, collision guard, and
+ * deepest-first ordering and differs only here: which sub-tree the
+ * siblings/children come from (`customBehaviorId` × `facetId`), where the member
+ * embeddings/summaries are read from (`listMembers`), and the wording `policy`.
+ * `nameClusterCore` owns everything else.
  */
 interface ClusterNamingSource {
-  /** Omit for the global taxonomy; set to scope the cluster tree to a behavior. */
-  readonly customBehaviorId?: CustomBehaviorId
+  /** Omit/null for whole-project scope; set to scope the cluster tree to a cohort. */
+  readonly customBehaviorId?: CustomBehaviorId | null
+  /** Omit/null for the topic lens; set to scope the cluster tree to a facet. */
+  readonly facetId?: FacetId | null
+  /** Per-tree naming wording. Defaults to `TOPIC_NAMING_POLICY`. */
+  readonly policy?: ClusterNamingPolicy
   readonly listMembers: (input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
     readonly clusterId: TaxonomyCluster["id"]
     readonly limit: number
-  }) => Effect.Effect<readonly TaxonomyMomentObservation[], RepositoryError, ChSqlClient>
+  }) => Effect.Effect<readonly TaxonomyClusterNamingMember[], RepositoryError, ChSqlClient>
 }
 
 interface NamingContext {
@@ -219,7 +268,10 @@ const loadNamingContext = (input: NameClusterInput, source: ClusterNamingSource)
       cluster.parentClusterId === null
         ? null
         : yield* clusters.findById(cluster.parentClusterId).pipe(Effect.orElseSucceed(() => null))
-    const scope = source.customBehaviorId ? { customBehaviorId: source.customBehaviorId } : {}
+    const scope = {
+      ...(source.customBehaviorId ? { customBehaviorId: source.customBehaviorId } : {}),
+      ...(source.facetId ? { facetId: source.facetId } : {}),
+    }
     const siblings = (yield* clusters.listActiveByProject({
       projectId: input.projectId,
       dimension: cluster.dimension,
@@ -261,13 +313,19 @@ const parentContext = (parent: TaxonomyCluster | null) => ({
   ...(parent && parent.description.trim().length > 0 ? { parentDescription: parent.description } : {}),
 })
 
-const generateName = (input: NameClusterInput, context: NamingContext, members: readonly MemberSummary[]) =>
+const generateName = (
+  input: NameClusterInput,
+  context: NamingContext,
+  members: readonly MemberSummary[],
+  policy: ClusterNamingPolicy,
+) =>
   Effect.gen(function* () {
     const { cluster, parent, children } = context
     const shared = {
       organizationId: input.organizationId,
       projectId: input.projectId,
       clusterId: input.clusterId,
+      policy,
       forbiddenNames: forbiddenNames(context),
       ...parentContext(parent),
     }
@@ -334,12 +392,16 @@ export const nameClusterCore = (input: NameClusterInput, source: ClusterNamingSo
     if (source.customBehaviorId) {
       yield* Effect.annotateCurrentSpan("taxonomy.customBehaviorId", source.customBehaviorId)
     }
+    if (source.facetId) {
+      yield* Effect.annotateCurrentSpan("taxonomy.facetId", source.facetId)
+    }
     yield* Effect.annotateCurrentSpan("taxonomy.clusterId", input.clusterId)
     const now = input.now ?? new Date()
+    const policy = source.policy ?? TOPIC_NAMING_POLICY
 
     const context = yield* loadNamingContext(input, source)
     const members = yield* loadMemberSummaries(input, source)
-    const generated = yield* generateName(input, context, members)
+    const generated = yield* generateName(input, context, members, policy)
     if (generated === null) {
       return {
         name: context.cluster.name,

--- a/packages/domain/taxonomy/src/use-cases/plan-facet-garden.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/plan-facet-garden.test.ts
@@ -1,0 +1,188 @@
+import {
+  AI,
+  type AIShape,
+  EMBEDDING_DIMENSIONS,
+  type EmbedResult,
+  type GenerateInput,
+  type GenerateResult,
+} from "@domain/ai"
+import {
+  ChSqlClient,
+  CustomBehaviorId,
+  FacetId,
+  OrganizationId,
+  ProjectId,
+  SessionId,
+  SqlClient,
+  TaxonomyRunId,
+} from "@domain/shared"
+import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { TaxonomyFacet } from "../entities/facet.ts"
+import type { TaxonomyMomentObservation } from "../entities/observation.ts"
+import { FacetProjectionRepository } from "../ports/facet-projection-repository.ts"
+import { FacetRepository } from "../ports/facet-repository.ts"
+import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
+import { TaxonomyObservationRepository } from "../ports/taxonomy-observation-repository.ts"
+import { createFakeFacetProjectionRepository } from "../testing/fake-facet-projection-repository.ts"
+import { createFakeFacetRepository } from "../testing/fake-facet-repository.ts"
+import { createFakeTaxonomyClusterRepository } from "../testing/fake-taxonomy-cluster-repository.ts"
+import { createFakeTaxonomyObservationRepository } from "../testing/fake-taxonomy-observation-repository.ts"
+import { planFacetGardenUseCase } from "./plan-facet-garden.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const facetId = FacetId("f".repeat(24))
+const customBehaviorId = CustomBehaviorId("b".repeat(24))
+const runId = TaxonomyRunId("r".repeat(24))
+const now = new Date("2026-06-04T00:00:00.000Z")
+const since = new Date("2026-06-01T00:00:00.000Z")
+
+const UNCLEAR_MARKER = "NO-CLEAR-GOAL"
+
+// A full-width unit embedding — clustering builds centroids, which require the
+// configured embedding dimensionality.
+const facetEmbedding = (): number[] => {
+  const vec = new Array(EMBEDDING_DIMENSIONS).fill(0)
+  vec[0] = 1
+  return vec
+}
+
+const facet: TaxonomyFacet = {
+  id: facetId,
+  organizationId,
+  projectId,
+  slug: "apparent-user-goal",
+  name: "Apparent user goal",
+  description: "What the user is trying to accomplish.",
+  instructions: "In one sentence, what was the user ultimately trying to accomplish?",
+  createdAt: now,
+  updatedAt: now,
+}
+
+// Each session's stored transcript summary is what listForFacetSample projects;
+// `unclear` sessions carry the marker so the fake AI reports them as unclear.
+const makeObservation = (index: number, unclear: boolean): TaxonomyMomentObservation => ({
+  organizationId,
+  projectId,
+  observationId: String(index).padStart(24, "0"),
+  sessionId: SessionId(`session-${index}`),
+  analysisHash: "a".repeat(64),
+  momentId: `moment-${index}`,
+  projectionMethod: "moment_text_embedding",
+  projectionHash: "b".repeat(64),
+  projectionMetadata: { summary: unclear ? UNCLEAR_MARKER : `User: help with task ${index}.` },
+  embedding: [1, 0],
+  assignedClusterId: null,
+  assignmentConfidence: 0,
+  assignmentMethod: "noise",
+  reassignmentRunId: null,
+  startTime: new Date(since.getTime() + index * 60_000),
+  endTime: new Date(since.getTime() + index * 60_000 + 1_000),
+  retentionDays: 90,
+  indexedAt: since,
+})
+
+const makeAi = (): AIShape => ({
+  generate: <T>(input: GenerateInput<T>) => {
+    const unclear = input.prompt.includes(UNCLEAR_MARKER)
+    const object = { unclear, answer: unclear ? "" : "The user wants to finish a task." }
+    return Effect.succeed({ object: object as T, tokens: 10, duration: 1 } satisfies GenerateResult<T>)
+  },
+  embed: () => Effect.succeed({ embedding: facetEmbedding() } satisfies EmbedResult),
+  rerank: () => Effect.die("rerank not used"),
+})
+
+const run = (
+  input: Parameters<typeof planFacetGardenUseCase>[0],
+  observations: readonly TaxonomyMomentObservation[],
+) => {
+  const facets = createFakeFacetRepository([facet])
+  const obsRepo = createFakeTaxonomyObservationRepository(observations)
+  const projections = createFakeFacetProjectionRepository([])
+  const clusters = createFakeTaxonomyClusterRepository([])
+  return Effect.runPromise(
+    planFacetGardenUseCase(input).pipe(
+      Effect.provide(Layer.succeed(FacetRepository, facets.repository)),
+      Effect.provide(Layer.succeed(TaxonomyObservationRepository, obsRepo.repository)),
+      Effect.provide(Layer.succeed(FacetProjectionRepository, projections.repository)),
+      Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+      Effect.provide(Layer.succeed(AI, makeAi())),
+      Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+      Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+    ),
+  )
+}
+
+const baseInput = { organizationId, projectId, runId, dimension: "topic" as const, facetId, customBehaviorId, now }
+
+describe("planFacetGardenUseCase", () => {
+  it("samples, extracts, and clusters a facet view; keys clusters + edges by (behavior, facet)", async () => {
+    const observations = Array.from({ length: 20 }, (_, index) => makeObservation(index, false))
+    const plan = await run({ ...baseInput, filterSet: { userId: [{ op: "in", value: ["u"] }] } }, observations)
+
+    expect(plan.facetId).toBe(facetId)
+    expect(plan.customBehaviorId).toBe(customBehaviorId)
+    expect(plan.clustersBorn).toBeGreaterThanOrEqual(1)
+    // All 20 clear projections were clustered (none dropped).
+    expect(plan.observationsSampled).toBe(20)
+    // Facet edges go to the view slice, never the inline global column.
+    expect(plan.observationAssignments).toEqual([])
+    expect(plan.customAssignments.length).toBeGreaterThan(0)
+    expect(plan.customAssignments.every((a) => a.customBehaviorId === customBehaviorId && a.facetId === facetId)).toBe(
+      true,
+    )
+    // sessionId is threaded from the extracted projections.
+    expect(plan.customAssignments.every((a) => (a.sessionId as string).startsWith("session-"))).toBe(true)
+    expect(plan.clusters.every((c) => c.customBehaviorId === customBehaviorId && c.facetId === facetId)).toBe(true)
+  })
+
+  it("excludes unclear projections from clustering", async () => {
+    // 20 clear (≥ the gardening minimum) + 5 unclear; only the clear ones cluster.
+    const observations = [
+      ...Array.from({ length: 20 }, (_, index) => makeObservation(index, false)),
+      ...Array.from({ length: 5 }, (_, index) => makeObservation(100 + index, true)),
+    ]
+    const plan = await run(baseInput, observations)
+
+    // Only the 20 clear projections reach clustering; the 5 unclear are dropped.
+    expect(plan.observationsSampled).toBe(20)
+    const unclearSessionIds = new Set(Array.from({ length: 5 }, (_, index) => `session-${100 + index}`))
+    expect(plan.customAssignments.some((a) => unclearSessionIds.has(a.sessionId as string))).toBe(false)
+  })
+
+  it("compiles the facet's instructions into the extraction prompt", async () => {
+    const systemPrompts: string[] = []
+    const facets = createFakeFacetRepository([facet])
+    const obsRepo = createFakeTaxonomyObservationRepository([makeObservation(0, false)])
+    const projections = createFakeFacetProjectionRepository([])
+    const clusters = createFakeTaxonomyClusterRepository([])
+    const spyingAi: AIShape = {
+      generate: <T>(input: GenerateInput<T>) => {
+        systemPrompts.push(input.system)
+        return Effect.succeed({
+          object: { unclear: false, answer: "goal" } as T,
+          tokens: 1,
+          duration: 1,
+        } satisfies GenerateResult<T>)
+      },
+      embed: () => Effect.succeed({ embedding: facetEmbedding() } satisfies EmbedResult),
+      rerank: () => Effect.die("rerank not used"),
+    }
+
+    await Effect.runPromise(
+      planFacetGardenUseCase(baseInput).pipe(
+        Effect.provide(Layer.succeed(FacetRepository, facets.repository)),
+        Effect.provide(Layer.succeed(TaxonomyObservationRepository, obsRepo.repository)),
+        Effect.provide(Layer.succeed(FacetProjectionRepository, projections.repository)),
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(AI, spyingAi)),
+        Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+      ),
+    )
+
+    expect(systemPrompts.some((prompt) => prompt.includes(facet.instructions))).toBe(true)
+  })
+})

--- a/packages/domain/taxonomy/src/use-cases/plan-facet-garden.ts
+++ b/packages/domain/taxonomy/src/use-cases/plan-facet-garden.ts
@@ -1,0 +1,87 @@
+import type { CustomBehaviorId, FacetId, FilterSet, OrganizationId, ProjectId, TaxonomyRunId } from "@domain/shared"
+import { Effect } from "effect"
+import { TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX, TAXONOMY_GARDENING_SAMPLE_LOOKBACK_DAYS } from "../constants.ts"
+import type { TaxonomyDimension } from "../entities/dimension.ts"
+import { FacetRepository } from "../ports/facet-repository.ts"
+import {
+  TaxonomyObservationRepository,
+  type TaxonomyScopedClusteringObservation,
+} from "../ports/taxonomy-observation-repository.ts"
+import { planHierarchicalTaxonomyUseCase, type TaxonomyClusterBuilder } from "./build-hierarchical-taxonomy.ts"
+import { extractFacetProjectionsUseCase, type FacetExtractionSample } from "./extract-facet-projections.ts"
+
+export interface PlanFacetGardenInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly runId: TaxonomyRunId
+  readonly dimension?: TaxonomyDimension
+  /** The lens to garden. */
+  readonly facetId: FacetId
+  /** Present ⇒ a cohort×facet view: sample only the cohort's sessions. Absent ⇒ whole-project facet. */
+  readonly customBehaviorId?: CustomBehaviorId
+  readonly filterSet?: FilterSet
+  readonly now?: Date
+  /** Offload the k-means build to a worker; omit for the in-process builder (tests). */
+  readonly clusterBuilder?: TaxonomyClusterBuilder
+}
+
+const lookbackStart = (now: Date): Date =>
+  new Date(now.getTime() - TAXONOMY_GARDENING_SAMPLE_LOOKBACK_DAYS * 24 * 60 * 60_000)
+
+/**
+ * Facet gardening plan: sample the facet's scope, extract (extract-if-missing)
+ * its projections, drop the "unclear" ones, and cluster the rest through the
+ * shared planner. The extraction side-effect (AI + projection cache) lives here,
+ * not in `planHierarchicalTaxonomyUseCase`, so that planner stays a pure
+ * embeddings→tree function; this use-case is the facet analogue of the topic
+ * path's in-repo sampling. Always `mode: "off"` — facet clusters live in the
+ * projection embedding space, where the adaptive full-window reassignment (which
+ * routes the observation window) does not apply.
+ */
+export const planFacetGardenUseCase = (input: PlanFacetGardenInput) =>
+  Effect.gen(function* () {
+    const now = input.now ?? new Date()
+    const facets = yield* FacetRepository
+    const facet = yield* facets.findById(input.facetId)
+
+    const observations = yield* TaxonomyObservationRepository
+    const samples = yield* observations.listForFacetSample({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      since: lookbackStart(now),
+      limit: TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX,
+      ...(input.filterSet ? { filterSet: input.filterSet } : {}),
+    })
+    const extractionSamples: FacetExtractionSample[] = samples.map((s) => ({
+      sessionObservationId: s.sessionObservationId,
+      sessionId: s.sessionId,
+      transcript: s.transcript,
+      startTime: s.startTime,
+    }))
+
+    const extraction = yield* extractFacetProjectionsUseCase({ facet, samples: extractionSamples, now })
+    // Unclear projections carry an empty extractedText + no embedding; exclude
+    // them from clustering (the noise path).
+    const lensObservations: readonly TaxonomyScopedClusteringObservation[] = extraction.projections
+      .filter((projection) => projection.extractedText.length > 0 && projection.embedding.length > 0)
+      .map((projection) => ({
+        observationId: projection.sessionObservationId,
+        sessionId: projection.sessionId,
+        startTime: projection.startTime,
+        embedding: projection.embedding,
+      }))
+
+    return yield* planHierarchicalTaxonomyUseCase({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      runId: input.runId,
+      ...(input.dimension ? { dimension: input.dimension } : {}),
+      now,
+      mode: "off",
+      facetId: input.facetId,
+      ...(input.customBehaviorId ? { customBehaviorId: input.customBehaviorId } : {}),
+      ...(input.filterSet ? { filterSet: input.filterSet } : {}),
+      ...(input.clusterBuilder ? { clusterBuilder: input.clusterBuilder } : {}),
+      lensObservations,
+    })
+  }).pipe(Effect.withSpan("taxonomy.planFacetGarden"))

--- a/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
@@ -88,6 +88,7 @@ const makeCluster = (overrides: Partial<TaxonomyCluster> = {}): TaxonomyCluster 
   organizationId,
   projectId,
   customBehaviorId: null,
+  facetId: null,
   dimension: "topic",
   parentClusterId: null,
   depth: 0,

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
@@ -576,3 +576,113 @@ describe("TaxonomyObservationRepositoryLive.listForCustomBehaviorSample", () => 
     expect(sample[0]?.sessionId).toBe(matchSession)
   })
 })
+
+describe("TaxonomyObservationRepositoryLive.listForFacetSample", () => {
+  it("projects each session's ids, start time, and transcript summary (whole-project, no filter)", async () => {
+    const scopedProjectId = ProjectId("u".repeat(24))
+    const at = new Date("2026-05-24T12:00:00.000Z")
+    await ch.client.insert({
+      table: "taxonomy_observations",
+      values: [
+        makeObservationRow(
+          makeObservation({
+            observationId: "g".repeat(24),
+            projectId: scopedProjectId,
+            sessionId: SessionId("facet-session-1"),
+            projectionMetadata: { summary: "User: cancel my order. Assistant: done." },
+            startTime: at,
+          }),
+        ),
+      ],
+      format: "JSONEachRow",
+    })
+
+    const sample = await runWithRepository(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyObservationRepository
+        return yield* repo.listForFacetSample({
+          organizationId,
+          projectId: scopedProjectId,
+          since: new Date("2026-05-23T00:00:00.000Z"),
+          limit: 10,
+        })
+      }),
+    )
+
+    expect(sample).toHaveLength(1)
+    expect(sample[0]?.sessionObservationId).toBe("g".repeat(24))
+    expect(sample[0]?.sessionId).toBe("facet-session-1")
+    expect(sample[0]?.transcript).toBe("User: cancel my order. Assistant: done.")
+  })
+
+  it("scopes the facet sample to a cohort's sessions when a filterSet is supplied (cohort × facet)", async () => {
+    const scopedProjectId = ProjectId("v".repeat(24))
+    const matchSession = "facet-cohort-match"
+    const otherSession = "facet-cohort-other"
+    const at = new Date("2026-05-24T12:00:00.000Z")
+
+    await ch.client.insert({
+      table: "spans",
+      values: [
+        makeLlmSpanRow({
+          projectId: scopedProjectId,
+          sessionId: matchSession,
+          model: "gpt-4",
+          startTime: at,
+          traceId: "ft1",
+          spanId: "fs1",
+        }),
+        makeLlmSpanRow({
+          projectId: scopedProjectId,
+          sessionId: otherSession,
+          model: "claude-3",
+          startTime: at,
+          traceId: "ft2",
+          spanId: "fs2",
+        }),
+      ],
+      format: "JSONEachRow",
+    })
+    await ch.client.insert({
+      table: "taxonomy_observations",
+      values: [
+        makeObservationRow(
+          makeObservation({
+            observationId: "h".repeat(24),
+            projectId: scopedProjectId,
+            sessionId: SessionId(matchSession),
+            projectionMetadata: { summary: "matched" },
+            startTime: at,
+          }),
+        ),
+        makeObservationRow(
+          makeObservation({
+            observationId: "i".repeat(24),
+            projectId: scopedProjectId,
+            sessionId: SessionId(otherSession),
+            projectionMetadata: { summary: "excluded" },
+            startTime: at,
+          }),
+        ),
+      ],
+      format: "JSONEachRow",
+    })
+
+    const sample = await runWithRepository(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyObservationRepository
+        return yield* repo.listForFacetSample({
+          organizationId,
+          projectId: scopedProjectId,
+          since: new Date("2026-05-23T00:00:00.000Z"),
+          limit: 10,
+          filterSet: { models: [{ op: "in", value: ["gpt-4"] }] },
+        })
+      }),
+    )
+
+    expect(sample).toHaveLength(1)
+    expect(sample[0]?.sessionObservationId).toBe("h".repeat(24))
+    expect(sample[0]?.transcript).toBe("matched")
+  })
+})

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
@@ -547,6 +547,98 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
             )
         }),
 
+      listForFacetSample: ({ organizationId, projectId, since, limit, filterSet }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const resolvedFilterSet = filterSet
+            ? yield* resolvePercentileFilters(organizationId, projectId, filterSet)
+            : undefined
+          return yield* chSqlClient
+            .query(async (client) => {
+              // Same day-stratified window + optional cohort session scoping as
+              // listForCustomBehaviorSample; additionally projects the stored
+              // transcript summary so the caller can build FacetExtractionSample.
+              let matchingSessionsClause = ""
+              let filterParams: Record<string, unknown> = {}
+              if (resolvedFilterSet) {
+                const { havingClauses, whereClauses, params } = buildSessionFilterClauses(resolvedFilterSet)
+                filterParams = params
+                const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
+                const havingClause = havingClauses.length > 0 ? `HAVING ${havingClauses.join(" AND ")}` : ""
+                matchingSessionsClause = `AND session_id IN (
+                        SELECT session_id
+                        FROM (
+                          SELECT ${LIST_SELECT}
+                          FROM sessions
+                          WHERE organization_id = {organizationId:String}
+                            AND project_id = {projectId:String}
+                            ${extraWhere}
+                          GROUP BY organization_id, project_id, session_id
+                          ${havingClause}
+                        )
+                      )`
+              }
+              const result = await client.query({
+                query: `SELECT
+                          observation_id,
+                          session_id,
+                          start_time,
+                          JSONExtractString(projection_metadata, 'summary') AS transcript
+                        FROM taxonomy_observations FINAL
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND ${validObservationIdClause}
+                          AND length(embedding) > 0
+                          AND start_time >= {since:DateTime64(9, 'UTC')}
+                          ${matchingSessionsClause}
+                          AND observation_id IN (
+                            SELECT observation_id
+                            FROM (
+                              SELECT
+                                observation_id,
+                                row_number() OVER (
+                                  PARTITION BY toDate(start_time)
+                                  ORDER BY cityHash64(observation_id)
+                                ) AS rn
+                              FROM taxonomy_observations FINAL
+                              WHERE organization_id = {organizationId:String}
+                                AND project_id = {projectId:String}
+                                AND ${validObservationIdClause}
+                                AND length(embedding) > 0
+                                AND start_time >= {since:DateTime64(9, 'UTC')}
+                                ${matchingSessionsClause}
+                            )
+                            ORDER BY rn ASC, observation_id ASC
+                            LIMIT {limit:UInt32}
+                          )
+                        ORDER BY start_time DESC, observation_id ASC`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  since: formatCHDate(since),
+                  limit,
+                  ...filterParams,
+                },
+                format: "JSONEachRow",
+              })
+              const rows = await result.json<{
+                observation_id: string
+                session_id: string
+                start_time: string
+                transcript: string
+              }>()
+              return rows.map((row) => ({
+                sessionObservationId: row.observation_id,
+                sessionId: SessionId(row.session_id),
+                startTime: parseCHDate(row.start_time),
+                transcript: row.transcript,
+              }))
+            })
+            .pipe(
+              Effect.mapError((error) => toRepositoryError(error, "TaxonomyObservationRepository.listForFacetSample")),
+            )
+        }),
+
       listWindowForReassignment: ({ organizationId, projectId, limit, filterSet, excludeAssignedClusterIds }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-view-assignment-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-view-assignment-repository.test.ts
@@ -225,8 +225,77 @@ describe("TaxonomyViewAssignmentRepositoryLive", () => {
     // Only clusterA members of THIS behavior, newest-first — excludes clusterB (m3)
     // and the other behavior's clusterA assignment (m4). The joined rows carry the
     // global observation's embedding + summary the naming step reads.
-    expect(observations.map((o) => o.observationId)).toEqual([m2, m1])
-    expect(observations[0]?.projectionMetadata).toEqual({ summary: "user asks about refunds" })
+    expect(observations.map((o) => o.projectionMetadata.summary)).toEqual([
+      "user asks about refunds",
+      "user asks about billing",
+    ])
     expect(observations[0]?.embedding).toEqual([1, 0, 0])
+  })
+
+  it("deleteByBehavior purges the cohort's edges across BOTH lenses (topic + facet)", async () => {
+    const cb = CustomBehaviorId("del".padEnd(24, "0"))
+    await run(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyViewAssignmentRepository
+        yield* repo.upsertMany([
+          makeAssignment({ observationId: "dt".padEnd(24, "0"), customBehaviorId: cb, facetId: null }),
+          makeAssignment({ observationId: "df".padEnd(24, "0"), customBehaviorId: cb, facetId }),
+        ])
+        yield* repo.deleteByBehavior({ organizationId, projectId, customBehaviorId: cb })
+      }),
+    )
+    // Count across ALL facet_ids for the behavior: the fix drops the `facet_id = ''`
+    // filter so a facet-lens edge is purged with its cohort, never orphaned.
+    const result = await ch.client.query({
+      query: `SELECT count() AS c FROM taxonomy_view_assignments FINAL WHERE custom_behavior_id = {cb:String}`,
+      query_params: { cb: cb as string },
+      format: "JSONEachRow",
+    })
+    const [row] = await result.json<{ c: string | number }>()
+    expect(Number(row?.c ?? -1)).toBe(0)
+  })
+
+  it("reads facet-lens cluster members from taxonomy_facet_projections (not taxonomy_observations)", async () => {
+    const fp = "fp".padEnd(24, "0")
+    await ch.client.insert({
+      table: "taxonomy_facet_projections",
+      values: [
+        {
+          organization_id: organizationId as string,
+          project_id: projectId as string,
+          facet_id: facetId as string,
+          session_observation_id: fp,
+          session_id: "session-fp",
+          extracted_text: "the user wants to cancel a subscription",
+          analysis_hash: "a".repeat(64),
+          embedding: [0, 1, 0],
+          start_time: toCh(now),
+          retention_days: 90,
+          indexed_at: toCh(now),
+        },
+      ],
+      format: "JSONEachRow",
+    })
+
+    const members = await run(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyViewAssignmentRepository
+        yield* repo.upsertMany([makeAssignment({ observationId: fp, assignedClusterId: clusterA, facetId })])
+        return yield* repo.listClusterMemberObservations({
+          organizationId,
+          projectId,
+          customBehaviorId,
+          facetId,
+          clusterId: clusterA,
+          limit: 100,
+        })
+      }),
+    )
+
+    expect(members).toHaveLength(1)
+    // The facet member's "summary" is its extracted one-sentence answer, and its
+    // embedding is the facet-projection embedding — not the observation's.
+    expect(members[0]?.projectionMetadata.summary).toBe("the user wants to cancel a subscription")
+    expect(members[0]?.embedding).toEqual([0, 1, 0])
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-view-assignment-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-view-assignment-repository.test.ts
@@ -244,8 +244,6 @@ describe("TaxonomyViewAssignmentRepositoryLive", () => {
         yield* repo.deleteByBehavior({ organizationId, projectId, customBehaviorId: cb })
       }),
     )
-    // Count across ALL facet_ids for the behavior: the fix drops the `facet_id = ''`
-    // filter so a facet-lens edge is purged with its cohort, never orphaned.
     const result = await ch.client.query({
       query: `SELECT count() AS c FROM taxonomy_view_assignments FINAL WHERE custom_behavior_id = {cb:String}`,
       query_params: { cb: cb as string },
@@ -293,8 +291,6 @@ describe("TaxonomyViewAssignmentRepositoryLive", () => {
     )
 
     expect(members).toHaveLength(1)
-    // The facet member's "summary" is its extracted one-sentence answer, and its
-    // embedding is the facet-projection embedding — not the observation's.
     expect(members[0]?.projectionMetadata.summary).toBe("the user wants to cancel a subscription")
     expect(members[0]?.embedding).toEqual([0, 1, 0])
   })

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-view-assignment-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-view-assignment-repository.ts
@@ -2,6 +2,7 @@ import type { ClickHouseClient } from "@clickhouse/client"
 import {
   ChSqlClient,
   type ChSqlClientShape,
+  CustomBehaviorId,
   FacetId,
   OrganizationId,
   ProjectId,
@@ -76,7 +77,7 @@ const toDomain = (row: TaxonomyViewAssignmentRow): TaxonomyViewAssignment =>
   taxonomyViewAssignmentSchema.parse({
     organizationId: OrganizationId(row.organization_id),
     projectId: ProjectId(row.project_id),
-    customBehaviorId: row.custom_behavior_id,
+    customBehaviorId: CustomBehaviorId(row.custom_behavior_id),
     facetId: row.facet_id === "" ? null : FacetId(row.facet_id),
     observationId: row.observation_id,
     sessionId: SessionId(row.session_id),
@@ -237,42 +238,70 @@ export const TaxonomyViewAssignmentRepositoryLive = Layer.effect(
             )
         }),
 
-      // Resolve a scoped cluster's members back to the global taxonomy_observations
-      // rows for the embeddings + summaries the naming step needs. Read-only on the
-      // global table.
-      listClusterMemberObservations: ({ organizationId, projectId, customBehaviorId, clusterId, limit }) =>
+      // Resolve a scoped cluster's members for the naming step. The topic lens
+      // (facetId null) joins the slice back to `taxonomy_observations` for the
+      // transcript summaries; a facet lens joins to `taxonomy_facet_projections`
+      // for the extracted one-sentence answers. Read-only on both source tables.
+      listClusterMemberObservations: ({ organizationId, projectId, customBehaviorId, facetId, clusterId, limit }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const customBehaviorParam = customBehaviorId as string
+          const facetParam = (facetId ?? "") as string
+          const memberIds = `
+            SELECT observation_id
+            FROM taxonomy_view_assignments FINAL
+            WHERE organization_id = {organizationId:String}
+              AND project_id = {projectId:String}
+              AND custom_behavior_id = {customBehaviorId:String}
+              AND facet_id = {facetId:String}
+              AND assigned_cluster_id = {clusterId:String}`
           return yield* chSqlClient
             .query(async (client) => {
+              const query =
+                facetParam === ""
+                  ? `SELECT ${taxonomyObservationSelectColumns}
+                     FROM taxonomy_observations FINAL
+                     WHERE organization_id = {organizationId:String}
+                       AND project_id = {projectId:String}
+                       AND ${validObservationIdClause}
+                       AND observation_id IN (${memberIds})
+                     ORDER BY start_time DESC, observation_id ASC
+                     LIMIT {limit:UInt32}`
+                  : `SELECT embedding, extracted_text, start_time
+                     FROM taxonomy_facet_projections FINAL
+                     WHERE organization_id = {organizationId:String}
+                       AND project_id = {projectId:String}
+                       AND facet_id = {facetId:String}
+                       AND length(extracted_text) > 0
+                       AND session_observation_id IN (${memberIds})
+                     ORDER BY start_time DESC, session_observation_id ASC
+                     LIMIT {limit:UInt32}`
               const result = await client.query({
-                query: `SELECT ${taxonomyObservationSelectColumns}
-                        FROM taxonomy_observations FINAL
-                        WHERE organization_id = {organizationId:String}
-                          AND project_id = {projectId:String}
-                          AND ${validObservationIdClause}
-                          AND observation_id IN (
-                            SELECT observation_id
-                            FROM taxonomy_view_assignments FINAL
-                            WHERE organization_id = {organizationId:String}
-                              AND project_id = {projectId:String}
-                              AND custom_behavior_id = {customBehaviorId:String}
-                              AND facet_id = ''
-                              AND assigned_cluster_id = {clusterId:String}
-                          )
-                        ORDER BY start_time DESC, observation_id ASC
-                        LIMIT {limit:UInt32}`,
+                query,
                 query_params: {
                   organizationId: organizationId as string,
                   projectId: projectId as string,
-                  customBehaviorId: customBehaviorId as string,
+                  customBehaviorId: customBehaviorParam,
+                  facetId: facetParam,
                   clusterId: clusterId as string,
                   limit,
                 },
                 format: "JSONEachRow",
               })
-              const rows = await result.json<TaxonomyObservationRow>()
-              return rows.map(toDomainObservation)
+              if (facetParam === "") {
+                const rows = await result.json<TaxonomyObservationRow>()
+                return rows.map(toDomainObservation)
+              }
+              const rows = await result.json<{
+                embedding: readonly number[]
+                extracted_text: string
+                start_time: string
+              }>()
+              return rows.map((row) => ({
+                embedding: row.embedding,
+                startTime: parseCHDate(row.start_time),
+                projectionMetadata: { summary: row.extracted_text },
+              }))
             })
             .pipe(
               Effect.mapError((error) =>
@@ -281,6 +310,9 @@ export const TaxonomyViewAssignmentRepositoryLive = Layer.effect(
             )
         }),
 
+      // Purge a cohort's edges across BOTH lenses — its topic slice AND every
+      // facet-lens slice applied to it — so deleting a cohort never orphans
+      // facet-lens edges (no `facet_id = ''` filter here).
       deleteByBehavior: ({ organizationId, projectId, customBehaviorId }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
@@ -290,8 +322,7 @@ export const TaxonomyViewAssignmentRepositoryLive = Layer.effect(
                 query: `DELETE FROM taxonomy_view_assignments
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
-                          AND custom_behavior_id = {customBehaviorId:String}
-                          AND facet_id = ''`,
+                          AND custom_behavior_id = {customBehaviorId:String}`,
                 query_params: {
                   organizationId: organizationId as string,
                   projectId: projectId as string,
@@ -301,6 +332,29 @@ export const TaxonomyViewAssignmentRepositoryLive = Layer.effect(
             })
             .pipe(
               Effect.mapError((error) => toRepositoryError(error, "TaxonomyViewAssignmentRepository.deleteByBehavior")),
+            )
+        }),
+
+      // Purge a facet's edges across every scope (whole-project + each cohort).
+      deleteByFacet: ({ organizationId, projectId, facetId }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          yield* chSqlClient
+            .query(async (client) => {
+              await client.command({
+                query: `DELETE FROM taxonomy_view_assignments
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND facet_id = {facetId:String}`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  facetId: facetId as string,
+                },
+              })
+            })
+            .pipe(
+              Effect.mapError((error) => toRepositoryError(error, "TaxonomyViewAssignmentRepository.deleteByFacet")),
             )
         }),
     }

--- a/packages/platform/db-postgres/drizzle/.migration-lock
+++ b/packages/platform/db-postgres/drizzle/.migration-lock
@@ -4,6 +4,6 @@
 # create migrations in parallel, preventing incompatible
 # migrations from being merged without conflict resolution.
 #
-# Generated: 2026-07-22T13:39:31.140Z
-# Hash: c55c3278-a5ec-4c82-8c7e-fae2290f5118
+# Generated: 2026-07-23T08:26:06.621Z
+# Hash: 41b84074-0d1f-4c0c-a126-53fc6909247f
 # Do not manually edit this file.

--- a/packages/platform/db-postgres/drizzle/20260723082606_facets-gardening/migration.sql
+++ b/packages/platform/db-postgres/drizzle/20260723082606_facets-gardening/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "latitude"."custom_behaviors" ADD COLUMN "facet_id" varchar(24);--> statement-breakpoint
+ALTER TABLE "latitude"."taxonomy_facets" DROP COLUMN "status";

--- a/packages/platform/db-postgres/drizzle/20260723082606_facets-gardening/snapshot.json
+++ b/packages/platform/db-postgres/drizzle/20260723082606_facets-gardening/snapshot.json
@@ -1,0 +1,12642 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "a977d34d-f4f8-40cc-8ba8-9f089789ba87",
+  "prevIds": [
+    "2667ca42-f3a4-4d17-a61a-9a49e35cda34"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": true,
+      "name": "agent_dispatch_configs",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "agent_dispatch_credentials",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "agent_dispatches",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "incidents",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "annotation_queue_items",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "annotation_queues",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "api_keys",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "accounts",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "invitations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "members",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_access_tokens",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "oauth_applications",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_consents",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "sso_providers",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "subscriptions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verifications",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "billing_overrides",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "billing_usage_events",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "billing_usage_periods",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "custom_behaviors",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "datasets",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "dataset_versions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "destination_sources",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "destination_sync_runs",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "destinations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "evaluations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "experiments",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "feature_flags",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "organization_feature_flags",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "flaggers",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "integrations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "monitors",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "notifications",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "organization_claims",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "outbox_events",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "projects",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "sandboxes",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "saved_searches",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "scores",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "showcase",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "signals",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "simulations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "slack_deliveries",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "slack_integration_details",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "taxonomy_cluster_lineage",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "taxonomy_clusters",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "taxonomy_facets",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "taxonomy_runs",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "wrapped_reports",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "integration_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "triggers",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "target",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "prompt_template",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "guardrails",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "integration_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cursor_api_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "claude_routine_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "linear_api_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "webhook_secret",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "config_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "claimed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dispatched_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "external_agent_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "external_run_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "external_url",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error_category",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error_detail",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "severity",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "condition",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "entry_signals",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "exit_eligible_since",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "queue_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_by",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "review_started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "system",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "instructions",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "assignees",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "total_items",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "completed_items",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_secret",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "redirect_urls",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "disabled",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consent_given",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "parent_org_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impersonated_by",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issuer",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "oidc_config",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "saml_config",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "domain_verified",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "enforced",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_subscription_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "'incomplete'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trial_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trial_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at_period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canceled_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seats",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_interval",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_schedule_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'user'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "banned",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_reason",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_expires",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "job_title",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "phone_number",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notification_preferences",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "included_credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "retention_days",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notes",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "action",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "happened_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_period_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan_slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "included_credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "consumed_credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "overage_credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "reported_overage_credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "overage_amount_mills",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "varchar(80)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filter_set",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "facet_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_gardened_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "file_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "columns",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "current_version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataset_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_inserted",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_updated",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_deleted",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'api'",
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "destination_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'enabled'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "config",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "watermark",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "watermark_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "coverage_start_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backfill_started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backfill_progress_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_run_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "consecutive_empty_runs",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "destination_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'live'",
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "window_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "window_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "spans_read",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "events_sent",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "events_dropped",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "config",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "credentials",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "consecutive_failures",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_failure_message",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "signal_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "script",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "script_hash",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "alignment",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aligned_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'[]'",
+      "generated": null,
+      "identity": null,
+      "name": "variants",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "enabled_for_all",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "enabled_by_admin_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "10",
+      "generated": null,
+      "identity": null,
+      "name": "sampling",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vendor_account_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "installed_by_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "installed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "system",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "target_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "target_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "config",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "severity",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "muted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seen_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "emailed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "claimed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "aggregate_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "published",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "occurred_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_trace_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_edited_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "linked_project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "varchar(20)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_activity_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "query",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filter_set",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "span_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "simulation_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "signal_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "passed",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "feedback",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "errored",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "duration",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "tokens",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "cost",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "drafted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "annotator_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "current_project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "next_project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "next_state",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "uuid",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'system'",
+      "generated": null,
+      "identity": null,
+      "name": "origin",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filters",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "assignee_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "priority",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "centroid",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "vector(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "centroid_embedding",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "tsvector",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "\n          setweight(to_tsvector('english', coalesce(name, '')), 'A') ||\n          setweight(to_tsvector('english', coalesce(description, '')), 'B')\n        ",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "search_document",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "clustered_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ignored_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "regressed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "muted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataset",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "evaluations",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "passed",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "errored",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "integration_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "channel_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "claimed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "posted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "message_ts",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "integration_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "team_name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "app_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bot_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bot_access_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bot_token_scopes",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reconnect_required_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "routes",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "run_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transition_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "from_cluster_ids",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "to_cluster_ids",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "similarity",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "custom_behavior_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "facet_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "parent_cluster_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "depth",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "path",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "split_link_threshold",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(80)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(280)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "centroid",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "vector(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "centroid_embedding",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "tsvector",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "\n          setweight(to_tsvector('english', coalesce(name, '')), 'A') ||\n          setweight(to_tsvector('english', coalesce(description, '')), 'B')\n        ",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "search_document",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "observation_count",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "merged_into_cluster_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_observed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_observed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "clustered_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "type": "varchar(80)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "type": "varchar(300)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "type": "varchar(4000)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "instructions",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_gardened_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "custom_behavior_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "facet_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "observations_scanned",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "observations_available",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "observations_sampled",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'day_stratified_hash_round_robin'",
+      "generated": null,
+      "identity": null,
+      "name": "sample_strategy",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1500",
+      "generated": null,
+      "identity": null,
+      "name": "sample_cap",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "noise_scanned",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "clusters_born",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "clusters_merged",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "clusters_deprecated",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'claude_code'",
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "window_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "window_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "owner_name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "report_version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "report",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatch_configs_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "integration_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatch_configs_integration_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "integration_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"project_id\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatch_configs_default_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "integration_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"project_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatch_configs_project_integration_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatches_idempotency_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatches_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "config_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatches_config_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "started_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "incidents_project_started_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "source_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "started_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "incidents_source_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "ended_at IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "incidents_open_source_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "queue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "completed_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "annotation_queue_items_queue_progress_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "annotation_queues_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "api_keys_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_email_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "inviter_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_inviterId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "client_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthAccessTokens_clientId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthAccessTokens_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthApplications_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthApplications_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "client_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthConsents_clientId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthConsents_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "parent_org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_parent_org_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"expires_at\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_expires_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "active_organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_activeOrganizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ssoProviders_organizationId_unique_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ssoProviders_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ssoProviders_domain_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ssoProviders_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "reference_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "period_end",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "subscriptions_reference_status_period_end_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_period_start",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "billing_usage_events_period_idempotency_key_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "happened_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "billing_usage_events_org_happened_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "billing_usage_events_idempotency_key_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "period_start",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "period_end",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "billing_usage_periods_org_period_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "custom_behaviors_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "datasets_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "datasets_project_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dataset_versions_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "dataset_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "version",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dataset_versions_dataset_id_version_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "last_run_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "destination_sources_last_run_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "destination_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "started_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "destination_sync_runs_destination_id_started_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "finished_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "brin",
+      "concurrently": false,
+      "name": "destination_sync_runs_finished_at_brin_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "destinations_project_id_kind_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "destinations_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "archived_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_project_lifecycle_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "signal_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_signal_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "signal_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"deleted_at\" IS NULL AND \"archived_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_active_detector_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "signal_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"deleted_at\" IS NULL AND \"archived_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_active_detector_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "deleted_at IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "experiments_project_slug_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "deleted_at IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "experiments_org_project_active_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_feature_flags_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_feature_flags_identifier_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "flaggers_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "integrations_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"revoked_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "integrations_active_organization_kind_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "vendor_account_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"revoked_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "integrations_active_kind_vendor_account_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "vendor_account_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "integrations_kind_vendor_account_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "deleted_at IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "monitors_project_slug_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "deleted_at IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "monitors_org_project_active_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "\"config\"->'filterSet'",
+          "isExpression": true,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "deleted_at IS NULL",
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "monitors_config_filter_set_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_recent_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"seen_at\" is null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_unread_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_idempotency_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"project_id\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_org_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "token_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_claims_token_hash_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_claims_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_events_workspace_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "aggregate_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_events_aggregate_type_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "projects_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "linked_project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "projects_linked_project_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "last_activity_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sandboxes_status_last_activity_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_by_user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sandboxes_created_by_user_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "saved_searches_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "saved_searches_project_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_source_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"source_type\" = 'evaluation' AND \"drafted_at\" IS NULL AND \"trace_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_canonical_evaluation_trace_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "signal_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"signal_id\" IS NOT NULL AND \"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_signal_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"trace_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_trace_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"session_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_session_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "span_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"span_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_span_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL AND \"errored\" = false AND \"passed\" = false AND \"signal_id\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_signal_discovery_work_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "updated_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_draft_finalization_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "ignored_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "resolved_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "muted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "signals_project_lifecycle_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "search_document",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "signals_search_document_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"deleted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "signals_unique_slug_per_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "simulations_project_created_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "channel_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "slack_deliveries_claim_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "integration_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "slack_deliveries_integration_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "slack_integration_details_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "taxonomy_cluster_lineage_project_created_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "state",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "last_observed_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "taxonomy_clusters_project_state_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "search_document",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "taxonomy_clusters_search_document_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "taxonomy_facets_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "started_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "taxonomy_runs_project_started_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "wrapped_reports_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "wrapped_reports_type_project_recent_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "accounts_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_inviter_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "client_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "oauth_applications",
+      "columnsTo": [
+        "client_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_access_tokens_client_id_oauth_applications_client_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_access_tokens_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_applications_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_applications_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "client_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "oauth_applications",
+      "columnsTo": [
+        "client_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_consents_client_id_oauth_applications_client_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_consents_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sso_providers_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sso_providers_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "columns": [
+        "id",
+        "billing_period_start"
+      ],
+      "nameExplicit": false,
+      "name": "billing_usage_events_pkey",
+      "entityType": "pks",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "columns": [
+        "destination_id",
+        "source"
+      ],
+      "nameExplicit": false,
+      "name": "destination_source_cursors_pkey",
+      "entityType": "pks",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_dispatch_configs_pkey",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "integration_id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_dispatch_credentials_pkey",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_dispatches_pkey",
+      "schema": "latitude",
+      "table": "agent_dispatches",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "incidents_pkey",
+      "schema": "latitude",
+      "table": "incidents",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "annotation_queue_items_pkey",
+      "schema": "latitude",
+      "table": "annotation_queue_items",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "annotation_queues_pkey",
+      "schema": "latitude",
+      "table": "annotation_queues",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "api_keys_pkey",
+      "schema": "latitude",
+      "table": "api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pkey",
+      "schema": "latitude",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "invitations_pkey",
+      "schema": "latitude",
+      "table": "invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "members_pkey",
+      "schema": "latitude",
+      "table": "members",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_access_tokens_pkey",
+      "schema": "latitude",
+      "table": "oauth_access_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_applications_pkey",
+      "schema": "latitude",
+      "table": "oauth_applications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_consents_pkey",
+      "schema": "latitude",
+      "table": "oauth_consents",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "latitude",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "latitude",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sso_providers_pkey",
+      "schema": "latitude",
+      "table": "sso_providers",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "subscriptions_pkey",
+      "schema": "latitude",
+      "table": "subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "latitude",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pkey",
+      "schema": "latitude",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "billing_overrides_pkey",
+      "schema": "latitude",
+      "table": "billing_overrides",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "billing_usage_periods_pkey",
+      "schema": "latitude",
+      "table": "billing_usage_periods",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "custom_behaviors_pkey",
+      "schema": "latitude",
+      "table": "custom_behaviors",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "datasets_pkey",
+      "schema": "latitude",
+      "table": "datasets",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dataset_versions_pkey",
+      "schema": "latitude",
+      "table": "dataset_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "destination_sync_runs_pkey",
+      "schema": "latitude",
+      "table": "destination_sync_runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "destinations_pkey",
+      "schema": "latitude",
+      "table": "destinations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "evaluations_pkey",
+      "schema": "latitude",
+      "table": "evaluations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "experiments_pkey",
+      "schema": "latitude",
+      "table": "experiments",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "identifier"
+      ],
+      "nameExplicit": false,
+      "name": "feature_flags_pkey",
+      "schema": "latitude",
+      "table": "feature_flags",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_feature_flags_pkey",
+      "schema": "latitude",
+      "table": "organization_feature_flags",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "flaggers_pkey",
+      "schema": "latitude",
+      "table": "flaggers",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "integrations_pkey",
+      "schema": "latitude",
+      "table": "integrations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "monitors_pkey",
+      "schema": "latitude",
+      "table": "monitors",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "notifications_pkey",
+      "schema": "latitude",
+      "table": "notifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_claims_pkey",
+      "schema": "latitude",
+      "table": "organization_claims",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "outbox_events_pkey",
+      "schema": "latitude",
+      "table": "outbox_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pkey",
+      "schema": "latitude",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sandboxes_pkey",
+      "schema": "latitude",
+      "table": "sandboxes",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "saved_searches_pkey",
+      "schema": "latitude",
+      "table": "saved_searches",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "scores_pkey",
+      "schema": "latitude",
+      "table": "scores",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "showcase_pkey",
+      "schema": "latitude",
+      "table": "showcase",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "signals_pkey",
+      "schema": "latitude",
+      "table": "signals",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "simulations_pkey",
+      "schema": "latitude",
+      "table": "simulations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "slack_deliveries_pkey",
+      "schema": "latitude",
+      "table": "slack_deliveries",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "integration_id"
+      ],
+      "nameExplicit": false,
+      "name": "slack_integration_details_pkey",
+      "schema": "latitude",
+      "table": "slack_integration_details",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "taxonomy_cluster_lineage_pkey",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "taxonomy_clusters_pkey",
+      "schema": "latitude",
+      "table": "taxonomy_clusters",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "taxonomy_facets_pkey",
+      "schema": "latitude",
+      "table": "taxonomy_facets",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "taxonomy_runs_pkey",
+      "schema": "latitude",
+      "table": "taxonomy_runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "wrapped_reports_pkey",
+      "schema": "latitude",
+      "table": "wrapped_reports",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "queue_id",
+        "trace_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "annotation_queue_items_unique_trace_per_queue_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "annotation_queues_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "annotation_queues_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "custom_behaviors_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "datasets_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "datasets_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "identifier"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organization_feature_flags_unique_org_identifier_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug"
+      ],
+      "nullsNotDistinct": true,
+      "name": "flaggers_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "projects_unique_slug_per_organization_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "saved_searches_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "taxonomy_facets_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token_hash"
+      ],
+      "nullsNotDistinct": false,
+      "name": "api_keys_token_hash_key",
+      "schema": "latitude",
+      "table": "api_keys",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "access_token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_access_tokens_access_token_key",
+      "schema": "latitude",
+      "table": "oauth_access_tokens",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "refresh_token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_access_tokens_refresh_token_key",
+      "schema": "latitude",
+      "table": "oauth_access_tokens",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "client_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_applications_client_id_key",
+      "schema": "latitude",
+      "table": "oauth_applications",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "latitude",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sessions_token_key",
+      "schema": "latitude",
+      "table": "sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "provider_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sso_providers_provider_id_key",
+      "schema": "latitude",
+      "table": "sso_providers",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "latitude",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "billing_overrides_organization_id_key",
+      "schema": "latitude",
+      "table": "billing_overrides",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sandboxes_organization_id_key",
+      "schema": "latitude",
+      "table": "sandboxes",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "uuid"
+      ],
+      "nullsNotDistinct": false,
+      "name": "signals_uuid_key",
+      "schema": "latitude",
+      "table": "signals",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"id\" = 1",
+      "name": "showcase_singleton_check",
+      "entityType": "checks",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "agent_dispatch_configs_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "agent_dispatch_credentials_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "agent_dispatches_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "incidents_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "annotation_queue_items_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "annotation_queues_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "api_keys_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "invitations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "members_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "oauth_applications_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "sso_providers_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "reference_id = get_current_organization_id()",
+      "withCheck": "reference_id = get_current_organization_id()",
+      "name": "subscriptions_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "billing_overrides_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "billing_usage_events_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "billing_usage_periods_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "custom_behaviors_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "custom_behaviors"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "datasets_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "dataset_versions_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "destination_sources_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "destination_sync_runs_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "destinations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "evaluations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "experiments_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "experiments"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "organization_feature_flags_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "flaggers_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "integrations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "monitors_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "notifications_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "organization_claims_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "projects_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "sandboxes_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "saved_searches_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "scores_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "signals_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "simulations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "slack_deliveries_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "slack_integration_details_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "taxonomy_cluster_lineage_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "taxonomy_clusters_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "taxonomy_facets_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "taxonomy_facets"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "taxonomy_runs_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "wrapped_reports_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    }
+  ],
+  "renames": []
+}

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -47,6 +47,7 @@ export { DestinationSyncRunRepositoryLive } from "./repositories/destination-syn
 export { EvaluationAlignmentExamplesRepositoryLive } from "./repositories/evaluation-alignment-examples-repository.ts"
 export { EvaluationRepositoryLive } from "./repositories/evaluation-repository.ts"
 export { ExperimentRepositoryLive } from "./repositories/experiment-repository.ts"
+export { FacetRepositoryLive } from "./repositories/facet-repository.ts"
 export { FeatureFlagRepositoryLive } from "./repositories/feature-flag-repository.ts"
 export { FlaggerRepositoryLive } from "./repositories/flagger-repository.ts"
 export {

--- a/packages/platform/db-postgres/src/repositories/custom-behavior-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/custom-behavior-repository.test.ts
@@ -31,6 +31,7 @@ const makeBehavior = (overrides: Partial<CustomBehavior> = {}): CustomBehavior =
     slug: "refunds",
     name: "Refunds",
     filterSet: { moments: [{ op: "in", value: ["escalation"] }] },
+    facetId: null,
     status: CustomBehaviorStatus.Pending,
     createdAt: now,
     updatedAt: now,

--- a/packages/platform/db-postgres/src/repositories/facet-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/facet-repository.ts
@@ -1,33 +1,24 @@
-import {
-  CustomBehaviorId,
-  FacetId,
-  NotFoundError,
-  OrganizationId,
-  ProjectId,
-  SqlClient,
-  type SqlClientShape,
-} from "@domain/shared"
-import { type CustomBehavior, CustomBehaviorRepository } from "@domain/taxonomy"
+import { FacetId, NotFoundError, OrganizationId, ProjectId, SqlClient, type SqlClientShape } from "@domain/shared"
+import { FacetRepository, type TaxonomyFacet } from "@domain/taxonomy"
 import { and, desc, eq, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
-import { customBehaviors } from "../schema/custom-behaviors.ts"
+import { taxonomyFacets } from "../schema/taxonomy-facets.ts"
 
-const toCustomBehavior = (row: typeof customBehaviors.$inferSelect): CustomBehavior => ({
-  id: CustomBehaviorId(row.id),
+const toFacet = (row: typeof taxonomyFacets.$inferSelect): TaxonomyFacet => ({
+  id: FacetId(row.id),
   organizationId: OrganizationId(row.organizationId),
   projectId: ProjectId(row.projectId),
   slug: row.slug,
   name: row.name,
-  filterSet: row.filterSet,
-  facetId: row.facetId === null ? null : FacetId(row.facetId),
-  status: row.status,
+  description: row.description,
+  instructions: row.instructions,
   createdAt: row.createdAt,
   updatedAt: row.updatedAt,
 })
 
-export const CustomBehaviorRepositoryLive = Layer.effect(
-  CustomBehaviorRepository,
+export const FacetRepositoryLive = Layer.effect(
+  FacetRepository,
   Effect.gen(function* () {
     return {
       findById: (id) =>
@@ -36,14 +27,12 @@ export const CustomBehaviorRepositoryLive = Layer.effect(
           const [row] = yield* sqlClient.query((db, organizationId) =>
             db
               .select()
-              .from(customBehaviors)
-              .where(and(eq(customBehaviors.organizationId, organizationId), eq(customBehaviors.id, id)))
+              .from(taxonomyFacets)
+              .where(and(eq(taxonomyFacets.organizationId, organizationId), eq(taxonomyFacets.id, id)))
               .limit(1),
           )
-          if (!row) {
-            return yield* new NotFoundError({ entity: "CustomBehavior", id })
-          }
-          return toCustomBehavior(row)
+          if (!row) return yield* new NotFoundError({ entity: "TaxonomyFacet", id })
+          return toFacet(row)
         }),
 
       findBySlug: ({ projectId, slug }) =>
@@ -52,17 +41,17 @@ export const CustomBehaviorRepositoryLive = Layer.effect(
           const [row] = yield* sqlClient.query((db, organizationId) =>
             db
               .select()
-              .from(customBehaviors)
+              .from(taxonomyFacets)
               .where(
                 and(
-                  eq(customBehaviors.organizationId, organizationId),
-                  eq(customBehaviors.projectId, projectId),
-                  eq(customBehaviors.slug, slug),
+                  eq(taxonomyFacets.organizationId, organizationId),
+                  eq(taxonomyFacets.projectId, projectId),
+                  eq(taxonomyFacets.slug, slug),
                 ),
               )
               .limit(1),
           )
-          return row ? toCustomBehavior(row) : null
+          return row ? toFacet(row) : null
         }),
 
       listByProject: ({ projectId }) =>
@@ -71,11 +60,11 @@ export const CustomBehaviorRepositoryLive = Layer.effect(
           const rows = yield* sqlClient.query((db, organizationId) =>
             db
               .select()
-              .from(customBehaviors)
-              .where(and(eq(customBehaviors.organizationId, organizationId), eq(customBehaviors.projectId, projectId)))
-              .orderBy(desc(customBehaviors.createdAt)),
+              .from(taxonomyFacets)
+              .where(and(eq(taxonomyFacets.organizationId, organizationId), eq(taxonomyFacets.projectId, projectId)))
+              .orderBy(desc(taxonomyFacets.createdAt)),
           )
-          return rows.map(toCustomBehavior)
+          return rows.map(toFacet)
         }),
 
       countByProject: ({ projectId }) =>
@@ -84,8 +73,8 @@ export const CustomBehaviorRepositoryLive = Layer.effect(
           const [row] = yield* sqlClient.query((db, organizationId) =>
             db
               .select({ count: sql<number>`count(*)::int` })
-              .from(customBehaviors)
-              .where(and(eq(customBehaviors.organizationId, organizationId), eq(customBehaviors.projectId, projectId))),
+              .from(taxonomyFacets)
+              .where(and(eq(taxonomyFacets.organizationId, organizationId), eq(taxonomyFacets.projectId, projectId))),
           )
           return row?.count ?? 0
         }),
@@ -96,44 +85,43 @@ export const CustomBehaviorRepositoryLive = Layer.effect(
           const [row] = yield* sqlClient.query((db, organizationId) =>
             db
               .select({ count: sql<number>`count(*)::int` })
-              .from(customBehaviors)
+              .from(taxonomyFacets)
               .where(
                 and(
-                  eq(customBehaviors.organizationId, organizationId),
-                  eq(customBehaviors.projectId, projectId),
-                  eq(customBehaviors.slug, slug),
+                  eq(taxonomyFacets.organizationId, organizationId),
+                  eq(taxonomyFacets.projectId, projectId),
+                  eq(taxonomyFacets.slug, slug),
                 ),
               ),
           )
           return row?.count ?? 0
         }),
 
-      save: (behavior) =>
+      save: (facet) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          // `instructions` is write-once, so it stays out of the conflict update set;
+          // only presentation + status + timestamp change on an update.
           yield* sqlClient.query((db, organizationId) =>
             db
-              .insert(customBehaviors)
+              .insert(taxonomyFacets)
               .values({
-                id: behavior.id,
+                id: facet.id,
                 organizationId,
-                projectId: behavior.projectId,
-                name: behavior.name,
-                slug: behavior.slug,
-                filterSet: behavior.filterSet,
-                facetId: behavior.facetId,
-                status: behavior.status,
-                createdAt: behavior.createdAt,
-                updatedAt: behavior.updatedAt,
+                projectId: facet.projectId,
+                slug: facet.slug,
+                name: facet.name,
+                description: facet.description,
+                instructions: facet.instructions,
+                createdAt: facet.createdAt,
+                updatedAt: facet.updatedAt,
               })
               .onConflictDoUpdate({
-                target: customBehaviors.id,
+                target: taxonomyFacets.id,
                 set: {
-                  name: behavior.name,
-                  slug: behavior.slug,
-                  filterSet: behavior.filterSet,
-                  status: behavior.status,
-                  updatedAt: behavior.updatedAt,
+                  name: facet.name,
+                  description: facet.description,
+                  updatedAt: facet.updatedAt,
                 },
               }),
           )
@@ -144,9 +132,9 @@ export const CustomBehaviorRepositoryLive = Layer.effect(
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           yield* sqlClient.query((db, organizationId) =>
             db
-              .update(customBehaviors)
+              .update(taxonomyFacets)
               .set({ lastGardenedAt: gardenedAt })
-              .where(and(eq(customBehaviors.organizationId, organizationId), eq(customBehaviors.id, id))),
+              .where(and(eq(taxonomyFacets.organizationId, organizationId), eq(taxonomyFacets.id, id))),
           )
         }),
 
@@ -155,8 +143,8 @@ export const CustomBehaviorRepositoryLive = Layer.effect(
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           yield* sqlClient.query((db, organizationId) =>
             db
-              .delete(customBehaviors)
-              .where(and(eq(customBehaviors.organizationId, organizationId), eq(customBehaviors.id, id))),
+              .delete(taxonomyFacets)
+              .where(and(eq(taxonomyFacets.organizationId, organizationId), eq(taxonomyFacets.id, id))),
           )
         }),
     }

--- a/packages/platform/db-postgres/src/repositories/facet-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/facet-repository.ts
@@ -100,8 +100,7 @@ export const FacetRepositoryLive = Layer.effect(
       save: (facet) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
-          // `instructions` is write-once, so it stays out of the conflict update set;
-          // only presentation + status + timestamp change on an update.
+          // `instructions` is write-once, so only presentation fields + updatedAt change on conflict.
           yield* sqlClient.query((db, organizationId) =>
             db
               .insert(taxonomyFacets)

--- a/packages/platform/db-postgres/src/repositories/taxonomy-cluster-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/taxonomy-cluster-repository.ts
@@ -1,6 +1,7 @@
 import { EMBEDDING_DIMENSIONS, resolveEmbeddingConfig } from "@domain/ai"
 import {
   type CustomBehaviorId,
+  type FacetId,
   NotFoundError,
   RepositoryError,
   SqlClient,
@@ -27,6 +28,7 @@ const toDomainCluster = (row: typeof taxonomyClusters.$inferSelect): TaxonomyClu
     organizationId: row.organizationId,
     projectId: row.projectId,
     customBehaviorId: row.customBehaviorId,
+    facetId: row.facetId,
     dimension: TaxonomyDimension.Topic,
     parentClusterId: row.parentClusterId,
     depth: row.depth,
@@ -114,6 +116,7 @@ const toInsertRow = (
   organizationId: cluster.organizationId,
   projectId: cluster.projectId,
   customBehaviorId: cluster.customBehaviorId,
+  facetId: cluster.facetId,
   parentClusterId: cluster.parentClusterId,
   depth: cluster.depth,
   path: cluster.path,
@@ -132,14 +135,20 @@ const toInsertRow = (
   updatedAt: cluster.updatedAt,
 })
 
-// Global taxonomy reads and scoped custom-behavior reads share one table.
-// Omit/null scopes to the global tree (custom_behavior_id IS NULL); an id
-// scopes to that behavior's sub-tree. Keeps the global Behaviours page and
-// Topics filter isolated from scoped rows.
-const scopeCondition = (customBehaviorId: CustomBehaviorId | null | undefined) =>
-  customBehaviorId == null
-    ? isNull(taxonomyClusters.customBehaviorId)
-    : eq(taxonomyClusters.customBehaviorId, customBehaviorId)
+// Every view's tree shares one table; a view is (scope × lens). Reads MUST pin
+// BOTH discriminators so the online whole-project topic tree (NULL, NULL) never
+// leaks cohort or facet rows: omit/null a discriminator ⇒ IS NULL, an id ⇒
+// equality. `(customBehaviorId=null, facetId=null)` is the online topic tree.
+const scopeCondition = (scope: {
+  readonly customBehaviorId: CustomBehaviorId | null | undefined
+  readonly facetId: FacetId | null | undefined
+}) =>
+  and(
+    scope.customBehaviorId == null
+      ? isNull(taxonomyClusters.customBehaviorId)
+      : eq(taxonomyClusters.customBehaviorId, scope.customBehaviorId),
+    scope.facetId == null ? isNull(taxonomyClusters.facetId) : eq(taxonomyClusters.facetId, scope.facetId),
+  )
 
 export const TaxonomyClusterRepositoryLive = Layer.effect(
   TaxonomyClusterRepository,
@@ -178,7 +187,7 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
           return rows.map(toDomainCluster)
         }),
 
-      listActiveByProject: ({ projectId, parentClusterId, customBehaviorId }) =>
+      listActiveByProject: ({ projectId, parentClusterId, customBehaviorId, facetId }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           const rows = yield* sqlClient.query((db, organizationId) =>
@@ -190,7 +199,7 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
                   eq(taxonomyClusters.organizationId, organizationId),
                   eq(taxonomyClusters.projectId, projectId),
                   eq(taxonomyClusters.state, "active"),
-                  scopeCondition(customBehaviorId),
+                  scopeCondition({ customBehaviorId, facetId }),
                   ...(parentClusterId === undefined
                     ? []
                     : parentClusterId === null
@@ -203,7 +212,7 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
           return rows.map(toDomainCluster)
         }),
 
-      listSubtreeIds: ({ projectId, clusterId, customBehaviorId }) =>
+      listSubtreeIds: ({ projectId, clusterId, customBehaviorId, facetId }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           const rows = yield* sqlClient.query((db, organizationId) =>
@@ -215,7 +224,7 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
                   eq(taxonomyClusters.organizationId, organizationId),
                   eq(taxonomyClusters.projectId, projectId),
                   eq(taxonomyClusters.state, "active"),
-                  scopeCondition(customBehaviorId),
+                  scopeCondition({ customBehaviorId, facetId }),
                   or(eq(taxonomyClusters.id, clusterId), like(taxonomyClusters.path, `%${clusterId}/%`)),
                 ),
               ),
@@ -239,6 +248,7 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
                   eq(taxonomyClusters.projectId, projectId),
                   eq(taxonomyClusters.state, "active"),
                   isNull(taxonomyClusters.customBehaviorId),
+                  isNull(taxonomyClusters.facetId),
                   isNotNull(taxonomyClusters.centroidEmbedding),
                   ...(parentClusterId === undefined
                     ? []
@@ -271,6 +281,7 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
             eq(taxonomyClusters.projectId, projectId),
             eq(taxonomyClusters.state, state ?? "active"),
             isNull(taxonomyClusters.customBehaviorId),
+            isNull(taxonomyClusters.facetId),
             isNotNull(taxonomyClusters.centroidEmbedding),
             or(gte(score, TAXONOMY_SEARCH_MIN_SCORE), gte(vectorScore, TAXONOMY_SEARCH_MIN_VECTOR_SIMILARITY)),
           ]
@@ -293,13 +304,13 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
           return rows.map((row) => ({ ...row, clusterId: TaxonomyClusterId(row.clusterId) }))
         }),
 
-      list: ({ projectId, state, sort, limit, offset, customBehaviorId }) =>
+      list: ({ projectId, state, sort, limit, offset, customBehaviorId, facetId }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           const conditions = [
             eq(taxonomyClusters.organizationId, sqlClient.organizationId),
             eq(taxonomyClusters.projectId, projectId),
-            scopeCondition(customBehaviorId),
+            scopeCondition({ customBehaviorId, facetId }),
           ]
           // `staging` is an internal publish-time state; never surface it from
           // list-clusters. An explicit `state` filter still narrows further.

--- a/packages/platform/db-postgres/src/repositories/taxonomy-cluster-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/taxonomy-cluster-repository.ts
@@ -150,6 +150,10 @@ const scopeCondition = (scope: {
     scope.facetId == null ? isNull(taxonomyClusters.facetId) : eq(taxonomyClusters.facetId, scope.facetId),
   )
 
+// The one online-routed tree. `listNearestActive`/`hybridSearch` pin this so the
+// live router and cluster search never see a cohort or facet cluster.
+const GLOBAL_TOPIC_SCOPE = { customBehaviorId: null, facetId: null } as const
+
 export const TaxonomyClusterRepositoryLive = Layer.effect(
   TaxonomyClusterRepository,
   Effect.gen(function* () {
@@ -247,8 +251,7 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
                   eq(taxonomyClusters.organizationId, organizationId),
                   eq(taxonomyClusters.projectId, projectId),
                   eq(taxonomyClusters.state, "active"),
-                  isNull(taxonomyClusters.customBehaviorId),
-                  isNull(taxonomyClusters.facetId),
+                  scopeCondition(GLOBAL_TOPIC_SCOPE),
                   isNotNull(taxonomyClusters.centroidEmbedding),
                   ...(parentClusterId === undefined
                     ? []
@@ -280,8 +283,7 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
             eq(taxonomyClusters.organizationId, sqlClient.organizationId),
             eq(taxonomyClusters.projectId, projectId),
             eq(taxonomyClusters.state, state ?? "active"),
-            isNull(taxonomyClusters.customBehaviorId),
-            isNull(taxonomyClusters.facetId),
+            scopeCondition(GLOBAL_TOPIC_SCOPE),
             isNotNull(taxonomyClusters.centroidEmbedding),
             or(gte(score, TAXONOMY_SEARCH_MIN_SCORE), gte(vectorScore, TAXONOMY_SEARCH_MIN_VECTOR_SIMILARITY)),
           ]

--- a/packages/platform/db-postgres/src/repositories/taxonomy-repositories.test.ts
+++ b/packages/platform/db-postgres/src/repositories/taxonomy-repositories.test.ts
@@ -58,6 +58,7 @@ const makeCluster = (overrides: Partial<TaxonomyCluster> = {}): TaxonomyCluster 
   organizationId,
   projectId,
   customBehaviorId: null,
+  facetId: null,
   dimension: "topic",
   parentClusterId: null,
   depth: 0,

--- a/packages/platform/db-postgres/src/schema/custom-behaviors.ts
+++ b/packages/platform/db-postgres/src/schema/custom-behaviors.ts
@@ -14,6 +14,11 @@ export const customBehaviors = latitudeSchema.table(
     name: varchar("name", { length: CUSTOM_BEHAVIOR_NAME_MAX_LENGTH }).notNull(),
     slug: varchar("slug", { length: SLUG_MAX_LENGTH }).notNull(),
     filterSet: jsonb("filter_set").$type<FilterSet>().notNull(),
+    // The lens this behavior gardens through. NULL = topic (cluster observation
+    // embeddings); non-null = a facet (cluster its extracted projections). A
+    // behavior is (facet_id? × filter_set); the only invalid state is topic lens
+    // with an empty filter, which is just the live global tree.
+    facetId: cuid("facet_id", { default: false }),
     status: varchar("status", { length: 16 }).$type<CustomBehaviorStatus>().notNull().default("pending"),
     // Gardening throttle anchor, stamped at each run start; null = never gardened.
     lastGardenedAt: tzTimestamp("last_gardened_at"),

--- a/packages/platform/db-postgres/src/schema/custom-behaviors.ts
+++ b/packages/platform/db-postgres/src/schema/custom-behaviors.ts
@@ -14,10 +14,7 @@ export const customBehaviors = latitudeSchema.table(
     name: varchar("name", { length: CUSTOM_BEHAVIOR_NAME_MAX_LENGTH }).notNull(),
     slug: varchar("slug", { length: SLUG_MAX_LENGTH }).notNull(),
     filterSet: jsonb("filter_set").$type<FilterSet>().notNull(),
-    // The lens this behavior gardens through. NULL = topic (cluster observation
-    // embeddings); non-null = a facet (cluster its extracted projections). A
-    // behavior is (facet_id? × filter_set); the only invalid state is topic lens
-    // with an empty filter, which is just the live global tree.
+    // The lens this behavior gardens through: NULL = topic, non-null = a facet.
     facetId: cuid("facet_id", { default: false }),
     status: varchar("status", { length: 16 }).$type<CustomBehaviorStatus>().notNull().default("pending"),
     // Gardening throttle anchor, stamped at each run start; null = never gardened.

--- a/packages/platform/db-postgres/src/schema/taxonomy-facets.ts
+++ b/packages/platform/db-postgres/src/schema/taxonomy-facets.ts
@@ -1,10 +1,5 @@
 import { SLUG_MAX_LENGTH } from "@domain/shared"
-import {
-  FACET_DESCRIPTION_MAX_LENGTH,
-  FACET_INSTRUCTIONS_MAX_LENGTH,
-  FACET_NAME_MAX_LENGTH,
-  type FacetStatus,
-} from "@domain/taxonomy"
+import { FACET_DESCRIPTION_MAX_LENGTH, FACET_INSTRUCTIONS_MAX_LENGTH, FACET_NAME_MAX_LENGTH } from "@domain/taxonomy"
 import { index, unique, varchar } from "drizzle-orm/pg-core"
 import { cuid, latitudeSchema, organizationRLSPolicy, timestamps, tzTimestamp } from "../schemaHelpers.ts"
 
@@ -25,7 +20,6 @@ export const taxonomyFacets = latitudeSchema.table(
     name: varchar("name", { length: FACET_NAME_MAX_LENGTH }).notNull(),
     description: varchar("description", { length: FACET_DESCRIPTION_MAX_LENGTH }).notNull(),
     instructions: varchar("instructions", { length: FACET_INSTRUCTIONS_MAX_LENGTH }).notNull(),
-    status: varchar("status", { length: 16 }).$type<FacetStatus>().notNull().default("pending"),
     // Gardening throttle anchor, stamped at each run start; null = never gardened.
     lastGardenedAt: tzTimestamp("last_gardened_at"),
     ...timestamps(),


### PR DESCRIPTION
Wires the **facet lens** into the shared gardening path. Builds on Phase 1 (LAT-779) + Phase 2 (LAT-780), both merged & deployed.

## Design change vs. the issue (decided with the author)
The issue proposed a standalone facet sweep (`gardenFacetSweep` / `listGardenableFacets` / auto-start on facet-create). We unified instead: **a facet is a lens *of a custom behavior***, so a view = `(scope × lens)`:

| behavior | lens | filter | valid |
|---|---|---|---|
| facet + filter | facet | set | ✅ cohort × facet |
| facet only | facet | empty | ✅ whole-project facet |
| filter only | topic | set | ✅ today's cohort |
| topic + no filter | topic | empty | ❌ that's the live global tree |

Only invalid state: topic lens + empty filter. Facets therefore garden through the **existing `gardenCustomBehaviorSweep` + `createCustomBehavior`** — no new sweep, cron, job, env var, or feature flag. Rollout gate = the existing `customBehaviors` flag (a facet only ever runs inside a flag-gated behavior).

## What changed
- **`planHierarchicalTaxonomyUseCase`** resolves scope (`customBehaviorId`) and lens (`facetId`) orthogonally. Facet lens clusters caller-supplied projection embeddings; clusters + edges key on `(customBehaviorId, facetId)`; only the whole-project topic tree writes the inline `taxonomy_observations` column. Facet runs use the off/static publish path (sample-only view-slice write). Global/cohort **topic** behavior is unchanged.
- **Gardening activity**: the custom-behavior start loads the behavior's `facet_id` + `filterSet`; a facet branch samples sessions (`listForFacetSample`), extracts projections (`extractFacetProjectionsUseCase`, unclear excluded), clusters them. Naming / quality / reassign scope by `facet_id`.
- **Facet-aware naming**: `name-taxonomy.ts` policy is parameterized per tree (`ClusterNamingPolicy`), defaulting to `TOPIC_NAMING_POLICY` — **byte-identical topic prompts** (golden-tested). Facet trees name in the lens's voice, reading members from `taxonomy_facet_projections`.
- **`custom_behaviors.facet_id`** (nullable) added; `createCustomBehavior` accepts a lens and relaxes the empty-filter rule only when a facet is chosen. `createFacet` persists an immutable lens definition (no standalone gardening).
- **Carry-over fix**: `deleteByBehavior` now purges a cohort's edges across **both** lenses (dropped the `facet_id = ''` filter) so facet edges are never orphaned.
- Dropped the now-vestigial `taxonomy_facets.status` (run status lives on the custom behavior). **One additive migration**: `+custom_behaviors.facet_id`, `-taxonomy_facets.status`.

## Isolation invariants
Topic reads pin `facet_id IS NULL` (cluster repo scope + online router `listNearestActive`/`hybridSearch`); facet gardening never writes `taxonomy_observations.assigned_cluster_id`.

## Tests
`pnpm typecheck` green (88/88). New tests:
- **Golden**: topic naming prompts byte-identical under the default policy.
- **Plan (scope × lens)**: cohort×facet + whole-project facet key clusters/edges by both ids; facet-without-behavior fails fast; facet run ignores a same-cohort topic tree (cross-lens isolation).
- **`listForFacetSample`**: projects transcript summary + ids; scopes to a cohort's sessions when filtered (cohort×facet sampling).
- **View slice**: `deleteByBehavior` purges both lenses; facet members read from `taxonomy_facet_projections`.
- `createFacet` (definition + cap) and `createCustomBehavior` with a facet lens.
Domain (230), db-clickhouse (477), db-postgres (271), workflows (81) suites pass locally.

## Review focus
1. The always-on **topic** paths I touched: naming prompt parity (golden test), the `build-hierarchical` global path, and `facet_id IS NULL` on the online router.
2. The migration (`+custom_behaviors.facet_id`, `-taxonomy_facets.status`).
3. Whether folding a slice of Phase 5 forward (lens-in-behavior-creation) is acceptable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added facet (lens) support across taxonomy gardening, hierarchical planning, and cluster naming, including facet-scoped view assignments.
  * Introduced facet-aware sampling and naming policies, plus a new use case to plan facet gardens.
  * Added facet validation and per-project facet limit enforcement with user-facing error reporting.
* **Bug Fixes**
  * Updated routing so facet-scoped runs write view assignments rather than updating global inline assignments.
  * Ensured facet-lens reads and deletions use facet projection data (not topic observations).
* **Chores**
  * Updated tests/fixtures to include optional `facetId` scoping and adjusted facet data assumptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->