### PR TITLE
fix(flaggers): soft-fail Bedrock grammar compilation timeouts

### DIFF
--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1581,6 +1581,112 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(calls.generate).toHaveLength(2)
   })
 
+  it("recovers to matched=false when Bedrock grammar compilation times out", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Please do the task." }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "text", content: "I'll look into that." }],
+            },
+          ]),
+        ),
+    })
+
+    const sdkError = new Error("The model returned the following errors: Grammar compilation timed out")
+    sdkError.name = "AI_APICallError"
+
+    const { layer: aiLayer } = createFakeAI({
+      generate: () =>
+        Effect.fail(
+          new AIError({
+            message: `AI generation failed (${FLAGGER_DEFAULT_CLASSIFIER_MODEL.provider}/${FLAGGER_DEFAULT_CLASSIFIER_MODEL.model}): ${sdkError.message}`,
+            cause: sdkError,
+          }),
+        ),
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "laziness" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+  })
+
+  it("drops matched annotations when the reviewer call fails because Bedrock grammar compilation timed out", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Please do the task." }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "text", content: "I'll look into that." }],
+            },
+          ]),
+        ),
+    })
+
+    const sdkError = new Error("The model returned the following errors: Grammar compilation timed out")
+    sdkError.name = "AI_APICallError"
+
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>(input: GenerateInput<T>) => {
+        const isAnnotationReview = input.system?.includes("adversarial quality reviewer") ?? false
+        if (isAnnotationReview) {
+          return Effect.fail(
+            new AIError({
+              message: `AI generation failed (${FLAGGER_DEFAULT_CLASSIFIER_MODEL.provider}/${FLAGGER_DEFAULT_CLASSIFIER_MODEL.model}): ${sdkError.message}`,
+              cause: sdkError,
+            }),
+          )
+        }
+        return Effect.succeed({
+          object: { matched: true, feedback: "The assistant refused a benign request." } as T,
+          tokens: 20,
+          duration: 90_000_000,
+        })
+      },
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "refusal" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+    expect(calls.generate).toHaveLength(2)
+  })
+
   it("uses flagger-specific prompt for laziness with work signals", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1601,7 +1601,7 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     const sdkError = new Error("The model returned the following errors: Grammar compilation timed out")
     sdkError.name = "AI_APICallError"
 
-    const { layer: aiLayer } = createFakeAI({
+    const { calls, layer: aiLayer } = createFakeAI({
       generate: () =>
         Effect.fail(
           new AIError({
@@ -1627,6 +1627,7 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     )
 
     expect(result).toEqual({ matched: false })
+    expect(calls.generate).toHaveLength(1)
   })
 
   it("drops matched annotations when the reviewer call fails because Bedrock grammar compilation timed out", async () => {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -839,10 +839,11 @@ const parseFlaggerOutput = (input: unknown): Effect.Effect<RunFlaggerResult> => 
 
 // The Vercel AI SDK raises `NoObjectGeneratedError` / `NoOutputGeneratedError`
 // when the model returns output that does not materialize as the requested schema,
-// and `AI_APICallError` with a "prompt is too long" message when the trace evidence
-// exceeds the model's context window. The flagger treats both as a "no match" signal
-// instead of propagating the failure — the model effectively failed to classify,
-// which for a triage flagger is indistinguishable from matched=false.
+// `AI_APICallError` with a "prompt is too long" message when the trace evidence
+// exceeds the model's context window, and Bedrock "Grammar compilation timed out"
+// when structured-output grammar compilation fails. The flagger treats these as a
+// "no match" signal instead of propagating the failure — the model effectively
+// failed to classify, which for a triage flagger is indistinguishable from matched=false.
 const isSchemaMismatchCause = (cause: unknown): boolean => {
   if (!(cause instanceof Error)) return false
   if (cause.name === "AI_NoObjectGeneratedError" || cause.name === "AI_NoOutputGeneratedError") return true
@@ -852,8 +853,11 @@ const isSchemaMismatchCause = (cause: unknown): boolean => {
 const isPromptTooLongCause = (cause: unknown): boolean =>
   cause instanceof Error && typeof cause.message === "string" && cause.message.includes("prompt is too long")
 
+const isGrammarCompilationTimeoutCause = (cause: unknown): boolean =>
+  cause instanceof Error && typeof cause.message === "string" && cause.message.includes("Grammar compilation timed out")
+
 const isUnclassifiableModelFailureCause = (cause: unknown): boolean =>
-  isSchemaMismatchCause(cause) || isPromptTooLongCause(cause)
+  isSchemaMismatchCause(cause) || isPromptTooLongCause(cause) || isGrammarCompilationTimeoutCause(cause)
 
 /**
  * Pure LLM classification for an already-loaded conversation — the screening


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes a production Error Tracking issue where Bedrock `Grammar compilation timed out` failures crash the Temporal `classifySessionFlagger` activity instead of degrading to no-match.

**Datadog issues:**
- [1a0a9fce-804a-11f1-a6bd-da7ad0900005](https://app.datadoghq.eu/error-tracking/issue/1a0a9fce-804a-11f1-a6bd-da7ad0900005) — `AIError: Grammar compilation timed out` (~12/7d, still firing)
- Siblings with the same root cause: [1a04c0a4](https://app.datadoghq.eu/error-tracking/issue/1a04c0a4-804a-11f1-a6bd-da7ad0900005), [1a0f33cc](https://app.datadoghq.eu/error-tracking/issue/1a0f33cc-804a-11f1-bbb2-da7ad0900005)

**Root cause:** `#3889` already taught flagger classification to treat schema-mismatch and `prompt is too long` as soft `matched=false`. Bedrock also returns `Grammar compilation timed out` for some structured-output calls; that message was not in `isUnclassifiableModelFailureCause`, so the `AIError` escaped and failed the activity (confirmed on today's `temporal.activity.classifySessionFlagger` spans).

**Fix:** extend the recovery predicate for grammar compilation timeouts at both the classification and annotation-review call sites, with tests mirroring the prompt-too-long coverage.

**Verification:** `pnpm --filter @domain/flaggers test` (331 passed). After deploy, occurrences of the issues above should stop failing the activity (and preferably drop once spans stop being tagged as errors for recovered paths).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C03BZFX9KCK/p1784893643073059?thread_ts=1784893643.073059&cid=C03BZFX9KCK)

<div><a href="https://cursor.com/agents/bc-a8818ee1-05c1-5384-b282-2ce5b188574e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8818ee1-05c1-5384-b282-2ce5b188574e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Flagging now safely returns “no match” when AI grammar compilation times out during classification or review.
  * Prevented grammar compilation timeout errors from surfacing as failures to end users.
* **Tests**
  * Added coverage for grammar compilation timeout scenarios during both classifier and reviewer processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->