### PR TITLE
fix(billing): lower AI pricing fallbacks to 4/1 and report in telemetry

### DIFF
--- a/apps/workers/src/workers/billing.test.ts
+++ b/apps/workers/src/workers/billing.test.ts
@@ -243,8 +243,8 @@ describe("billing runtime integration", () => {
       .where(eq(billingUsagePeriods.organizationId, organizationId))
 
     expect(events).toHaveLength(2)
-    expect(events.map((event) => event.credits).sort((a, b) => a - b)).toEqual([15, 30])
-    expect(period?.consumedCredits).toBe(45)
+    expect(events.map((event) => event.credits).sort((a, b) => a - b)).toEqual([1, 4])
+    expect(period?.consumedCredits).toBe(5)
   })
 
   it("treats concurrent duplicate record deliveries as one billed action", async () => {
@@ -291,10 +291,10 @@ describe("billing runtime integration", () => {
       .where(eq(billingUsagePeriods.organizationId, organizationId))
     const outbox = await pg.db.select().from(outboxEvents).where(eq(outboxEvents.organizationId, organizationId))
 
-    expect(first.consumedCredits).toBe(15)
-    expect(second.consumedCredits).toBe(15)
+    expect(first.consumedCredits).toBe(1)
+    expect(second.consumedCredits).toBe(1)
     expect(events).toHaveLength(1)
-    expect(period?.consumedCredits).toBe(15)
+    expect(period?.consumedCredits).toBe(1)
     expect(outbox).toHaveLength(1)
   })
 
@@ -350,7 +350,7 @@ describe("billing runtime integration", () => {
 
     expect(events).toHaveLength(1)
     expect(events[0]?.action).toBe("semantic-query")
-    expect(period?.consumedCredits).toBe(15)
+    expect(period?.consumedCredits).toBe(1)
   })
 
   it("records trace usage batches idempotently across queue retries", async () => {
@@ -833,24 +833,24 @@ describe("billing runtime integration", () => {
      * Setup shared by both tests:
      *
      * - Pro org sitting at exactly 100% of included credits (consumed = includedCredits = 100_000).
-     * - Spending limit = base $99 + $0.15 of overage headroom = 9915 cents. The Pro overage rate
-     *   is $0.002/credit, so $0.15 buys exactly 75 overage credits.
-     * - Each `semantic-query` costs 15 credits → 5 reservations fit, the 6th overshoots.
+     * - Spending limit = base $99 + $0.01 of overage headroom = 9901 cents. The Pro overage rate
+     *   is $0.002/credit, so $0.01 buys exactly 5 overage credits.
+     * - Each `semantic-query` costs 1 credit → 5 reservations fit, the 6th overshoots.
      * - 10 concurrent authorizations.
      *
      * Without atomic reservation, every concurrent caller reads the same 100_000 snapshot, projects
-     * `100_015 ≤ 100_075 (cap)` and is allowed. All 10 then record → final consumed = 100_150, overage = 150,
-     * spend = $99.30, overshooting the $99.15 cap by 100% of available overage.
+     * `100_001 ≤ 100_005 (cap)` and is allowed. All 10 then record → final consumed = 100_010, overage = 10,
+     * spend = $99.02, overshooting the $99.01 cap by 100% of available overage.
      *
-     * With atomic reservation, exactly 5 succeed and the worker writes 5 records → final consumed = 100_075,
-     * overage = 75, spend = $99.15 = cap.
+     * With atomic reservation, exactly 5 succeed and the worker writes 5 records → final consumed = 100_005,
+     * overage = 5, spend = $99.01 = cap.
      */
     const PRO_BASE_CENTS = PLAN_CONFIGS.pro.priceCents as number
-    const SPENDING_LIMIT_CENTS = PRO_BASE_CENTS + 15
+    const SPENDING_LIMIT_CENTS = PRO_BASE_CENTS + 1
     const PERIOD_START = new Date("2026-08-01T00:00:00.000Z")
     const PERIOD_END = new Date("2026-09-01T00:00:00.000Z")
     const CONCURRENCY = 10
-    const ACTION_COST = 15
+    const ACTION_COST = 1
 
     const seedCappedProOrgAtIncludedLimit = async (organizationId: string) => {
       await pg.db.insert(organizations).values({

--- a/dev-docs/billing.md
+++ b/dev-docs/billing.md
@@ -24,8 +24,8 @@ Chargeable actions:
 
 - `trace = 1 credit`
 - `eval-scan = 1 credit`
-- `semantic-query = cost-based` (flat `15 credits` as authorization estimate and fallback)
-- `llm-call = cost-based` (flat `30 credits` as authorization estimate and fallback)
+- `semantic-query = cost-based` (flat `1 credit` as authorization estimate and fallback)
+- `llm-call = cost-based` (flat `4 credits` as authorization estimate and fallback)
 
 AI work is billed per primitive produced, not per feature-level scan: every hosted LLM
 generation is one `llm-call` and every query-time semantic embedding (a query embed
@@ -50,7 +50,9 @@ One credit is worth `2` mills at the Pro overage rate (`$20` per `10,000` credit
   26; a Sonnet-tier GEPA proposal (~`$0.30`) bills 195.
   **Fallback**: when the registry has no pricing for the configured model or the
   provider reported no usage (including errored calls), the flat
-  `ACTION_CREDITS["llm-call"] = 30` applies and a warning is logged — keep the
+  `ACTION_CREDITS["llm-call"] = 4` applies. The metering layer logs a warning and
+  annotates the active OTel span with `billing.pricing=flat-fallback` (plus action,
+  provider, and model) so Datadog can alert on silent registry gaps — keep the
   registry data current for every model configured via `LAT_AI_*`.
 - `semantic-query`: each query embedding bills its **estimated provider cost with a
   `2x` margin** (`SEMANTIC_QUERY_BILLING_MARGIN`), converted and rounded the same way
@@ -58,8 +60,8 @@ One credit is worth `2` mills at the Pro overage rate (`$20` per `10,000` credit
   registry, so cost uses the adapter-reported token count priced at the hardcoded
   voyage-4-large rate (`$0.12` per 1M tokens, `SEMANTIC_QUERY_EMBED_USD_PER_TOKEN`).
   **Fallback**: when the adapter reports no token usage, the flat
-  `ACTION_CREDITS["semantic-query"] = 15` applies (2x the worst case: a 32k-token
-  query embed ≈ `$0.004` plus a rerank pass ≈ `$0.01`). Reranking and document-side
+  `ACTION_CREDITS["semantic-query"] = 1` applies, with the same warning +
+  `billing.pricing=flat-fallback` span annotation. Reranking and document-side
   embeddings ride on this charge (document embeds are part of trace ingest and are
   covered by the `trace` credit).
 - `eval-scan`: flat 1 credit baseline for every evaluation scan — it prices the
@@ -137,12 +139,12 @@ LLM calls and semantic queries are metered at the AI layer, not per feature. The
 `withAIMetering`, which charges against the ambient `AIMeteringScope`
 (`@domain/billing/src/ai-metering.ts`) when one is present in context:
 
-- `generate` → one `llm-call` billed at estimated cost x 1.3 (flat 30-credit fallback
+- `generate` → one `llm-call` billed at estimated cost x 1.3 (flat 4-credit fallback
   when registry pricing or provider usage is unavailable), recorded on success and on
   `AIError` (the provider call was attempted, tokens may have been consumed — flat
   price, no usage to bill) but not on `AICredentialError`
 - `embed` with `inputType: "query"` → one `semantic-query` billed at estimated cost x 2
-  (flat 15-credit fallback when the adapter reports no token usage); document embeds and
+  (flat 1-credit fallback when the adapter reports no token usage); document embeds and
   rerank are never charged directly — `semanticSimilarity()` in evaluation scripts embeds
   content-addressed documents, so its cost rides on the scan's flat credit
 

--- a/packages/domain/billing/src/constants.ts
+++ b/packages/domain/billing/src/constants.ts
@@ -15,16 +15,17 @@ export const CHARGEABLE_ACTIONS = ["trace", "eval-scan", "semantic-query", "llm-
 export type ChargeableAction = (typeof CHARGEABLE_ACTIONS)[number]
 
 /**
- * Flat credit prices at the Pro overage rate ($0.002/credit). `llm-call` is the
- * authorization estimate and the fallback when the model registry has no pricing —
- * actual generations bill their estimated provider cost through
- * `creditsForLlmGenerationCost`. Derivation lives in dev-docs/billing.md.
+ * Flat credit prices at the Pro overage rate ($0.002/credit). `llm-call` and
+ * `semantic-query` are authorization estimates and fallbacks when cost cannot be
+ * determined — actual generations/embeds bill estimated provider cost through
+ * `creditsForLlmGenerationCost` / `creditsForSemanticQueryCost`. Derivation lives
+ * in dev-docs/billing.md.
  */
 export const ACTION_CREDITS: Record<ChargeableAction, number> = {
   trace: 1,
   "eval-scan": 1,
-  "semantic-query": 15,
-  "llm-call": 30,
+  "semantic-query": 1,
+  "llm-call": 4,
 } as const
 
 export const FREE_PLAN_CONFIG = {

--- a/packages/domain/billing/src/use-cases/authorize-billable-action.test.ts
+++ b/packages/domain/billing/src/use-cases/authorize-billable-action.test.ts
@@ -102,7 +102,7 @@ describe("authorizeBillableAction", () => {
             periodStart: PERIOD_START,
             periodEnd: PERIOD_END,
             includedCredits: 20_000,
-            consumedCredits: 19_990,
+            consumedCredits: 20_000,
           }),
         )
         .pipe(Effect.provideService(SqlClient, SQL_CLIENT)),
@@ -118,7 +118,7 @@ describe("authorizeBillableAction", () => {
     )
 
     expect(result.allowed).toBe(false)
-    expect(result.period?.consumedCredits).toBe(19_990)
+    expect(result.period?.consumedCredits).toBe(20_000)
   })
 
   it("blocks a pro action when the snapshot projection already exceeds the spending cap", async () => {
@@ -202,7 +202,7 @@ describe("authorizeBillableAction", () => {
     expect(first.allowed).toBe(true)
     expect(second.allowed).toBe(true)
     expect(counters.size).toBe(1)
-    expect([...counters.values()][0]?.reservedCredits).toBe(100_015)
+    expect([...counters.values()][0]?.reservedCredits).toBe(100_001)
   })
 
   it("routes hard-capped free-plan authorization through the reservation port", async () => {
@@ -219,6 +219,6 @@ describe("authorizeBillableAction", () => {
 
     expect(result.allowed).toBe(true)
     expect(counters.size).toBe(1)
-    expect([...counters.values()][0]?.reservedCredits).toBe(15)
+    expect([...counters.values()][0]?.reservedCredits).toBe(1)
   })
 })

--- a/packages/domain/billing/src/use-cases/metering-and-overage.test.ts
+++ b/packages/domain/billing/src/use-cases/metering-and-overage.test.ts
@@ -88,7 +88,7 @@ describe("recordBillableActionUseCase", () => {
       }).pipe(Effect.provide(layer)),
     )
 
-    expect(result.overageCredits).toBe(15)
+    expect(result.overageCredits).toBe(1)
     expect(outboxEvents[0]).toMatchObject({
       eventName: "BillingUsagePeriodUpdated",
       payload: {
@@ -97,7 +97,7 @@ describe("recordBillableActionUseCase", () => {
         periodEnd: PERIOD_END.toISOString(),
         planSource: "subscription",
         overageAllowed: true,
-        overageCredits: 15,
+        overageCredits: 1,
         reportedOverageCredits: 0,
       },
     })

--- a/packages/domain/billing/src/use-cases/record-billable-action.ts
+++ b/packages/domain/billing/src/use-cases/record-billable-action.ts
@@ -21,6 +21,10 @@ export const recordBillableActionUseCase = Effect.fn("billing.recordBillableActi
 ) {
   yield* Effect.annotateCurrentSpan("billing.action", input.action)
   yield* Effect.annotateCurrentSpan("billing.idempotencyKey", input.idempotencyKey)
+  const pricing = input.metadata?.pricing
+  if (typeof pricing === "string") {
+    yield* Effect.annotateCurrentSpan("billing.pricing", pricing)
+  }
 
   const updated = yield* recordUsageEventUseCase({
     organizationId: input.organizationId,

--- a/packages/domain/billing/src/use-cases/record-usage-event.test.ts
+++ b/packages/domain/billing/src/use-cases/record-usage-event.test.ts
@@ -232,7 +232,7 @@ describe("checkCreditAvailabilityUseCase", () => {
             periodStart: PERIOD_START,
             periodEnd: PERIOD_END,
             includedCredits: 20_000,
-            consumedCredits: 19_990,
+            consumedCredits: 20_000,
           }),
         )
         .pipe(Effect.provideService(SqlClient, SQL_CLIENT)),

--- a/packages/domain/billing/src/use-cases/record-usage-event.ts
+++ b/packages/domain/billing/src/use-cases/record-usage-event.ts
@@ -55,6 +55,10 @@ export const recordUsageEventUseCase = Effect.fn("billing.recordUsageEvent")(fun
   yield* Effect.annotateCurrentSpan("billing.organizationId", input.organizationId)
   yield* Effect.annotateCurrentSpan("billing.action", input.action)
   yield* Effect.annotateCurrentSpan("billing.idempotencyKey", input.idempotencyKey)
+  const pricing = input.metadata?.pricing
+  if (typeof pricing === "string") {
+    yield* Effect.annotateCurrentSpan("billing.pricing", pricing)
+  }
 
   // A credits override outside the ledger's invariants (positive integer) is a caller
   // bug, never a runtime condition — die instead of widening every caller's error union.

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
@@ -939,7 +939,7 @@ describe("runLiveEvaluationUseCase", () => {
             periodStart: currentPeriodStart,
             periodEnd: currentPeriodEnd,
             includedCredits: 20_000,
-            consumedCredits: 19_980,
+            consumedCredits: 20_000,
           }),
         )
         .pipe(

--- a/packages/platform/ai/src/metering.test.ts
+++ b/packages/platform/ai/src/metering.test.ts
@@ -140,8 +140,12 @@ describe("withAIMetering", () => {
     )
 
     expect(exit._tag).toBe("Failure")
-    expect(recorded.map((entry) => entry.action)).toEqual(["llm-call"])
-    expect(recorded[0]?.credits).toBeUndefined()
+    expect(recorded).toEqual([
+      {
+        action: "llm-call",
+        metadata: { provider: "p", model: "m", pricing: "flat-fallback" },
+      },
+    ])
   })
 
   it("passes through unbilled without a scope", async () => {

--- a/packages/platform/ai/src/metering.ts
+++ b/packages/platform/ai/src/metering.ts
@@ -11,6 +11,7 @@ import {
   type AIMeteringRecordError,
   AIMeteringScope,
   type AIMeteringScopeShape,
+  type MeteredAIAction,
   creditsForLlmGenerationCost,
   creditsForSemanticQueryCost,
   semanticQueryEmbedCostUsd,
@@ -44,10 +45,19 @@ export const withAIMetering = (ai: AIShape): AIShape => ({
           return ai.generate(input)
         }
 
-        const recordFlat = recordScoped(scope.value, {
+        const recordFlat = reportPricingFallback({
           action: "llm-call",
-          metadata: { provider: input.provider, model: input.model },
-        })
+          provider: input.provider,
+          model: input.model,
+          reason: "provider call failed after attempt; no usage to price",
+        }).pipe(
+          Effect.andThen(
+            recordScoped(scope.value, {
+              action: "llm-call",
+              metadata: { provider: input.provider, model: input.model, pricing: "flat-fallback" },
+            }),
+          ),
+        )
 
         // tapError attaches before tap so it only sees provider failures — a
         // failed recordGeneration must not also commit the flat fallback record.
@@ -72,6 +82,25 @@ export const withAIMetering = (ai: AIShape): AIShape => ({
   rerank: ai.rerank,
 })
 
+const reportPricingFallback = (input: {
+  readonly action: MeteredAIAction
+  readonly provider: string
+  readonly model: string
+  readonly reason: string
+  readonly details?: Record<string, unknown>
+}): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* Effect.logWarning(`AI metering: ${input.reason}; billing flat ${input.action} price`, {
+      provider: input.provider,
+      model: input.model,
+      ...input.details,
+    })
+    yield* Effect.annotateCurrentSpan("billing.pricing", "flat-fallback")
+    yield* Effect.annotateCurrentSpan("billing.action", input.action)
+    yield* Effect.annotateCurrentSpan("billing.provider", input.provider)
+    yield* Effect.annotateCurrentSpan("billing.model", input.model)
+  })
+
 const recordGeneration = <T>(
   scope: AIMeteringScopeShape,
   input: GenerateInput<T>,
@@ -81,11 +110,12 @@ const recordGeneration = <T>(
   const costSpec = getCostSpec(input.provider, input.model)
 
   if (usage === undefined || !costSpec.costImplemented) {
-    return Effect.logWarning("AI metering: no usage or registry pricing for model; billing flat llm-call price", {
+    return reportPricingFallback({
+      action: "llm-call",
       provider: input.provider,
       model: input.model,
-      hasUsage: usage !== undefined,
-      costImplemented: costSpec.costImplemented,
+      reason: "no usage or registry pricing for model",
+      details: { hasUsage: usage !== undefined, costImplemented: costSpec.costImplemented },
     }).pipe(
       Effect.andThen(
         recordScoped(scope, {
@@ -120,9 +150,11 @@ const recordSemanticQuery = (
   result: EmbedResult,
 ): Effect.Effect<void, AIError> => {
   if (result.tokens === undefined) {
-    return Effect.logWarning("AI metering: embed adapter reported no token usage; billing flat semantic-query price", {
+    return reportPricingFallback({
+      action: "semantic-query",
       provider: input.provider,
       model: input.model,
+      reason: "embed adapter reported no token usage",
     }).pipe(
       Effect.andThen(
         recordScoped(scope, {

--- a/packages/platform/ai/src/metering.ts
+++ b/packages/platform/ai/src/metering.ts
@@ -11,9 +11,9 @@ import {
   type AIMeteringRecordError,
   AIMeteringScope,
   type AIMeteringScopeShape,
-  type MeteredAIAction,
   creditsForLlmGenerationCost,
   creditsForSemanticQueryCost,
+  type MeteredAIAction,
   semanticQueryEmbedCostUsd,
 } from "@domain/billing"
 import { estimateTotalCost, getCostSpec } from "@domain/models"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Follow-up to #3915. When we can't estimate provider cost for an AI call, the flat fallback prices were 30 credits (`llm-call`) and 15 credits (`semantic-query`). That overcharges orgs whenever the model registry is missing pricing or a provider omits usage.

This PR:

- Lowers the flat fallbacks to **4** (`llm-call`) and **1** (`semantic-query`) — same values used for authorization estimates via `ACTION_CREDITS`
- Reports every fallback in telemetry: warning log + OTel span attributes (`billing.pricing=flat-fallback`, plus action/provider/model), and the same `billing.pricing` annotation on the billing record spans when metadata carries it
- Tags errored provider calls with `pricing: "flat-fallback"` as well (they already billed the flat price but didn't mark it)

Also includes the Fern SDK/CLI regen from #4212 so the `manifests` check stays green (export `429` response drift on `development`).

Refs #3915

## How was this tested?

- `@domain/billing`: 30 tests passed
- `@platform/ai`: 29 tests passed (including flat-fallback metadata on missing pricing, missing usage, and `AIError`)
- `@app/workers` `billing.test.ts`: 15 tests passed
- `@domain/evaluations` billing-block fixture updated for the 4-credit `llm-call` estimate

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858800f6-7bf5-4b55-b0b9-769c0e9c7705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858800f6-7bf5-4b55-b0b9-769c0e9c7705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

