### PR TITLE
fix(web): use HotkeyBadge for sidebar search shortcut

### DIFF
--- a/apps/web/src/components/hotkey-badge.tsx
+++ b/apps/web/src/components/hotkey-badge.tsx
@@ -4,10 +4,10 @@ import { formatForDisplay, type RegisterableHotkey } from "@tanstack/react-hotke
 export function HotkeyBadge({ hotkey }: { readonly hotkey: RegisterableHotkey }) {
   const label = formatForDisplay(hotkey)
   return (
-    <div className="inline-flex shrink-0 items-center rounded border border-current/30 px-1">
+    <span className="inline-flex shrink-0 items-center rounded border border-current/30 px-1">
       <Text.H7 asChild color="inherit">
         <kbd>{label}</kbd>
       </Text.H7>
-    </div>
+    </span>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -10,6 +10,7 @@ import { Effect } from "effect"
 import { SearchIcon } from "lucide-react"
 import { z } from "zod"
 import { useCommandPalette } from "../../../components/command-palette/command-palette-provider.tsx"
+import { HotkeyBadge } from "../../../components/hotkey-badge.tsx"
 import { CHANGELOG_UI_ENABLED } from "../../../domains/changelog/changelog.collection.ts"
 import {
   ProjectScopeProvider,
@@ -108,7 +109,9 @@ function SidebarSearchButton({ collapsed }: { collapsed: boolean }) {
           <Text.H5 color="foregroundMuted" className="min-w-0 flex-1 text-left">
             Search
           </Text.H5>
-          <kbd className="rounded bg-muted px-1 font-mono text-xs text-muted-foreground">⌘K</kbd>
+          <span className="text-muted-foreground">
+            <HotkeyBadge hotkey="Mod+K" />
+          </span>
         </>
       ) : null}
     </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The sidebar search box was hardcoding a raw `<kbd>⌘K</kbd>` with `font-mono`. That glyph looks cramped/broken in mono fonts, and it doesn't match how hotkeys are shown everywhere else.

Swaps it for `HotkeyBadge` with `Mod+K`, same pattern as the sidebar collapse control. That gives platform-correct labels (`⌘ K` on Mac, `Ctrl+K` elsewhere) and the shared badge styling.

## How was this tested?

Manual check in the web app after login. Sidebar search shortcut renders with HotkeyBadge:

[Sidebar search hotkey badge](https://cursor.com/agents/bc-45a06082-13f7-5d7b-92ff-7fbc36d71dd1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar-search-hotkey-fixed.png)

[Search hotkey closeup](https://cursor.com/agents/bc-45a06082-13f7-5d7b-92ff-7fbc36d71dd1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar-search-hotkey-fixed-closeup.png)

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C0456PX26N7/p1784899131173269?thread_ts=1784899131.173269&cid=C0456PX26N7)

<div><a href="https://cursor.com/agents/bc-45a06082-13f7-5d7b-92ff-7fbc36d71dd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45a06082-13f7-5d7b-92ff-7fbc36d71dd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the sidebar search button to display the `Mod+K` shortcut using a consistent hotkey badge.
  - Adjusted the hotkey badge markup styling while preserving its visible label and formatting.
  - No changes to routing, data loading, or layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->