### PR TITLE
fix(flaggers): treat Bedrock grammar-compilation timeouts as unclassifiable

### DIFF
--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1581,6 +1581,112 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(calls.generate).toHaveLength(2)
   })
 
+  it("recovers to matched=false when Bedrock's grammar compiler times out on the classify schema", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Please do the task." }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "text", content: "I'll look into that." }],
+            },
+          ]),
+        ),
+    })
+
+    const sdkError = new Error("The model returned the following errors: Grammar compilation timed out")
+    sdkError.name = "AI_APICallError"
+
+    const { layer: aiLayer } = createFakeAI({
+      generate: () =>
+        Effect.fail(
+          new AIError({
+            message: `AI generation failed (${FLAGGER_DEFAULT_CLASSIFIER_MODEL.provider}/${FLAGGER_DEFAULT_CLASSIFIER_MODEL.model}): ${sdkError.message}`,
+            cause: sdkError,
+          }),
+        ),
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "laziness" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+  })
+
+  it("drops matched annotations when the reviewer call fails because the grammar compiler timed out", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Please do the task." }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "text", content: "I'll look into that." }],
+            },
+          ]),
+        ),
+    })
+
+    const sdkError = new Error("The model returned the following errors: Grammar compilation timed out")
+    sdkError.name = "AI_APICallError"
+
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>(input: GenerateInput<T>) => {
+        const isAnnotationReview = input.system?.includes("adversarial quality reviewer") ?? false
+        if (isAnnotationReview) {
+          return Effect.fail(
+            new AIError({
+              message: `AI generation failed (${FLAGGER_DEFAULT_CLASSIFIER_MODEL.provider}/${FLAGGER_DEFAULT_CLASSIFIER_MODEL.model}): ${sdkError.message}`,
+              cause: sdkError,
+            }),
+          )
+        }
+        return Effect.succeed({
+          object: { matched: true, feedback: "The assistant refused a benign request." } as T,
+          tokens: 20,
+          duration: 90_000_000,
+        })
+      },
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "refusal" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+    expect(calls.generate).toHaveLength(2)
+  })
+
   it("uses flagger-specific prompt for laziness with work signals", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -839,10 +839,16 @@ const parseFlaggerOutput = (input: unknown): Effect.Effect<RunFlaggerResult> => 
 
 // The Vercel AI SDK raises `NoObjectGeneratedError` / `NoOutputGeneratedError`
 // when the model returns output that does not materialize as the requested schema,
-// and `AI_APICallError` with a "prompt is too long" message when the trace evidence
-// exceeds the model's context window. The flagger treats both as a "no match" signal
-// instead of propagating the failure — the model effectively failed to classify,
-// which for a triage flagger is indistinguishable from matched=false.
+// `AI_APICallError` with a "prompt is too long" message when the trace evidence
+// exceeds the model's context window, and `AI_APICallError` with a "Grammar
+// compilation timed out" message when Bedrock's constrained decoder fails to
+// compile the structured-output grammar in time (the classify schema's
+// `messageIndex` enum grows with the trace's message count, up to
+// `FLAGGER_MESSAGE_INDEX_ENUM_LIMIT`). All three are deterministic on the
+// input for a given call, so retries don't help. The flagger treats all of
+// them as a "no match" signal instead of propagating the failure — the model
+// effectively failed to classify, which for a triage flagger is
+// indistinguishable from matched=false.
 const isSchemaMismatchCause = (cause: unknown): boolean => {
   if (!(cause instanceof Error)) return false
   if (cause.name === "AI_NoObjectGeneratedError" || cause.name === "AI_NoOutputGeneratedError") return true
@@ -852,8 +858,11 @@ const isSchemaMismatchCause = (cause: unknown): boolean => {
 const isPromptTooLongCause = (cause: unknown): boolean =>
   cause instanceof Error && typeof cause.message === "string" && cause.message.includes("prompt is too long")
 
+const isGrammarCompilationTimeoutCause = (cause: unknown): boolean =>
+  cause instanceof Error && typeof cause.message === "string" && cause.message.includes("Grammar compilation timed out")
+
 const isUnclassifiableModelFailureCause = (cause: unknown): boolean =>
-  isSchemaMismatchCause(cause) || isPromptTooLongCause(cause)
+  isSchemaMismatchCause(cause) || isPromptTooLongCause(cause) || isGrammarCompilationTimeoutCause(cause)
 
 /**
  * Pure LLM classification for an already-loaded conversation — the screening


### PR DESCRIPTION
## What does this PR do?

The flagger classifier (`packages/domain/flaggers/src/use-cases/run-flagger.ts`) already recovers to `matched: false` instead of failing the whole run when the model returns a schema mismatch (`AI_NoObjectGeneratedError`/`AI_NoOutputGeneratedError`) or a "prompt is too long" `AI_APICallError` (fixed previously in #3889). It did not cover a third deterministic failure mode from the same call sites: Bedrock's constrained decoder returning `AI_APICallError: "Grammar compilation timed out"` when it fails to compile the structured-output grammar in time (the classify schema's `messageIndex` enum grows with the trace's message count, up to `FLAGGER_MESSAGE_INDEX_ENUM_LIMIT`).

Left uncaught, this failed the classify/annotation-review calls entirely instead of degrading gracefully like the other two causes — for a triage flagger, a model that can't produce parseable structured output is indistinguishable from "no match".

**Datadog:** `AI_APICallError`/`AIError` "Grammar compilation timed out" cluster (services `workers`/`workflows`, ~21 occurrences over the past week, resource `flagger.classify`), previously untriaged.

**Root cause:** `isUnclassifiableModelFailureCause` in `run-flagger.ts` only checked for schema-mismatch and prompt-too-long causes.

**Fix:** added `isGrammarCompilationTimeoutCause` and included it in `isUnclassifiableModelFailureCause`, so both the classify and annotation-review call sites recover to `matched: false` for this cause too, exactly like the existing two.

## Related issue (if applicable)

Closes #

## How was this tested?

Added two regression tests mirroring the existing "prompt too long" coverage:
- `recovers to matched=false when Bedrock's grammar compiler times out on the classify schema`
- `drops matched annotations when the reviewer call fails because the grammar compiler timed out`

Both tests fail without the fix (confirmed by temporarily reverting `run-flagger.ts` — the `AIError` propagates uncaught) and pass with it. Full `run-flagger.test.ts` suite (48 tests) passes. Typecheck was run for `@domain/flaggers`; two unrelated pre-existing failures remain in `regression/*.test.ts` from an unbuilt `@latitude-data/sdk`/`@latitude-data/telemetry` workspace package (present identically without this change). Biome lint clean on both changed files.

**Verification in production:** after deploy, occurrences of the "Grammar compilation timed out" issue cluster should drop to zero (flagger runs recover instead of failing).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01FBCqy33FzMFDw3imiA5VT9)_