### PR TITLE
fix(web): silence stale server-fn hash errors after deploys

### DIFF
--- a/apps/web/src/lib/data/handle-mutation-error.test.ts
+++ b/apps/web/src/lib/data/handle-mutation-error.test.ts
@@ -72,4 +72,15 @@ describe("handleMutationError", () => {
     expect(toastMock).not.toHaveBeenCalled()
     expect(reload).toHaveBeenCalledTimes(1)
   })
+
+  it("reloads when the missing-hash text is nested inside a recordServerFnError JSON payload", () => {
+    handleMutationError(
+      serverError({
+        message: "Server function info not found for 8ae8498b6e8c600abff6cc7c428fc166b1bb45613094b806f08105bfc6f1344d",
+      }),
+    )
+
+    expect(toastMock).not.toHaveBeenCalled()
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/web/src/lib/data/handle-mutation-error.test.ts
+++ b/apps/web/src/lib/data/handle-mutation-error.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { STALE_SERVER_FN_ERROR_TAG, STALE_SERVER_FN_USER_MESSAGE } from "../stale-server-fn.ts"
 
 const toastMock = vi.hoisted(() => vi.fn())
 vi.mock("@repo/ui", () => ({ toast: toastMock }))
@@ -9,7 +10,17 @@ const serverError = (payload: { _tag?: string; message: string; status?: number 
   new Error(JSON.stringify({ status: 500, ...payload }))
 
 describe("handleMutationError", () => {
-  beforeEach(() => toastMock.mockClear())
+  const reload = vi.fn()
+
+  beforeEach(() => {
+    toastMock.mockClear()
+    reload.mockClear()
+    vi.stubGlobal("window", { location: { reload } })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
 
   it("toasts the decoded message for a generic server error", () => {
     handleMutationError(serverError({ message: "Something broke" }))
@@ -42,5 +53,23 @@ describe("handleMutationError", () => {
     })
 
     expect(toastMock).not.toHaveBeenCalled()
+  })
+
+  it("reloads the page for a stale server-fn error instead of toasting", () => {
+    handleMutationError(
+      serverError({ _tag: STALE_SERVER_FN_ERROR_TAG, message: STALE_SERVER_FN_USER_MESSAGE, status: 404 }),
+    )
+
+    expect(toastMock).not.toHaveBeenCalled()
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it("reloads when the client still sees TanStack's raw missing-hash message", () => {
+    handleMutationError(
+      new Error("Server function info not found for 8ae8498b6e8c600abff6cc7c428fc166b1bb45613094b806f08105bfc6f1344d"),
+    )
+
+    expect(toastMock).not.toHaveBeenCalled()
+    expect(reload).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/lib/data/handle-mutation-error.ts
+++ b/apps/web/src/lib/data/handle-mutation-error.ts
@@ -1,5 +1,6 @@
 import { toast } from "@repo/ui"
 import { parseServerError } from "../errors.ts"
+import { STALE_SERVER_FN_ERROR_TAG } from "../stale-server-fn.ts"
 
 /** `_tag` of the read-only (showcase) write rejection. */
 export const READ_ONLY_PROJECT_ERROR_TAG = "ReadOnlyProjectError"
@@ -33,6 +34,11 @@ export function handleMutationError(error: unknown, options: HandleMutationError
     // The read-only "demo" modal is opened once, centrally, by the write-gate
     // client middleware (the single choke point every write flows through). Here
     // we only swallow the error so it isn't also toasted.
+    return
+  }
+
+  if (parsed._tag === STALE_SERVER_FN_ERROR_TAG) {
+    if (typeof window !== "undefined") window.location.reload()
     return
   }
 

--- a/apps/web/src/lib/data/query-client.tsx
+++ b/apps/web/src/lib/data/query-client.tsx
@@ -1,9 +1,21 @@
-import { isServer, MutationCache, QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { isServer, MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ReactNode } from "react"
+import { parseServerError } from "../errors.ts"
+import { STALE_SERVER_FN_ERROR_TAG } from "../stale-server-fn.ts"
 import { handleMutationError } from "./handle-mutation-error.ts"
+
+const reloadOnStaleServerFn = (error: unknown): void => {
+  if (parseServerError(error)._tag !== STALE_SERVER_FN_ERROR_TAG) return
+  if (typeof window !== "undefined") window.location.reload()
+}
 
 const makeQueryClient = () =>
   new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error) => {
+        reloadOnStaleServerFn(error)
+      },
+    }),
     mutationCache: new MutationCache({
       onError: (error, _variables, _context, mutation) => {
         // opt-in: most callers already surface errors (mutateAsync+catch, form handlers)

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -33,9 +33,14 @@ export function parseServerError(err: unknown): ServerError {
   try {
     const parsed = JSON.parse(raw)
     if (typeof parsed === "object" && parsed !== null && "message" in parsed) {
+      const message = typeof parsed.message === "string" ? parsed.message : String(parsed.message)
+      // Nested payload from recordServerFnError may still carry TanStack's raw text.
+      if (parsed._tag === STALE_SERVER_FN_ERROR_TAG || isMissingServerFnErrorMessage(message)) {
+        return { _tag: STALE_SERVER_FN_ERROR_TAG, message: STALE_SERVER_FN_USER_MESSAGE, status: 404 }
+      }
       return {
         _tag: parsed._tag,
-        message: parsed.message,
+        message,
         status: typeof parsed.status === "number" ? parsed.status : 500,
       }
     }

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -7,6 +7,12 @@
  * These helpers decode that payload back into structured data.
  */
 
+import {
+  isMissingServerFnErrorMessage,
+  STALE_SERVER_FN_ERROR_TAG,
+  STALE_SERVER_FN_USER_MESSAGE,
+} from "./stale-server-fn.ts"
+
 /**
  * Structured error returned by `parseServerError`.
  */
@@ -35,6 +41,9 @@ export function parseServerError(err: unknown): ServerError {
     }
   } catch {
     // not JSON — fall through
+  }
+  if (isMissingServerFnErrorMessage(raw)) {
+    return { _tag: STALE_SERVER_FN_ERROR_TAG, message: STALE_SERVER_FN_USER_MESSAGE, status: 404 }
   }
   return { _tag: undefined, message: raw, status: 500 }
 }

--- a/apps/web/src/lib/stale-server-fn.test.ts
+++ b/apps/web/src/lib/stale-server-fn.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { isMissingServerFnError, isMissingServerFnErrorMessage } from "./stale-server-fn.ts"
+
+describe("isMissingServerFnErrorMessage", () => {
+  it("matches TanStack's unknown server-fn hash message", () => {
+    expect(
+      isMissingServerFnErrorMessage(
+        "Server function info not found for 8ae8498b6e8c600abff6cc7c428fc166b1bb45613094b806f08105bfc6f1344d",
+      ),
+    ).toBe(true)
+  })
+
+  it("rejects unrelated messages", () => {
+    expect(isMissingServerFnErrorMessage("boom")).toBe(false)
+    expect(isMissingServerFnErrorMessage("Server function info not found for not-a-hash")).toBe(false)
+  })
+})
+
+describe("isMissingServerFnError", () => {
+  it("requires an Error with the matching message", () => {
+    expect(
+      isMissingServerFnError(
+        new Error(
+          "Server function info not found for 8ae8498b6e8c600abff6cc7c428fc166b1bb45613094b806f08105bfc6f1344d",
+        ),
+      ),
+    ).toBe(true)
+    expect(isMissingServerFnError("Server function info not found for abc")).toBe(false)
+  })
+})

--- a/apps/web/src/lib/stale-server-fn.ts
+++ b/apps/web/src/lib/stale-server-fn.ts
@@ -1,0 +1,11 @@
+// TanStack Start throws this when a stale tab calls a server-fn hash from a prior deploy.
+export const STALE_SERVER_FN_ERROR_TAG = "StaleServerFnError"
+
+export const STALE_SERVER_FN_USER_MESSAGE = "This page is out of date. Please reload."
+
+const MISSING_SERVER_FN_MESSAGE = /^Server function info not found for [a-f0-9]{64}$/
+
+export const isMissingServerFnErrorMessage = (message: string): boolean => MISSING_SERVER_FN_MESSAGE.test(message)
+
+export const isMissingServerFnError = (error: unknown): boolean =>
+  error instanceof Error && isMissingServerFnErrorMessage(error.message)

--- a/apps/web/src/middlewares/server-fn-error.test.ts
+++ b/apps/web/src/middlewares/server-fn-error.test.ts
@@ -2,7 +2,12 @@ import { NotFoundError, RepositoryError, UnauthorizedError } from "@domain/share
 import type { Span } from "@repo/observability"
 import { isHttpError } from "@repo/utils"
 import { describe, expect, it, vi } from "vitest"
-import { recordRequestError, recordServerFnError } from "./server-fn-error.ts"
+import { STALE_SERVER_FN_ERROR_TAG, STALE_SERVER_FN_USER_MESSAGE } from "../lib/stale-server-fn.ts"
+import { asStaleServerFnError, recordRequestError, recordServerFnError } from "./server-fn-error.ts"
+
+const MISSING_SERVER_FN = new Error(
+  "Server function info not found for 8ae8498b6e8c600abff6cc7c428fc166b1bb45613094b806f08105bfc6f1344d",
+)
 
 const fakeSpan = () => {
   const span = {
@@ -118,5 +123,35 @@ describe("recordRequestError", () => {
     recordRequestError(span, new Error("boom"))
 
     expect(span.recordException).toHaveBeenCalledTimes(1)
+  })
+
+  it("does NOT report a raw missing server-fn hash (deploy skew) to Datadog", () => {
+    const span = fakeSpan()
+    recordRequestError(span, MISSING_SERVER_FN)
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(span.setStatus).not.toHaveBeenCalled()
+  })
+
+  it("does NOT report the reshaped stale server-fn 404 to Datadog", () => {
+    const span = fakeSpan()
+    recordRequestError(span, asStaleServerFnError(MISSING_SERVER_FN))
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(span.setStatus).not.toHaveBeenCalled()
+  })
+})
+
+describe("asStaleServerFnError", () => {
+  it("shapes a client-bound 404 payload and preserves HttpError classification", () => {
+    const shaped = asStaleServerFnError(MISSING_SERVER_FN)
+
+    expect(JSON.parse(shaped.message)).toEqual({
+      _tag: STALE_SERVER_FN_ERROR_TAG,
+      message: STALE_SERVER_FN_USER_MESSAGE,
+      status: 404,
+    })
+    expect(isHttpError(shaped)).toBe(true)
+    expect(shaped.stack).toBe(MISSING_SERVER_FN.stack)
   })
 })

--- a/apps/web/src/middlewares/server-fn-error.test.ts
+++ b/apps/web/src/middlewares/server-fn-error.test.ts
@@ -155,3 +155,20 @@ describe("asStaleServerFnError", () => {
     expect(shaped.stack).toBe(MISSING_SERVER_FN.stack)
   })
 })
+
+describe("recordServerFnError stale server-fn", () => {
+  it("maps a missing server-fn hash to StaleServerFnError without recording", () => {
+    const span = fakeSpan()
+    const info = recordServerFnError(span, MISSING_SERVER_FN)
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(info.isClientError).toBe(true)
+    expect(info.status).toBe(404)
+    expect(info.tag).toBe(STALE_SERVER_FN_ERROR_TAG)
+    expect(JSON.parse(info.error.message)).toEqual({
+      _tag: STALE_SERVER_FN_ERROR_TAG,
+      message: STALE_SERVER_FN_USER_MESSAGE,
+      status: 404,
+    })
+  })
+})

--- a/apps/web/src/middlewares/server-fn-error.test.ts
+++ b/apps/web/src/middlewares/server-fn-error.test.ts
@@ -3,7 +3,12 @@ import type { Span } from "@repo/observability"
 import { isHttpError } from "@repo/utils"
 import { describe, expect, it, vi } from "vitest"
 import { STALE_SERVER_FN_ERROR_TAG, STALE_SERVER_FN_USER_MESSAGE } from "../lib/stale-server-fn.ts"
-import { asStaleServerFnError, recordRequestError, recordServerFnError } from "./server-fn-error.ts"
+import {
+  asStaleServerFnError,
+  recordRequestError,
+  recordServerFnError,
+  staleServerFnResponse,
+} from "./server-fn-error.ts"
 
 const MISSING_SERVER_FN = new Error(
   "Server function info not found for 8ae8498b6e8c600abff6cc7c428fc166b1bb45613094b806f08105bfc6f1344d",
@@ -153,6 +158,20 @@ describe("asStaleServerFnError", () => {
     })
     expect(isHttpError(shaped)).toBe(true)
     expect(shaped.stack).toBe(MISSING_SERVER_FN.stack)
+  })
+})
+
+describe("staleServerFnResponse", () => {
+  it("returns a non-serialized 404 body the client turns into Error(message)", async () => {
+    const response = staleServerFnResponse(asStaleServerFnError(MISSING_SERVER_FN))
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get("Content-Type")).toBe("text/plain;charset=UTF-8")
+    expect(JSON.parse(await response.text())).toEqual({
+      _tag: STALE_SERVER_FN_ERROR_TAG,
+      message: STALE_SERVER_FN_USER_MESSAGE,
+      status: 404,
+    })
   })
 })
 

--- a/apps/web/src/middlewares/server-fn-error.ts
+++ b/apps/web/src/middlewares/server-fn-error.ts
@@ -70,6 +70,16 @@ export const recordRequestError = (span: Span, error: unknown): void => {
  * so the request middleware can recognise a 4xx and likewise skip recording it.
  */
 export const recordServerFnError = (span: Span, e: unknown): ServerFnErrorInfo => {
+  if (isMissingServerFnError(e) && e instanceof Error) {
+    return {
+      error: asStaleServerFnError(e),
+      tag: STALE_SERVER_FN_ERROR_TAG,
+      message: STALE_SERVER_FN_USER_MESSAGE,
+      status: 404,
+      isClientError: true,
+    }
+  }
+
   const httpError = isHttpError(e)
   const tag = errorTag(e)
   const message = httpError ? e.httpMessage : e instanceof Error ? e.message : "Unknown error occurred"

--- a/apps/web/src/middlewares/server-fn-error.ts
+++ b/apps/web/src/middlewares/server-fn-error.ts
@@ -48,6 +48,14 @@ export const asStaleServerFnError = (error: Error): Error => {
   return shaped
 }
 
+// getServerFnById throws outside Start's serializer; return a Response so the
+// client path still gets Error(text) instead of a host-level generic 500.
+export const staleServerFnResponse = (shaped: Error): Response =>
+  new Response(shaped.message, {
+    status: 404,
+    headers: { "Content-Type": "text/plain;charset=UTF-8" },
+  })
+
 /**
  * Records a request-level error onto its span unless it's an expected 4xx.
  * Used by the request middleware, which also sees the re-thrown server-fn error

--- a/apps/web/src/middlewares/server-fn-error.ts
+++ b/apps/web/src/middlewares/server-fn-error.ts
@@ -2,6 +2,11 @@ import type { DomainError } from "@domain/shared"
 import type { Span } from "@repo/observability"
 import { recordSpanExceptionForDatadog, SpanStatusCode } from "@repo/observability"
 import { isHttpError } from "@repo/utils"
+import {
+  isMissingServerFnError,
+  STALE_SERVER_FN_ERROR_TAG,
+  STALE_SERVER_FN_USER_MESSAGE,
+} from "../lib/stale-server-fn.ts"
 
 type ServerFnErrorInfo = {
   readonly error: Error
@@ -14,7 +19,12 @@ type ServerFnErrorInfo = {
 const errorTag = (e: unknown): string | undefined =>
   typeof e === "object" && e !== null && "_tag" in (e as DomainError) ? (e as DomainError)._tag : undefined
 
-const errorStatus = (e: unknown): number => (isHttpError(e) ? e.httpStatus : 500)
+const errorStatus = (e: unknown): number => {
+  if (isHttpError(e)) return e.httpStatus
+  // Stale-tab server-fn hashes after a deploy — expected 404, not a 500.
+  if (isMissingServerFnError(e)) return 404
+  return 500
+}
 
 // A 4xx means the caller was rejected as designed (not logged in, no access,
 // bad input) — expected control flow, not a server fault. Such errors are kept
@@ -22,6 +32,21 @@ const errorStatus = (e: unknown): number => (isHttpError(e) ? e.httpStatus : 500
 // still carries http.status_code for APM/metrics. Anything ≥ 500 or non-HTTP
 // (treated as 500) is recorded as before.
 const isExpectedClientError = (status: number): boolean => status >= 400 && status < 500
+
+/** Reshape TanStack's unknown-hash throw into our client-bound 404 payload. */
+export const asStaleServerFnError = (error: Error): Error => {
+  const shaped = new Error(
+    JSON.stringify({
+      _tag: STALE_SERVER_FN_ERROR_TAG,
+      message: STALE_SERVER_FN_USER_MESSAGE,
+      status: 404,
+    }),
+  )
+  if (error.stack) shaped.stack = error.stack
+  Object.defineProperty(shaped, "httpStatus", { value: 404 })
+  Object.defineProperty(shaped, "httpMessage", { value: STALE_SERVER_FN_USER_MESSAGE })
+  return shaped
+}
 
 /**
  * Records a request-level error onto its span unless it's an expected 4xx.

--- a/apps/web/src/middlewares/tracing-request-middleware.ts
+++ b/apps/web/src/middlewares/tracing-request-middleware.ts
@@ -1,7 +1,8 @@
 import type { Span, Tracer } from "@repo/observability"
 import { SpanStatusCode } from "@repo/observability"
 import { createMiddleware } from "@tanstack/react-start"
-import { recordRequestError } from "./server-fn-error.ts"
+import { isMissingServerFnError } from "../lib/stale-server-fn.ts"
+import { asStaleServerFnError, recordRequestError } from "./server-fn-error.ts"
 
 export const tracingRequestMiddleware = ({ tracer }: { tracer: Tracer }) =>
   createMiddleware({ type: "request" }).server(async ({ next, request }) => {
@@ -23,8 +24,9 @@ export const tracingRequestMiddleware = ({ tracer }: { tracer: Tracer }) =>
         }
         return result
       } catch (error) {
-        recordRequestError(span, error)
-        throw error
+        const normalized = isMissingServerFnError(error) && error instanceof Error ? asStaleServerFnError(error) : error
+        recordRequestError(span, normalized)
+        throw normalized
       } finally {
         span.end()
       }

--- a/apps/web/src/middlewares/tracing-request-middleware.ts
+++ b/apps/web/src/middlewares/tracing-request-middleware.ts
@@ -2,7 +2,7 @@ import type { Span, Tracer } from "@repo/observability"
 import { SpanStatusCode } from "@repo/observability"
 import { createMiddleware } from "@tanstack/react-start"
 import { isMissingServerFnError } from "../lib/stale-server-fn.ts"
-import { asStaleServerFnError, recordRequestError } from "./server-fn-error.ts"
+import { asStaleServerFnError, recordRequestError, staleServerFnResponse } from "./server-fn-error.ts"
 
 export const tracingRequestMiddleware = ({ tracer }: { tracer: Tracer }) =>
   createMiddleware({ type: "request" }).server(async ({ next, request }) => {
@@ -24,9 +24,15 @@ export const tracingRequestMiddleware = ({ tracer }: { tracer: Tracer }) =>
         }
         return result
       } catch (error) {
-        const normalized = isMissingServerFnError(error) && error instanceof Error ? asStaleServerFnError(error) : error
-        recordRequestError(span, normalized)
-        throw normalized
+        if (isMissingServerFnError(error) && error instanceof Error) {
+          const shaped = asStaleServerFnError(error)
+          recordRequestError(span, shaped)
+          const response = staleServerFnResponse(shaped)
+          span.setAttribute("http.status_code", response.status)
+          return response
+        }
+        recordRequestError(span, error)
+        throw error
       } finally {
         span.end()
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Maps TanStack Start's `Server function info not found for <hash>` throws to an expected 404 so they stop opening new Datadog Error Tracking issues after every web deploy.

## Context

[Datadog issue](https://app.datadoghq.eu/error-tracking/issue/07a2e60e-8750-11f1-bf35-da7ad0900005) fired ~5 minutes after deploy `7585b8a1` when stale tabs called server-fn hashes from the previous bundle. Volume is low (~10 hits / 30d across a few hashes), but each unique hash fingerprints a *new* Error Tracking issue and trips the "new issue" monitor.

This is deploy/version skew, not a logic bug. Stack: `getServerFnById` → request middleware → recorded as an unclassified 500.

## Change

- Detect the missing-hash message in request middleware
- Return a 404 `text/plain` Response with a structured `StaleServerFnError` payload (rethrowing a plain `Error` escapes Start's serializer because `getServerFnById` runs outside its try/catch)
- Also reshape inside `recordServerFnError` if that path is hit
- Skip Datadog Error Tracking for that 4xx path
- Reload the page when the client still hits one (mutation + query error caches), including raw TanStack text and JSON-wrapped nested copies

## Verification

- Unit tests for matcher, reshape/skip-Datadog path, Response body, nested JSON reload, and client reload
- `pnpm --filter @app/web typecheck`
- After deploy: new occurrences of this fingerprint family should stop appearing in Error Tracking; stale tabs should reload instead of toasting a 500-looking error

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C03BZFX9KCK/p1784891892772699?thread_ts=1784891892.772699&cid=C03BZFX9KCK)

<div><a href="https://cursor.com/agents/bc-33d94b23-40c9-5387-80b9-e706a64e6461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33d94b23-40c9-5387-80b9-e706a64e6461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of outdated server errors by automatically reloading the page when needed.
  * Prevented stale deployment errors from showing misleading toast notifications or being reported as unexpected failures.
  * Added a clear message when the page needs to be refreshed: “This page is out of date. Please reload.”

* **Tests**
  * Added coverage for stale server errors, page reload behavior, error classification, and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->