### PR TITLE
fix(web): unblock conversation timeline and auto-scroll on long sessions

### DIFF
--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -234,7 +234,8 @@ export const listAnnotationsByTrace = createServerFn({ method: "GET" })
  * than `session_id` so orphan sessions — whose scores carry no `session_id` —
  * still surface their annotations.
  */
-export const listAnnotationsBySession = createServerFn({ method: "GET" })
+// POST keeps the up-to-500 trace-id payload below HTTP request-line limits.
+export const listAnnotationsBySession = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       projectId: z.string(),

--- a/apps/web/src/domains/scores/scores.functions.ts
+++ b/apps/web/src/domains/scores/scores.functions.ts
@@ -111,7 +111,8 @@ export const listScoresByTrace = createServerFn({ method: "GET" })
  * `trace_id IN (...)` rather than `session_id` so orphan sessions still surface
  * their scores.
  */
-export const listScoresBySession = createServerFn({ method: "GET" })
+// POST keeps the up-to-500 trace-id payload below HTTP request-line limits.
+export const listScoresBySession = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       projectId: z.string(),

--- a/apps/web/src/domains/sessions/sessions.functions.ts
+++ b/apps/web/src/domains/sessions/sessions.functions.ts
@@ -367,7 +367,8 @@ export interface SessionSignalRecord {
   readonly traceIds: readonly string[]
 }
 
-export const listSessionSignals = createServerFn({ method: "GET" })
+// POST keeps the up-to-500 trace-id payload below HTTP request-line limits.
+export const listSessionSignals = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       projectId: z.string(),

--- a/apps/web/src/domains/spans/select-traces-for-loaded-conversation.test.ts
+++ b/apps/web/src/domains/spans/select-traces-for-loaded-conversation.test.ts
@@ -51,6 +51,23 @@ describe("selectTracesForLoadedConversation", () => {
     expect(selected[7]?.traceId).toBe("t007")
   })
 
+  it.each([
+    { traceCount: 121, totalMessages: 242 },
+    { traceCount: 241, totalMessages: 482 },
+    { traceCount: 421, totalMessages: 842 },
+  ])("selects 17 traces for the first page of the $totalMessages-message large conversation", ({
+    traceCount,
+    totalMessages,
+  }) => {
+    const selected = selectTracesForLoadedConversation({
+      traces: traces(traceCount),
+      loadedMessageCount: 25,
+      totalMessages,
+    })
+
+    expect(selected).toHaveLength(17)
+  })
+
   it("grows the window as more of the conversation is loaded", () => {
     const all = traces(100)
     const early = selectTracesForLoadedConversation({

--- a/apps/web/src/domains/spans/select-traces-for-loaded-conversation.test.ts
+++ b/apps/web/src/domains/spans/select-traces-for-loaded-conversation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { selectTracesForLoadedConversation } from "./select-traces-for-loaded-conversation.ts"
+
+function traces(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    traceId: `t${String(i).padStart(3, "0")}`,
+    startTime: `2026-01-01T00:${String(i).padStart(2, "0")}:00.000Z`,
+  }))
+}
+
+describe("selectTracesForLoadedConversation", () => {
+  it("returns nothing when no messages are loaded", () => {
+    expect(
+      selectTracesForLoadedConversation({ traces: traces(10), loadedMessageCount: 0, totalMessages: 100 }),
+    ).toEqual([])
+  })
+
+  it("returns traces oldest-first", () => {
+    const input = [
+      { traceId: "new", startTime: "2026-01-01T00:02:00.000Z" },
+      { traceId: "old", startTime: "2026-01-01T00:00:00.000Z" },
+      { traceId: "mid", startTime: "2026-01-01T00:01:00.000Z" },
+    ]
+    const selected = selectTracesForLoadedConversation({
+      traces: input,
+      loadedMessageCount: 10,
+      totalMessages: 10,
+    })
+    expect(selected.map((t) => t.traceId)).toEqual(["old", "mid", "new"])
+  })
+
+  it("fetches all traces once the conversation is fully loaded", () => {
+    const all = traces(20)
+    const selected = selectTracesForLoadedConversation({
+      traces: all,
+      loadedMessageCount: 200,
+      totalMessages: 200,
+    })
+    expect(selected).toHaveLength(20)
+  })
+
+  it("keeps a small window for the first conversation page on a long session", () => {
+    const selected = selectTracesForLoadedConversation({
+      traces: traces(100),
+      loadedMessageCount: 25,
+      totalMessages: 2000,
+    })
+    // ceil(25/2000 * 100) + 4 = 6, raised to MIN_TRACES (8)
+    expect(selected).toHaveLength(8)
+    expect(selected[0]?.traceId).toBe("t000")
+    expect(selected[7]?.traceId).toBe("t007")
+  })
+
+  it("grows the window as more of the conversation is loaded", () => {
+    const all = traces(100)
+    const early = selectTracesForLoadedConversation({
+      traces: all,
+      loadedMessageCount: 25,
+      totalMessages: 500,
+    })
+    const later = selectTracesForLoadedConversation({
+      traces: all,
+      loadedMessageCount: 250,
+      totalMessages: 500,
+    })
+    expect(later.length).toBeGreaterThan(early.length)
+    expect(later.map((t) => t.traceId).slice(0, early.length)).toEqual(early.map((t) => t.traceId))
+  })
+})

--- a/apps/web/src/domains/spans/select-traces-for-loaded-conversation.ts
+++ b/apps/web/src/domains/spans/select-traces-for-loaded-conversation.ts
@@ -1,0 +1,40 @@
+export interface TraceTimeRef {
+  readonly traceId: string
+  readonly startTime: string
+}
+
+const MIN_TRACES = 8
+const TRACE_BUFFER = 4
+
+/**
+ * Oldest-first subset of session traces whose message-bearing spans are worth
+ * fetching to attribute the currently loaded conversation prefix.
+ *
+ * Conversation chunks load from the start; early messages almost always come
+ * from early traces. Scale the fetch with loaded/total and keep a buffer so
+ * short multi-trace openings are covered without pulling the whole session.
+ */
+export function selectTracesForLoadedConversation({
+  traces,
+  loadedMessageCount,
+  totalMessages,
+}: {
+  readonly traces: readonly TraceTimeRef[]
+  readonly loadedMessageCount: number
+  readonly totalMessages: number
+}): readonly TraceTimeRef[] {
+  if (loadedMessageCount <= 0 || traces.length === 0) return []
+
+  const oldestFirst = [...traces].sort(
+    (a, b) => a.startTime.localeCompare(b.startTime) || a.traceId.localeCompare(b.traceId),
+  )
+
+  if (totalMessages > 0 && loadedMessageCount >= totalMessages) return oldestFirst
+
+  const fraction = totalMessages > 0 ? Math.min(1, loadedMessageCount / totalMessages) : 1
+  const count = Math.min(
+    oldestFirst.length,
+    Math.max(MIN_TRACES, Math.ceil(fraction * oldestFirst.length) + TRACE_BUFFER),
+  )
+  return oldestFirst.slice(0, count)
+}

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -9,6 +9,7 @@ import type { GenAIMessage } from "rosetta-ai"
 import { createAppCollection } from "../../lib/data/create-app-collection.ts"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import { projectScopeData, sandboxOrgIdForScope, useProjectScope } from "../projects/project-scope.tsx"
+import { traceIdsSignature } from "../traces/trace-ids.ts"
 import { selectTracesForLoadedConversation, type TraceTimeRef } from "./select-traces-for-loaded-conversation.ts"
 import {
   getSpanDetail,
@@ -88,11 +89,6 @@ export const useSpansByTraceCollection = ({
     [projectId, traceId, startTimeFrom, startTimeTo, sandboxOrgIdForScope(scope)],
   )
 }
-
-// Order-independent signature of the session's trace set, so the collection
-// cache/query refresh when a live session gains a trace (traceIds changes) but
-// stay stable across reorderings of the same set.
-const traceIdsSignature = (traceIds: readonly string[]): string => [...traceIds].sort().join(",")
 
 const makeSpansBySessionCollection = (
   projectId: string,

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -182,6 +182,56 @@ export const useSpansBySessionCollection = ({
   )
 }
 
+export const useSpansBySessionPages = ({
+  projectId,
+  sessionId,
+  traceIdPages,
+  startTimeFrom,
+  startTimeTo,
+}: {
+  readonly projectId: string
+  readonly sessionId: string
+  readonly traceIdPages: readonly (readonly string[])[]
+  readonly startTimeFrom?: string | undefined
+  readonly startTimeTo?: string | undefined
+}) => {
+  const scope = useProjectScope()
+  const sandboxOrgId = sandboxOrgIdForScope(scope)
+  const pages = traceIdPages.filter((traceIds) => traceIds.length > 0)
+  const queries = useQueries({
+    queries: pages.map((traceIds) => ({
+      queryKey: [
+        "spans",
+        "session-page",
+        sandboxOrgId,
+        projectId,
+        sessionId,
+        traceIdsSignature(traceIds),
+        startTimeFrom,
+        startTimeTo,
+      ],
+      queryFn: () =>
+        listSpansBySession({
+          data: {
+            ...(sandboxOrgId ? { sandboxOrgId } : {}),
+            projectId,
+            traceIds: [...traceIds],
+            startTimeFrom,
+            startTimeTo,
+          },
+        }),
+      staleTime: Infinity,
+    })),
+  })
+  const data = useMemo(() => queries.flatMap((query) => query.data ?? []), [queries])
+
+  return {
+    data,
+    isLoading: queries.some((query) => query.isPending),
+    isError: queries.some((query) => query.isError),
+  }
+}
+
 export const useSpanDetail = ({
   projectId,
   traceId,

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -1,17 +1,18 @@
 import { SpanId, TraceId } from "@domain/shared"
-import type { SpanMessagesData } from "@domain/spans"
+import type { ConversationSpanRef, SpanMessagesData } from "@domain/spans"
 import { buildConversationSpanMaps } from "@domain/spans"
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
 import { useLiveQuery } from "@tanstack/react-db"
-import { useQuery } from "@tanstack/react-query"
+import { useQueries, useQuery } from "@tanstack/react-query"
+import { useMemo } from "react"
 import type { GenAIMessage } from "rosetta-ai"
 import { createAppCollection } from "../../lib/data/create-app-collection.ts"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import { projectScopeData, sandboxOrgIdForScope, useProjectScope } from "../projects/project-scope.tsx"
+import { selectTracesForLoadedConversation, type TraceTimeRef } from "./select-traces-for-loaded-conversation.ts"
 import {
   getSpanDetail,
   listConversationMessageSpans,
-  listSessionConversationMessageSpans,
   listSpansBySession,
   listSpansByTrace,
   type SpanDetailRecord,
@@ -221,49 +222,89 @@ const asMessageSpans = (records: readonly SpanMessagesRecord[]): readonly SpanMe
     outputMessages: record.outputMessages as readonly GenAIMessage[],
   }))
 
+const conversationMessageSpansQueryKey = (sandboxOrgId: string | undefined, projectId: string, traceId: string) =>
+  ["conversationMessageSpans", sandboxOrgId, projectId, traceId] as const
+
+function toolCallSpanRefsFromSpans(spans: readonly SpanRecord[] | undefined): Record<string, ConversationSpanRef> {
+  const map: Record<string, ConversationSpanRef> = {}
+  for (const span of spans ?? []) {
+    if (!span.toolCallId) continue
+    map[span.toolCallId] = { traceId: span.traceId, spanId: span.spanId }
+  }
+  return map
+}
+
+/**
+ * Session conversation → span attribution for the *loaded* message prefix.
+ * Fetches per-trace message spans (same cache as the single-trace path) for an
+ * oldest-first window that grows with pagination — never the full-session
+ * findMessagesForSession payload. Tool-call links also come from lightweight
+ * session spans so execute_tool navigation works before message spans arrive.
+ */
 export function useSessionConversationSpanMaps({
   projectId,
-  sessionId,
-  latestTraceId,
-  sessionStartTime,
-  sessionEndTime,
-  allMessages,
+  traces,
+  loadedMessages,
+  totalMessages,
+  sessionSpans,
   enabled = true,
 }: {
   readonly projectId: string
-  readonly sessionId: string
-  readonly latestTraceId: string
-  readonly sessionStartTime: string
-  readonly sessionEndTime: string
-  readonly allMessages: readonly GenAIMessage[] | undefined
+  readonly traces: readonly TraceTimeRef[]
+  readonly loadedMessages: readonly GenAIMessage[] | undefined
+  readonly totalMessages: number
+  readonly sessionSpans?: readonly SpanRecord[] | undefined
   readonly enabled?: boolean
 }) {
   const scope = useProjectScope()
-  return useQuery({
-    queryKey: [
-      "sessionConversationSpanMaps",
-      sandboxOrgIdForScope(scope),
-      projectId,
-      sessionId,
-      latestTraceId,
-      sessionStartTime,
-      sessionEndTime,
-    ],
-    queryFn: async () => {
-      const spans = await listSessionConversationMessageSpans({
-        data: {
-          ...projectScopeData(scope),
-          projectId,
-          sessionId,
-          sessionStartTime,
-          sessionEndTime,
-        },
-      })
-      return buildConversationSpanMaps(allMessages ?? [], asMessageSpans(spans))
-    },
-    enabled:
-      enabled && projectId.length > 0 && sessionId.length > 0 && latestTraceId.length > 0 && allMessages !== undefined,
+  const sandboxOrgId = sandboxOrgIdForScope(scope)
+  const selectedTraces = useMemo(
+    () =>
+      selectTracesForLoadedConversation({
+        traces,
+        loadedMessageCount: loadedMessages?.length ?? 0,
+        totalMessages,
+      }),
+    [traces, loadedMessages?.length, totalMessages],
+  )
+
+  const spanQueries = useQueries({
+    queries: selectedTraces.map((trace) => ({
+      queryKey: conversationMessageSpansQueryKey(sandboxOrgId, projectId, trace.traceId),
+      queryFn: () =>
+        listConversationMessageSpans({
+          data: {
+            ...projectScopeData(scope),
+            projectId,
+            traceId: trace.traceId,
+            startTime: trace.startTime,
+          },
+        }),
+      enabled:
+        enabled &&
+        projectId.length > 0 &&
+        trace.traceId.length > 0 &&
+        trace.startTime.length > 0 &&
+        loadedMessages !== undefined,
+      staleTime: Number.POSITIVE_INFINITY,
+    })),
   })
+
+  const messageSpanPages = spanQueries.map((query) => query.data)
+  const isPending = spanQueries.some((query) => query.isPending)
+  const isFetching = spanQueries.some((query) => query.isFetching)
+
+  const data = useMemo(() => {
+    if (loadedMessages === undefined) return undefined
+    const spans = messageSpanPages.flatMap((page) => (page ? asMessageSpans(page) : []))
+    const maps = buildConversationSpanMaps(loadedMessages, spans)
+    return {
+      messageSpanMap: maps.messageSpanMap,
+      toolCallSpanMap: { ...toolCallSpanRefsFromSpans(sessionSpans), ...maps.toolCallSpanMap },
+    }
+  }, [loadedMessages, messageSpanPages, sessionSpans])
+
+  return { data, isPending, isFetching, isLoading: isPending }
 }
 
 export function useConversationSpanMaps({
@@ -280,20 +321,26 @@ export function useConversationSpanMaps({
   readonly enabled?: boolean
 }) {
   const scope = useProjectScope()
-  return useQuery({
-    queryKey: ["conversationSpanMaps", sandboxOrgIdForScope(scope), projectId, traceId],
-    queryFn: async () => {
-      const spans = await listConversationMessageSpans({
+  const spansQuery = useQuery({
+    queryKey: conversationMessageSpansQueryKey(sandboxOrgIdForScope(scope), projectId, traceId),
+    queryFn: () =>
+      listConversationMessageSpans({
         data: {
           ...projectScopeData(scope),
           projectId,
           traceId,
           startTime: startTime ?? "",
         },
-      })
-      return buildConversationSpanMaps(allMessages ?? [], asMessageSpans(spans))
-    },
+      }),
     enabled:
       enabled && projectId.length > 0 && traceId.length > 0 && startTime !== undefined && allMessages !== undefined,
+    staleTime: Number.POSITIVE_INFINITY,
   })
+
+  const data = useMemo(() => {
+    if (!spansQuery.data || allMessages === undefined) return undefined
+    return buildConversationSpanMaps(allMessages, asMessageSpans(spansQuery.data))
+  }, [spansQuery.data, allMessages])
+
+  return { ...spansQuery, data }
 }

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -1,4 +1,4 @@
-import { ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
+import { ProjectId, SpanId, TraceId } from "@domain/shared"
 import type { Operation, Span, SpanDetail, SpanKind, SpanMessagesData, SpanStatusCode } from "@domain/spans"
 import { SpanRepository } from "@domain/spans"
 import { SpanRepositoryLive } from "@platform/db-clickhouse"
@@ -248,32 +248,6 @@ export const listConversationMessageSpans = createServerFn({ method: "GET" })
           traceId: TraceId(data.traceId),
           startTimeFrom: new Date(data.startTime.getTime() - 60 * 1000),
           startTimeTo: new Date(data.startTime.getTime() + 24 * 60 * 60 * 1000),
-        })
-      }).pipe(withScopedClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
-    )
-    return spans.map(serializeSpanMessages)
-  })
-
-export const listSessionConversationMessageSpans = createServerFn({ method: "GET" })
-  .inputValidator(
-    z.object({
-      projectId: z.string(),
-      sessionId: z.string(),
-      sessionStartTime: dateTimeParamSchema,
-      sessionEndTime: dateTimeParamSchema,
-    }),
-  )
-  .handler(async ({ data, context }): Promise<SpanMessagesRecord[]> => {
-    const orgId = await resolveOrgScope(context)
-    const spans = await Effect.runPromise(
-      Effect.gen(function* () {
-        const spanRepo = yield* SpanRepository
-        return yield* spanRepo.findMessagesForSession({
-          organizationId: orgId,
-          projectId: ProjectId(data.projectId),
-          sessionId: SessionId(data.sessionId),
-          startTimeFrom: new Date(data.sessionStartTime.getTime() - 60 * 1000),
-          startTimeTo: new Date(data.sessionEndTime.getTime() + 24 * 60 * 60 * 1000),
         })
       }).pipe(withScopedClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -176,7 +176,8 @@ export const listSpansByTrace = createServerFn({ method: "GET" })
 // Reads by the session's authoritative `traceIds` rather than `session_id`
 // membership, so subagent spans that override `session_id` to the child's own
 // value still surface in the session's Spans tab and breakdowns.
-export const listSpansBySession = createServerFn({ method: "GET" })
+// POST keeps the up-to-500 trace-id payload below HTTP request-line limits.
+export const listSpansBySession = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       projectId: z.string(),

--- a/apps/web/src/domains/traces/trace-ids.ts
+++ b/apps/web/src/domains/traces/trace-ids.ts
@@ -1,0 +1,1 @@
+export const traceIdsSignature = (traceIds: readonly string[]): string => [...traceIds].sort().join(",")

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -231,6 +231,47 @@ export const listTracesByProject = createServerFn({ method: "GET" })
     }
   })
 
+export const listSessionTraces = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      traceIds: z.array(traceIdSchema).max(500),
+      limit: z.number().int().min(1).max(500),
+      cursor: traceListCursorSchema.optional(),
+      sortDirection: z.enum(["asc", "desc"]).optional(),
+    }),
+  )
+  .handler(async ({ data, context }): Promise<TraceListResult> => {
+    const orgId = await resolveOrgScope(context)
+
+    const page = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TraceRepository
+        return yield* repo.listByProjectId({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          options: {
+            limit: data.limit,
+            ...(data.cursor ? { cursor: data.cursor } : {}),
+            sortBy: "startTime",
+            sortDirection: data.sortDirection ?? "desc",
+            filters: { traceId: [{ op: "in", value: data.traceIds }] },
+          },
+        })
+      }).pipe(
+        withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withAi(AIEmbedLive, getRedisClient()),
+        withTracing,
+      ),
+    )
+
+    return {
+      traces: page.items.map(toTraceRecord),
+      hasMore: page.hasMore,
+      ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+    }
+  })
+
 export const countTracesByProject = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-adapters.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-adapters.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+import { toolCallSpanMapFromSpans } from "./timeline-adapters.ts"
+
+function makeSpan(partial: Partial<SpanRecord> & Pick<SpanRecord, "spanId" | "toolCallId">): SpanRecord {
+  return {
+    organizationId: "org",
+    projectId: "proj",
+    traceId: "trace",
+    parentSpanId: "",
+    simulationId: "",
+    name: "span",
+    serviceName: "",
+    kind: "internal",
+    statusCode: "unset",
+    statusMessage: "",
+    operation: "execute_tool",
+    provider: "",
+    model: "",
+    agentName: "",
+    toolName: "",
+    toolNames: [],
+    tokensInput: 0,
+    tokensOutput: 0,
+    costTotalMicrocents: 0,
+    timeToFirstTokenNs: 0,
+    isStreaming: false,
+    startTime: "2026-01-01T00:00:00.000Z",
+    endTime: "2026-01-01T00:00:01.000Z",
+    ingestedAt: "2026-01-01T00:00:01.000Z",
+    ...partial,
+  }
+}
+
+describe("toolCallSpanMapFromSpans", () => {
+  it("maps toolCallId to spanId and skips empty ids", () => {
+    const spans = [
+      makeSpan({ spanId: "s1", toolCallId: "call-a" }),
+      makeSpan({ spanId: "s2", toolCallId: "" }),
+      makeSpan({ spanId: "s3", toolCallId: "call-b" }),
+    ]
+    expect(toolCallSpanMapFromSpans(spans)).toEqual({ "call-a": "s1", "call-b": "s3" })
+  })
+
+  it("returns an empty map for undefined spans", () => {
+    expect(toolCallSpanMapFromSpans(undefined)).toEqual({})
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-adapters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-adapters.ts
@@ -28,6 +28,15 @@ export function toTimelineSpan(span: SpanRecord): TimelineSpanInput {
   }
 }
 
+/** toolCallId → spanId from lightweight span rows (no message payload fetch). */
+export function toolCallSpanMapFromSpans(spans: readonly SpanRecord[] | undefined): Record<string, string> {
+  const map: Record<string, string> = {}
+  for (const span of spans ?? []) {
+    if (span.toolCallId) map[span.toolCallId] = span.spanId
+  }
+  return map
+}
+
 export function toTimelineTrace(trace: TraceRecord): TimelineTraceInput {
   return {
     traceId: trace.traceId,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
@@ -53,16 +53,13 @@ export function useSessionTimeline({
     startTimeFrom: session.startTime,
     startTimeTo: session.endTime,
   })
-  // Cache-only: conversation tab owns the heavy findMessagesForSession fetch.
-  // Timeline must not wait on (or trigger) that payload for long sessions.
   const { data: spanMaps } = useSessionConversationSpanMaps({
     projectId,
-    sessionId: session.sessionId,
-    latestTraceId,
-    sessionStartTime: session.startTime,
-    sessionEndTime: session.endTime,
-    allMessages: conversation.messages,
-    enabled: false,
+    traces,
+    loadedMessages: conversation.messages,
+    totalMessages: conversation.totalMessages,
+    sessionSpans: spans,
+    enabled: conversation.messages.length > 0,
   })
   const { data: annotationsData } = useAnnotationsBySession({
     projectId,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
@@ -17,6 +17,7 @@ import {
 import { useAgentGraph } from "../session-detail-drawer/agents-breakdown/use-agent-graph.ts"
 import {
   annotatorNameFor,
+  toolCallSpanMapFromSpans,
   toTimelineAnnotation,
   toTimelineSpan,
   toTimelineSubagents,
@@ -52,6 +53,8 @@ export function useSessionTimeline({
     startTimeFrom: session.startTime,
     startTimeTo: session.endTime,
   })
+  // Cache-only: conversation tab owns the heavy findMessagesForSession fetch.
+  // Timeline must not wait on (or trigger) that payload for long sessions.
   const { data: spanMaps } = useSessionConversationSpanMaps({
     projectId,
     sessionId: session.sessionId,
@@ -59,7 +62,7 @@ export function useSessionTimeline({
     sessionStartTime: session.startTime,
     sessionEndTime: session.endTime,
     allMessages: conversation.messages,
-    enabled: conversation.messages.length > 0,
+    enabled: false,
   })
   const { data: annotationsData } = useAnnotationsBySession({
     projectId,
@@ -70,12 +73,12 @@ export function useSessionTimeline({
   const agentGraph = useAgentGraph(spans)
 
   return useMemo(() => {
-    if (!traceDetail || !spanMaps || conversation.messages.length === 0) return null
+    if (!traceDetail || conversation.messages.length === 0) return null
     return buildConversationTimeline({
       messages: conversation.messages,
       spans: (spans ?? []).map(toTimelineSpan),
-      messageSpanMap: toSpanIdMap(spanMaps.messageSpanMap),
-      toolCallSpanMap: toSpanIdMap(spanMaps.toolCallSpanMap),
+      messageSpanMap: spanMaps ? toSpanIdMap(spanMaps.messageSpanMap) : {},
+      toolCallSpanMap: spanMaps ? toSpanIdMap(spanMaps.toolCallSpanMap) : toolCallSpanMapFromSpans(spans),
       traces: traces.map(toTimelineTrace),
       annotations: (annotationsData?.items ?? []).map((a) =>
         toTimelineAnnotation(a, annotatorNameFor(a, memberByUserId)),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-trace-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-trace-timeline.ts
@@ -13,6 +13,7 @@ import {
 import { useAgentGraph } from "../session-detail-drawer/agents-breakdown/use-agent-graph.ts"
 import {
   annotatorNameFor,
+  toolCallSpanMapFromSpans,
   toTimelineAnnotation,
   toTimelineSpan,
   toTimelineSubagents,
@@ -56,12 +57,12 @@ export function useTraceTimeline({
   const agentGraph = useAgentGraph(spans)
 
   return useMemo(() => {
-    if (!traceDetail || !spanMaps || conversation.messages.length === 0) return null
+    if (!traceDetail || conversation.messages.length === 0) return null
     return buildConversationTimeline({
       messages: conversation.messages,
       spans: (spans ?? []).map(toTimelineSpan),
-      messageSpanMap: toSpanIdMap(spanMaps.messageSpanMap),
-      toolCallSpanMap: toSpanIdMap(spanMaps.toolCallSpanMap),
+      messageSpanMap: spanMaps ? toSpanIdMap(spanMaps.messageSpanMap) : {},
+      toolCallSpanMap: spanMaps ? toSpanIdMap(spanMaps.toolCallSpanMap) : toolCallSpanMapFromSpans(spans),
       traces: [toTimelineTrace(traceRecord ?? traceDetail)],
       annotations: (annotationsData?.items ?? []).map((a) =>
         toTimelineAnnotation(a, annotatorNameFor(a, memberByUserId)),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -8,6 +8,7 @@ import { useProjectScope } from "../../../../../domains/projects/project-scope.t
 import { useSessionDetail } from "../../../../../domains/sessions/sessions.collection.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { SignalLifecycleActions } from "../signals/-components/signal-lifecycle-actions.tsx"
+import { isLargeSession } from "./session-detail-drawer/session-size.ts"
 import {
   isSessionTab,
   normalizeSessionTab,
@@ -90,7 +91,12 @@ export function SessionDetailDrawer({
     projectId,
     sessionId,
   })
-  const { traces } = useSessionTraces({ projectId, sessionId, traceIds: session?.traceIds ?? [] })
+  const { traces } = useSessionTraces({
+    projectId,
+    sessionId,
+    traceIds: session?.traceIds ?? [],
+    enabled: session ? !isLargeSession(session) : false,
+  })
 
   // The session search returns hits from the trace search index, which can
   // reference traces that have no row in the `sessions` table. Two cases

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -8,7 +8,7 @@ import { useProjectScope } from "../../../../../domains/projects/project-scope.t
 import { useSessionDetail } from "../../../../../domains/sessions/sessions.collection.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { SignalLifecycleActions } from "../signals/-components/signal-lifecycle-actions.tsx"
-import { isLargeSession } from "./session-detail-drawer/session-size.ts"
+import { isLargeSession, MAX_SESSION_ANALYSIS_TRACE_COUNT } from "./session-detail-drawer/session-size.ts"
 import {
   isSessionTab,
   normalizeSessionTab,
@@ -95,7 +95,10 @@ export function SessionDetailDrawer({
     projectId,
     sessionId,
     traceIds: session?.traceIds ?? [],
-    enabled: session ? !isLargeSession(session) : false,
+    enabled: session
+      ? !isLargeSession(session) ||
+        (activeTab === "scores" && session.traceIds.length <= MAX_SESSION_ANALYSIS_TRACE_COUNT)
+      : false,
   })
 
   // The session search returns hits from the trace search index, which can

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -1,16 +1,7 @@
 import type { MomentKind } from "@domain/conversation-intelligence"
 import { Button, Icon, Popover, PopoverClose, PopoverContent, PopoverTrigger, Text } from "@repo/ui"
 import { XIcon } from "lucide-react"
-import {
-  type ReactNode,
-  type RefObject,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react"
+import { type ReactNode, useCallback, useMemo, useState, useSyncExternalStore } from "react"
 import { useProjectScope } from "../../../../../../domains/projects/project-scope.tsx"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
@@ -21,13 +12,11 @@ import {
 import type { SessionMomentIntelligenceRecord, TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { useConversationAnnotationFocus } from "../annotations/hooks/use-conversation-annotation-focus.ts"
-import { findNearestMessageAnchor } from "../conversation-timeline/flash-highlight.ts"
 import { useSessionTimeline } from "../conversation-timeline/use-session-timeline.ts"
 import { ConversationTab as TraceConversationTab } from "../trace-detail-drawer/tabs/conversation-tab.tsx"
 import { useAgentGraph } from "./agents-breakdown/use-agent-graph.ts"
 import { isLargeSession } from "./session-size.ts"
-
-const MOMENT_FOCUS_OBSERVER_TIMEOUT_MS = 2000
+import { useScrollToFocusedMoment } from "./use-scroll-to-focused-moment.ts"
 
 type MomentLabelRecord = SessionMomentIntelligenceRecord["labels"][number]
 
@@ -168,168 +157,6 @@ function MomentLabelBadge({ label, store }: { readonly label: MomentLabelRecord;
       </PopoverContent>
     </Popover>
   )
-}
-
-function findMomentRangeAnchors(
-  container: HTMLElement,
-  firstMessageIndex: number,
-  lastMessageIndex: number,
-): readonly HTMLElement[] {
-  const anchors: HTMLElement[] = []
-  for (const node of container.querySelectorAll<HTMLElement>("[data-message-index]")) {
-    const raw = node.getAttribute("data-message-index")
-    if (raw == null) continue
-    const index = Number.parseInt(raw, 10)
-    if (Number.isNaN(index)) continue
-    if (index >= firstMessageIndex && index <= lastMessageIndex) anchors.push(node)
-  }
-
-  if (anchors.length > 0) return anchors
-  const fallback = findNearestMessageAnchor(container, firstMessageIndex)
-  return fallback ? [fallback] : []
-}
-
-function flashMomentAnchors(container: HTMLElement, anchors: readonly HTMLElement[]) {
-  if (anchors.length === 0) return
-
-  if (anchors.length === 1) {
-    const anchor = anchors[0]
-    if (!anchor) return
-    anchor.style.boxShadow = "0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--primary) / 0.5)"
-    window.setTimeout(() => {
-      anchor.style.boxShadow = ""
-    }, 4000)
-    return
-  }
-
-  const containerRect = container.getBoundingClientRect()
-  const rects = anchors.map((anchor) => anchor.getBoundingClientRect())
-  const top = Math.min(...rects.map((rect) => rect.top)) - containerRect.top + container.scrollTop
-  const left = Math.min(...rects.map((rect) => rect.left)) - containerRect.left + container.scrollLeft
-  const right = Math.max(...rects.map((rect) => rect.right)) - containerRect.left + container.scrollLeft
-  const bottom = Math.max(...rects.map((rect) => rect.bottom)) - containerRect.top + container.scrollTop
-  const previousPosition = container.style.position
-  if (getComputedStyle(container).position === "static") container.style.position = "relative"
-
-  const highlight = document.createElement("div")
-  highlight.setAttribute("aria-hidden", "true")
-  highlight.style.position = "absolute"
-  highlight.style.pointerEvents = "none"
-  highlight.style.zIndex = "1"
-  highlight.style.top = `${top - 4}px`
-  highlight.style.left = `${left - 4}px`
-  highlight.style.width = `${right - left + 8}px`
-  highlight.style.height = `${bottom - top + 8}px`
-  highlight.style.borderRadius = "12px"
-  highlight.style.boxShadow = "0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--primary) / 0.5)"
-  highlight.style.transition = "opacity 300ms ease"
-  container.appendChild(highlight)
-
-  window.setTimeout(() => {
-    highlight.style.opacity = "0"
-  }, 3700)
-  window.setTimeout(() => {
-    highlight.remove()
-    container.style.position = previousPosition
-  }, 4000)
-}
-
-/** Scrolls once per (sessionId, focusMomentKind) to the first moment carrying
- * a label of that kind, flashing the anchored message and opening the label's
- * evidence popover. Retries via MutationObserver until the conversation DOM
- * has mounted. */
-function useScrollToFocusedMoment({
-  scrollRef,
-  sessionId,
-  focusMomentKind,
-  focusMomentId,
-  moments,
-  isActive,
-  isConversationReady,
-  loadedMessageCount,
-  onFocused,
-}: {
-  readonly scrollRef: RefObject<HTMLDivElement | null>
-  readonly sessionId: string
-  readonly focusMomentKind: string | undefined
-  readonly focusMomentId: string | undefined
-  readonly moments: readonly SessionMomentIntelligenceRecord[] | undefined
-  readonly isActive: boolean
-  /** The conversation has rendered, so the scroll container ref is attached. */
-  readonly isConversationReady: boolean
-  /** How many conversation messages are currently mounted (chunked load). */
-  readonly loadedMessageCount: number
-  readonly onFocused: (labelId: string) => void
-}): void {
-  const lastScrolledKey = useRef<string | null>(null)
-  useEffect(() => {
-    if ((!focusMomentKind && !focusMomentId) || !isActive || !isConversationReady || !moments) return
-    const container = scrollRef.current
-    if (!container) return
-    const key = `${sessionId}::${focusMomentKind ?? ""}::${focusMomentId ?? ""}`
-    if (lastScrolledKey.current === key) return
-    // A focused label kind wins (it carries the badge to open); otherwise fall
-    // back to the semantic moment that linked the session to the topic.
-    const labelTarget = focusMomentKind
-      ? moments.find((row) => row.labels.some((label) => label.kind === focusMomentKind))
-      : undefined
-    const targetLabel = labelTarget?.labels.find((label) => label.kind === focusMomentKind)
-    const momentTarget =
-      !targetLabel && focusMomentId ? moments.find((row) => row.moment.momentId === focusMomentId) : undefined
-    const anchorIndex = targetLabel?.lastMessageIndex ?? momentTarget?.moment.firstMessageIndex
-    if (anchorIndex === undefined) return
-
-    // Chunked conversations load 25 messages at a time — wait for the target
-    // index to exist before arming the short DOM timeout.
-    if (anchorIndex >= loadedMessageCount) return
-
-    let done = false
-
-    function findAndScroll(): boolean {
-      if (done || !container || anchorIndex === undefined) return true
-      const anchors = momentTarget
-        ? findMomentRangeAnchors(container, momentTarget.moment.firstMessageIndex, momentTarget.moment.lastMessageIndex)
-        : [findNearestMessageAnchor(container, anchorIndex)].filter((anchor): anchor is HTMLElement => anchor !== null)
-      const anchor = anchors[0]
-      if (!anchor) return false
-      lastScrolledKey.current = key
-      anchor.scrollIntoView({ block: "center", behavior: "smooth" })
-      flashMomentAnchors(container, anchors)
-      if (targetLabel) onFocused(targetLabel.labelId)
-      return true
-    }
-
-    if (findAndScroll()) return
-
-    const observer = new MutationObserver(() => {
-      if (done) return
-      if (findAndScroll()) {
-        done = true
-        observer.disconnect()
-        window.clearTimeout(timeout)
-      }
-    })
-    observer.observe(container, { childList: true, subtree: true })
-    const timeout = window.setTimeout(() => {
-      done = true
-      observer.disconnect()
-    }, MOMENT_FOCUS_OBSERVER_TIMEOUT_MS)
-    return () => {
-      done = true
-      observer.disconnect()
-      window.clearTimeout(timeout)
-    }
-  }, [
-    focusMomentId,
-    focusMomentKind,
-    isActive,
-    isConversationReady,
-    loadedMessageCount,
-    moments,
-    onFocused,
-    scrollRef,
-    sessionId,
-  ])
 }
 
 /**

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -196,6 +196,7 @@ export function ConversationTab({
   readonly navigateToSpan?: ((spanId: string, traceId?: string) => void) | undefined
 }) {
   const sessionId = session.sessionId
+  const largeSession = isLargeSession(session)
   // Annotations are an LLM-feedback feature — off under a sandbox scope.
   const annotationsEnabled = useProjectScope().kind === "live"
   const { data: moments } = useSessionMomentIntelligence({ projectId, sessionId })
@@ -304,12 +305,12 @@ export function ConversationTab({
     scrollContainerRef,
     textSelectionPopoverControlsRef,
     focusMessageIndex,
-    ...(navigateToSpan ? { navigateToSpan } : {}),
+    ...(navigateToSpan && !largeSession ? { navigateToSpan } : {}),
     ...(labelsByMessageIndex.size > 0 ? { messageTrailingSlot } : {}),
     ...(searchQuery ? { searchQuery } : {}),
   }
 
-  if (isLargeSession(session)) {
+  if (largeSession) {
     return (
       <TraceConversationTab
         {...conversationProps}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -1,7 +1,16 @@
 import type { MomentKind } from "@domain/conversation-intelligence"
 import { Button, Icon, Popover, PopoverClose, PopoverContent, PopoverTrigger, Text } from "@repo/ui"
 import { XIcon } from "lucide-react"
-import { type RefObject, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
+import {
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react"
 import { useProjectScope } from "../../../../../../domains/projects/project-scope.tsx"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
@@ -16,6 +25,7 @@ import { findNearestMessageAnchor } from "../conversation-timeline/flash-highlig
 import { useSessionTimeline } from "../conversation-timeline/use-session-timeline.ts"
 import { ConversationTab as TraceConversationTab } from "../trace-detail-drawer/tabs/conversation-tab.tsx"
 import { useAgentGraph } from "./agents-breakdown/use-agent-graph.ts"
+import { isLargeSession } from "./session-size.ts"
 
 const MOMENT_FOCUS_OBSERVER_TIMEOUT_MS = 2000
 
@@ -29,6 +39,53 @@ function capitalizeMomentKind(kind: string) {
 // Older analyses baked the detector version into the stored summary; strip it
 // for display (newer analyses no longer write it).
 const displayLabelSummary = (summary: string) => summary.replace(/\s*\(moment-label-anchors-v\d+\)$/, "")
+
+function SessionConversationVisuals({
+  projectId,
+  session,
+  traces,
+  latestTraceId,
+  annotationsEnabled,
+  moments,
+  children,
+}: {
+  readonly projectId: string
+  readonly session: SessionDetailRecord
+  readonly traces: readonly TraceRecord[]
+  readonly latestTraceId: string
+  readonly annotationsEnabled: boolean
+  readonly moments: readonly {
+    readonly id: string
+    readonly messageIndex: number
+    readonly kind: string
+    readonly summary: string
+    readonly confidence: number
+  }[]
+  readonly children: (visuals: {
+    readonly timeline: ReturnType<typeof useSessionTimeline>
+    readonly sessionSpans: ReturnType<typeof useSpansBySessionCollection>["data"]
+    readonly agentGraph: ReturnType<typeof useAgentGraph>
+  }) => ReactNode
+}) {
+  const { data: sessionSpans } = useSpansBySessionCollection({
+    projectId,
+    sessionId: session.sessionId,
+    traceIds: session.traceIds,
+    startTimeFrom: session.startTime,
+    startTimeTo: session.endTime,
+  })
+  const agentGraph = useAgentGraph(sessionSpans)
+  const timeline = useSessionTimeline({
+    projectId,
+    session,
+    traces,
+    latestTraceId,
+    annotationsEnabled,
+    moments,
+  })
+
+  return children({ timeline, sessionSpans, agentGraph })
+}
 
 function MomentLabelEvidence({ label }: { readonly label: MomentLabelRecord }) {
   return (
@@ -309,24 +366,12 @@ export function ConversationTab({
   /** Scrolls to this semantic moment when no label kind is focused. */
   readonly focusMomentId?: string | undefined
   /** Navigates to a span in the session Spans tab; enables the conversation's span-link affordances. */
-  readonly navigateToSpan?: ((spanId: string) => void) | undefined
+  readonly navigateToSpan?: ((spanId: string, traceId?: string) => void) | undefined
 }) {
   const sessionId = session.sessionId
   // Annotations are an LLM-feedback feature — off under a sandbox scope.
   const annotationsEnabled = useProjectScope().kind === "live"
   const { data: moments } = useSessionMomentIntelligence({ projectId, sessionId })
-
-  // The conversation is the latest trace's accumulated history, but it shows tool
-  // calls from every trace in the session — so decoration needs the session-wide
-  // agent graph, not just the latest trace's. Shares the Spans-tab collection key.
-  const { data: sessionSpans } = useSpansBySessionCollection({
-    projectId,
-    sessionId,
-    traceIds: session.traceIds,
-    startTimeFrom: session.startTime,
-    startTimeTo: session.endTime,
-  })
-  const agentGraph = useAgentGraph(sessionSpans)
 
   const timelineMoments = useMemo(
     () =>
@@ -342,14 +387,6 @@ export function ConversationTab({
     [moments],
   )
 
-  const timeline = useSessionTimeline({
-    projectId,
-    session,
-    traces,
-    latestTraceId,
-    annotationsEnabled,
-    moments: timelineMoments,
-  })
   const [focusAnnotationId, setFocusAnnotationId] = useParamState("annotationId", "")
   const selectedLabelStore = useSelectedLabelStore()
   const { scrollContainerRef, textSelectionPopoverControlsRef, traceDetail, isDetailLoading } =
@@ -431,25 +468,46 @@ export function ConversationTab({
     )
   }
 
+  const conversationProps = {
+    traceDetail,
+    isDetailLoading,
+    projectId,
+    isActive,
+    annotationsEnabled,
+    scrollContainerRef,
+    textSelectionPopoverControlsRef,
+    focusMessageIndex,
+    ...(navigateToSpan ? { navigateToSpan } : {}),
+    ...(labelsByMessageIndex.size > 0 ? { messageTrailingSlot } : {}),
+    ...(searchQuery ? { searchQuery } : {}),
+  }
+
+  if (isLargeSession(session)) {
+    return (
+      <TraceConversationTab
+        {...conversationProps}
+        timelineNotice="Timeline hidden for large sessions. Open an individual trace to inspect its timeline."
+      />
+    )
+  }
+
   return (
-    <TraceConversationTab
-      traceDetail={traceDetail}
-      isDetailLoading={isDetailLoading}
+    <SessionConversationVisuals
       projectId={projectId}
-      isActive={isActive}
+      session={session}
+      traces={traces}
+      latestTraceId={latestTraceId}
       annotationsEnabled={annotationsEnabled}
-      scrollContainerRef={scrollContainerRef}
-      textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
-      timeline={timeline}
-      focusMessageIndex={focusMessageIndex}
-      sessionSpanScope={{
-        traces,
-        sessionSpans: sessionSpans ?? [],
-      }}
-      agentGraph={agentGraph}
-      {...(navigateToSpan ? { navigateToSpan } : {})}
-      {...(labelsByMessageIndex.size > 0 ? { messageTrailingSlot } : {})}
-      {...(searchQuery ? { searchQuery } : {})}
-    />
+      moments={timelineMoments}
+    >
+      {({ timeline, sessionSpans, agentGraph }) => (
+        <TraceConversationTab
+          {...conversationProps}
+          timeline={timeline}
+          sessionSpanScope={{ traces, sessionSpans: sessionSpans ?? [] }}
+          agentGraph={agentGraph}
+        />
+      )}
+    </SessionConversationVisuals>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -443,9 +443,8 @@ export function ConversationTab({
       timeline={timeline}
       focusMessageIndex={focusMessageIndex}
       sessionSpanScope={{
-        sessionId,
-        sessionStartTime: session.startTime,
-        sessionEndTime: session.endTime,
+        traces,
+        sessionSpans: sessionSpans ?? [],
       }}
       agentGraph={agentGraph}
       {...(navigateToSpan ? { navigateToSpan } : {})}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -5,7 +5,10 @@ import { type RefObject, useCallback, useEffect, useMemo, useRef, useState, useS
 import { useProjectScope } from "../../../../../../domains/projects/project-scope.tsx"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
-import { useSessionMomentIntelligence } from "../../../../../../domains/traces/traces.collection.ts"
+import {
+  useSessionMomentIntelligence,
+  useTraceConversationMessages,
+} from "../../../../../../domains/traces/traces.collection.ts"
 import type { SessionMomentIntelligenceRecord, TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { useConversationAnnotationFocus } from "../annotations/hooks/use-conversation-annotation-focus.ts"
@@ -186,6 +189,7 @@ function useScrollToFocusedMoment({
   moments,
   isActive,
   isConversationReady,
+  loadedMessageCount,
   onFocused,
 }: {
   readonly scrollRef: RefObject<HTMLDivElement | null>
@@ -196,6 +200,8 @@ function useScrollToFocusedMoment({
   readonly isActive: boolean
   /** The conversation has rendered, so the scroll container ref is attached. */
   readonly isConversationReady: boolean
+  /** How many conversation messages are currently mounted (chunked load). */
+  readonly loadedMessageCount: number
   readonly onFocused: (labelId: string) => void
 }): void {
   const lastScrolledKey = useRef<string | null>(null)
@@ -215,6 +221,10 @@ function useScrollToFocusedMoment({
       !targetLabel && focusMomentId ? moments.find((row) => row.moment.momentId === focusMomentId) : undefined
     const anchorIndex = targetLabel?.lastMessageIndex ?? momentTarget?.moment.firstMessageIndex
     if (anchorIndex === undefined) return
+
+    // Chunked conversations load 25 messages at a time — wait for the target
+    // index to exist before arming the short DOM timeout.
+    if (anchorIndex >= loadedMessageCount) return
 
     let done = false
 
@@ -252,7 +262,17 @@ function useScrollToFocusedMoment({
       observer.disconnect()
       window.clearTimeout(timeout)
     }
-  }, [focusMomentId, focusMomentKind, isActive, isConversationReady, moments, onFocused, scrollRef, sessionId])
+  }, [
+    focusMomentId,
+    focusMomentKind,
+    isActive,
+    isConversationReady,
+    loadedMessageCount,
+    moments,
+    onFocused,
+    scrollRef,
+    sessionId,
+  ])
 }
 
 /**
@@ -341,6 +361,11 @@ export function ConversationTab({
       onFocusConsumed: () => setFocusAnnotationId(""),
       annotationsEnabled,
     })
+  const conversation = useTraceConversationMessages({
+    projectId,
+    traceId: latestTraceId,
+    enabled: traceDetail != null,
+  })
 
   // Labels are scored per turn, so each badge anchors to the exact message
   // that triggered the detection (label.lastMessageIndex), not the end of the
@@ -378,6 +403,7 @@ export function ConversationTab({
     moments,
     isActive,
     isConversationReady: !isDetailLoading && traceDetail != null,
+    loadedMessageCount: conversation.messages.length,
     onFocused: selectedLabelStore.set,
   })
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
@@ -12,7 +12,7 @@ import {
 } from "@repo/ui"
 import { formatCount, formatDuration, relativeTime } from "@repo/utils"
 import { ArrowDownRightIcon, ArrowUpRightIcon, BrainIcon, FingerprintIcon, TextIcon, WrenchIcon } from "lucide-react"
-import { useMemo } from "react"
+import { type ReactNode, useMemo } from "react"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
 import { MemoryChangesSection } from "../memory-changes/memory-changes-section.tsx"
@@ -25,6 +25,7 @@ import { ModelFilterLink } from "../trace-detail-drawer/tabs/spans-tab/model-fil
 import { UsageSummary } from "../trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx"
 import { AgentsBreakdown } from "./agents-breakdown/agents-breakdown.tsx"
 import { useAgentGraph } from "./agents-breakdown/use-agent-graph.ts"
+import { isLargeSession } from "./session-size.ts"
 
 // Sessions only expose percentile filters for duration/TTFT/cost
 // (`PERCENTILE_SESSION_FILTER_FIELDS`), so the tokens badge stays informational
@@ -38,6 +39,71 @@ const METRIC_FILTER_FIELD: Partial<Record<SessionOutlierMetric, string>> = {
 function JsonBlock({ value }: { readonly value: unknown }) {
   const formatted = useMemo(() => JSON.stringify(value, null, 2), [value])
   return <CodeBlock value={formatted} className="bg-secondary" />
+}
+
+function MetadataSpanBreakdown({
+  session,
+  durationBadge,
+  costBadges,
+}: {
+  readonly session: SessionDetailRecord
+  readonly durationBadge: ReactNode
+  readonly costBadges: ReactNode
+}) {
+  const { data: spans, isLoading } = useSpansBySessionCollection({
+    projectId: session.projectId,
+    sessionId: session.sessionId,
+    traceIds: session.traceIds,
+    startTimeFrom: session.startTime,
+    startTimeTo: session.endTime,
+  })
+  const durationBreakdown = useMemo(() => computeSessionDurationBreakdown(spans ?? []), [spans])
+  const agentGraph = useAgentGraph(spans)
+  const fallbackDurationMs = session.durationNs / 1_000_000
+  const durationWallClockMs = durationBreakdown.wallClockMs > 0 ? durationBreakdown.wallClockMs : fallbackDurationMs
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <DurationBar
+          segments={durationBreakdown.segments}
+          wallClockMs={durationWallClockMs}
+          badges={durationBadge}
+          isLoading={isLoading}
+        />
+        <UsageSummary data={session} costBadges={costBadges} />
+        <MemorySummary projectId={session.projectId} sessionId={session.sessionId} />
+      </div>
+      <AgentsBreakdown graph={agentGraph} />
+    </>
+  )
+}
+
+function MetadataToolsSection({ session }: { readonly session: SessionDetailRecord }) {
+  const { data: spans, isLoading } = useSpansBySessionCollection({
+    projectId: session.projectId,
+    sessionId: session.sessionId,
+    traceIds: session.traceIds,
+    startTimeFrom: session.startTime,
+    startTimeTo: session.endTime,
+  })
+  const toolPills = useMemo(() => aggregateToolPills(spans), [spans])
+
+  return (
+    <DetailSection icon={<WrenchIcon className="h-4 w-4" />} label="Tools" defaultOpen={false}>
+      {() =>
+        isLoading ? (
+          <Skeleton className="h-7 w-48" />
+        ) : toolPills.length > 0 ? (
+          <ToolPillList tools={toolPills} scopeLabel="session" />
+        ) : (
+          <Text.H6 color="foregroundMuted" italic>
+            No tools
+          </Text.H6>
+        )
+      }
+    </DetailSection>
+  )
 }
 
 export function MetadataTab({
@@ -84,18 +150,7 @@ export function MetadataTab({
     />
   )
 
-  const { data: spans, isLoading: isSpansLoading } = useSpansBySessionCollection({
-    projectId: session.projectId,
-    sessionId: session.sessionId,
-    traceIds: session.traceIds,
-    startTimeFrom: session.startTime,
-    startTimeTo: session.endTime,
-  })
-  const durationBreakdown = useMemo(() => computeSessionDurationBreakdown(spans ?? []), [spans])
-  const agentGraph = useAgentGraph(spans)
-  const toolPills = useMemo(() => aggregateToolPills(spans), [spans])
-  const fallbackDurationMs = session.durationNs / 1_000_000
-  const durationWallClockMs = durationBreakdown.wallClockMs > 0 ? durationBreakdown.wallClockMs : fallbackDurationMs
+  const largeSession = isLargeSession(session)
   const durationBadge = renderBadge("durationNs", session.durationNs)
 
   const ttftValue = (
@@ -159,18 +214,18 @@ export function MetadataTab({
         </div>
       )}
 
-      <div className="flex flex-col gap-2">
-        <DurationBar
-          segments={durationBreakdown.segments}
-          wallClockMs={durationWallClockMs}
-          badges={durationBadge}
-          isLoading={isSpansLoading}
-        />
-        <UsageSummary data={session} costBadges={costBadgesNode} />
-        <MemorySummary projectId={session.projectId} sessionId={session.sessionId} />
-      </div>
-
-      <AgentsBreakdown graph={agentGraph} />
+      {largeSession ? (
+        <div className="flex flex-col gap-2">
+          <DurationBar segments={[]} wallClockMs={session.durationNs / 1_000_000} badges={durationBadge} />
+          <UsageSummary data={session} costBadges={costBadgesNode} />
+          <MemorySummary projectId={session.projectId} sessionId={session.sessionId} />
+          <Text.H6 color="foregroundMuted">
+            Duration, agent, and tool breakdowns are deferred for large sessions. Open Spans to inspect details.
+          </Text.H6>
+        </div>
+      ) : (
+        <MetadataSpanBreakdown session={session} durationBadge={durationBadge} costBadges={costBadgesNode} />
+      )}
 
       <div className="flex flex-col gap-1">
         <Text.H6 color="foregroundMuted">Tags</Text.H6>
@@ -183,19 +238,7 @@ export function MetadataTab({
         )}
       </div>
 
-      <DetailSection icon={<WrenchIcon className="h-4 w-4" />} label="Tools" defaultOpen={false}>
-        {() =>
-          isSpansLoading ? (
-            <Skeleton className="h-7 w-48" />
-          ) : toolPills.length > 0 ? (
-            <ToolPillList tools={toolPills} scopeLabel="session" />
-          ) : (
-            <Text.H6 color="foregroundMuted" italic>
-              No tools
-            </Text.H6>
-          )
-        }
-      </DetailSection>
+      {largeSession ? null : <MetadataToolsSection session={session} />}
 
       <MemoryChangesSection projectId={session.projectId} sessionId={session.sessionId} />
 
@@ -239,7 +282,7 @@ export function MetadataTab({
         }
       </DetailSection>
 
-      <DetailSection icon={<ArrowUpRightIcon className="h-4 w-4" />} label="Output" defaultOpen={true}>
+      <DetailSection icon={<ArrowUpRightIcon className="h-4 w-4" />} label="Output" defaultOpen={!largeSession}>
         {() =>
           session.outputMessages.length ? (
             <div className="flex flex-col rounded-lg bg-secondary p-4">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-size.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-size.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+import { isLargeSession, LARGE_SESSION_SPAN_THRESHOLD, LARGE_SESSION_TRACE_THRESHOLD } from "./session-size.ts"
+
+describe("isLargeSession", () => {
+  it("keeps session-wide visualizations for sessions at the limits", () => {
+    expect(isLargeSession({ traceCount: LARGE_SESSION_TRACE_THRESHOLD, spanCount: LARGE_SESSION_SPAN_THRESHOLD })).toBe(
+      false,
+    )
+  })
+
+  it("defers session-wide visualizations above either limit", () => {
+    expect(isLargeSession({ traceCount: LARGE_SESSION_TRACE_THRESHOLD + 1, spanCount: 1 })).toBe(true)
+    expect(isLargeSession({ traceCount: 1, spanCount: LARGE_SESSION_SPAN_THRESHOLD + 1 })).toBe(true)
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-size.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-size.ts
@@ -1,0 +1,7 @@
+export const LARGE_SESSION_TRACE_THRESHOLD = 100
+export const LARGE_SESSION_SPAN_THRESHOLD = 1_000
+export const MAX_SESSION_ANALYSIS_TRACE_COUNT = 500
+
+export function isLargeSession({ traceCount, spanCount }: { readonly traceCount: number; readonly spanCount: number }) {
+  return traceCount > LARGE_SESSION_TRACE_THRESHOLD || spanCount > LARGE_SESSION_SPAN_THRESHOLD
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -18,6 +18,7 @@ import { useSpanFilters } from "../trace-detail-drawer/tabs/spans-tab/use-span-f
 import { ConversationTab } from "./conversation-tab.tsx"
 import { MetadataTab } from "./metadata-tab.tsx"
 import { ScoresTab } from "./scores-tab.tsx"
+import { isLargeSession, MAX_SESSION_ANALYSIS_TRACE_COUNT } from "./session-size.ts"
 import { SessionSpansTab } from "./session-spans-tab.tsx"
 import { SessionStatusPill } from "./session-status-pill.tsx"
 import { SignalsTab } from "./signals-tab.tsx"
@@ -82,11 +83,11 @@ export function SessionSlot({
 }) {
   const traceIds = session.traceIds
 
-  // Annotations and issues are analysis/feedback features the sandbox doesn't
-  // produce — both off under a sandbox scope: hide the tabs and skip the fetches.
   const isSandbox = useProjectScope().kind === "sandbox"
-  const scoresEnabled = !isSandbox
-  const signalsEnabled = !isSandbox
+  const analysisTabsSupported = !isSandbox && traceIds.length <= MAX_SESSION_ANALYSIS_TRACE_COUNT
+  const scoresEnabled = analysisTabsSupported
+  const signalsEnabled = analysisTabsSupported
+  const deferAnalysisCounts = isLargeSession(session)
   const [selectedSpanId, setSelectedSpanId] = useParamState("spanId", "")
   const [selectedSpanTraceId, setSelectedSpanTraceId] = useParamState("spanTraceId", "")
   const { openWithErrors, openWithModel } = useSpanFilters()
@@ -134,14 +135,17 @@ export function SessionSlot({
     setSelectedSpanId(selection?.spanId ?? "")
   }
 
-  // Badge counts. Both queries are shared (same key) with the tab panes, so
-  // mounting a tab doesn't refetch.
+  // Large sessions fetch analysis counts only when their tab is opened.
   const { data: scoresData } = useScoresBySession({
     projectId,
     traceIds,
-    enabled: scoresEnabled,
+    enabled: scoresEnabled && (!deferAnalysisCounts || visitedTabs.has("scores")),
   })
-  const { data: issues } = useSessionSignals({ projectId, traceIds, enabled: signalsEnabled })
+  const { data: issues } = useSessionSignals({
+    projectId,
+    traceIds,
+    enabled: signalsEnabled && (!deferAnalysisCounts || visitedTabs.has("issues")),
+  })
   const scoreCount = scoresData?.items.length ?? 0
   const signalCount = issues?.length ?? 0
 
@@ -315,7 +319,6 @@ export function SessionSlot({
             <SessionSpansTab
               projectId={projectId}
               session={session}
-              traces={traces}
               selectedSpanId={selectedSpanId}
               selectedSpanTraceId={selectedSpanTraceId}
               onSelectSpan={selectSpan}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
@@ -184,13 +184,11 @@ export function SessionSpansTab({
   }
 
   const paginationStatus = (
-    <div className="flex shrink-0 flex-col items-center gap-0.5 border-t px-4 py-3">
+    <div className="flex shrink-0 items-center justify-center border-t px-4 py-3">
       <Text.H6 color="foregroundMuted">
         Showing spans from {loadedTraceIds.length} of {session.traceCount} traces
         {!traceQuery.hasNextPage && loadedTraceIds.length < session.traceCount ? " (display limit reached)" : ""}
-      </Text.H6>
-      <Text.H6 color="foregroundMuted">
-        {isLoadingMore ? "Loading more spans…" : "Filters apply to loaded traces."}
+        {isLoadingMore ? " · Loading…" : ""}
       </Text.H6>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
@@ -150,13 +150,13 @@ export function SessionSpansTab({
   }, [groups, isLoading, onSelectSpan, selectedSpanId, selectedSpanTraceId])
 
   useEffect(() => {
-    if (!selectedSpan || isLoading) return
+    if (!selectedSpan || isLoading || isLoadingSpans) return
     const isVisible = filteredGroups.some(
       (group) =>
         group.traceId === selectedSpan.traceId && group.spans.some((span) => span.spanId === selectedSpan.spanId),
     )
     if (!isVisible) onSelectSpan(null)
-  }, [filteredGroups, isLoading, onSelectSpan, selectedSpan])
+  }, [filteredGroups, isLoading, isLoadingSpans, onSelectSpan, selectedSpan])
 
   useEffect(() => {
     if (!selectedSpan || groups.length === 0) return

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react"
 import { sandboxOrgIdForScope, useProjectScope } from "../../../../../../domains/projects/project-scope.tsx"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { useSpansBySessionPages } from "../../../../../../domains/spans/spans.collection.ts"
+import { traceIdsSignature } from "../../../../../../domains/traces/trace-ids.ts"
 import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
 import { SpanDetail } from "../trace-detail-drawer/tabs/spans-tab/span-detail/index.tsx"
 import { SpanFiltersBar } from "../trace-detail-drawer/tabs/spans-tab/span-filters-bar.tsx"
@@ -39,7 +40,7 @@ function useSessionSpanTraces({
   const scope = useProjectScope()
   const sandboxOrgId = sandboxOrgIdForScope(scope)
   const query = useInfiniteQuery({
-    queryKey: ["session-span-traces", sandboxOrgId, projectId, sessionId, traceIds] as const,
+    queryKey: ["session-span-traces", sandboxOrgId, projectId, sessionId, traceIdsSignature(traceIds)] as const,
     queryFn: ({ pageParam }) =>
       sessionTracePageQueryOptions(sandboxOrgId, projectId, sessionId, traceIds, SESSION_SPAN_TRACE_PAGE_SIZE, {
         sortDirection: "asc",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
@@ -1,9 +1,10 @@
 import { Button, Icon, Text } from "@repo/ui"
+import { useInfiniteQuery } from "@tanstack/react-query"
 import { ArrowUpRightIcon } from "lucide-react"
-import { useEffect, useMemo, useRef } from "react"
+import { useCallback, useEffect, useMemo, useRef } from "react"
+import { sandboxOrgIdForScope, useProjectScope } from "../../../../../../domains/projects/project-scope.tsx"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
-import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
-import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import { useSpansBySessionPages } from "../../../../../../domains/spans/spans.collection.ts"
 import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
 import { SpanDetail } from "../trace-detail-drawer/tabs/spans-tab/span-detail/index.tsx"
 import { SpanFiltersBar } from "../trace-detail-drawer/tabs/spans-tab/span-filters-bar.tsx"
@@ -16,16 +17,48 @@ import { getTraceTimeRange } from "../trace-detail-drawer/tabs/spans-tab/span-tr
 import { useSpanFilters } from "../trace-detail-drawer/tabs/spans-tab/use-span-filters.ts"
 import {
   filterSessionSpanGroups,
+  getLoadedSessionSpanTraceIds,
   getSessionTraceNumberById,
   groupSessionSpans,
   resolveSpanTraceId,
   spanSelectionKey,
 } from "./session-spans.ts"
+import { sessionTracePageQueryOptions } from "./use-session-traces.ts"
+
+const SESSION_SPAN_TRACE_PAGE_SIZE = 25
+
+function useSessionSpanTraces({
+  projectId,
+  sessionId,
+  traceIds,
+}: {
+  readonly projectId: string
+  readonly sessionId: string
+  readonly traceIds: readonly string[]
+}) {
+  const scope = useProjectScope()
+  const sandboxOrgId = sandboxOrgIdForScope(scope)
+  const query = useInfiniteQuery({
+    queryKey: ["session-span-traces", sandboxOrgId, projectId, sessionId, traceIds] as const,
+    queryFn: ({ pageParam }) =>
+      sessionTracePageQueryOptions(sandboxOrgId, projectId, sessionId, traceIds, SESSION_SPAN_TRACE_PAGE_SIZE, {
+        sortDirection: "asc",
+        ...(pageParam ? { cursor: pageParam } : {}),
+      }).queryFn(),
+    initialPageParam: undefined as
+      | { readonly sortValue: string; readonly secondaryValue?: string | undefined; readonly traceId: string }
+      | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    enabled: projectId.length > 0 && sessionId.length > 0 && traceIds.length > 0,
+  })
+  const traces = useMemo(() => query.data?.pages.flatMap((page) => page.traces) ?? [], [query.data])
+
+  return { ...query, traces }
+}
 
 export function SessionSpansTab({
   projectId,
   session,
-  traces,
   selectedSpanId,
   selectedSpanTraceId,
   onSelectSpan,
@@ -34,7 +67,6 @@ export function SessionSpansTab({
 }: {
   readonly projectId: string
   readonly session: SessionDetailRecord
-  readonly traces: readonly TraceRecord[]
   readonly selectedSpanId: string
   readonly selectedSpanTraceId: string
   readonly onSelectSpan: (selection: SpanTreeSelection | null) => void
@@ -42,19 +74,50 @@ export function SessionSpansTab({
   readonly isActive: boolean
 }) {
   const { filters, clearFilters, toggleErrors, toggleTools, toggleMemory, selectModel } = useSpanFilters()
-  const {
-    data: spans,
-    isLoading,
-    isError,
-  } = useSpansBySessionCollection({
+  const traceQuery = useSessionSpanTraces({
     projectId,
     sessionId: session.sessionId,
     traceIds: session.traceIds,
+  })
+  const paginatedTraceIdPages = useMemo(
+    () => traceQuery.data?.pages.map((page) => page.traces.map((trace) => trace.traceId)) ?? [],
+    [traceQuery.data],
+  )
+  const loadedTraceIds = useMemo(
+    () =>
+      getLoadedSessionSpanTraceIds({
+        loadedTraceIds: paginatedTraceIdPages.flat(),
+        sessionTraceIds: session.traceIds,
+        selectedSpanTraceId,
+      }),
+    [paginatedTraceIdPages, selectedSpanTraceId, session.traceIds],
+  )
+  const spanTraceIdPages = useMemo(() => {
+    const paginatedTraceIds = new Set(paginatedTraceIdPages.flat())
+    const extraTraceId = loadedTraceIds.find((traceId) => !paginatedTraceIds.has(traceId))
+    return extraTraceId ? [...paginatedTraceIdPages, [extraTraceId]] : paginatedTraceIdPages
+  }, [loadedTraceIds, paginatedTraceIdPages])
+  const loadedTraces = useMemo(() => {
+    const traceById = new Map(traceQuery.traces.map((trace) => [trace.traceId, trace]))
+    return loadedTraceIds.flatMap((traceId) => {
+      const trace = traceById.get(traceId)
+      return trace ? [trace] : []
+    })
+  }, [loadedTraceIds, traceQuery.traces])
+  const {
+    data: spans,
+    isLoading: isLoadingSpans,
+    isError: isSpansError,
+  } = useSpansBySessionPages({
+    projectId,
+    sessionId: session.sessionId,
+    traceIdPages: spanTraceIdPages,
     startTimeFrom: session.startTime,
     startTimeTo: session.endTime,
   })
   const treeContainerRef = useRef<HTMLDivElement | null>(null)
-  const groups = useMemo(() => groupSessionSpans(spans ?? [], traces), [spans, traces])
+  const autoLoadingMoreRef = useRef(false)
+  const groups = useMemo(() => groupSessionSpans(spans ?? [], loadedTraces), [loadedTraces, spans])
   const filteredGroups = useMemo(() => filterSessionSpanGroups(groups, filters), [filters, groups])
   const traceNumberById = useMemo(() => getSessionTraceNumberById(groups), [groups])
   const timeRangeByTraceId = useMemo(
@@ -66,8 +129,18 @@ export function SessionSpansTab({
     () => (selectedSpanId && resolvedTraceId ? { traceId: resolvedTraceId, spanId: selectedSpanId } : null),
     [resolvedTraceId, selectedSpanId],
   )
+  const isLoading = traceQuery.isLoading || (isLoadingSpans && (!spans || spans.length === 0))
+  const isLoadingMore = traceQuery.isFetchingNextPage || (isLoadingSpans && (spans?.length ?? 0) > 0)
+  const isError = traceQuery.isError || (isSpansError && (!spans || spans.length === 0))
+  const loadMoreTraces = useCallback(() => {
+    if (!traceQuery.hasNextPage || isLoadingMore || autoLoadingMoreRef.current) return
 
-  // TODO(frontend-use-effect-policy): legacy span links only stored spanId; resolve their trace after spans load.
+    autoLoadingMoreRef.current = true
+    void traceQuery.fetchNextPage().finally(() => {
+      autoLoadingMoreRef.current = false
+    })
+  }, [isLoadingMore, traceQuery.fetchNextPage, traceQuery.hasNextPage])
+
   useEffect(() => {
     if (!selectedSpanId || selectedSpanTraceId || isLoading) return
     const resolved = resolveSpanTraceId(groups, selectedSpanId)
@@ -75,8 +148,6 @@ export function SessionSpansTab({
     else if (resolved.ambiguous || groups.length > 0) onSelectSpan(null)
   }, [groups, isLoading, onSelectSpan, selectedSpanId, selectedSpanTraceId])
 
-  // TODO(frontend-use-effect-policy): active filters can remove a URL-selected span from the rendered trees.
-  // Gate on `isLoading` so an empty in-flight `filteredGroups` doesn't read as "filtered out" and clear a freshly-selected span before its trees exist.
   useEffect(() => {
     if (!selectedSpan || isLoading) return
     const isVisible = filteredGroups.some(
@@ -86,13 +157,18 @@ export function SessionSpansTab({
     if (!isVisible) onSelectSpan(null)
   }, [filteredGroups, isLoading, onSelectSpan, selectedSpan])
 
-  // TODO(frontend-use-effect-policy): external conversation/deep-link selection needs imperative scrolling after load.
   useEffect(() => {
     if (!selectedSpan || groups.length === 0) return
     requestAnimationFrame(() => {
       scrollSpanIntoView(treeContainerRef.current, selectedSpan.spanId, selectedSpan.traceId)
     })
   }, [groups.length, selectedSpan])
+
+  // TODO(frontend-use-effect-policy): keep loading empty pages until spans match the current filters or pagination ends.
+  useEffect(() => {
+    if (isLoading || isLoadingMore || !traceQuery.hasNextPage) return
+    if (!spans || spans.length === 0 || filteredGroups.length === 0) loadMoreTraces()
+  }, [filteredGroups.length, isLoading, isLoadingMore, loadMoreTraces, spans, traceQuery.hasNextPage])
 
   function handleSelectSpan(selection: SpanTreeSelection | null) {
     if (!selection || (selectedSpan && spanSelectionKey(selection) === spanSelectionKey(selectedSpan))) {
@@ -106,6 +182,18 @@ export function SessionSpansTab({
     onSelectSpan(null)
     onOpenTrace(traceId, { targetTab: "trace" })
   }
+
+  const paginationStatus = (
+    <div className="flex shrink-0 flex-col items-center gap-0.5 border-t px-4 py-3">
+      <Text.H6 color="foregroundMuted">
+        Showing spans from {loadedTraceIds.length} of {session.traceCount} traces
+        {!traceQuery.hasNextPage && loadedTraceIds.length < session.traceCount ? " (display limit reached)" : ""}
+      </Text.H6>
+      <Text.H6 color="foregroundMuted">
+        {isLoadingMore ? "Loading more spans…" : "Filters apply to loaded traces."}
+      </Text.H6>
+    </div>
+  )
 
   if (isLoading) {
     return (
@@ -125,8 +213,11 @@ export function SessionSpansTab({
 
   if (!spans || spans.length === 0) {
     return (
-      <div className="flex items-center justify-center py-6">
-        <Text.H5 color="foregroundMuted">No spans found</Text.H5>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex flex-1 items-center justify-center py-6">
+          <Text.H5 color="foregroundMuted">No spans found</Text.H5>
+        </div>
+        {paginationStatus}
       </div>
     )
   }
@@ -146,6 +237,7 @@ export function SessionSpansTab({
         <div className="flex flex-1 items-center justify-center py-6">
           <Text.H5 color="foregroundMuted">No spans match the active filters</Text.H5>
         </div>
+        {paginationStatus}
       </div>
     )
   }
@@ -192,6 +284,8 @@ export function SessionSpansTab({
         selectedSpan={selectedSpan}
         onSelectSpan={handleSelectSpan}
         isActive={isActive}
+        footer={paginationStatus}
+        onScrollEnd={loadMoreTraces}
       />
       {selectedSpan && selectedGroup && (
         <SpanDetail

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.test.ts
@@ -4,6 +4,7 @@ import type { TraceRecord } from "../../../../../../domains/traces/traces.functi
 import { getTraceTimeRange } from "../trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.ts"
 import {
   filterSessionSpanGroups,
+  getLoadedSessionSpanTraceIds,
   getSessionTraceNumberById,
   groupSessionSpans,
   resolveSpanTraceId,
@@ -75,6 +76,16 @@ function makeTrace(
 }
 
 describe("session span groups", () => {
+  it("includes a selected session trace that has not reached the loaded page", () => {
+    expect(
+      getLoadedSessionSpanTraceIds({
+        loadedTraceIds: ["trace-a", "trace-b"],
+        sessionTraceIds: ["trace-a", "trace-b", "trace-c"],
+        selectedSpanTraceId: "trace-c",
+      }),
+    ).toEqual(["trace-a", "trace-b", "trace-c"])
+  })
+
   it("groups spans oldest-first and falls back to span timing when trace metadata is missing", () => {
     const spans = [
       makeSpan({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.ts
@@ -19,6 +19,20 @@ export function spanSelectionKey(selection: SpanSelection): string {
   return `${selection.traceId}:${selection.spanId}`
 }
 
+export function getLoadedSessionSpanTraceIds({
+  loadedTraceIds,
+  sessionTraceIds,
+  selectedSpanTraceId,
+}: {
+  readonly loadedTraceIds: readonly string[]
+  readonly sessionTraceIds: readonly string[]
+  readonly selectedSpanTraceId: string
+}): readonly string[] {
+  const traceIds = new Set(loadedTraceIds)
+  if (selectedSpanTraceId && sessionTraceIds.includes(selectedSpanTraceId)) traceIds.add(selectedSpanTraceId)
+  return [...traceIds]
+}
+
 export function getSessionTraceNumberById(groups: readonly SessionSpanGroup[]): ReadonlyMap<string, number> {
   return new Map(groups.map((group, index) => [group.traceId, index + 1]))
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-scroll-to-focused-moment.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-scroll-to-focused-moment.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+import type { SessionMomentIntelligenceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import { resolveFocusedMomentTarget } from "./use-scroll-to-focused-moment.ts"
+
+function moment({
+  momentId,
+  firstMessageIndex,
+  label,
+}: {
+  readonly momentId: string
+  readonly firstMessageIndex: number
+  readonly label?: { readonly labelId: string; readonly kind: string; readonly lastMessageIndex: number }
+}): SessionMomentIntelligenceRecord {
+  return {
+    moment: {
+      momentId,
+      analysisHash: "hash",
+      firstMessageIndex,
+      lastMessageIndex: firstMessageIndex + 1,
+      boundaryReason: "test",
+      coherenceScore: 1,
+    },
+    labels: label
+      ? [
+          {
+            ...label,
+            actor: "assistant",
+            firstMessageIndex,
+            summary: "summary",
+            evidence: "evidence",
+            confidence: 1,
+          },
+        ]
+      : [],
+    taxonomyObservations: [],
+  }
+}
+
+const moments = [
+  moment({ momentId: "moment-a", firstMessageIndex: 2 }),
+  moment({
+    momentId: "moment-b",
+    firstMessageIndex: 10,
+    label: { labelId: "label-b", kind: "handoff", lastMessageIndex: 12 },
+  }),
+]
+
+describe("resolveFocusedMomentTarget", () => {
+  it("prefers a focused label kind over a moment id", () => {
+    const target = resolveFocusedMomentTarget({
+      focusMomentKind: "handoff",
+      focusMomentId: "moment-a",
+      moments,
+      loadedMessageCount: 25,
+    })
+
+    expect(target?.anchorIndex).toBe(12)
+    expect(target?.targetLabel?.labelId).toBe("label-b")
+    expect(target?.momentTarget).toBeUndefined()
+  })
+
+  it("falls back to the focused semantic moment", () => {
+    const target = resolveFocusedMomentTarget({
+      focusMomentKind: undefined,
+      focusMomentId: "moment-a",
+      moments,
+      loadedMessageCount: 25,
+    })
+
+    expect(target?.anchorIndex).toBe(2)
+    expect(target?.momentTarget?.moment.momentId).toBe("moment-a")
+  })
+
+  it("waits until the target message is loaded", () => {
+    expect(
+      resolveFocusedMomentTarget({
+        focusMomentKind: "handoff",
+        focusMomentId: undefined,
+        moments,
+        loadedMessageCount: 12,
+      }),
+    ).toBeNull()
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-scroll-to-focused-moment.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-scroll-to-focused-moment.ts
@@ -1,0 +1,173 @@
+import { type RefObject, useEffect, useRef } from "react"
+import type { SessionMomentIntelligenceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import { findNearestMessageAnchor } from "../conversation-timeline/flash-highlight.ts"
+
+const MOMENT_FOCUS_OBSERVER_TIMEOUT_MS = 2000
+
+export function resolveFocusedMomentTarget({
+  focusMomentKind,
+  focusMomentId,
+  moments,
+  loadedMessageCount,
+}: {
+  readonly focusMomentKind: string | undefined
+  readonly focusMomentId: string | undefined
+  readonly moments: readonly SessionMomentIntelligenceRecord[]
+  readonly loadedMessageCount: number
+}) {
+  const labelTarget = focusMomentKind
+    ? moments.find((row) => row.labels.some((label) => label.kind === focusMomentKind))
+    : undefined
+  const targetLabel = labelTarget?.labels.find((label) => label.kind === focusMomentKind)
+  const momentTarget =
+    !targetLabel && focusMomentId ? moments.find((row) => row.moment.momentId === focusMomentId) : undefined
+  const anchorIndex = targetLabel?.lastMessageIndex ?? momentTarget?.moment.firstMessageIndex
+
+  if (anchorIndex === undefined || anchorIndex >= loadedMessageCount) return null
+  return { anchorIndex, momentTarget, targetLabel }
+}
+
+function findMomentRangeAnchors(
+  container: HTMLElement,
+  firstMessageIndex: number,
+  lastMessageIndex: number,
+): readonly HTMLElement[] {
+  const anchors: HTMLElement[] = []
+  for (const node of container.querySelectorAll<HTMLElement>("[data-message-index]")) {
+    const raw = node.getAttribute("data-message-index")
+    if (raw == null) continue
+    const index = Number.parseInt(raw, 10)
+    if (Number.isNaN(index)) continue
+    if (index >= firstMessageIndex && index <= lastMessageIndex) anchors.push(node)
+  }
+
+  if (anchors.length > 0) return anchors
+  const fallback = findNearestMessageAnchor(container, firstMessageIndex)
+  return fallback ? [fallback] : []
+}
+
+function flashMomentAnchors(container: HTMLElement, anchors: readonly HTMLElement[]) {
+  if (anchors.length === 0) return
+
+  if (anchors.length === 1) {
+    const anchor = anchors[0]
+    if (!anchor) return
+    anchor.style.boxShadow = "0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--primary) / 0.5)"
+    window.setTimeout(() => {
+      anchor.style.boxShadow = ""
+    }, 4000)
+    return
+  }
+
+  const containerRect = container.getBoundingClientRect()
+  const rects = anchors.map((anchor) => anchor.getBoundingClientRect())
+  const top = Math.min(...rects.map((rect) => rect.top)) - containerRect.top + container.scrollTop
+  const left = Math.min(...rects.map((rect) => rect.left)) - containerRect.left + container.scrollLeft
+  const right = Math.max(...rects.map((rect) => rect.right)) - containerRect.left + container.scrollLeft
+  const bottom = Math.max(...rects.map((rect) => rect.bottom)) - containerRect.top + container.scrollTop
+  const previousPosition = container.style.position
+  if (getComputedStyle(container).position === "static") container.style.position = "relative"
+
+  const highlight = document.createElement("div")
+  highlight.setAttribute("aria-hidden", "true")
+  highlight.style.position = "absolute"
+  highlight.style.pointerEvents = "none"
+  highlight.style.zIndex = "1"
+  highlight.style.top = `${top - 4}px`
+  highlight.style.left = `${left - 4}px`
+  highlight.style.width = `${right - left + 8}px`
+  highlight.style.height = `${bottom - top + 8}px`
+  highlight.style.borderRadius = "12px"
+  highlight.style.boxShadow = "0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--primary) / 0.5)"
+  highlight.style.transition = "opacity 300ms ease"
+  container.appendChild(highlight)
+
+  window.setTimeout(() => {
+    highlight.style.opacity = "0"
+  }, 3700)
+  window.setTimeout(() => {
+    highlight.remove()
+    container.style.position = previousPosition
+  }, 4000)
+}
+
+export function useScrollToFocusedMoment({
+  scrollRef,
+  sessionId,
+  focusMomentKind,
+  focusMomentId,
+  moments,
+  isActive,
+  isConversationReady,
+  loadedMessageCount,
+  onFocused,
+}: {
+  readonly scrollRef: RefObject<HTMLDivElement | null>
+  readonly sessionId: string
+  readonly focusMomentKind: string | undefined
+  readonly focusMomentId: string | undefined
+  readonly moments: readonly SessionMomentIntelligenceRecord[] | undefined
+  readonly isActive: boolean
+  readonly isConversationReady: boolean
+  readonly loadedMessageCount: number
+  readonly onFocused: (labelId: string) => void
+}): void {
+  const lastScrolledKey = useRef<string | null>(null)
+  useEffect(() => {
+    if ((!focusMomentKind && !focusMomentId) || !isActive || !isConversationReady || !moments) return
+    const container = scrollRef.current
+    if (!container) return
+    const key = `${sessionId}::${focusMomentKind ?? ""}::${focusMomentId ?? ""}`
+    if (lastScrolledKey.current === key) return
+
+    const target = resolveFocusedMomentTarget({ focusMomentKind, focusMomentId, moments, loadedMessageCount })
+    if (!target) return
+    const { anchorIndex, momentTarget, targetLabel } = target
+    let done = false
+
+    function findAndScroll(): boolean {
+      if (done || !container) return true
+      const anchors = momentTarget
+        ? findMomentRangeAnchors(container, momentTarget.moment.firstMessageIndex, momentTarget.moment.lastMessageIndex)
+        : [findNearestMessageAnchor(container, anchorIndex)].filter((anchor): anchor is HTMLElement => anchor !== null)
+      const anchor = anchors[0]
+      if (!anchor) return false
+      lastScrolledKey.current = key
+      anchor.scrollIntoView({ block: "center", behavior: "smooth" })
+      flashMomentAnchors(container, anchors)
+      if (targetLabel) onFocused(targetLabel.labelId)
+      return true
+    }
+
+    if (findAndScroll()) return
+
+    const observer = new MutationObserver(() => {
+      if (done) return
+      if (findAndScroll()) {
+        done = true
+        observer.disconnect()
+        window.clearTimeout(timeout)
+      }
+    })
+    observer.observe(container, { childList: true, subtree: true })
+    const timeout = window.setTimeout(() => {
+      done = true
+      observer.disconnect()
+    }, MOMENT_FOCUS_OBSERVER_TIMEOUT_MS)
+    return () => {
+      done = true
+      observer.disconnect()
+      window.clearTimeout(timeout)
+    }
+  }, [
+    focusMomentId,
+    focusMomentKind,
+    isActive,
+    isConversationReady,
+    loadedMessageCount,
+    moments,
+    onFocused,
+    scrollRef,
+    sessionId,
+  ])
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.test.ts
@@ -1,19 +1,64 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
 
+const listSessionTraces = vi.fn()
 const listTracesByProject = vi.fn()
 
 vi.mock("../../../../../../domains/traces/traces.functions.ts", () => ({
+  listSessionTraces: (...args: unknown[]) => listSessionTraces(...args),
   listTracesByProject: (...args: unknown[]) => listTracesByProject(...args),
 }))
 
 // Imported after the mock is registered.
-const { sessionTracesQueryOptions } = await import("./use-session-traces.ts")
+const { sessionTracePageQueryOptions, sessionTracesQueryOptions } = await import("./use-session-traces.ts")
 
 const trace = (traceId: string, startTime: string): TraceRecord => ({ traceId, startTime }) as unknown as TraceRecord
 
 beforeEach(() => {
+  listSessionTraces.mockReset()
   listTracesByProject.mockReset()
+})
+
+describe("sessionTracePageQueryOptions queryFn", () => {
+  it("fetches only the requested session trace page", async () => {
+    const ids = Array.from({ length: 100 }, (_, index) => `t${index}`)
+    listSessionTraces.mockResolvedValue({ traces: [], hasMore: true })
+
+    const result = await sessionTracePageQueryOptions(undefined, "p1", "s1", ids, 25).queryFn()
+
+    expect(listSessionTraces).toHaveBeenCalledWith({ data: { projectId: "p1", traceIds: ids, limit: 25 } })
+    expect(result).toEqual({ traces: [], hasMore: true })
+  })
+
+  it("supports chronological cursor pages for session spans", async () => {
+    const cursor = { sortValue: "2026-01-01T00:00:00.000Z", traceId: "t25" }
+    listSessionTraces.mockResolvedValue({ traces: [], hasMore: true })
+
+    await sessionTracePageQueryOptions(undefined, "p1", "s1", ["t1", "t25"], 25, {
+      cursor,
+      sortDirection: "asc",
+    }).queryFn()
+
+    expect(listSessionTraces).toHaveBeenCalledWith({
+      data: {
+        projectId: "p1",
+        traceIds: ["t1", "t25"],
+        limit: 25,
+        cursor,
+        sortDirection: "asc",
+      },
+    })
+  })
+
+  it("caps oversized sessions at 500 traces", async () => {
+    const ids = Array.from({ length: 650 }, (_, index) => `t${index}`)
+    listSessionTraces.mockResolvedValue({ traces: [], hasMore: false })
+
+    await sessionTracePageQueryOptions(undefined, "p1", "s1", ids, 650).queryFn()
+
+    expect(listSessionTraces.mock.calls[0]?.[0]?.data.traceIds).toHaveLength(500)
+    expect(listSessionTraces.mock.calls[0]?.[0]?.data.limit).toBe(500)
+  })
 })
 
 describe("sessionTracesQueryOptions queryFn", () => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.ts
@@ -1,5 +1,6 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import { sandboxOrgIdForScope, useProjectScope } from "../../../../../../domains/projects/project-scope.tsx"
+import { traceIdsSignature } from "../../../../../../domains/traces/trace-ids.ts"
 import {
   listSessionTraces,
   listTracesByProject,
@@ -99,7 +100,7 @@ export const sessionTracePageQueryOptions = (
     sandboxOrgId,
     projectId,
     sessionId,
-    traceIds,
+    traceIdsSignature(traceIds),
     limit,
     options?.cursor,
     options?.sortDirection,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.ts
@@ -1,6 +1,10 @@
-import { useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import { sandboxOrgIdForScope, useProjectScope } from "../../../../../../domains/projects/project-scope.tsx"
-import { listTracesByProject, type TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import {
+  listSessionTraces,
+  listTracesByProject,
+  type TraceRecord,
+} from "../../../../../../domains/traces/traces.functions.ts"
 
 const EMPTY: readonly TraceRecord[] = []
 
@@ -46,21 +50,24 @@ export const sessionTracesQueryOptions = (
     const ordered = traceIds.slice(0, SESSION_TRACES_HARD_CAP)
     if (ordered.length === 0) return [] as TraceRecord[]
 
-    const traces: TraceRecord[] = []
-    for (let i = 0; i < ordered.length; i += TRACE_ID_CHUNK_SIZE) {
-      const chunk = ordered.slice(i, i + TRACE_ID_CHUNK_SIZE)
-      const page = await listTracesByProject({
-        data: {
-          ...(sandboxOrgId ? { sandboxOrgId } : {}),
-          projectId,
-          limit: chunk.length,
-          sortBy: "startTime",
-          sortDirection: "desc",
-          filters: { traceId: [{ op: "in" as const, value: chunk }] },
-        },
-      })
-      if (page?.traces.length) traces.push(...page.traces)
-    }
+    const chunks = Array.from({ length: Math.ceil(ordered.length / TRACE_ID_CHUNK_SIZE) }, (_, index) =>
+      ordered.slice(index * TRACE_ID_CHUNK_SIZE, (index + 1) * TRACE_ID_CHUNK_SIZE),
+    )
+    const pages = await Promise.all(
+      chunks.map((chunk) =>
+        listTracesByProject({
+          data: {
+            ...(sandboxOrgId ? { sandboxOrgId } : {}),
+            projectId,
+            limit: chunk.length,
+            sortBy: "startTime",
+            sortDirection: "desc",
+            filters: { traceId: [{ op: "in" as const, value: chunk }] },
+          },
+        }),
+      ),
+    )
+    const traces = pages.flatMap((page) => page?.traces ?? [])
 
     // Child traces are shown newest-first, matching the sessions table's
     // last-activity ordering. Each chunk is fetched desc, but the chunks are
@@ -69,6 +76,48 @@ export const sessionTracesQueryOptions = (
     traces.sort((a, b) => b.startTime.localeCompare(a.startTime) || b.traceId.localeCompare(a.traceId))
     return traces
   },
+  staleTime: 30_000,
+})
+
+export const sessionTracePageQueryOptions = (
+  sandboxOrgId: string | undefined,
+  projectId: string,
+  sessionId: string,
+  traceIds: readonly string[],
+  limit: number,
+  options?: {
+    readonly cursor?: {
+      readonly sortValue: string
+      readonly secondaryValue?: string | undefined
+      readonly traceId: string
+    }
+    readonly sortDirection?: "asc" | "desc"
+  },
+) => ({
+  queryKey: [
+    "session-trace-page",
+    sandboxOrgId,
+    projectId,
+    sessionId,
+    traceIds,
+    limit,
+    options?.cursor,
+    options?.sortDirection,
+  ] as const,
+  queryFn: async () => {
+    if (traceIds.length === 0) return { traces: [] as readonly TraceRecord[], hasMore: false }
+    return await listSessionTraces({
+      data: {
+        ...(sandboxOrgId ? { sandboxOrgId } : {}),
+        projectId,
+        traceIds: traceIds.slice(0, SESSION_TRACES_HARD_CAP),
+        limit: Math.min(limit, SESSION_TRACES_HARD_CAP),
+        ...(options?.cursor ? { cursor: options.cursor } : {}),
+        ...(options?.sortDirection ? { sortDirection: options.sortDirection } : {}),
+      },
+    })
+  },
+  placeholderData: keepPreviousData,
   staleTime: 30_000,
 })
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -1,5 +1,6 @@
 import type { FilterSet } from "@domain/shared"
 import {
+  Button,
   type ExpandedRows,
   InfiniteTable,
   type InfiniteTableColumn,
@@ -13,7 +14,7 @@ import { formatCount, formatDuration, formatPercentage, formatPrice, relativeTim
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { useQueries } from "@tanstack/react-query"
 import { ChevronsDownUpIcon, ChevronsUpDownIcon } from "lucide-react"
-import { useCallback, useMemo, useState } from "react"
+import { type ReactNode, useCallback, useMemo, useState } from "react"
 import { useAnnotationCountsByTraceIds } from "../../../../../domains/annotations/annotations.collection.ts"
 import { sandboxOrgIdForScope, useProjectScope } from "../../../../../domains/projects/project-scope.tsx"
 import {
@@ -22,13 +23,14 @@ import {
   useSessionsCountWithoutLlmActivityFilter,
   useSessionsInfiniteScroll,
 } from "../../../../../domains/sessions/sessions.collection.ts"
-import type { SessionRecord } from "../../../../../domains/sessions/sessions.functions.ts"
+import type { SessionRecord, SessionSearchMatchRecord } from "../../../../../domains/sessions/sessions.functions.ts"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
 import { ListingLayout as Layout, listingLayoutIntrinsicScroll } from "../../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import type { SelectionState } from "../../../../../lib/hooks/useSelectableRows.ts"
 import { FiltersSidebar } from "./filters-sidebar.tsx"
-import { sessionTracesQueryOptions } from "./session-detail-drawer/use-session-traces.ts"
+import { isLargeSession } from "./session-detail-drawer/session-size.ts"
+import { sessionTracePageQueryOptions } from "./session-detail-drawer/use-session-traces.ts"
 import { SessionOutlierBadge } from "./session-outlier-badge.tsx"
 import { SessionsOrphanFragmentsBlankSlate } from "./sessions-orphan-fragments-blank-slate.tsx"
 import { CacheHitRateSubheader } from "./table/cache-hit-rate-subheader.tsx"
@@ -46,6 +48,11 @@ function field<K extends keyof SessionRecord & keyof TraceRecord>(row: SessionTa
 }
 
 const EMPTY_CELL = <Text.H5 color="foregroundMuted">-</Text.H5>
+const EXPANDED_TRACE_PAGE_SIZE = 25
+
+function expandedTraceStateKey(searchQuery: string | undefined, sessionId: string) {
+  return `${searchQuery ?? ""}:${sessionId}`
+}
 
 export const DEFAULT_SESSION_SORTING: InfiniteTableSorting = {
   column: "lastActivity",
@@ -75,31 +82,65 @@ export function getSessionColumnOptions(isSearching: boolean): readonly (typeof 
   return SESSION_COLUMN_OPTIONS.filter((column) => column.id !== "searchMatches")
 }
 
-function useExpandedSessionTraces(
-  projectId: string,
-  expandedIds: ReadonlySet<string>,
-  sessions: readonly SessionRecord[],
-) {
+function useExpandedSessionTraces({
+  projectId,
+  expandedIds,
+  sessions,
+  searchMatches,
+  showAllInSessionIds,
+  visibleTraceCountBySessionId,
+  searchQuery,
+}: {
+  readonly projectId: string
+  readonly expandedIds: ReadonlySet<string>
+  readonly sessions: readonly SessionRecord[]
+  readonly searchMatches: Readonly<Record<string, SessionSearchMatchRecord>> | undefined
+  readonly showAllInSessionIds: ReadonlySet<string>
+  readonly visibleTraceCountBySessionId: ReadonlyMap<string, number>
+  readonly searchQuery: string | undefined
+}) {
   const scope = useProjectScope()
-  const expandedSessions = useMemo(() => sessions.filter((s) => expandedIds.has(s.sessionId)), [sessions, expandedIds])
+  const expandedSessions = useMemo(
+    () =>
+      sessions
+        .filter((session) => expandedIds.has(session.sessionId))
+        .map((session) => {
+          const stateKey = expandedTraceStateKey(searchQuery, session.sessionId)
+          const match = searchMatches?.[session.sessionId]
+          const showingAll = showAllInSessionIds.has(stateKey)
+          return {
+            session,
+            traceIds: match && !showingAll ? match.matchingTraceIds : session.traceIds,
+            limit: visibleTraceCountBySessionId.get(stateKey) ?? EXPANDED_TRACE_PAGE_SIZE,
+          }
+        }),
+    [expandedIds, searchMatches, searchQuery, sessions, showAllInSessionIds, visibleTraceCountBySessionId],
+  )
 
-  // Shared cache with the session panel's `useSessionTraces` — same key, same
-  // query function. With the panel open on an expanded row the ClickHouse query
-  // runs once and both surfaces read from it.
   const results = useQueries({
-    queries: expandedSessions.map((s) =>
-      sessionTracesQueryOptions(sandboxOrgIdForScope(scope), projectId, s.sessionId, s.traceIds),
+    queries: expandedSessions.map(({ session, traceIds, limit }) =>
+      sessionTracePageQueryOptions(sandboxOrgIdForScope(scope), projectId, session.sessionId, traceIds, limit, {
+        sortDirection: "desc",
+      }),
     ),
   })
 
   return useMemo(() => {
-    const traceMap = new Map<string, { data: readonly TraceRecord[]; isLoading: boolean }>()
+    const traceMap = new Map<
+      string,
+      { data: readonly TraceRecord[]; hasMore: boolean; isLoading: boolean; isLoadingMore: boolean }
+    >()
     for (let i = 0; i < results.length; i++) {
-      const r = results[i]
-      const session = expandedSessions[i]
-      if (!r || !session) continue
-      const isLoading = r.isPending || (r.isFetching && r.data === undefined)
-      traceMap.set(session.sessionId, { data: r.data ?? [], isLoading })
+      const result = results[i]
+      const expanded = expandedSessions[i]
+      if (!result || !expanded) continue
+      const isLoading = result.isPending || (result.isFetching && result.data === undefined)
+      traceMap.set(expanded.session.sessionId, {
+        data: result.data?.traces ?? [],
+        hasMore: result.data?.hasMore ?? false,
+        isLoading,
+        isLoadingMore: result.isFetching && result.data !== undefined,
+      })
     }
     return traceMap
   }, [results, expandedSessions])
@@ -161,58 +202,93 @@ export function SessionsView({
     () => (isSearching ? visibleColumnIds : visibleColumnIds.filter((id) => id !== "searchMatches")),
     [visibleColumnIds, isSearching],
   )
-  // Inline expansion (independent of the row-body click, which opens the panel).
-  // The chevron toggles `expandedIds`; `showAllInSessionIds` is the per-session
-  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() =>
-    activeSessionId ? new Set([activeSessionId]) : new Set(),
-  )
+  // Inline expansion is independent of the row-body click, which opens the panel.
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(new Set())
   const [showAllInSessionIds, setShowAllInSessionIds] = useState<ReadonlySet<string>>(new Set())
-  const toggleShowAllForSession = useCallback((sessionId: string) => {
-    setShowAllInSessionIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(sessionId)) next.delete(sessionId)
-      else next.add(sessionId)
-      return next
-    })
-  }, [])
+  const [visibleTraceCountBySessionId, setVisibleTraceCountBySessionId] = useState<ReadonlyMap<string, number>>(
+    new Map(),
+  )
+  const expansionStateKey = useCallback((sessionId: string) => `${searchQuery ?? ""}:${sessionId}`, [searchQuery])
+  const toggleShowAllForSession = useCallback(
+    (sessionId: string) => {
+      const stateKey = expansionStateKey(sessionId)
+      setShowAllInSessionIds((prev) => {
+        const next = new Set(prev)
+        if (next.has(stateKey)) next.delete(stateKey)
+        else next.add(stateKey)
+        return next
+      })
+    },
+    [expansionStateKey],
+  )
 
-  const toggleSessionExpanded = useCallback((sessionId: string) => {
-    setExpandedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(sessionId)) next.delete(sessionId)
-      else next.add(sessionId)
-      return next
-    })
-    // Collapsing resets the matches-only view for next time.
-    setShowAllInSessionIds((prev) => {
-      if (!prev.has(sessionId)) return prev
-      const next = new Set(prev)
-      next.delete(sessionId)
-      return next
-    })
-  }, [])
+  const toggleSessionExpanded = useCallback(
+    (sessionId: string) => {
+      const stateKey = expansionStateKey(sessionId)
+      setExpandedIds((prev) => {
+        const next = new Set(prev)
+        if (next.has(sessionId)) next.delete(sessionId)
+        else next.add(sessionId)
+        return next
+      })
+      setShowAllInSessionIds((prev) => {
+        if (!prev.has(stateKey)) return prev
+        const next = new Set(prev)
+        next.delete(stateKey)
+        return next
+      })
+      setVisibleTraceCountBySessionId((prev) => {
+        if (!prev.has(stateKey)) return prev
+        const next = new Map(prev)
+        next.delete(stateKey)
+        return next
+      })
+    },
+    [expansionStateKey],
+  )
 
-  // Row click ensures the session is expanded (never collapses — that's the
-  // chevron's job), so returning to a session from one of its traces keeps the
-  // inline trace rows visible instead of toggling them shut.
+  // Row click expands regular sessions without toggling them shut. Large
+  // sessions wait for the explicit chevron so opening their drawer stays fast.
   const expandSession = useCallback((sessionId: string) => {
     setExpandedIds((prev) => (prev.has(sessionId) ? prev : new Set([...prev, sessionId])))
   }, [])
 
-  const collapseSession = useCallback((sessionId: string) => {
-    setExpandedIds((prev) => {
-      if (!prev.has(sessionId)) return prev
-      const next = new Set(prev)
-      next.delete(sessionId)
-      return next
-    })
-    setShowAllInSessionIds((prev) => {
-      if (!prev.has(sessionId)) return prev
-      const next = new Set(prev)
-      next.delete(sessionId)
-      return next
-    })
-  }, [])
+  const collapseSession = useCallback(
+    (sessionId: string) => {
+      const stateKey = expansionStateKey(sessionId)
+      setExpandedIds((prev) => {
+        if (!prev.has(sessionId)) return prev
+        const next = new Set(prev)
+        next.delete(sessionId)
+        return next
+      })
+      setShowAllInSessionIds((prev) => {
+        if (!prev.has(stateKey)) return prev
+        const next = new Set(prev)
+        next.delete(stateKey)
+        return next
+      })
+      setVisibleTraceCountBySessionId((prev) => {
+        if (!prev.has(stateKey)) return prev
+        const next = new Map(prev)
+        next.delete(stateKey)
+        return next
+      })
+    },
+    [expansionStateKey],
+  )
+
+  const loadMoreSessionTraces = useCallback(
+    (sessionId: string) => {
+      const stateKey = expansionStateKey(sessionId)
+      setVisibleTraceCountBySessionId((prev) => {
+        const next = new Map(prev)
+        next.set(stateKey, (prev.get(stateKey) ?? EXPANDED_TRACE_PAGE_SIZE) + EXPANDED_TRACE_PAGE_SIZE)
+        return next
+      })
+    },
+    [expansionStateKey],
+  )
 
   const isRelevanceSort = sorting.column === RELEVANCE_SORT_COLUMN
 
@@ -549,7 +625,15 @@ export function SessionsView({
     })
   }, [allColumns, effectiveVisibleColumnIds])
 
-  const traceMap = useExpandedSessionTraces(projectId, expandedIds, sessions)
+  const traceMap = useExpandedSessionTraces({
+    projectId,
+    expandedIds,
+    sessions,
+    searchMatches,
+    showAllInSessionIds,
+    visibleTraceCountBySessionId,
+    searchQuery,
+  })
 
   const selection = useSessionSelectionAdapter({
     selectionState,
@@ -581,7 +665,7 @@ export function SessionsView({
         return
       }
       onOpenSession(sessionId)
-      if (row.session.traceCount > 1) expandSession(sessionId)
+      if (row.session.traceCount > 1 && !isLargeSession(row.session)) expandSession(sessionId)
     } else {
       onOpenSession(row.trace.sessionId, row.trace.traceId)
     }
@@ -661,39 +745,72 @@ export function SessionsView({
     const entry = traceMap.get(sessionId)
     if (!entry) return { data: [], isLoading: true }
 
+    const stateKey = expansionStateKey(sessionId)
+    const paginateTraces = (
+      traces: readonly TraceRecord[],
+      totalCount: number,
+      leadingControl?: ReactNode,
+    ): ExpandedRows<SessionTableRow> => {
+      const displayLimitReached = !entry.isLoadingMore && !entry.hasMore && totalCount > traces.length
+      const footer =
+        leadingControl || entry.hasMore || entry.isLoadingMore || displayLimitReached ? (
+          <div className="flex w-full items-center px-4 py-2">
+            <div className="flex min-w-0 flex-1 items-center justify-start">{leadingControl}</div>
+            <div className="flex min-w-0 flex-1 items-center justify-center gap-3">
+              <Text.H6 color="foregroundMuted" noWrap>
+                Showing {traces.length} of {totalCount} traces
+                {displayLimitReached ? " (display limit reached)" : ""}
+              </Text.H6>
+              {entry.hasMore ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0"
+                  disabled={entry.isLoadingMore}
+                  onClick={() => loadMoreSessionTraces(sessionId)}
+                >
+                  {entry.isLoadingMore
+                    ? "Loading…"
+                    : `Load ${Math.min(EXPANDED_TRACE_PAGE_SIZE, Math.max(totalCount - traces.length, 0))} more`}
+                </Button>
+              ) : null}
+            </div>
+            <div className="flex-1" />
+          </div>
+        ) : undefined
+
+      return {
+        data: traces.map((trace): SessionTableRow => ({ kind: "trace", trace })),
+        isLoading: entry.isLoading,
+        blankSlate: "No traces in this session",
+        ...(footer ? { footer } : {}),
+      }
+    }
+
     // Search mode: default-hide non-matching traces behind a show/hide toggle row.
     const match = searchMatches?.[sessionId]
     if (match) {
       const matchingSet = new Set(match.matchingTraceIds)
-      const showingAll = showAllInSessionIds.has(sessionId)
+      const showingAll = showAllInSessionIds.has(stateKey)
       const matchingTraces = entry.data.filter((t) => matchingSet.has(t.traceId))
-      const visibleTraces = showingAll ? entry.data : matchingTraces
-      const hiddenCount = entry.data.length - matchingTraces.length
-      const header =
+      const eligibleTraces = showingAll ? entry.data : matchingTraces
+      const hiddenCount = row.session.traceCount - match.matchingTraceCount
+      const searchControl =
         hiddenCount > 0 ? (
-          <button
-            type="button"
-            onClick={() => toggleShowAllForSession(sessionId)}
-            className="flex w-full items-center justify-start gap-2 px-4 py-2 text-xs font-medium text-muted-foreground hover:text-foreground"
-          >
+          <Button variant="ghost" size="sm" onClick={() => toggleShowAllForSession(sessionId)}>
             {showingAll ? <ChevronsDownUpIcon className="size-3.5" /> : <ChevronsUpDownIcon className="size-3.5" />}
             {showingAll ? "Hide" : "Show"} {hiddenCount} non-matching trace
             {hiddenCount === 1 ? "" : "s"}
-          </button>
+          </Button>
         ) : undefined
-      return {
-        data: visibleTraces.map((trace): SessionTableRow => ({ kind: "trace", trace })),
-        isLoading: entry.isLoading,
-        blankSlate: "No traces in this session",
-        ...(header ? { header } : {}),
-      }
+      return paginateTraces(
+        eligibleTraces,
+        showingAll ? row.session.traceCount : match.matchingTraceCount,
+        searchControl,
+      )
     }
 
-    return {
-      data: entry.data.map((trace): SessionTableRow => ({ kind: "trace", trace })),
-      isLoading: entry.isLoading,
-      blankSlate: "No traces in this session",
-    }
+    return paginateTraces(entry.data, row.session.traceCount)
   }
 
   return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -783,7 +783,7 @@ export function SessionsView({
         data: traces.map((trace): SessionTableRow => ({ kind: "trace", trace })),
         isLoading: entry.isLoading,
         blankSlate: "No traces in this session",
-        ...(footer ? { footer } : {}),
+        ...(footer ? { header: footer } : {}),
       }
     }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -123,6 +123,7 @@ function ConversationContent({
   searchQuery,
   messageTrailingSlot,
   timeline,
+  timelineNotice,
   focusMessageIndex,
   totalMessages,
   payloadBytes,
@@ -155,6 +156,7 @@ function ConversationContent({
   readonly messageTrailingSlot?: ((messageIndex: number, role: string) => ReactNode) | undefined
   /** Timeline for the minimap bar: null while loading, undefined when the feature is off. */
   readonly timeline?: ConversationTimeline | null | undefined
+  readonly timelineNotice?: string | undefined
   readonly focusMessageIndex?: number | undefined
   readonly totalMessages: number
   readonly payloadBytes: number
@@ -707,6 +709,11 @@ function ConversationContent({
           onMarkerClick={handleMarkerClick}
         />
       )}
+      {timeline === undefined && timelineNotice ? (
+        <div className="border-t border-border bg-background px-4 py-3">
+          <Text.H6 color="foregroundMuted">{timelineNotice}</Text.H6>
+        </div>
+      ) : null}
     </div>
   )
 }
@@ -725,6 +732,7 @@ export function ConversationTab({
   searchQuery,
   messageTrailingSlot,
   timeline,
+  timelineNotice,
   focusMessageIndex,
   agentGraph,
 }: {
@@ -754,6 +762,7 @@ export function ConversationTab({
   readonly messageTrailingSlot?: ((messageIndex: number, role: string) => ReactNode) | undefined
   /** Timeline for the minimap bar: null while loading, undefined when the feature is off. */
   readonly timeline?: ConversationTimeline | null | undefined
+  readonly timelineNotice?: string | undefined
   readonly focusMessageIndex?: number | undefined
   /** Session-wide agent graph for decoration; when omitted the conversation derives a trace-local one. */
   readonly agentGraph?: AgentGraph | undefined
@@ -845,6 +854,7 @@ export function ConversationTab({
               searchQuery={searchQuery}
               messageTrailingSlot={messageTrailingSlot}
               timeline={timeline}
+              timelineNotice={timelineNotice}
               focusMessageIndex={focusMessageIndex}
               totalMessages={conversation.totalMessages}
               payloadBytes={conversation.payloadBytes}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -174,12 +174,17 @@ function ConversationContent({
   const autoLoadingMoreRef = useRef(false)
   const hasScrolledToSearchRef = useRef<string | null>(null)
 
+  const pendingFocusLoad = focusMessageIndex !== undefined && focusMessageIndex >= messages.length
+
   const { data: spanMaps } = useConversationSpanMaps({
     projectId,
     traceId: traceDetail.traceId,
     startTime: traceDetail.startTime,
     allMessages: messages,
-    enabled: messages.length > 0 && (annotationsEnabled || (navigateToSpan !== undefined && sessionSpanScope == null)),
+    enabled:
+      messages.length > 0 &&
+      !pendingFocusLoad &&
+      (annotationsEnabled || (navigateToSpan !== undefined && sessionSpanScope == null)),
   })
 
   const { data: sessionSpanMaps } = useSessionConversationSpanMaps({
@@ -189,7 +194,7 @@ function ConversationContent({
     sessionStartTime: sessionSpanScope?.sessionStartTime ?? "",
     sessionEndTime: sessionSpanScope?.sessionEndTime ?? "",
     allMessages: messages,
-    enabled: sessionSpanScope != null && messages.length > 0 && navigateToSpan !== undefined,
+    enabled: sessionSpanScope != null && messages.length > 0 && navigateToSpan !== undefined && !pendingFocusLoad,
   })
 
   const navSpanMaps = sessionSpanScope ? sessionSpanMaps : spanMaps
@@ -525,9 +530,10 @@ function ConversationContent({
       target: searchScrollTarget,
     })
     if (hasScrolledToSearchRef.current === scrollKey) return
-    hasScrolledToSearchRef.current = scrollKey
 
-    return scrollToSearchMatch(container, searchScrollTarget)
+    return scrollToSearchMatch(container, searchScrollTarget, "smooth", () => {
+      hasScrolledToSearchRef.current = scrollKey
+    })
   }, [activeMatchIndex, activeSearchQuery, messages.length, scrollRef, searchScrollTarget])
 
   if (textSelectionPopoverControlsRef) {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -31,6 +31,7 @@ import {
   useSessionConversationSpanMaps,
   useSpansByTraceCollection,
 } from "../../../../../../../domains/spans/spans.collection.ts"
+import type { SpanRecord } from "../../../../../../../domains/spans/spans.functions.ts"
 import {
   useTraceConversationMessages,
   useTraceSearchHighlights,
@@ -134,13 +135,12 @@ function ConversationContent({
   readonly traceDetail: TraceDetailRecord
   readonly messages: readonly GenAIMessage[]
   readonly navigateToSpan?: ((spanId: string, traceId?: string) => void) | undefined
-  /** When set, message/tool-call navigation links resolve against ALL session spans
+  /** When set, message/tool-call navigation links resolve against session spans
    *  (not just this trace); annotations still anchor to this trace. */
   readonly sessionSpanScope?:
     | {
-        readonly sessionId: string
-        readonly sessionStartTime: string
-        readonly sessionEndTime: string
+        readonly traces: readonly { readonly traceId: string; readonly startTime: string }[]
+        readonly sessionSpans?: readonly SpanRecord[]
       }
     | undefined
   readonly projectId: string
@@ -189,11 +189,10 @@ function ConversationContent({
 
   const { data: sessionSpanMaps } = useSessionConversationSpanMaps({
     projectId,
-    sessionId: sessionSpanScope?.sessionId ?? "",
-    latestTraceId: traceDetail.traceId,
-    sessionStartTime: sessionSpanScope?.sessionStartTime ?? "",
-    sessionEndTime: sessionSpanScope?.sessionEndTime ?? "",
-    allMessages: messages,
+    traces: sessionSpanScope?.traces ?? [],
+    loadedMessages: messages,
+    totalMessages,
+    sessionSpans: sessionSpanScope?.sessionSpans,
     enabled: sessionSpanScope != null && messages.length > 0 && navigateToSpan !== undefined && !pendingFocusLoad,
   })
 
@@ -733,13 +732,12 @@ export function ConversationTab({
   readonly isDetailLoading: boolean
   /** Optional callback to navigate to a span. If not provided, message/tool call actions are hidden. */
   readonly navigateToSpan?: ((spanId: string, traceId?: string) => void) | undefined
-  /** When set, message/tool-call navigation links resolve against ALL session spans
+  /** When set, message/tool-call navigation links resolve against session spans
    *  (not just this trace); annotations still anchor to this trace. */
   readonly sessionSpanScope?:
     | {
-        readonly sessionId: string
-        readonly sessionStartTime: string
-        readonly sessionEndTime: string
+        readonly traces: readonly { readonly traceId: string; readonly startTime: string }[]
+        readonly sessionSpans?: readonly SpanRecord[]
       }
     | undefined
   readonly projectId: string

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/scroll-to-highlight-match.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/scroll-to-highlight-match.ts
@@ -8,6 +8,7 @@ export function scrollToSearchMatch(
   container: HTMLElement,
   target: SearchScrollTarget,
   behavior: ScrollBehavior = "smooth",
+  onScrolled?: () => void,
 ): () => void {
   let done = false
 
@@ -19,6 +20,7 @@ export function scrollToSearchMatch(
         : findNearestMessageAnchor(container, target.messageIndex)
     if (!node) return false
     centerHighlightInView(container, node, behavior)
+    onScrolled?.()
     return true
   }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
@@ -197,11 +197,15 @@ export function GroupedSpanTree({
   selectedSpan,
   onSelectSpan,
   isActive,
+  footer,
+  onScrollEnd,
 }: {
   readonly groups: readonly SpanTreeGroup[]
   readonly selectedSpan: SpanTreeSelection | null
   readonly onSelectSpan: (selection: SpanTreeSelection | null) => void
   readonly isActive: boolean
+  readonly footer?: ReactNode | undefined
+  readonly onScrollEnd?: (() => void) | undefined
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
@@ -318,7 +322,15 @@ export function GroupedSpanTree({
 
   return (
     <div ref={containerRef} className="relative flex flex-1 flex-col overflow-hidden">
-      <div className="flex flex-1 flex-col overflow-y-auto">
+      <div
+        className="flex flex-1 flex-col overflow-y-auto"
+        onScroll={(event) => {
+          if (!onScrollEnd) return
+          const container = event.currentTarget
+          const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
+          if (distanceFromBottom <= ROW_HEIGHT * 5) onScrollEnd()
+        }}
+      >
         <TreeAxisHeader
           treeWidth={resolvedTreeWidth}
           timeRange={axisTimeRange}
@@ -354,6 +366,7 @@ export function GroupedSpanTree({
             </div>
           )
         })}
+        {footer}
       </div>
 
       {/* biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events */}

--- a/dev-docs/conversation-timeline.md
+++ b/dev-docs/conversation-timeline.md
@@ -22,7 +22,7 @@ The timeline is reconstructed entirely from recorded span timing — nothing ext
 
 - Spans carry `startTime`/`endTime` (ns precision in ClickHouse, ms after ISO serialization), `timeToFirstTokenNs`, `isStreaming`, `operation`, and `statusCode`.
 - Message↔span attribution uses `buildConversationSpanMaps` (`packages/domain/spans/src/use-cases/map-conversation-to-spans.ts`), which fingerprints assistant message content against span `output_messages` and disambiguates duplicates by preceding-context score. It only maps **assistant** messages; user/system/tool messages get derived times (see scheduling rules).
-- Per-trace maps come from the `mapConversationToSpans` server function. Session-wide maps come from `mapSessionConversationToSpans` (`apps/web/src/domains/spans/spans.functions.ts`), backed by `SpanRepository.findMessagesForSession` — the same projection as `findMessagesForTrace` but with the `sessions_mv` membership predicate `coalesce(nullIf(session_id, ''), toString(trace_id)) = {sessionId}`, so orphan single-trace sessions work. Keys index into the **latest output trace's `allMessages`** (the canonical session conversation, same source as the session Conversation tab); values are span ids from any trace in the session.
+- Per-trace message spans come from `listConversationMessageSpans` → `SpanRepository.findMessagesForTrace`, cached under `conversationMessageSpans`. Session attribution (`useSessionConversationSpanMaps`) does **not** load every session message payload: it fetches that same per-trace projection for an oldest-first window of traces that grows with the loaded conversation prefix (`selectTracesForLoadedConversation`), then runs `buildConversationSpanMaps` against the loaded messages only. Tool-call → span links also come from lightweight `listSpansBySession` rows (`toolCallId`), so execute_tool navigation works before message spans arrive. Keys index into the **latest output trace's loaded conversation chunks**; values are span refs (`traceId` + `spanId`) from any fetched trace in the window.
 
 ## Core model
 
@@ -92,5 +92,5 @@ The shared `@repo/ui` `genai-conversation` component carries two timeline-generi
 ## Testing
 
 - The pure model is unit-tested with colocated vitest files in `apps/web/src/lib/conversation-timeline/` (`timeline-scale`, `build-conversation-timeline`, `build-activity-track`, `message-windows`, `cluster-markers`) against a shared fixture session (`timeline-fixture.ts`: two turns, streaming + non-streaming spans, a tool loop, an idle gap, annotations, a moment). Key covered properties: coordinate round-trips, gap compression, scheduling rules and fallbacks, marker placement and anchors, time→message resolution (including gap clicks), and band math.
-- `findMessagesForSession` has a chdb integration test in `packages/platform/db-clickhouse/src/repositories/span-repository.test.ts` (orphan-session membership, ReplacingMergeTree dedupe).
+- Trace-window selection for session attribution is unit-tested in `apps/web/src/domains/spans/select-traces-for-loaded-conversation.test.ts`.
 - Bar/track components are verified manually; they intentionally have no unit tests.

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.test.ts
@@ -1,12 +1,79 @@
 import { createSeedScope, SEED_API_KEY_ID, SEED_ORG_ID, SEED_PROJECT_ID } from "@domain/shared/seeding"
 import { describe, expect, it } from "vitest"
-import { buildTau2TrajectorySpans } from "./fixed-traces.ts"
+import { buildLargeConversationSpans, buildTau2TrajectorySpans, fixedTraceSlots } from "./fixed-traces.ts"
 
 const scope = createSeedScope({
   organizationId: SEED_ORG_ID,
   projectId: SEED_PROJECT_ID,
   timelineAnchor: new Date("2026-06-16T12:00:00.000Z"),
   apiKeyId: SEED_API_KEY_ID,
+})
+
+describe("buildLargeConversationSpans", () => {
+  const sessions = [
+    { sessionId: "seed-large-conversation-1", turnCount: 120, renderedMessageCount: 242 },
+    { sessionId: "seed-large-conversation-2", turnCount: 240, renderedMessageCount: 482 },
+    { sessionId: "seed-large-conversation-3", turnCount: 420, renderedMessageCount: 842 },
+  ] as const
+
+  it("creates deterministic trace slots for all turn and terminal spans", () => {
+    const spans = buildLargeConversationSpans(scope)
+    const traceIds = spans.map((span) => span.trace_id)
+    const expectedTraceIds = Array.from({ length: 783 }, (_, slot) => scope.traceHex("large-conversation", slot))
+    const largeConversationSlots = fixedTraceSlots.filter((slot) => slot.traceKey === "large-conversation")
+
+    expect(spans).toHaveLength(783)
+    expect(new Set(traceIds).size).toBe(783)
+    expect([...traceIds].sort()).toEqual([...expectedTraceIds].sort())
+    expect(buildLargeConversationSpans(scope).map((span) => span.trace_id)).toEqual(traceIds)
+    expect(largeConversationSlots.map((slot) => slot.index)).toEqual(Array.from({ length: 783 }, (_, slot) => slot))
+  })
+
+  it("stores one turn per earlier trace and the full conversation on the latest terminal trace", () => {
+    const spans = buildLargeConversationSpans(scope)
+
+    for (const [sessionIndex, session] of sessions.entries()) {
+      const sessionSpans = spans.filter((span) => span.session_id === session.sessionId)
+      const turnSpans = sessionSpans.slice(0, -1)
+      const terminalSpan = sessionSpans.at(-1)
+
+      expect(sessionSpans).toHaveLength(session.turnCount + 1)
+      expect(sessionSpans.map((span) => span.start_time)).toEqual(
+        [...sessionSpans.map((span) => span.start_time)].sort(),
+      )
+      expect(terminalSpan?.trace_id).toBe(scope.traceHex("large-conversation", sessionIndex))
+
+      for (const [turnIndex, span] of turnSpans.entries()) {
+        const inputMessages = JSON.parse(span.input_messages)
+        const outputMessages = JSON.parse(span.output_messages)
+
+        expect(inputMessages).toHaveLength(1)
+        expect(outputMessages).toHaveLength(1)
+        expect(inputMessages[0]?.role).toBe("user")
+        expect(outputMessages[0]?.role).toBe("assistant")
+        expect(inputMessages[0]?.parts[0]?.content).toContain(`user turn ${turnIndex + 1}`)
+        expect(outputMessages[0]?.parts[0]?.content).toContain(`assistant turn ${turnIndex + 1}`)
+      }
+
+      const terminalInputMessages = JSON.parse(terminalSpan?.input_messages ?? "[]")
+      const terminalOutputMessages = JSON.parse(terminalSpan?.output_messages ?? "[]")
+      const systemInstructions = JSON.parse(terminalSpan?.system_instructions ?? "[]")
+      const turnHistory = turnSpans.flatMap((span) => [
+        ...JSON.parse(span.input_messages),
+        ...JSON.parse(span.output_messages),
+      ])
+
+      expect(terminalInputMessages).toEqual(turnHistory)
+      expect(terminalInputMessages).toHaveLength(session.turnCount * 2)
+      expect(terminalOutputMessages).toHaveLength(1)
+      expect(systemInstructions.length + terminalInputMessages.length + terminalOutputMessages.length).toBe(
+        session.renderedMessageCount,
+      )
+      expect(terminalOutputMessages[0]?.parts[0]?.content).toBe(
+        `Large conversation seed ${sessionIndex + 1} final answer. This trace intentionally contains ${session.renderedMessageCount} rendered messages so the conversation drawer must page through chunks instead of returning the whole payload at once.`,
+      )
+    }
+  })
 })
 
 describe("buildTau2TrajectorySpans message serialization", () => {

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
@@ -422,7 +422,8 @@ export function buildCompatibilitySupportSpans(scope: SeedScope): SpanRow[] {
 
 type LargeConversationSpec = {
   readonly traceKey: string
-  readonly index: number
+  readonly conversationIndex: number
+  readonly terminalTraceSlot: number
   readonly sessionId: string
   readonly daysAgo: number
   readonly turnCount: number
@@ -454,10 +455,10 @@ function largeConversationText(spec: LargeConversationSpec, turnIndex: number, r
   }).join("; ")
 
   if (role === "user") {
-    return `Large conversation seed ${spec.index + 1}, user turn ${checkpoint}. I need the assistant to keep every previous detail in mind while we test streamed conversation loading. ${context}. Please cross-check these facts before changing the recommendation.`
+    return `Large conversation seed ${spec.conversationIndex + 1}, user turn ${checkpoint}. I need the assistant to keep every previous detail in mind while we test streamed conversation loading. ${context}. Please cross-check these facts before changing the recommendation.`
   }
 
-  return `Large conversation seed ${spec.index + 1}, assistant turn ${checkpoint}. I am retaining the running case state, separating verified facts from pending checks, and keeping the recommendation conditional until the required evidence is complete. ${context}. Next I would verify the newest customer statement against the tool-backed record before committing to an outcome.`
+  return `Large conversation seed ${spec.conversationIndex + 1}, assistant turn ${checkpoint}. I am retaining the running case state, separating verified facts from pending checks, and keeping the recommendation conditional until the required evidence is complete. ${context}. Next I would verify the newest customer statement against the tool-backed record before committing to an outcome.`
 }
 
 function buildLargeConversationMessages(spec: LargeConversationSpec): Tau2Message[] {
@@ -470,27 +471,34 @@ function buildLargeConversationMessages(spec: LargeConversationSpec): Tau2Messag
   ])
 }
 
-function createLargeConversationChatSpan(opts: { scope: SeedScope; spec: LargeConversationSpec }): SpanRow {
-  const { scope, spec } = opts
-  const start = scope.dateDaysAgo(spec.daysAgo, 13 + spec.index, 15)
-  const traceId = scope.traceHex(spec.traceKey, spec.index)
-  const spanId = scope.spanHex(spec.traceKey, spec.index)
-  const inputMessages = buildLargeConversationMessages(spec)
-  const renderedMessageCount = inputMessages.length + 2
-  const outputMessages: Tau2Message[] = [
-    {
-      role: "assistant",
-      parts: [
-        {
-          type: "text",
-          content: `Large conversation seed ${spec.index + 1} final answer. This trace intentionally contains ${renderedMessageCount} rendered messages so the conversation drawer must page through chunks instead of returning the whole payload at once.`,
-        },
-      ],
-    },
-  ]
+function largeConversationFinalAnswer(spec: LargeConversationSpec): Tau2Message {
+  const renderedMessageCount = spec.turnCount * 2 + 2
+  return {
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        content: `Large conversation seed ${spec.conversationIndex + 1} final answer. This trace intentionally contains ${renderedMessageCount} rendered messages so the conversation drawer must page through chunks instead of returning the whole payload at once.`,
+      },
+    ],
+  }
+}
+
+function createLargeConversationChatSpan(opts: {
+  scope: SeedScope
+  spec: LargeConversationSpec
+  traceSlot: number
+  startTime: Date
+  inputMessages: readonly Tau2Message[]
+  outputMessage: Tau2Message
+}): SpanRow {
+  const { scope, spec, traceSlot, startTime, inputMessages, outputMessage } = opts
+  const traceId = scope.traceHex(spec.traceKey, traceSlot)
+  const spanId = scope.spanHex(spec.traceKey, traceSlot)
+  const outputMessages = [outputMessage]
   const inputTokens = estimateTau2Tokens(inputMessages)
   const outputTokens = estimateTau2Tokens(outputMessages)
-  const durationMs = spec.turnCount * 1200
+  const durationMs = 1200
 
   return {
     organization_id: scope.organizationId,
@@ -503,8 +511,8 @@ function createLargeConversationChatSpan(opts: { scope: SeedScope; spec: LargeCo
     parent_span_id: "",
     api_key_id: scope.apiKeyId,
     simulation_id: "",
-    start_time: formatClickHouseTimestamp(start),
-    end_time: formatClickHouseTimestamp(new Date(start.getTime() + durationMs)),
+    start_time: formatClickHouseTimestamp(startTime),
+    end_time: formatClickHouseTimestamp(new Date(startTime.getTime() + durationMs)),
     name: "chat gpt-4.1 large conversation",
     service_name: spec.serviceName,
     kind: 1,
@@ -563,7 +571,8 @@ function createLargeConversationChatSpan(opts: { scope: SeedScope; spec: LargeCo
 const LARGE_CONVERSATION_SPECS: readonly LargeConversationSpec[] = [
   {
     traceKey: "large-conversation",
-    index: 0,
+    conversationIndex: 0,
+    terminalTraceSlot: 0,
     sessionId: "seed-large-conversation-1",
     daysAgo: 1,
     turnCount: 120,
@@ -573,7 +582,8 @@ const LARGE_CONVERSATION_SPECS: readonly LargeConversationSpec[] = [
   },
   {
     traceKey: "large-conversation",
-    index: 1,
+    conversationIndex: 1,
+    terminalTraceSlot: 1,
     sessionId: "seed-large-conversation-2",
     daysAgo: 1,
     turnCount: 240,
@@ -583,7 +593,8 @@ const LARGE_CONVERSATION_SPECS: readonly LargeConversationSpec[] = [
   },
   {
     traceKey: "large-conversation",
-    index: 2,
+    conversationIndex: 2,
+    terminalTraceSlot: 2,
     sessionId: "seed-large-conversation-3",
     daysAgo: 1,
     turnCount: 420,
@@ -593,8 +604,48 @@ const LARGE_CONVERSATION_SPECS: readonly LargeConversationSpec[] = [
   },
 ]
 
-function buildLargeConversationSpans(scope: SeedScope): SpanRow[] {
-  return LARGE_CONVERSATION_SPECS.map((spec) => createLargeConversationChatSpan({ scope, spec }))
+const LARGE_CONVERSATION_TRACE_INTERVAL_MS = 2000
+const LARGE_CONVERSATION_TURN_TRACE_SLOT_START = LARGE_CONVERSATION_SPECS.length
+const LARGE_CONVERSATION_TRACE_SLOT_COUNT = LARGE_CONVERSATION_SPECS.reduce(
+  (count, spec) => count + spec.turnCount + 1,
+  0,
+)
+
+export function buildLargeConversationSpans(scope: SeedScope): SpanRow[] {
+  let turnTraceSlot = LARGE_CONVERSATION_TURN_TRACE_SLOT_START
+
+  return LARGE_CONVERSATION_SPECS.flatMap((spec) => {
+    const start = scope.dateDaysAgo(spec.daysAgo, 13 + spec.conversationIndex, 15)
+    const turnSpans = Array.from({ length: spec.turnCount }, (_, turnIndex) => {
+      const inputMessage: Tau2Message = {
+        role: "user",
+        parts: [{ type: "text", content: largeConversationText(spec, turnIndex, "user") }],
+      }
+      const outputMessage: Tau2Message = {
+        role: "assistant",
+        parts: [{ type: "text", content: largeConversationText(spec, turnIndex, "assistant") }],
+      }
+      const span = createLargeConversationChatSpan({
+        scope,
+        spec,
+        traceSlot: turnTraceSlot++,
+        startTime: new Date(start.getTime() + turnIndex * LARGE_CONVERSATION_TRACE_INTERVAL_MS),
+        inputMessages: [inputMessage],
+        outputMessage,
+      })
+      return span
+    })
+    const terminalSpan = createLargeConversationChatSpan({
+      scope,
+      spec,
+      traceSlot: spec.terminalTraceSlot,
+      startTime: new Date(start.getTime() + spec.turnCount * LARGE_CONVERSATION_TRACE_INTERVAL_MS),
+      inputMessages: buildLargeConversationMessages(spec),
+      outputMessage: largeConversationFinalAnswer(spec),
+    })
+
+    return [...turnSpans, terminalSpan]
+  })
 }
 
 export function buildTau2TrajectorySpans(scope: SeedScope, maxTrajectories = TAU2_SEED_TRAJECTORIES.length): SpanRow[] {
@@ -842,6 +893,9 @@ export const fixedTraceSeeders: readonly Seeder[] = [seedFixedTraces, seedLargeC
  */
 export const fixedTraceSlots: readonly TraceSlot[] = [
   ...TAU2_SEED_TRAJECTORIES.map((_, index) => ({ traceKey: "tau2-trajectory", index })),
-  ...LARGE_CONVERSATION_SPECS.map((spec) => ({ traceKey: spec.traceKey, index: spec.index })),
+  ...Array.from({ length: LARGE_CONVERSATION_TRACE_SLOT_COUNT }, (_, index) => ({
+    traceKey: "large-conversation",
+    index,
+  })),
   ...COMPATIBILITY_TRACE_SPECS.map((spec) => ({ traceKey: spec.traceKey, index: spec.index })),
 ]

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -511,6 +511,17 @@ export function InfiniteTable<T>({
                         />
                       )
                     })}
+                  {isExpanded && expanded && !expanded.isLoading && expanded.footer !== undefined && (
+                    <tr>
+                      {hasExpansion && <td className="px-2 py-2 w-8 border-none" />}
+                      {selection && (
+                        <td style={{ width: 48, minWidth: 48, maxWidth: 48 }} className="px-4 py-2 border-none" />
+                      )}
+                      <td colSpan={colCount - (hasExpansion ? 1 : 0) - (selection ? 1 : 0)} className="p-0 border-none">
+                        {expanded.footer}
+                      </td>
+                    </tr>
+                  )}
                   {isExpanded &&
                     expanded &&
                     !expanded.isLoading &&

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -460,17 +460,6 @@ export function InfiniteTable<T>({
                         </td>
                       </tr>
                     )}
-                  {isExpanded && expanded && !expanded.isLoading && expanded.header !== undefined && (
-                    <tr>
-                      {hasExpansion && <td className="px-2 py-2 w-8 border-none" />}
-                      {selection && (
-                        <td style={{ width: 48, minWidth: 48, maxWidth: 48 }} className="px-4 py-2 border-none" />
-                      )}
-                      <td colSpan={colCount - (hasExpansion ? 1 : 0) - (selection ? 1 : 0)} className="p-0 border-none">
-                        {expanded.header}
-                      </td>
-                    </tr>
-                  )}
                   {expanded &&
                     !expanded.isLoading &&
                     expanded.data.map((subRow) => {
@@ -511,14 +500,14 @@ export function InfiniteTable<T>({
                         />
                       )
                     })}
-                  {isExpanded && expanded && !expanded.isLoading && expanded.footer !== undefined && (
+                  {isExpanded && expanded && !expanded.isLoading && expanded.header !== undefined && (
                     <tr>
                       {hasExpansion && <td className="px-2 py-2 w-8 border-none" />}
                       {selection && (
                         <td style={{ width: 48, minWidth: 48, maxWidth: 48 }} className="px-4 py-2 border-none" />
                       )}
                       <td colSpan={colCount - (hasExpansion ? 1 : 0) - (selection ? 1 : 0)} className="p-0 border-none">
-                        {expanded.footer}
+                        {expanded.header}
                       </td>
                     </tr>
                   )}

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -59,6 +59,8 @@ export interface ExpandedRows<T> {
    * like "show hidden rows" toggles that don't fit cleanly as a data row.
    */
   header?: ReactNode
+  /** Rendered BELOW the expanded `data` rows (when present and not loading). */
+  footer?: ReactNode
 }
 
 export interface InfiniteTableSharedProps<T> {

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -54,13 +54,10 @@ export interface ExpandedRows<T> {
   /** Shown when expanded data finished loading and `data` is empty. */
   blankSlate?: ReactNode | string
   /**
-   * Rendered ABOVE the expanded `data` rows (when present and not loading).
-   * Spans the table width via `colSpan`. Useful for per-expansion affordances
-   * like "show hidden rows" toggles that don't fit cleanly as a data row.
+   * Rendered below the expanded `data` rows (when present and not loading).
+   * Spans the table width via `colSpan` for pagination and expansion controls.
    */
   header?: ReactNode
-  /** Rendered BELOW the expanded `data` rows (when present and not loading). */
-  footer?: ReactNode
 }
 
 export interface InfiniteTableSharedProps<T> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On long sessions the conversation timeline stayed on a skeleton for a long time, and focus/search auto-scroll often never fired. Both looked tied together: auto-scroll appeared broken until the timeline finally showed up.

Root cause: session span attribution called `findMessagesForSession`, which loads **every** message-bearing span’s full `input_messages` / `output_messages` for the session. Conversation pagination (`getTraceConversationChunk`, 25 at a time) only covered the rendered messages; this side path undid that.

## Fix

### Windowed per-trace attribution (replaces full-session fetch)

- Removed the web `listSessionConversationMessageSpans` server function.
- `useSessionConversationSpanMaps` now fetches `listConversationMessageSpans` / `findMessagesForTrace` for an oldest-first **window of traces** that grows with the loaded conversation prefix (`selectTracesForLoadedConversation`).
- Maps are rebuilt against **loaded messages only** as chunks arrive.
- Tool-call → span links also come from lightweight `listSpansBySession` rows (`toolCallId`), so execute_tool navigation works before message spans land.
- Per-trace message spans share the `conversationMessageSpans` React Query cache with the single-trace path.

### Timeline + auto-scroll

- Session/trace timelines render as soon as conversation chunks exist; they refine when span maps arrive and do not block on a session-wide payload.
- Moment focus waits until `anchorIndex < loadedMessageCount` before arming the short DOM timeout.
- Search scroll only records success after a real scroll (`onScrolled`), so timed-out attempts can retry.
- Heavy span-map fetches stay deferred while still loading toward a focus index.

## Testing

- `select-traces-for-loaded-conversation.test.ts`
- `timeline-adapters.test.ts`
- `pnpm --filter @app/web typecheck`

Manual: open a long multi-trace session Conversation tab (especially from a behaviour/search focus). Timeline should appear with the first chunk; auto-scroll should land after chunks catch up; network should show per-trace message-span fetches, not one giant session messages query.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-519f3ba1-7f06-48f5-af92-c8c108aefe52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-519f3ba1-7f06-48f5-af92-c8c108aefe52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved large-session handling with incremental loading for traces and spans.
  * Added “load more” pagination for session spans and expanded trace browsing.
  * Conversation and timeline views can render progressively while details load.
  * Enhanced navigation to focused moments/tool calls with smoother scrolling and highlight feedback.
* **Bug Fixes**
  * Prevented overly large trace/span requests from exceeding HTTP limits by switching relevant requests to safer payloads.
* **Documentation / Tests**
  * Updated developer notes for conversation timeline data-loading behavior.
  * Added/expanded unit tests for trace-window selection, adapters, and scrolling behavior.
* **Chores**
  * Adjusted deterministic large-conversation span seeding behavior for fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->