### PR TITLE
fix(web): opt in before identify so landing→app sessions stitch

### DIFF
--- a/apps/web/src/lib/posthog/posthog-client.ts
+++ b/apps/web/src/lib/posthog/posthog-client.ts
@@ -148,13 +148,16 @@ interface SyncSessionInput {
  * org group, then opt in.
  *
  * Ordering matters: `register()` runs first so `organizationId` rides on every
- * subsequent event (including the opt-in event and first pageview). Then
- * `opt_in_capturing()` runs BEFORE `identify()` — while opted out every
- * capture() is dropped, so an identify sent while opted out never transmits the
- * `$identify` merge event, orphaning the anonymous latitude.so visitor from the
- * signed-up user. Opting in first lets identify stitch the pre-signup landing
- * session to the user. `group()` runs last; the super property from `register()`
- * keeps org-based breakdowns correct even before `$group_0` is set.
+ * subsequent event (including the opt-in event and first pageview). The org
+ * group is then associated (without properties) BEFORE `opt_in_capturing()` —
+ * `group()`'s `$groups` registration is an opt-out-agnostic persistence write,
+ * so `$group_0` rides on the opt-in event and first pageview; the paired
+ * `$groupidentify` capture is dropped while opted out, so org properties are
+ * sent by a second `group()` call after opting in. `opt_in_capturing()` runs
+ * BEFORE `identify()` — while opted out every capture() is dropped, so an
+ * identify sent while opted out never transmits the `$identify` merge event,
+ * orphaning the anonymous latitude.so visitor from the signed-up user. Opting
+ * in first lets identify stitch the pre-signup landing session to the user.
  */
 export const syncPostHogSession = async (input: SyncSessionInput): Promise<void> => {
   if (input.excludeFromAnalytics) {
@@ -179,6 +182,12 @@ export const syncPostHogSession = async (input: SyncSessionInput): Promise<void>
   // including the opt-in event and first pageview fired below.
   posthog.register({ organizationId: input.organizationId })
 
+  // Associate the org group BEFORE opting in so $group_0 rides on the opt-in
+  // event and first pageview. $groups is a persistence write with no opt-out
+  // gate; the paired $groupidentify capture is dropped while opted out, so
+  // properties are sent by the second group() call once opted in below.
+  posthog.group("organization", input.organizationId)
+
   // Opt in BEFORE identify. The SDK inits with opt_out_capturing_by_default,
   // so while opted out every capture() — including the $identify event that
   // merges the anonymous latitude.so visitor into this user — is silently
@@ -195,12 +204,15 @@ export const syncPostHogSession = async (input: SyncSessionInput): Promise<void>
   })
 
   // Group properties power org-named cells in group-aggregated insights and
-  // plan/slug breakdowns. Only send keys we actually have.
+  // plan/slug breakdowns. Sent now (opted in) so the $groupidentify transmits;
+  // the association itself was already set before opt-in above.
   const orgProps: Record<string, string> = {}
   if (input.organizationName) orgProps.name = input.organizationName
   if (input.organizationSlug) orgProps.slug = input.organizationSlug
   if (input.organizationPlan) orgProps.plan = input.organizationPlan
-  posthog.group("organization", input.organizationId, Object.keys(orgProps).length > 0 ? orgProps : undefined)
+  if (Object.keys(orgProps).length > 0) {
+    posthog.group("organization", input.organizationId, orgProps)
+  }
 }
 
 /**

--- a/apps/web/src/lib/posthog/posthog-client.ts
+++ b/apps/web/src/lib/posthog/posthog-client.ts
@@ -147,12 +147,14 @@ interface SyncSessionInput {
  * it's a real customer session, set identity + super properties + the active
  * org group, then opt in.
  *
- * Ordering matters: `opt_in_capturing()` fires the session's first `$pageview`,
- * so identify/register/group MUST run first. Otherwise that pageview (and any
- * autocapture before group() resolves) lands with `organizationId = None` and
- * no `$group_0`, which makes org-based retention / funnels / breakdowns read as
- * zero. `register()` is the belt-and-suspenders that keeps `organizationId` on
- * events even if they fire before `group()` takes effect.
+ * Ordering matters: `register()` runs first so `organizationId` rides on every
+ * subsequent event (including the opt-in event and first pageview). Then
+ * `opt_in_capturing()` runs BEFORE `identify()` — while opted out every
+ * capture() is dropped, so an identify sent while opted out never transmits the
+ * `$identify` merge event, orphaning the anonymous latitude.so visitor from the
+ * signed-up user. Opting in first lets identify stitch the pre-signup landing
+ * session to the user. `group()` runs last; the super property from `register()`
+ * keeps org-based breakdowns correct even before `$group_0` is set.
  */
 export const syncPostHogSession = async (input: SyncSessionInput): Promise<void> => {
   if (input.excludeFromAnalytics) {
@@ -174,8 +176,17 @@ export const syncPostHogSession = async (input: SyncSessionInput): Promise<void>
   }
 
   // Super property: attaches organizationId to every subsequent event,
-  // including ones captured before group() is wired up.
+  // including the opt-in event and first pageview fired below.
   posthog.register({ organizationId: input.organizationId })
+
+  // Opt in BEFORE identify. The SDK inits with opt_out_capturing_by_default,
+  // so while opted out every capture() — including the $identify event that
+  // merges the anonymous latitude.so visitor into this user — is silently
+  // dropped. Opting in first lets identify actually transmit, so the pre-signup
+  // landing session stitches to the identified user. register() above keeps
+  // organizationId on the opt-in event and first pageview even though group()
+  // runs after.
+  posthog.opt_in_capturing()
 
   posthog.identify(input.user.id, {
     email: input.user.email,
@@ -190,10 +201,6 @@ export const syncPostHogSession = async (input: SyncSessionInput): Promise<void>
   if (input.organizationSlug) orgProps.slug = input.organizationSlug
   if (input.organizationPlan) orgProps.plan = input.organizationPlan
   posthog.group("organization", input.organizationId, Object.keys(orgProps).length > 0 ? orgProps : undefined)
-
-  // Opt in last so the implicit first pageview inherits identity + super
-  // properties + the org group set above.
-  posthog.opt_in_capturing()
 }
 
 /**


### PR DESCRIPTION
## Problem

Anonymous visitors on the marketing site (\`latitude.so\`) are never merged with their signed-up user in the app (\`console.latitude.so\`). The pre-signup landing journey is orphaned, so acquisition funnels and attribution across the landing→app boundary read as broken.

## Root cause

\`syncPostHogSession\` calls \`posthog.identify()\` **while PostHog is still opted out**. The SDK inits with \`opt_out_capturing_by_default: true\` (login/signup stay silent), and the old ordering only called \`opt_in_capturing()\` *after* identify/group:

\`\`\`
register() → identify() → group() → opt_in_capturing()   // opt-in last
\`\`\`

While opted out, \`posthog.capture()\` is a no-op — and \`identify()\` sends its anon→user merge via \`capture('\$identify')\`. So the \`\$identify\` event never leaves the browser, and when opt-in finally flips capture on, \`distinct_id\` is already \`user.id\` with no \`\$anon_distinct_id\`. The anonymous landing person is orphaned.

The prior comment ("Opt in last so the first pageview inherits identity") was exactly backwards — opting in last is precisely what drops the merge.

## Evidence (PostHog, last 30 days)

- \`latitude.so\`: **50,131 distinct_ids == 50,131 persons** — perfect 1:1, i.e. zero merging ever happens.
- Browser \`\$identify\` events carrying \`\$anon_distinct_id\` (the only path that can stitch landing→app): **34**, vs **974** \`UserSignedUp\`. ~96% of signups never attach their landing journey.
- \`\$opt_in\` fired 7,189× but browser \`\$identify\` only 34× — opt-in works, identify doesn't.

## Fix

Move \`opt_in_capturing()\` **before** \`identify()\`, keeping \`register()\` first so \`organizationId\` still rides on the opt-in event and first pageview:

\`\`\`
register() → opt_in_capturing() → identify() → group()
\`\`\`

The 34 identifies that did get through prove the token/cookie/cross-subdomain plumbing already works when identify actually transmits — so this reorder is the whole fix. No landing-side change needed. Server-side \`UserSignedUp\` identify is untouched (fine for the user record; it can't carry the browser anon id anyway).

## Verification after deploy

- Browser \`\$identify\` on \`console.latitude.so\` should climb from ~34/mo toward the signup count (~974/mo).
- \`latitude.so\` distinct_ids-to-persons ratio should drop below 1:1 as landing sessions merge into users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved analytics session initialization to establish organization context before identity details are sent.
  - Ensured event capturing is enabled prior to identity updates so identity merges are recorded with the correct attribution.
  - Updated organization grouping and properties so they’re applied in the proper order for more reliable organization-level analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->