### PR TITLE
fix(infra): reduce CloudWatch usage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -408,7 +408,16 @@ jobs:
                 --output json | jq \
                   --arg image "${IMAGE}" \
                   --arg name "${SERVICE}" '
-                  .containerDefinitions |= map(if .name == $name then .image = $image else . end) |
+                  .containerDefinitions |= map(
+                    if .name == $name then .image = $image
+                    elif .name == "datadog-agent" then
+                      .environment = (
+                        (.environment // []) |
+                        map(if .name == "DD_LOG_LEVEL" then .value = "info" else . end) |
+                        if any(.[]; .name == "DD_LOG_LEVEL") then . else . + [{ name: "DD_LOG_LEVEL", value: "info" }] end
+                      )
+                    else . end
+                  ) |
                   del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
                 ')" > /dev/null
             local update_response
@@ -781,7 +790,16 @@ jobs:
                 --output json | jq \
                   --arg image "${IMAGE}" \
                   --arg name "${SERVICE}" '
-                  .containerDefinitions |= map(if .name == $name then .image = $image else . end) |
+                  .containerDefinitions |= map(
+                    if .name == $name then .image = $image
+                    elif .name == "datadog-agent" then
+                      .environment = (
+                        (.environment // []) |
+                        map(if .name == "DD_LOG_LEVEL" then .value = "info" else . end) |
+                        if any(.[]; .name == "DD_LOG_LEVEL") then . else . + [{ name: "DD_LOG_LEVEL", value: "info" }] end
+                      )
+                    else . end
+                  ) |
                   del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
                 ')" > /dev/null
             local update_response

--- a/apps/api/src/middleware/access-logger.test.ts
+++ b/apps/api/src/middleware/access-logger.test.ts
@@ -1,0 +1,48 @@
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { accessLogger } from "./access-logger.ts"
+
+const createApp = () => {
+  const logs: string[] = []
+  const app = new Hono()
+  app.use(accessLogger((message) => logs.push(message)))
+
+  return { app, logs }
+}
+
+describe("accessLogger", () => {
+  it("suppresses successful GET /health logs", async () => {
+    const { app, logs } = createApp()
+    app.get("/health", (c) => c.json({ status: "ok" }))
+
+    await app.request("/health")
+
+    expect(logs).toEqual([])
+  })
+
+  it("logs failed GET /health requests", async () => {
+    const { app, logs } = createApp()
+    app.get("/health", (c) => c.json({ status: "starting" }, 503))
+
+    await app.request("/health")
+
+    expect(logs).toHaveLength(2)
+    expect(logs[0]).toBe("<-- GET /health")
+    expect(logs[1]).toContain("--> GET /health")
+    expect(logs[1]).toContain("503")
+    expect(logs[1]).toMatch(/\d+ms$/)
+  })
+
+  it("logs requests other than GET /health", async () => {
+    const { app, logs } = createApp()
+    app.get("/status", (c) => c.json({ status: "ok" }))
+
+    await app.request("/status")
+
+    expect(logs).toHaveLength(2)
+    expect(logs[0]).toBe("<-- GET /status")
+    expect(logs[1]).toContain("--> GET /status")
+    expect(logs[1]).toContain("200")
+    expect(logs[1]).toMatch(/\d+ms$/)
+  })
+})

--- a/apps/api/src/middleware/access-logger.ts
+++ b/apps/api/src/middleware/access-logger.ts
@@ -1,0 +1,21 @@
+import { createMiddleware } from "hono/factory"
+import { logger } from "hono/logger"
+
+type AccessLog = (message: string) => void
+
+export const accessLogger = (log: AccessLog) => {
+  const logRequest = logger(log)
+
+  return createMiddleware(async (c, next) => {
+    if (c.req.method !== "GET" || c.req.path !== "/health") {
+      return logRequest(c, next)
+    }
+
+    const messages: string[] = []
+    await logger((message) => messages.push(message))(c, next)
+
+    if (!c.res.ok) {
+      messages.forEach(log)
+    }
+  })
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -8,7 +8,6 @@ import { initializeObservability, shutdownObservability } from "@repo/observabil
 import { loadDevelopmentEnvironments } from "@repo/utils/env"
 import { Effect } from "effect"
 import type { Hono } from "hono"
-import { logger as honoLogger } from "hono/logger"
 import {
   getClickhouseClient,
   getPostgresClient,
@@ -19,6 +18,7 @@ import {
   getWorkflowStarter,
 } from "./clients.ts"
 import { API_INFO, API_SECURITY_SCHEME } from "./constants.ts"
+import { accessLogger } from "./middleware/access-logger.ts"
 import { registerCorsMiddleware } from "./middleware/cors.ts"
 import { honoErrorHandler } from "./middleware/error-handler.ts"
 import { suppressHttpErrorTelemetry } from "./middleware/suppress-http-error-telemetry.ts"
@@ -37,11 +37,7 @@ const startServer = async () => {
   const url = Effect.runSync(parseEnv("LAT_API_URL", "string", "http://localhost:3001"))
   const port = Effect.runSync(parseEnv("LAT_API_PORT", "number", 3001))
 
-  app.use(
-    honoLogger((message: string, ...rest: string[]) => {
-      logger.info(message, ...rest)
-    }),
-  )
+  app.use(accessLogger((message) => logger.info(message)))
 
   // Add Hono OpenTelemetry middleware
   app.use(otel())

--- a/infra/lib/ecs.ts
+++ b/infra/lib/ecs.ts
@@ -51,7 +51,7 @@ export function createEcs(
     settings: [
       {
         name: "containerInsights",
-        value: "enabled",
+        value: "disabled",
       },
     ],
     tags: {
@@ -671,7 +671,7 @@ function createTaskDefinition(
             { name: "DD_OTLP_CONFIG_TRACES_ENABLED", value: "true" },
             { name: "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT", value: "0.0.0.0:4318" },
             { name: "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT", value: "0.0.0.0:4317" },
-            { name: "DD_LOG_LEVEL", value: "debug" },
+            { name: "DD_LOG_LEVEL", value: "info" },
           ],
           secrets: [
             { name: "DD_API_KEY", valueFrom: datadogApiKeyArn },


### PR DESCRIPTION
## What does this PR do?

Disables ECS Container Insights for staging and production. The standard configuration publishes about 138 paid CloudWatch metrics per cluster, which exceeds the account's 10-metric free tier before application traffic is considered.

It also reduces CloudWatch Logs ingestion by:

- changing Datadog agents from debug to info logging in Pulumi and both deployment flows
- suppressing successful `GET /health` API access logs while retaining failed health checks and all other requests

The deployment workflow updates the Datadog setting when it clones live task definitions, so regular service rollouts do not restore debug logging. Production autoscaling policies and their managed CloudWatch alarms are unchanged.

## Deployment

The Container Insights setting takes effect after applying both Pulumi stacks. The Datadog setting takes effect on the next staging and production service rollouts.

## Verification

- `pnpm --filter @app/api check`
- `pnpm exec vitest run apps/api/src/middleware/access-logger.test.ts`
- `pnpm --filter latitude-infra typecheck`
- deployment workflow YAML parse
- staging and production task-definition `jq` transform checks
- commit hook workspace formatting and Knip checks

The API typecheck could not run locally because the installed `@typescript/native-preview` package is missing its `tsgo.js` entrypoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added request access logging for API traffic, including HTTP status and request duration.
  - Failed health checks now produce diagnostic logs, while successful health checks remain quiet.

- **Bug Fixes**
  - Standardized Datadog agent logging to `info` level across deployments.

- **Performance**
  - Disabled ECS container insights to reduce monitoring overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->