### PR TITLE
refactor(web,email): humanize AI-sounding UI copy

### DIFF
--- a/apps/web/src/components/filters-builder/filters-builder-fields.tsx
+++ b/apps/web/src/components/filters-builder/filters-builder-fields.tsx
@@ -651,7 +651,7 @@ export function FiltersBuilderFields({
             <Text.H7 color="foregroundMuted">
               {getHasAnnotationsOn(filters)
                 ? "Showing only items with a human score."
-                : "Off — scores don't filter results."}
+                : "Showing all items, scored or not."}
             </Text.H7>
             <Switch
               checked={getHasAnnotationsOn(filters)}

--- a/apps/web/src/components/read-only-project-modal.tsx
+++ b/apps/web/src/components/read-only-project-modal.tsx
@@ -34,7 +34,7 @@ export function ReadOnlyProjectModal() {
       dismissible
       onOpenChange={setOpen}
       title="This is a demo project"
-      description="The Latitude Demo is read-only. Explore everything you like — but to make changes, create your own project and start sending your own data."
+      description="It's read-only, so look around as much as you like. To make changes, create your own project and start sending it data."
       footer={
         <div className="flex justify-end gap-2">
           <Button variant="outline" onClick={() => setOpen(false)}>

--- a/apps/web/src/lib/auth/oauth-errors.test.ts
+++ b/apps/web/src/lib/auth/oauth-errors.test.ts
@@ -7,7 +7,7 @@ describe("oauthCallbackErrorMessage", () => {
   })
 
   it("maps account_not_linked to copy that steers the user to email sign-in", () => {
-    expect(oauthCallbackErrorMessage("account_not_linked")).toContain("Continue with email")
+    expect(oauthCallbackErrorMessage("account_not_linked")).toContain("Sign in with your email")
   })
 
   it("falls back to a generic message without echoing unknown codes", () => {

--- a/apps/web/src/lib/auth/oauth-errors.ts
+++ b/apps/web/src/lib/auth/oauth-errors.ts
@@ -12,7 +12,7 @@ const SIGN_IN_EXPIRED_MESSAGE = "That sign-in attempt expired or was interrupted
 
 const OAUTH_ERROR_MESSAGES: Record<string, string> = {
   account_not_linked:
-    "This email already has an account that isn't connected to that provider. Continue with email below to sign in — you can then connect it under Settings → Account.",
+    "This email already has an account that isn't linked to that provider. Sign in with your email below, then link the provider under Settings → Account.",
   access_denied: "Sign-in was cancelled before it completed. Please try again.",
   please_restart_the_process: SIGN_IN_EXPIRED_MESSAGE,
   state_mismatch: SIGN_IN_EXPIRED_MESSAGE,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/enrichment-popover.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/enrichment-popover.tsx
@@ -89,7 +89,7 @@ export function EnrichmentPopover({ annotationId, rawFeedback }: EnrichmentPopov
 
             <div className="flex flex-col gap-2 pt-2 border-t border-border">
               <Text.H6 color="foregroundMuted">
-                Let Latitude know how this enrichment looks — your feedback helps us improve.
+                Does this enrichment look right? Your feedback helps us improve it.
               </Text.H6>
               <div className="flex items-center gap-2">
                 <Button

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/flaggers/flagger-badge.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/flaggers/flagger-badge.tsx
@@ -57,7 +57,7 @@ export function FlaggerBadge({ projectId, projectSlug, slug }: FlaggerBadgeProps
         </Link>
       }
     >
-      Flagged automatically by the {name} flagger — open its settings
+      Flagged automatically by the {name} flagger. Click to open its settings.
     </Tooltip>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/onboarding-gallery.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/onboarding-gallery.tsx
@@ -6,7 +6,7 @@ import { GALLERY_DWELL_MS, usePrefersReducedMotion } from "./motion.ts"
 const INTRO_GALLERY: ReadonlyArray<{ readonly title: string; readonly description: string; readonly image: string }> = [
   {
     title: "See every request your AI makes",
-    description: "Each call captured with full context — inputs, outputs, timing, and cost.",
+    description: "Inputs, outputs, timing, and cost, captured for every call.",
     image: "/onboarding/traces.png",
   },
   {
@@ -16,7 +16,7 @@ const INTRO_GALLERY: ReadonlyArray<{ readonly title: string; readonly descriptio
   },
   {
     title: "Catch problems before your users do",
-    description: "Latitude flags refusals, errors, and hallucinations — and groups them into issues.",
+    description: "Latitude flags refusals, errors, and hallucinations, then groups them into issues.",
     image: "/onboarding/issues.png",
   },
 ]

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/flaggers-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/flaggers-step.tsx
@@ -64,7 +64,7 @@ export function Left({
           <div className="flex flex-col gap-2">
             <Text.H2 weight="medium">Choose automatic flaggers</Text.H2>
             <Text.H4 color="foregroundMuted">
-              Latitude inspects all incoming traces and creates issues when they detect common failure patterns. Choose
+              Latitude inspects all incoming traces and creates issues when it detects common failure patterns. Choose
               the patterns you want to monitor.
             </Text.H4>
           </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/role-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/role-step.tsx
@@ -20,7 +20,7 @@ export function Left({
           </div>
           <div className="flex flex-col gap-2">
             <Text.H2 weight="medium">Tell us about yourself</Text.H2>
-            <Text.H4 color="foregroundMuted">Help Latitude personalize your experience.</Text.H4>
+            <Text.H4 color="foregroundMuted">This helps us tailor Latitude to how you'll use it.</Text.H4>
           </div>
         </div>
         <form.Field

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-instructions.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-instructions.tsx
@@ -329,8 +329,8 @@ function CodingMachineInstructions({
         <div className="flex flex-col gap-2">
           <Text.H5M>Restart and verify</Text.H5M>
           <Text.H5 color="foregroundMuted">
-            Restart pi to load the extension, send a prompt that uses the model or a tool, then open Traces in
-            Latitude. Your first trace should appear within a few seconds.
+            Restart pi to load the extension, send a prompt that uses the model or a tool, then open Traces in Latitude.
+            Your first trace should appear within a few seconds.
           </Text.H5>
         </div>
       </>
@@ -391,8 +391,8 @@ function CloudflareAiGatewayInstructions({
       <div className="flex flex-col gap-2">
         <Text.H5M>Cloudflare AI Gateway</Text.H5M>
         <Text.H5 color="foregroundMuted">
-          Cloudflare AI Gateway exports OpenTelemetry spans for every request it proxies, so you don't need an SDK. In your
-          gateway's <span className="font-medium">Settings → OpenTelemetry</span>, click{" "}
+          Cloudflare AI Gateway exports OpenTelemetry spans for every request it proxies, so you don't need an SDK. In
+          your gateway's <span className="font-medium">Settings → OpenTelemetry</span>, click{" "}
           <span className="font-medium">Add Otel Destination</span> and fill in the fields below.{" "}
           {defaultApiKeyToken ? (
             "The Authorization header is prefilled with your default Latitude API key."
@@ -519,12 +519,12 @@ export function TelemetryInstructions({ projectSlug }: { readonly projectSlug: s
             <Badge variant="accent">Recommended</Badge>
           </span>
           <Text.H5 color="foregroundMuted">
-            Paste this into your coding agent's chat (Cursor, Claude Code, Codex, or anything else) to set up
-            Latitude telemetry in your project.
+            Paste this into your coding agent's chat (Cursor, Claude Code, Codex, or anything else) to set up Latitude
+            telemetry in your project.
           </Text.H5>
           <CodeBlock value={codingAgentPrompt} copyable wrapLines />
           <Text.H5 color="foregroundMuted">
-            For the smoothest experience, install both the{" "}
+            Install both the{" "}
             <a
               href="https://github.com/latitude-dev/skills"
               target="_blank"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-instructions.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-instructions.tsx
@@ -300,8 +300,8 @@ function CodingMachineInstructions({
         <div className="flex flex-col gap-2">
           <Text.H5M>Enable in `~/.hermes/config.yaml`</Text.H5M>
           <Text.H5 color="foregroundMuted">
-            Add <code className="text-xs">latitude</code> under <code className="text-xs">plugins.enabled</code> — do
-            not use <code className="text-xs">hermes plugins enable</code> for pip-installed plugins.
+            Add <code className="text-xs">latitude</code> under <code className="text-xs">plugins.enabled</code>. Don't
+            use <code className="text-xs">hermes plugins enable</code> for pip-installed plugins.
           </Text.H5>
           <CodeBlock value={getHermesConfigYamlBlock()} copyable />
         </div>
@@ -329,8 +329,8 @@ function CodingMachineInstructions({
         <div className="flex flex-col gap-2">
           <Text.H5M>Restart and verify</Text.H5M>
           <Text.H5 color="foregroundMuted">
-            Restart pi so it loads the extension, send a prompt that uses the model or a tool, then open Traces in
-            Latitude — the new trace should appear within a few seconds.
+            Restart pi to load the extension, send a prompt that uses the model or a tool, then open Traces in
+            Latitude. Your first trace should appear within a few seconds.
           </Text.H5>
         </div>
       </>
@@ -349,7 +349,7 @@ function CodingMachineInstructions({
         <div className="flex flex-col gap-2">
           <Text.H5M>Latitude API key</Text.H5M>
           <Text.H5 color="foregroundMuted">
-            Default organization key (<code className="text-xs">{DEFAULT_API_KEY_NAME}</code>) — paste when the
+            Default organization key (<code className="text-xs">{DEFAULT_API_KEY_NAME}</code>). Paste it when the
             installer asks for your API key.
           </Text.H5>
           {defaultApiKeyToken ? (
@@ -391,7 +391,7 @@ function CloudflareAiGatewayInstructions({
       <div className="flex flex-col gap-2">
         <Text.H5M>Cloudflare AI Gateway</Text.H5M>
         <Text.H5 color="foregroundMuted">
-          Cloudflare AI Gateway exports OpenTelemetry spans for every request it proxies — no SDK needed. In your
+          Cloudflare AI Gateway exports OpenTelemetry spans for every request it proxies, so you don't need an SDK. In your
           gateway's <span className="font-medium">Settings → OpenTelemetry</span>, click{" "}
           <span className="font-medium">Add Otel Destination</span> and fill in the fields below.{" "}
           {defaultApiKeyToken ? (
@@ -519,7 +519,7 @@ export function TelemetryInstructions({ projectSlug }: { readonly projectSlug: s
             <Badge variant="accent">Recommended</Badge>
           </span>
           <Text.H5 color="foregroundMuted">
-            Paste this into the chat with your coding agent — Cursor, Claude Code, Codex, or any other — to set up
+            Paste this into your coding agent's chat (Cursor, Claude Code, Codex, or anything else) to set up
             Latitude telemetry in your project.
           </Text.H5>
           <CodeBlock value={codingAgentPrompt} copyable wrapLines />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-step.tsx
@@ -19,7 +19,7 @@ export function Left({
   readonly onOpenSampleProject: () => void
 }) {
   const heading = traceReceived ? "Trace received. Redirecting…" : "Set up your first project"
-  const subheading = traceReceived ? "Taking you to your traces…" : "Initiate your first project on Latitude"
+  const subheading = traceReceived ? "Taking you to your traces…" : "Instrument your app so its traces show up here."
 
   return (
     <div className="mx-auto w-full max-w-[560px]">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-status-pill.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-status-pill.tsx
@@ -17,7 +17,7 @@ export function SessionStatusPill({
 
   return (
     <Tooltip asChild trigger={<Status variant="success" label={`Live · ${lastActivity}`} />}>
-      This session had activity in the last 5 minutes — more may still be coming in.
+      Active within the last 5 minutes. More may still be on the way.
     </Tooltip>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/signals-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/signals-tab.tsx
@@ -96,7 +96,7 @@ export function SignalsTab({
   if (isError) {
     return (
       <div className="flex flex-1 items-center justify-center px-6 py-10">
-        <Text.H5 color="foregroundMuted">Couldn't load signals — retry.</Text.H5>
+        <Text.H5 color="foregroundMuted">Couldn't load signals. Please try again.</Text.H5>
       </div>
     )
   }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-empty-onboarding.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-empty-onboarding.tsx
@@ -202,7 +202,7 @@ function ConnectCard({
 
   const headline = orgHasConnectedProjects ? "Send traces to this project" : "Waiting for your first trace"
   const subcopy = orgHasConnectedProjects
-    ? "Your organization already sends traces to Latitude. Point some of your traffic to this project's slug — or set it up from scratch."
+    ? "Your organization already sends traces to Latitude. Point some traffic at this project's slug, or set it up from scratch."
     : "This is where your traces will appear. Instrument your app with Latitude to start streaming them in."
   const ctaLabel = orgHasConnectedProjects ? "Full setup instructions" : "Set up tracing"
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-page.tsx
@@ -50,7 +50,7 @@ function ScopedTreeWaiting({ behaviour }: { readonly behaviour: CustomBehaviorRe
         <Loader2Icon className="h-6 w-6 animate-spin text-muted-foreground" />
         <Text.H4>Building this behavior</Text.H4>
         <Text.H5 color="foregroundMuted" centered className="max-w-md">
-          Analyzing the matching sessions now — it'll appear here when it's ready.
+          We're analyzing the matching sessions now. This behavior will appear here once it's ready.
         </Text.H5>
       </div>
     )
@@ -64,8 +64,7 @@ function ScopedTreeWaiting({ behaviour }: { readonly behaviour: CustomBehaviorRe
       <Text.H4>Waiting for the next run</Text.H4>
       <Text.H5 color="foregroundMuted" centered className="max-w-md">
         {count !== undefined ? `${count.toLocaleString()} matching sessions found. ` : ""}
-        This behavior is built automatically on a schedule — it'll appear after the next run, which can take a few
-        hours.
+        This behavior is built on a schedule. It'll appear after the next run, which can take a few hours.
       </Text.H5>
     </div>
   )
@@ -85,7 +84,7 @@ function GlobalEmptyState({ isDemoProject }: { readonly isDemoProject: boolean }
         <Text.H3>{isDemoProject ? "Sample behaviors are loading" : "No behaviors yet"}</Text.H3>
         <Text.H5 color="foregroundMuted" centered className="max-w-md">
           {isDemoProject
-            ? "We found the sample traces and signals. The behavior taxonomy is still being prepared — check back in about a minute."
+            ? "We found the sample traces and signals. The behavior taxonomy is still being prepared, so check back in about a minute."
             : "Live taxonomy behaviors will appear here after sessions have been clustered."}
         </Text.H5>
       </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-scope-header.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-scope-header.tsx
@@ -83,8 +83,8 @@ function ScopeTitle({ current }: { readonly current: CustomBehaviorRecord | null
       <div className="flex flex-row items-center gap-1.5">
         <Text.H4M>{GLOBAL_LABEL}</Text.H4M>
         <Tooltip asChild trigger={<Icon icon={InfoIcon} size="sm" color="foregroundMuted" />}>
-          Shown by default — captures every behavior in this project. You can also create your own custom behavior to
-          discover the patterns within a filtered set of sessions.
+          Shown by default. It captures every behavior in this project. Create a custom behavior to surface patterns
+          within a filtered set of sessions.
         </Tooltip>
       </div>
       <Text.H6 color="foregroundMuted">No filters applied</Text.H6>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/datasets-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/datasets-empty-state.tsx
@@ -17,8 +17,7 @@ export function DatasetsEmptyState({
         <div className="flex flex-col items-center gap-2">
           <Text.H3 centered>No datasets yet</Text.H3>
           <Text.H5 color="foregroundMuted" centered>
-            Datasets let you curate traces for evaluation and regression testing. Create your first dataset to get
-            started.
+            Datasets let you curate traces for evaluation and regression testing.
           </Text.H5>
         </div>
         <div className="flex items-center gap-2">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/row-detail-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/row-detail-panel.tsx
@@ -31,7 +31,7 @@ const BUILTIN_META: Record<
 > = {
   expectedOutput: {
     icon: SparklesIcon,
-    hint: "The correct answer for this row. Fill in by hand — not the same as `output`.",
+    hint: "The correct answer for this row. Fill it in by hand; it's different from `output`.",
   },
   input: { icon: ArrowDownRightIcon },
   output: { icon: ArrowUpRightIcon },

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/experiment-modals.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/experiment-modals.tsx
@@ -82,7 +82,7 @@ export function ExperimentCreateModal({
       dismissible
       onOpenChange={(next) => (!next ? onClose() : undefined)}
       title="New experiment"
-      description="Experiments compare sessions, users, tools, signals, and behaviours across variants of filters, search queries and time ranges."
+      description="Compare variants side by side, each with its own filters, search query, or time range. See how sessions, users, tools, signals, and behaviours differ across them."
       footer={
         <>
           <CloseTrigger />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/experiments-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/experiments-empty-state.tsx
@@ -6,7 +6,7 @@ export function ExperimentsEmptyState({ onCreate }: { readonly onCreate: () => v
     <BlankSlate
       icon={FlaskConical}
       title="No experiments yet"
-      description="Experiments compare sessions, users, tools, signals, and behaviours across variants of filters, search queries and time ranges."
+      description="Compare variants side by side, each with its own filters, search query, or time range. See how sessions, users, tools, signals, and behaviours differ across them."
       action={{ label: "New experiment", icon: PlusIcon, onClick: onCreate }}
       docsHref="https://docs.latitude.so/experiments/overview"
     />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-stores-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-stores-view.tsx
@@ -163,8 +163,8 @@ export function MemoryStoresView({
       sortKey: "ratio",
       render: (store) => (
         <Tooltip asChild trigger={endValue(formatRatio(store.reads, store.writes))}>
-          {formatCount(store.reads)} reads per {formatCount(store.writes)} writes — how much this store is used versus
-          maintained.
+          {formatCount(store.reads)} reads per {formatCount(store.writes)} writes. Shows how often the store is read
+          versus updated.
         </Tooltip>
       ),
     },
@@ -224,8 +224,8 @@ export function MemoryStoresView({
             asChild
             trigger={endValue(`${(store.updateEvents / store.recordsTouched).toFixed(1).replace(/\.0$/, "")}×`)}
           >
-            {formatCount(store.updateEvents)} updates across {formatCount(store.recordsTouched)} records touched — how
-            often records are rewritten.
+            {formatCount(store.updateEvents)} updates across {formatCount(store.recordsTouched)} records. Shows how
+            often records get rewritten.
           </Tooltip>
         ) : (
           endValue("-")

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-card-form.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-card-form.tsx
@@ -197,9 +197,9 @@ function MetricSelector({
 // alert opens (incident lists, chart markers, notifications) — it doesn't
 // change when or how the alert fires.
 const SEVERITY_HELP: Record<AlertSeverity, string> = {
-  low: "Incidents open as low priority — informational, review when convenient",
-  medium: "Incidents open as medium priority — worth attention soon",
-  high: "Incidents open as high priority — needs immediate attention",
+  low: "Opens incidents as low priority. Informational; review when you have time.",
+  medium: "Opens incidents as medium priority. Worth a look soon.",
+  high: "Opens incidents as high priority. Needs attention right away.",
 }
 
 const COMPARISON_TABS: readonly TabOption<ComparisonMode>[] = [

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/backfill-destination-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/backfill-destination-modal.tsx
@@ -48,11 +48,11 @@ export function BackfillDestinationModal({
     onSuccess: (result) => {
       void queryClient.invalidateQueries({ queryKey: destinationsQueryKey(projectId) })
       if (result.failed > 0) {
-        toast({ variant: "destructive", description: "Backfill couldn't start for every source — try again." })
+        toast({ variant: "destructive", description: "Backfill couldn't start for some sources. Try again." })
       } else if (result.enqueued === 0) {
-        toast({ description: "Nothing to import — already backfilled as far back as your plan retains." })
+        toast({ description: "Nothing to import. You've already backfilled as far back as your plan retains." })
       } else {
-        toast({ description: "Backfill started — historical windows will appear in the run history." })
+        toast({ description: "Backfill started. Historical windows will show up in the run history." })
         onStarted?.()
       }
       onClose()
@@ -84,7 +84,7 @@ export function BackfillDestinationModal({
           label="Import history since"
           value={since}
           max={todayStr}
-          description="Leave empty to import as far back as your plan retains. Re-running is safe — duplicates are ignored at the destination."
+          description="Leave empty to import as far back as your plan retains. Re-running is safe; the destination ignores duplicates."
           onChange={(event) => setSince(event.target.value)}
         />
       </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-card.tsx
@@ -108,7 +108,7 @@ export function DestinationCard({
       if (result.backfillsFailed > 0) {
         toast({
           variant: "destructive",
-          description: "Resumed, but the gap backfill couldn't start for every source — retry from Backfill.",
+          description: "Resumed, but the gap backfill couldn't start for some sources. Retry it from Backfill.",
         })
       } else if (result.backfillsStarted > 0) {
         toast({ description: "Resumed. Backfilling the window it missed while paused." })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-form-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-form-modal.tsx
@@ -156,7 +156,7 @@ export function DestinationFormModal({
         setConnectionTest({
           phase: "error",
           message: result.retryable
-            ? `Connection failed (${result.reason ?? "unknown"}). This may be transient — try again.`
+            ? `Connection failed (${result.reason ?? "unknown"}). This is often temporary, so try again.`
             : `Connection rejected (${result.reason ?? "unknown"}). Check the configuration and credentials.`,
         })
       }
@@ -224,7 +224,7 @@ export function DestinationFormModal({
           <div className="flex flex-col gap-3 rounded-lg border border-border p-3">
             <SwitchInput
               label="Import past traces"
-              description="Backfill your retained history after connecting (up to your plan's retention). Off by default — new destinations sync going forward."
+              description="After connecting, backfill your retained history (up to your plan's limit). Off by default, so new destinations sync only going forward."
               checked={importSince !== null}
               onCheckedChange={(checked) => setImportSince(checked ? "" : null)}
             />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-forms/posthog-form.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-forms/posthog-form.tsx
@@ -82,7 +82,7 @@ function SpansPreviewBody({
   return query.data.hasData ? (
     <pre className="max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs">{query.data.eventsJson}</pre>
   ) : (
-    <Text.H6 color="foregroundMuted">No data yet — send spans to this project to preview a payload.</Text.H6>
+    <Text.H6 color="foregroundMuted">Nothing to preview yet. Send spans to this project first.</Text.H6>
   )
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-runs-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-runs-table.tsx
@@ -117,7 +117,7 @@ export function DestinationRunsTable({ destinationId }: { readonly destinationId
       getRowKey={(run) => run.id}
       infiniteScroll={infiniteScroll}
       scrollAreaLayout="fill"
-      blankSlate="No data syncronization runs yet."
+      blankSlate="No sync runs yet."
     />
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
@@ -216,7 +216,7 @@ function TraceSamplingSection({
               {isDirty ? <DotIndicator variant="primary" aria-label="Unsaved changes" /> : null}
             </Label>
             <Text.H6 color="foregroundMuted">
-              Process and store only a fraction of the traces you send, to cut costs. Best for high-traffic projects
+              Choose how much of your traffic to process and store, to cut costs. Best for high-traffic projects
               where a sample is still enough to spot issues.
             </Text.H6>
           </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
@@ -216,9 +216,8 @@ function TraceSamplingSection({
               {isDirty ? <DotIndicator variant="primary" aria-label="Unsaved changes" /> : null}
             </Label>
             <Text.H6 color="foregroundMuted">
-              Process and store only a portion of the traces you send, instead of all of them. Useful for reducing
-              costs. Only recommended if you have really high traffic, where a smaller sample is still enough to spot
-              issues.
+              Process and store only a fraction of the traces you send, to cut costs. Best for high-traffic projects
+              where a sample is still enough to spot issues.
             </Text.H6>
           </div>
           <Switch id="trace-sampling-enabled" checked={enabled} onCheckedChange={onEnabledChange} />
@@ -397,7 +396,7 @@ function ChangeSlugForm({ projectId, currentSlug }: { projectId: string; current
           if (!v) closeAndReset()
           else setOpen(v)
         }}
-        title="⚠️ Change project slug"
+        title="Change project slug"
         description={`Changing the slug from "${currentSlug}" breaks ingestion until your app points at the new slug. Existing traces stay under the project; only newly ingested traces are affected.`}
         footer={
           <form.Subscribe selector={(s) => [s.values.slug, s.isSubmitting] as const}>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
@@ -216,8 +216,8 @@ function TraceSamplingSection({
               {isDirty ? <DotIndicator variant="primary" aria-label="Unsaved changes" /> : null}
             </Label>
             <Text.H6 color="foregroundMuted">
-              Choose how much of your traffic to process and store, to cut costs. Best for high-traffic projects
-              where a sample is still enough to spot issues.
+              Choose how much of your traffic to process and store, to cut costs. Best for high-traffic projects where a
+              sample is still enough to spot issues.
             </Text.H6>
           </div>
           <Switch id="trace-sampling-enabled" checked={enabled} onCheckedChange={onEnabledChange} />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/keys.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/keys.tsx
@@ -55,7 +55,7 @@ function CreateApiKeyModal({ open, setOpen }: { open: boolean; setOpen: (open: b
           setOpen(false)
           toast({
             title: "Success",
-            description: "API Key created successfully.",
+            description: "API key created successfully.",
           })
         },
         onError: (error) => {
@@ -75,8 +75,8 @@ function CreateApiKeyModal({ open, setOpen }: { open: boolean; setOpen: (open: b
           }}
         >
           <Modal.Header
-            title="Create API Key"
-            description="Create a new API Key for your organization to access the Latitude API."
+            title="Create API key"
+            description="Create a new API key for your organization to access the Latitude API."
           />
           <Modal.Body>
             <FormWrapper>
@@ -89,8 +89,8 @@ function CreateApiKeyModal({ open, setOpen }: { open: boolean; setOpen: (open: b
                     value={field.state.value}
                     onChange={(e) => field.handleChange(e.target.value)}
                     errors={fieldErrorsAsStrings(field.state.meta.errors)}
-                    placeholder="My API Key"
-                    description="A descriptive name for this API Key"
+                    placeholder="My API key"
+                    description="A descriptive name for this API key"
                   />
                 )}
               </form.Field>
@@ -99,7 +99,7 @@ function CreateApiKeyModal({ open, setOpen }: { open: boolean; setOpen: (open: b
           <Modal.Footer>
             <CloseTrigger />
             <Button type="submit" disabled={form.state.isSubmitting}>
-              Create API Key
+              Create API key
             </Button>
           </Modal.Footer>
         </form>
@@ -121,7 +121,7 @@ function UpdateApiKeyModal({ apiKey, onClose }: { apiKey: ApiKeyRecord; onClose:
         onSuccess: async () => {
           toast({
             title: "Success",
-            description: "API Key name updated.",
+            description: "API key name updated.",
           })
           onClose()
         },
@@ -141,7 +141,7 @@ function UpdateApiKeyModal({ apiKey, onClose }: { apiKey: ApiKeyRecord; onClose:
             void form.handleSubmit()
           }}
         >
-          <Modal.Header title="Update API Key" description="Update the name for your API Key." />
+          <Modal.Header title="Update API key" description="Update the name for your API key." />
           <Modal.Body>
             <FormWrapper>
               <form.Field name="name">
@@ -153,7 +153,7 @@ function UpdateApiKeyModal({ apiKey, onClose }: { apiKey: ApiKeyRecord; onClose:
                     value={field.state.value}
                     onChange={(e) => field.handleChange(e.target.value)}
                     errors={fieldErrorsAsStrings(field.state.meta.errors)}
-                    placeholder="API Key name"
+                    placeholder="API key name"
                   />
                 )}
               </form.Field>
@@ -162,7 +162,7 @@ function UpdateApiKeyModal({ apiKey, onClose }: { apiKey: ApiKeyRecord; onClose:
           <Modal.Footer>
             <CloseTrigger />
             <Button type="submit" disabled={form.state.isSubmitting}>
-              Update API Key
+              Update API key
             </Button>
           </Modal.Footer>
         </form>
@@ -174,13 +174,13 @@ function UpdateApiKeyModal({ apiKey, onClose }: { apiKey: ApiKeyRecord; onClose:
 function DeleteApiKeyModal({ apiKey, onClose }: { apiKey: ApiKeyRecord; onClose: () => void }) {
   const { toast } = useToast()
   const [deleting, setDeleting] = useState(false)
-  const displayName = apiKey.name || "Latitude API Key"
+  const displayName = apiKey.name || "Latitude API key"
 
   const handleConfirm = async () => {
     setDeleting(true)
     try {
       await deleteApiKeyMutation(apiKey.id).isPersisted.promise
-      toast({ description: "API Key deleted" })
+      toast({ description: "API key deleted" })
       onClose()
     } catch (error) {
       setDeleting(false)
@@ -194,7 +194,7 @@ function DeleteApiKeyModal({ apiKey, onClose }: { apiKey: ApiKeyRecord; onClose:
       onOpenChange={(open) => {
         if (!open && !deleting) onClose()
       }}
-      title="Delete API Key"
+      title="Delete API key"
       description={`Are you sure you want to delete "${displayName}"? Any application using this Key will immediately lose access to the Latitude API. This action cannot be undone.`}
       dismissible
       footer={
@@ -204,7 +204,7 @@ function DeleteApiKeyModal({ apiKey, onClose }: { apiKey: ApiKeyRecord; onClose:
           </Button>
           <Button variant="destructive" onClick={() => void handleConfirm()} disabled={deleting}>
             {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-            <Text.H5 color="white">{deleting ? "Deleting..." : "Delete API Key"}</Text.H5>
+            <Text.H5 color="white">{deleting ? "Deleting..." : "Delete API key"}</Text.H5>
           </Button>
         </div>
       }
@@ -231,13 +231,13 @@ function ApiKeysTable({ apiKeys }: { apiKeys: ApiKeyRecord[] }) {
           {apiKeys.map((apiKey) => (
             <TableRow key={apiKey.id} verticalPadding hoverable={false}>
               <TableCell>
-                <Text.H5>{apiKey.name || "Latitude API Key"}</Text.H5>
+                <Text.H5>{apiKey.name || "Latitude API key"}</Text.H5>
               </TableCell>
               <TableCell>
                 <CopyableText
                   value={apiKey.token}
                   displayValue={maskSensitiveValue(apiKey.token)}
-                  tooltip="Copy API Key"
+                  tooltip="Copy API key"
                 />
               </TableCell>
               <TableCell>
@@ -253,7 +253,7 @@ function ApiKeysTable({ apiKeys }: { apiKeys: ApiKeyRecord[] }) {
                       </Button>
                     }
                   >
-                    Edit API Key name
+                    Edit API key name
                   </Tooltip>
                   <Tooltip
                     asChild
@@ -263,7 +263,7 @@ function ApiKeysTable({ apiKeys }: { apiKeys: ApiKeyRecord[] }) {
                       </Button>
                     }
                   >
-                    {apiKeys.length === 1 ? "You can't delete the last API Key" : "Delete API Key"}
+                    {apiKeys.length === 1 ? "You can't delete the last API key" : "Delete API key"}
                   </Tooltip>
                 </div>
               </TableCell>
@@ -288,7 +288,7 @@ function OAuthKeysTable({ oauthKeys }: { oauthKeys: OAuthKeyRecord[] }) {
     setRevoking(true)
     try {
       await revokeOAuthKeyMutation({ clientId: keyToRevoke.clientId, userId: keyToRevoke.userId })
-      toast({ description: "OAuth Key revoked" })
+      toast({ description: "OAuth key revoked" })
       setKeyToRevoke(null)
     } catch (error) {
       toast({ variant: "destructive", description: toUserMessage(error) })
@@ -346,7 +346,7 @@ function OAuthKeysTable({ oauthKeys }: { oauthKeys: OAuthKeyRecord[] }) {
                     </Button>
                   }
                 >
-                  Revoke OAuth Key
+                  Revoke OAuth key
                 </Tooltip>
               </TableCell>
             </TableRow>
@@ -360,7 +360,7 @@ function OAuthKeysTable({ oauthKeys }: { oauthKeys: OAuthKeyRecord[] }) {
           onOpenChange={(open) => {
             if (!open && !revoking) setKeyToRevoke(null)
           }}
-          title="Revoke OAuth Key"
+          title="Revoke OAuth key"
           description={`Are you sure you want to revoke "${keyToRevoke.clientName ?? "this OAuth client"}" for ${
             keyToRevoke.userName ?? keyToRevoke.userEmail
           }? The client will immediately lose access to the Latitude API. This action cannot be undone.`}
@@ -372,7 +372,7 @@ function OAuthKeysTable({ oauthKeys }: { oauthKeys: OAuthKeyRecord[] }) {
               </Button>
               <Button variant="destructive" onClick={() => void handleConfirm()} disabled={revoking}>
                 {revoking ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-                <Text.H5 color="white">{revoking ? "Revoking..." : "Revoke OAuth Key"}</Text.H5>
+                <Text.H5 color="white">{revoking ? "Revoking..." : "Revoke OAuth key"}</Text.H5>
               </Button>
             </div>
           }
@@ -402,7 +402,7 @@ function KeysSettingsPage() {
       actions={
         <Button variant="outline" onClick={() => setCreateOpen(true)}>
           <Icon size="sm" icon={PlusIcon} />
-          API Key
+          API key
         </Button>
       }
     >
@@ -410,7 +410,7 @@ function KeysSettingsPage() {
 
       <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
-          <Text.H4 weight="bold">API Keys</Text.H4>
+          <Text.H4 weight="bold">API keys</Text.H4>
           <Text.H5 color="foregroundMuted">
             Application keys with access to this organization (through API or SDK)
           </Text.H5>
@@ -422,7 +422,7 @@ function KeysSettingsPage() {
 
       <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
-          <Text.H4 weight="bold">OAuth Keys</Text.H4>
+          <Text.H4 weight="bold">OAuth keys</Text.H4>
           <Text.H5 color="foregroundMuted">
             Connected OAuth clients with access to this organization (Claude Code, Codex, Cursor... through MCP)
           </Text.H5>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/sso.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/sso.tsx
@@ -419,7 +419,7 @@ function DomainVerificationCard({
     try {
       const result = await verifySsoDomainMutation()
       if (result.verified) {
-        toast({ description: `${provider.domain} verified — SSO sign-in is now active` })
+        toast({ description: `${provider.domain} is verified. SSO sign-in is now active.` })
       } else {
         toast({ variant: "destructive", description: result.message ?? "Domain verification failed" })
       }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/sso.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/sso.tsx
@@ -279,7 +279,7 @@ function OidcRegisterForm({ onRegistered }: { onRegistered: (record: SsoDomainVe
           <Input
             type="text"
             name={field.name}
-            label="Signalr URL"
+            label="Issuer URL"
             description="OIDC discovery is fetched from <issuer>/.well-known/openid-configuration."
             value={field.state.value}
             onChange={(e) => field.handleChange(e.target.value)}
@@ -361,7 +361,7 @@ function ProviderCard({
                 <Badge variant="warningMuted">Domain unverified</Badge>
               )}
             </div>
-            <Text.H6 color="foregroundMuted">Signalr: {provider.issuer}</Text.H6>
+            <Text.H6 color="foregroundMuted">Issuer: {provider.issuer}</Text.H6>
           </div>
         </div>
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/describe-signal-intro.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/describe-signal-intro.tsx
@@ -101,8 +101,8 @@ export function DescribeSignalIntro({
         <div className="flex min-w-64 flex-1 basis-80 flex-col gap-1.5">
           <Text.H4M>What's a signal?</Text.H4M>
           <Text.H5 color="foregroundMuted">
-            A collection of sessions that share a behavior you care about: frustrated users, failed tool calls, slow
-            runs. Latitude checks every session as it comes in and adds the ones that match.
+            A collection of sessions that share a behavior you care about, like frustrated users or failed tool calls.
+            Latitude checks every session as it comes in and adds the ones that match.
           </Text.H5>
         </div>
         <SignalFlowDiagram />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/signal-builder-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/signal-builder-modal.tsx
@@ -552,7 +552,7 @@ export function SignalBuilderModal({
           <div className="flex flex-col gap-4">
             <StepHeading
               title="Try it on your real traffic"
-              hint="We run your evaluation against recent sessions from this project. Nothing is saved. If the verdicts look off, go back and adjust."
+              hint="We run your evaluation against recent sessions from this project without saving anything. If the verdicts look off, go back and adjust."
             />
             <SignalPreviewStep
               result={previewResult}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/signal-preview-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/signal-preview-step.tsx
@@ -96,7 +96,7 @@ function PreviewResultCard({
   const prompt = row.summary?.firstUserMessage?.trim()
   const reason =
     verdict === "skipped"
-      ? "Session not embedded yet — it'll be scored once embeddings are ready"
+      ? "This session isn't embedded yet. It'll be scored once its embeddings are ready"
       : (row.error ?? (row.feedback.trim().length > 0 ? row.feedback : null))
 
   return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-lifecycle-actions.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-lifecycle-actions.tsx
@@ -268,7 +268,7 @@ export function SignalLifecycleActions({
             </div>
           ) : lifecycleConfirmAction === "ignore" && issue?.origin === "user" ? (
             <Text.H6 color="foregroundMuted">
-              This signal's evaluation will be archived. Unignoring won't restore it — re-create it from Edit.
+              This signal's evaluation will be archived. Unignoring won't bring it back; re-create it from Edit.
             </Text.H6>
           ) : null}
         </Modal>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
@@ -197,7 +197,7 @@ function ToolDetailPageContent() {
               <Text.H5 color="foregroundMuted" italic>
                 {notFound
                   ? "No definition or calls were found for this tool in the selected time window."
-                  : "Definition not found — this tool was called but no chat span in this window carried its definition."}
+                  : "Definition not found. This tool was called, but no chat span in this window carried its definition."}
               </Text.H5>
             )
           }
@@ -214,12 +214,12 @@ function ToolDetailPageContent() {
               <Text.H5 color="foregroundMuted">
                 No calls in this window.
                 {definition
-                  ? ` It was offered to the model ${formatCount(definition.offeredCount)} times — the model never selected it.`
+                  ? ` It was offered to the model ${formatCount(definition.offeredCount)} times but never selected.`
                   : ""}
               </Text.H5>
             ) : !isLoading && errorsOnly && errorsUsage === null ? (
               <Text.H5 color="foregroundMuted">
-                No failed calls in this window — all {usage ? formatCount(usage.calls) : ""} calls succeeded.
+                No failed calls in this window. All {usage ? formatCount(usage.calls) : ""} succeeded.
               </Text.H5>
             ) : errorsOnly ? (
               <div className="flex flex-row flex-wrap gap-x-8 gap-y-4">
@@ -265,7 +265,7 @@ function ToolDetailPageContent() {
                       : "-"
                   }
                   tooltip={
-                    errorsUsage ? `p50 / p95 of failed calls — avg ${formatDuration(errorsUsage.avgDurationNs)}` : null
+                    errorsUsage ? `p50 / p95 of failed calls (avg ${formatDuration(errorsUsage.avgDurationNs)})` : null
                   }
                   isLoading={isLoading}
                 />
@@ -299,7 +299,7 @@ function ToolDetailPageContent() {
                   }
                   tooltip={
                     definition
-                      ? `How often the model picks this tool when it's available — offered ${formatCount(definition.offeredCount)} times. Can exceed 100% when one turn calls it multiple times.`
+                      ? `How often the model picks this tool when it's available, across ${formatCount(definition.offeredCount)} offers. Can exceed 100% when one turn calls it multiple times.`
                       : "Calls per offer needs tool definitions on chat spans."
                   }
                   isLoading={isLoading}
@@ -315,7 +315,7 @@ function ToolDetailPageContent() {
                   value={
                     usage ? `${formatDuration(usage.p50DurationNs)} / ${formatDuration(usage.p95DurationNs)}` : "-"
                   }
-                  tooltip={usage ? `p50 / p95 — avg ${formatDuration(usage.avgDurationNs)}` : null}
+                  tooltip={usage ? `p50 / p95 (avg ${formatDuration(usage.avgDurationNs)})` : null}
                   isLoading={isLoading}
                 />
                 <MetricTile

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-discovery-banner.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-discovery-banner.tsx
@@ -9,7 +9,7 @@ export function ToolsDiscoveryBanner({ projectId }: { readonly projectId: string
   if (dismissed) return null
   return (
     <Alert
-      description="These tools were detected automatically from tool definitions on your LLM spans — none have been called in this window. Open a tool to see where it's offered."
+      description="We detected these tools from the definitions on your LLM spans. None have been called in this window. Open a tool to see where it's offered."
       cta={
         <Button variant="ghost" size="icon-xs" onClick={() => setDismissed(true)} aria-label="Dismiss">
           <XIcon className="h-4 w-4" />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-view.tsx
@@ -213,7 +213,7 @@ export function ToolsView({
           </Tooltip>
         ) : (
           <Tooltip asChild trigger={<span>-</span>}>
-            Calls per offer needs tool definitions on chat spans — none were found for this tool.
+            Calls per offer needs tool definitions on chat spans. None were found for this tool.
           </Tooltip>
         ),
     },

--- a/apps/web/src/routes/_authenticated/projects/-components/showcase-banner.tsx
+++ b/apps/web/src/routes/_authenticated/projects/-components/showcase-banner.tsx
@@ -15,7 +15,7 @@ export function ShowcaseBanner() {
       <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-2">
         <Icon icon={EyeIcon} size="sm" color="white" className="opacity-90" />
         <Text.H6 color="white" className="opacity-95">
-          Demo project — read-only
+          Read-only demo
         </Text.H6>
       </div>
       <div className="pointer-events-auto shrink-0">
@@ -62,7 +62,7 @@ function RemoveDemoButton() {
               if (!next && !isSubmitting) setOpen(false)
             }}
             title="Remove the demo?"
-            description="This removes the demo for your whole team, not just you — every member of your organization will lose access to it. Support can restore it later if you need it back."
+            description="This removes the demo for everyone on your team, not just you. Every member of your organization loses access to it. Support can restore it later if you need it back."
             footer={
               <div className="flex justify-end gap-2">
                 <Button variant="outline" disabled={isSubmitting} onClick={() => setOpen(false)}>

--- a/apps/web/src/routes/backoffice/-components/account-actions/promote-demote.tsx
+++ b/apps/web/src/routes/backoffice/-components/account-actions/promote-demote.tsx
@@ -121,7 +121,7 @@ export function PromoteDemoteStaffButton({ userId, userEmail, currentRole }: Pro
           <div className="flex flex-col gap-4">
             <Alert
               variant="destructive"
-              description="This user loses backoffice access on their next request. Their active sessions stay signed in; they just stop seeing /backoffice routes."
+              description="This user loses backoffice access on their next request. Their active sessions stay signed in, but /backoffice routes become inaccessible."
             />
             <label className="flex cursor-pointer items-start gap-2" htmlFor="demote-acknowledge">
               <Checkbox

--- a/apps/web/src/routes/backoffice/-components/account-actions/promote-demote.tsx
+++ b/apps/web/src/routes/backoffice/-components/account-actions/promote-demote.tsx
@@ -121,7 +121,7 @@ export function PromoteDemoteStaffButton({ userId, userEmail, currentRole }: Pro
           <div className="flex flex-col gap-4">
             <Alert
               variant="destructive"
-              description="This user will lose access to the backoffice on their next request. Active sessions are not signed out — they just stop seeing /backoffice routes."
+              description="This user loses backoffice access on their next request. Their active sessions stay signed in; they just stop seeing /backoffice routes."
             />
             <label className="flex cursor-pointer items-start gap-2" htmlFor="demote-acknowledge">
               <Checkbox

--- a/apps/web/src/routes/backoffice/-components/account-actions/revoke-all-sessions.tsx
+++ b/apps/web/src/routes/backoffice/-components/account-actions/revoke-all-sessions.tsx
@@ -78,7 +78,7 @@ export function RevokeAllSessionsButton({ userId, userEmail }: RevokeAllSessions
       >
         <Alert
           variant="warning"
-          description="This signs the user out everywhere — every browser, every device. They'll need to sign in again. The user's data and memberships are not affected."
+          description="This signs the user out of every browser and device. They'll need to sign in again. Their data and memberships aren't affected."
         />
       </Modal>
     </>

--- a/apps/web/src/routes/backoffice/-components/account-actions/section.tsx
+++ b/apps/web/src/routes/backoffice/-components/account-actions/section.tsx
@@ -11,7 +11,7 @@ export function AccountActionsSection({ children }: { children: ReactNode }) {
   return (
     <ActionsSection
       title="Account actions"
-      description="Mutations on this user — impersonation, role changes, email, sign-outs."
+      description="Actions on this user: impersonation, role changes, email, and sign-outs."
     >
       {children}
     </ActionsSection>

--- a/apps/web/src/routes/backoffice/-components/organization-actions/enable-showcase.tsx
+++ b/apps/web/src/routes/backoffice/-components/organization-actions/enable-showcase.tsx
@@ -80,7 +80,7 @@ export function EnableShowcaseButton({ organizationId, wantsShowcase }: EnableSh
           variant={next ? "default" : "warning"}
           description={
             next
-              ? "Sets wantsShowcase = true for the whole org. The 'Latitude Demo' entry appears in every member's project switcher — but only once a showcase has actually been built. Use this to re-enable the demo for an org that dismissed it, or to opt in an org created before the feature existed."
+              ? "Sets wantsShowcase = true for the whole org. The 'Latitude Demo' entry then appears in every member's project switcher, but only once a showcase has been built. Use this to re-enable the demo for an org that dismissed it, or to opt in an org created before the feature existed."
               : "Sets wantsShowcase = false for the whole org. The demo entry disappears from every member's switcher and /projects/lat-demo 404s. Same effect as a member using 'Remove demo'."
           }
         />

--- a/apps/web/src/routes/backoffice/-components/organization-actions/section.tsx
+++ b/apps/web/src/routes/backoffice/-components/organization-actions/section.tsx
@@ -11,7 +11,7 @@ export function OrganizationActionsSection({ children }: { children: ReactNode }
   return (
     <ActionsSection
       title="Organization actions"
-      description="Org-wide mutations — showcase visibility and future tenant operations."
+      description="Org-wide actions: showcase visibility and other tenant operations."
     >
       {children}
     </ActionsSection>

--- a/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
+++ b/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
@@ -294,7 +294,7 @@ function BillingSummarySection({ billing }: { billing: AdminOrganizationBillingD
       value: `${formatCredits(billing.includedCredits)} / ${numberFormatter.format(billing.consumedCredits)}`,
       muted:
         billing.includedCredits === null
-          ? "No fixed monthly bundle — entitlement scales with contract"
+          ? "No fixed monthly bundle. Entitlement scales with the contract."
           : `${numberFormatter.format(Math.max(billing.includedCredits - billing.consumedCredits, 0))} credits remaining`,
     },
     {

--- a/apps/web/src/routes/backoffice/projects/$projectId.tsx
+++ b/apps/web/src/routes/backoffice/projects/$projectId.tsx
@@ -131,7 +131,7 @@ function BackofficeProjectDetailPage() {
 
       <ActionsSection
         title="Project actions"
-        description="Operational actions for this project — manually trigger background jobs, etc."
+        description="Operational actions for this project, like manually triggering background jobs."
       >
         <ActionRow
           icon={ClaudeCodeIcon}

--- a/apps/web/src/routes/backoffice/showcase/index.tsx
+++ b/apps/web/src/routes/backoffice/showcase/index.tsx
@@ -77,15 +77,15 @@ function NoShowcase({ onSuccess }: { readonly onSuccess: () => void | Promise<vo
         <div className="flex flex-col gap-1">
           <Text.H5 weight="semibold">No showcase exists</Text.H5>
           <Text.H6 color="foregroundMuted">
-            Create the showcase to bootstrap its dedicated organization and the singleton pointer row. No project is
-            built yet — trigger the first regeneration afterwards.
+            Create the showcase to bootstrap its dedicated organization and singleton pointer row. No project is built
+            yet; trigger the first regeneration afterward.
           </Text.H6>
         </div>
         <ShowcaseActionButton
           label="Create showcase"
           variant="default"
           description="Bootstrap the shared demo showcase."
-          confirmBody="Creates the dedicated 'Showcase' organization and inserts the singleton pointer row (no project yet). Fails loudly if a showcase already exists — there is exactly one, ever."
+          confirmBody="Creates the dedicated 'Showcase' organization and inserts the singleton pointer row (no project yet). Fails loudly if a showcase already exists, since there's only ever one."
           errorTitle="Could not create showcase"
           onSuccess={onSuccess}
           run={async () => {
@@ -169,7 +169,7 @@ function ExistingShowcase({
         <ActionRow
           icon={RefreshCw}
           title="Regenerate"
-          description="Build a fresh next project, gate it, and auto-swap on ready — the same job the daily cron fires."
+          description="Build a fresh next project, gate it, and auto-swap when ready. This is the same job the daily cron fires."
           action={
             <ShowcaseActionButton
               label="Regenerate"
@@ -197,7 +197,7 @@ function ExistingShowcase({
               label="Swap now"
               disabled={!canSwap}
               description="Promote the ready build to current."
-              confirmBody="Runs the transactional pointer flip (current ← next) and invalidates the resolver cache. Only succeeds when the next build is ready — a not-ready swap fails cleanly."
+              confirmBody="Runs the transactional pointer flip (current ← next) and invalidates the resolver cache. It only succeeds when the next build is ready; a not-ready swap fails cleanly."
               errorTitle="Could not swap"
               onSuccess={onSuccess}
               run={async () => {
@@ -215,7 +215,7 @@ function ExistingShowcase({
             <ShowcaseActionButton
               label="Reclaim"
               description="Self-heal a wedged build."
-              confirmBody="Publishes the cleanup job: reclaims a 'building' pointer whose regeneration run has died (resetting it to idle) and retires orphaned showcase projects. Once it lands the pointer is idle — click Regenerate to build a fresh project. Idempotent; a healthy in-flight build is left untouched."
+              confirmBody="Publishes the cleanup job: it reclaims a 'building' pointer whose regeneration run has died (resetting it to idle) and retires orphaned showcase projects. Once it lands, the pointer is idle, so click Regenerate to build a fresh project. Idempotent; a healthy in-flight build is left untouched."
               errorTitle="Could not reclaim"
               onSuccess={onSuccess}
               run={async () => {

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -121,7 +121,7 @@ function BackofficeUserDetailPage() {
           description={
             user.role === "admin"
               ? "Revoke this user's platform-staff access. They keep their organization memberships."
-              : "Grant this user platform-staff access — backoffice + cross-org visibility + impersonation."
+              : "Grant this user platform-staff access: backoffice, cross-org visibility, and impersonation."
           }
           action={<PromoteDemoteStaffButton userId={user.id} userEmail={user.email} currentRole={user.role} />}
         />

--- a/apps/web/src/routes/backoffice/wrapped.tsx
+++ b/apps/web/src/routes/backoffice/wrapped.tsx
@@ -399,7 +399,7 @@ function ToolMixSection({ rows }: { readonly rows: ReadonlyArray<ToolMixCheckRow
       <CardContent className="flex flex-col gap-0 px-4 pb-4 pt-0">
         <Text.H6 color="foregroundMuted" className="mb-4 italic">
           Types of Claude Code tool calls this week, compared against our expected baselines. Large drift means
-          personalities may be mis-assigned — a "Retune" row is the clearest signal to update the baseline.
+          personalities may be mis-assigned. A "Retune" row is the clearest sign to update the baseline.
         </Text.H6>
         <div className="flex flex-col gap-2">
           {sorted.map((row) => {
@@ -505,8 +505,8 @@ function ConfidenceSection({
         {/* 4B: Always-fires fallbacks */}
         <div className="flex flex-col gap-2">
           <Text.H6 color="foregroundMuted" className="italic">
-            Fallback archetypes win when no conditional gate clears. A weak score here is healthy — it means the
-            conditional archetypes are well-calibrated and winning cleanly.
+            Fallback archetypes win when no conditional gate clears. A weak score here is healthy: the conditional
+            archetypes are well-calibrated and winning cleanly.
           </Text.H6>
           {alwaysFired.length === 0 ? (
             <Text.H6 color="foregroundMuted">No fallback archetypes fired this week.</Text.H6>

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/-components/sandbox-project-chooser.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/-components/sandbox-project-chooser.tsx
@@ -67,7 +67,7 @@ export function SandboxProjectChooser({
         <Select
           name="sandbox-production-project"
           label="Project to debug"
-          description="Reuses a production project's identifier so your dev traces land in the sandbox — production is untouched."
+          description="Reuses a production project's identifier so your dev traces land in the sandbox. Production stays untouched."
           placeholder="Select a production project"
           options={productionProjects.map((p) => ({
             label: p.name,
@@ -83,7 +83,7 @@ export function SandboxProjectChooser({
           required
           type="text"
           label="New project name"
-          description="A sandbox-only project that doesn't exist in production — that's perfectly fine, create whatever you need to experiment."
+          description="A sandbox-only project with no production counterpart. That's fine; create whatever you need to experiment."
           value={newName}
           onChange={(e) => onNewNameChange(e.target.value)}
           placeholder="My sandbox project"

--- a/packages/domain/email/src/templates/dataset-export/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/dataset-export/EmailTemplate.tsx
@@ -19,7 +19,7 @@ export function DatasetExportEmail({ datasetName, downloadUrl, recipientName = "
     <ContainerLayout previewText={`Your "${datasetName}" export is ready`}>
       <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>{`Hi ${recipientName},`}</EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-        {`Good news — your "${datasetName}" dataset has been exported and is ready for download.`}
+        {`Your "${datasetName}" dataset has been exported and is ready to download.`}
       </EmailText>
 
       <Section className={emailDesignTokens.spacing.buttonTop}>

--- a/packages/domain/email/src/templates/export-ready/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/export-ready/EmailTemplate.tsx
@@ -19,7 +19,7 @@ export function ExportReadyEmail({ exportName, downloadUrl, recipientName = "the
     <ContainerLayout previewText={`Your "${exportName}" export is ready`}>
       <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>{`Hi ${recipientName},`}</EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-        {`Good news — your "${exportName}" export has been generated and is ready for download.`}
+        {`Your "${exportName}" export is ready to download.`}
       </EmailText>
 
       <Section className={emailDesignTokens.spacing.buttonTop}>

--- a/packages/domain/email/src/templates/invite-magic-link/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/invite-magic-link/EmailTemplate.tsx
@@ -20,7 +20,7 @@ export function InviteMagicLinkEmail({ inviterName, organizationName, magicLinkU
         {`You have been invited to ${organizationName}`}
       </EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-        {`${inviterName} would like you to collaborate in the ${organizationName} organization on Latitude — the open-source AI Agent Monitoring platform.`}
+        {`${inviterName} invited you to collaborate in the ${organizationName} organization on Latitude, the open-source AI agent monitoring platform.`}
       </EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
         Tap the button below to join the team and start exploring.

--- a/packages/domain/email/src/templates/invite-magic-link/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/invite-magic-link/EmailTemplate.tsx
@@ -20,7 +20,7 @@ export function InviteMagicLinkEmail({ inviterName, organizationName, magicLinkU
         {`You have been invited to ${organizationName}`}
       </EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-        {`${inviterName} invited you to collaborate in the ${organizationName} organization on Latitude, the open-source AI agent monitoring platform.`}
+        {`${inviterName} invited you to collaborate in the ${organizationName} organization on Latitude.`}
       </EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
         Tap the button below to join the team.

--- a/packages/domain/email/src/templates/invite-magic-link/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/invite-magic-link/EmailTemplate.tsx
@@ -23,7 +23,7 @@ export function InviteMagicLinkEmail({ inviterName, organizationName, magicLinkU
         {`${inviterName} invited you to collaborate in the ${organizationName} organization on Latitude, the open-source AI agent monitoring platform.`}
       </EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-        Tap the button below to join the team and start exploring.
+        Tap the button below to join the team.
       </EmailText>
 
       <Section className={emailDesignTokens.spacing.buttonTop}>

--- a/packages/domain/email/src/templates/invite-magic-link/index.tsx
+++ b/packages/domain/email/src/templates/invite-magic-link/index.tsx
@@ -20,7 +20,7 @@ export async function inviteMagicLinkTemplate(data: InviteMagicLinkEmailData): P
         magicLinkUrl={data.magicLinkUrl}
       />,
     ),
-    subject: `Join ${data.organizationName} on Latitude — invited by ${data.inviterName}`,
+    subject: `${data.inviterName} invited you to ${data.organizationName} on Latitude`,
     text: `${data.inviterName} wants you to join the ${data.organizationName} workspace on Latitude. Accept here: ${data.magicLinkUrl}`,
   }
 }

--- a/packages/domain/email/src/templates/notifications/incident-closed/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-closed/EmailTemplate.tsx
@@ -64,13 +64,13 @@ export function IncidentClosedEmail({
   const isMonitorIncident = incidentKind.startsWith("monitor.")
   const heading = "Resolved escalation"
   const subtitle = isMonitorIncident
-    ? "We notified everyone watching this project — the monitored target has returned below the threshold."
-    : "We notified everyone watching this project — the occurrence rate has returned to baseline."
+    ? "We notified everyone watching this project. The monitored target is back below its threshold."
+    : "We notified everyone watching this project. The occurrence rate is back to baseline."
   const scope = formatScope(organizationName, projectName)
   const duration = humanizeDurationMs(recovery.durationMs)
   const recoveryLine = isMonitorIncident
-    ? `Elevated for ${duration} — no further action needed unless the monitored target climbs again.`
-    : `Elevated for ${duration} — no further action needed unless the signal regresses again.`
+    ? `Elevated for ${duration}. No action needed unless the target climbs again.`
+    : `Elevated for ${duration}. No action needed unless the signal regresses again.`
   const ctaHref = isMonitorIncident ? monitor?.url : signalUrl
 
   const metadataRows = [

--- a/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
@@ -26,12 +26,12 @@ import {
 
 const ALERT_KIND_TO_SUBTITLE: Record<IncidentNotificationKey, string> = {
   "signal.escalating":
-    "We notified everyone watching this project — an ongoing signal is being detected more than expected.",
-  "monitor.match": "We notified everyone watching this project — a new match was detected.",
+    "We notified everyone watching this project. A signal is being detected more often than expected.",
+  "monitor.match": "We notified everyone watching this project. A new match came in.",
   "monitor.threshold":
-    "We notified everyone watching this project — a monitored metric crossed its configured threshold.",
+    "We notified everyone watching this project. A monitored metric crossed its threshold.",
   "monitor.escalating":
-    "We notified everyone watching this project — a monitored metric stayed over its threshold for the configured window.",
+    "We notified everyone watching this project. A monitored metric stayed over its threshold for the configured window.",
 }
 
 interface IncidentEventEmailProps {
@@ -139,7 +139,7 @@ IncidentEventEmail.PreviewProps = {
   assigneeName: "Anna Bosch",
   tags: ["env:prod", "model:claude-3.5-sonnet", "service:agents"],
   sampleExcerpt: {
-    text: "Reviewer flagged a tool-call loop after the third retry — model kept invoking `search` with the same query.",
+    text: "Reviewer flagged a tool-call loop after the third retry. The model kept calling `search` with the same query.",
     truncated: false,
     author: { kind: "user", name: "Anna Bosch", imageUrl: null },
   },

--- a/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
@@ -28,8 +28,7 @@ const ALERT_KIND_TO_SUBTITLE: Record<IncidentNotificationKey, string> = {
   "signal.escalating":
     "We notified everyone watching this project. A signal is being detected more often than expected.",
   "monitor.match": "We notified everyone watching this project. A new match came in.",
-  "monitor.threshold":
-    "We notified everyone watching this project. A monitored metric crossed its threshold.",
+  "monitor.threshold": "We notified everyone watching this project. A monitored metric crossed its threshold.",
   "monitor.escalating":
     "We notified everyone watching this project. A monitored metric stayed over its threshold for the configured window.",
 }

--- a/packages/domain/email/src/templates/notifications/incident-opened/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-opened/EmailTemplate.tsx
@@ -57,7 +57,7 @@ const buildBreachLine = (breach: IncidentBreach | undefined): string | null => {
   }
   const multiplier = breach.triggerRate / breach.baselineRate
   const multiplierStr = multiplier >= 10 ? `${Math.round(multiplier)}×` : `${multiplier.toFixed(1)}×`
-  return `Rate climbed to ${trigger} — ${multiplierStr} the baseline of ${baseline}.`
+  return `Rate climbed to ${trigger}, ${multiplierStr} the baseline of ${baseline}.`
 }
 
 export function IncidentOpenedEmail({
@@ -82,8 +82,8 @@ export function IncidentOpenedEmail({
   const isMonitorIncident = incidentKind.startsWith("monitor.")
   const heading = INCIDENT_NOTIFICATION_KEY_LABEL[incidentKind]
   const subtitle = isMonitorIncident
-    ? "We notified everyone watching this project — the monitor stayed above its configured threshold."
-    : "We notified everyone watching this project — an ongoing signal is being detected more than expected."
+    ? "We notified everyone watching this project. The monitor stayed above its threshold."
+    : "We notified everyone watching this project. A signal is being detected more often than expected."
   const scope = formatScope(organizationName, projectName)
   const breachLine = buildBreachLine(breach)
   const ctaHref = isMonitorIncident ? monitor?.url : signalUrl

--- a/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v1/EmailTemplateV1.tsx
+++ b/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v1/EmailTemplateV1.tsx
@@ -193,7 +193,7 @@ function CtaBanner({ url }: { url: string }) {
           margin: "10px 0 0 0",
         }}
       >
-        Heatmap, workspaces, files, moments — the full story is on the web.
+        Heatmaps, workspaces, files, and moments. See the full story on the web.
       </p>
     </Section>
   )
@@ -244,7 +244,7 @@ function WrappedFooter({
         <Link href={homeUrl}>
           <Img src={logoUrl} alt="Latitude" width="120" height="22" style={{ display: "inline-block" }} />
         </Link>
-        <p style={{ ...footerLineStyle, marginTop: "8px" }}>Latitude — the AI observability platform.</p>
+        <p style={{ ...footerLineStyle, marginTop: "8px" }}>Latitude, the AI observability platform.</p>
       </div>
     </>
   )

--- a/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v2/EmailTemplateV2.tsx
+++ b/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v2/EmailTemplateV2.tsx
@@ -279,7 +279,7 @@ function CtaBanner({ url }: { url: string }) {
           margin: "10px 0 0 0",
         }}
       >
-        Heatmap, workspaces, files, moments — the full story is on the web.
+        Heatmaps, workspaces, files, and moments. See the full story on the web.
       </p>
     </Section>
   )
@@ -330,7 +330,7 @@ function WrappedFooter({
         <Link href={homeUrl}>
           <Img src={logoUrl} alt="Latitude" width="120" height="22" style={{ display: "inline-block" }} />
         </Link>
-        <p style={{ ...footerLineStyle, marginTop: "8px" }}>Latitude — the AI observability platform.</p>
+        <p style={{ ...footerLineStyle, marginTop: "8px" }}>Latitude, the AI observability platform.</p>
       </div>
     </>
   )

--- a/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v3/EmailTemplateV3.tsx
+++ b/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v3/EmailTemplateV3.tsx
@@ -302,7 +302,7 @@ function CtaBanner({ url }: { url: string }) {
           margin: "10px 0 0 0",
         }}
       >
-        Heatmap, workspaces, files, moments — the full story is on the web.
+        Heatmaps, workspaces, files, and moments. See the full story on the web.
       </p>
     </Section>
   )
@@ -353,7 +353,7 @@ function WrappedFooter({
         <Link href={homeUrl}>
           <Img src={logoUrl} alt="Latitude" width="120" height="22" style={{ display: "inline-block" }} />
         </Link>
-        <p style={{ ...footerLineStyle, marginTop: "8px" }}>Latitude — the AI observability platform.</p>
+        <p style={{ ...footerLineStyle, marginTop: "8px" }}>Latitude, the AI observability platform.</p>
       </div>
     </>
   )

--- a/packages/domain/email/src/templates/organization-claim/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/organization-claim/EmailTemplate.tsx
@@ -20,7 +20,7 @@ export function OrganizationClaimEmail({ claimUrl, organizationName, expiresAtLa
         {`Claim ${organizationName} on Latitude`}
       </EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-        {`Your new ${organizationName} organization has been set up for you on Latitude, the open-source AI Agent Monitoring platform. Claim it before ${expiresAtLabel} to capture Agent trajectories, discover behavior patterns, and catch issues before your users do!`}
+        {`Your ${organizationName} organization is set up on Latitude, the open-source AI agent monitoring platform. Claim it before ${expiresAtLabel} to start monitoring your agents and catching issues before your users do.`}
       </EmailText>
 
       <Section className={emailDesignTokens.spacing.buttonTop}>

--- a/packages/domain/email/src/templates/organization-claim/index.tsx
+++ b/packages/domain/email/src/templates/organization-claim/index.tsx
@@ -27,7 +27,7 @@ export async function organizationClaimTemplate(data: OrganizationClaimEmailData
       />,
     ),
     subject: `Claim ${data.organizationName} on Latitude`,
-    text: `Your new ${data.organizationName} organization has been set up for you on Latitude. Claim it before ${expiresAtLabel}: ${data.claimUrl}`,
+    text: `Your ${data.organizationName} organization is set up on Latitude. Claim it before ${expiresAtLabel}: ${data.claimUrl}`,
   }
 }
 

--- a/packages/domain/email/src/templates/signup-existing-account-magic-link/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/signup-existing-account-magic-link/EmailTemplate.tsx
@@ -27,7 +27,7 @@ export function SignupExistingAccountMagicLinkEmail({
         Latitude workspace.
       </EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-        No worries — just tap the button below to sign in directly.
+        No problem. Tap the button below to sign in directly.
       </EmailText>
 
       <Section className={emailDesignTokens.spacing.buttonTop}>

--- a/packages/domain/email/src/templates/signup-magic-link/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/signup-magic-link/EmailTemplate.tsx
@@ -20,8 +20,8 @@ export function SignupMagicLinkEmail({ userName, magicLinkUrl }: SignupMagicLink
         className={emailDesignTokens.spacing.headingGap}
       >{`Hey ${userName}, let's get you set up`}</EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-        Thanks for signing up for Latitude. Confirm your email address by tapping the button below, and we&apos;ll have
-        your workspace ready in seconds.
+        Thanks for signing up for Latitude. Tap the button below to confirm your email and finish setting up your
+        workspace.
       </EmailText>
 
       <Section className={emailDesignTokens.spacing.buttonTop}>

--- a/packages/domain/integrations/src/templates/notifications/incident-closed.ts
+++ b/packages/domain/integrations/src/templates/notifications/incident-closed.ts
@@ -46,10 +46,10 @@ export const incidentClosedRenderer: SlackNotificationRenderer<"incident.closed"
     if (isMonitorIncident) {
       const searchRef = sourceName ?? "a monitored target"
       return {
-        text: `Resolved: escalation on ${searchRef} — elevated for ${duration}`,
+        text: `Resolved: escalation on ${searchRef}, elevated for ${duration}`,
         color: COLORS.resolved,
         blocks: [
-          sectionMarkdown(`Escalation resolved on *${searchRef}* — elevated for *${duration}*.`),
+          sectionMarkdown(`Escalation resolved on *${searchRef}*, elevated for *${duration}*.`),
           ...attribution,
           context,
           actionsLink("View monitor", monitorUrl),
@@ -60,7 +60,7 @@ export const incidentClosedRenderer: SlackNotificationRenderer<"incident.closed"
     const chart = trendChartBlock(ctx.notificationId, ctx.webAppUrl)
 
     return {
-      text: `Signal recovered in ${projectName} — elevated for ${duration}`,
+      text: `Signal recovered in ${projectName}, elevated for ${duration}`,
       color: COLORS.resolved,
       blocks: [
         ...(sourceName ? [sectionMarkdown(`*<${signalUrl}|${sourceName}>*`)] : []),

--- a/packages/domain/integrations/src/templates/notifications/incident-opened.ts
+++ b/packages/domain/integrations/src/templates/notifications/incident-opened.ts
@@ -57,7 +57,7 @@ export const incidentOpenedRenderer: SlackNotificationRenderer<"incident.opened"
     }
 
     const breachLine = payload.breach
-      ? `Rate climbed to *${formatRate(payload.breach.triggerRate)}/hr* — ${formatMultiple(payload.breach.triggerRate, payload.breach.baselineRate)} the baseline of ${formatRate(payload.breach.baselineRate)}/hr`
+      ? `Rate climbed to *${formatRate(payload.breach.triggerRate)}/hr*, ${formatMultiple(payload.breach.triggerRate, payload.breach.baselineRate)} the baseline of ${formatRate(payload.breach.baselineRate)}/hr`
       : null
 
     const tags = payload.tags ?? []


### PR DESCRIPTION
Rewrites user-facing copy that read as AI-generated across the web app and the email/Slack templates. A lot of our microcopy had the usual tells: em dashes, promotional filler, forced rule-of-three, an emoji in a heading, subjectless fragments. This is a copy-only pass to make it sound like a person wrote it.

The starting signal was em-dash usage, which flagged the AI-written strings. From there each string was rewritten based on what it actually does in the UI (toast, tooltip, empty state, confirm body, email line), not mechanically re-punctuated. Clean, terse technical microcopy was left alone.

Scope is copy only, no behavior changes. Touches toasts, tooltips, empty states, confirmation modals, onboarding steps, and transactional email + Slack notification templates. Placeholders, code comments, tests, LLM prompts, and email sign-offs were left untouched.

While auditing I also fixed a few non-copy defects: the enterprise SSO form mislabeled its OIDC issuer field as "Signalr", a "syncronization" typo, a subject/verb agreement slip in the flaggers onboarding step, and inconsistent title-casing of "API Key"/"OAuth Key".

All affected packages typecheck; pre-commit format + knip pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined user-facing wording across onboarding, filters, sessions, signals, tools, datasets, experiments, settings, and backoffice screens.
  * Clarified empty states, tooltips, help text, error messages, confirmation dialogs, and status notifications.
  * Updated OAuth, SSO, API key, destination, and telemetry setup guidance.

* **Notifications**
  * Updated email and Slack copy for invitations, exports, incidents, and wrapped/report messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->