### PR TITLE
fix(conversation-intelligence): prevent lone UTF-16 surrogates in moment-classifier prompts

### DIFF
--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
@@ -751,6 +751,41 @@ describe("analyzeSessionUseCase", () => {
     expect(momentLabels.rows.every((moment) => moment.evidence.length > 0 && moment.confidence >= 0.65)).toBe(true)
   })
 
+  it("sanitizes evidence when the 240-character slice splits a surrogate pair", async () => {
+    const frustratedUserMessage = `${"a".repeat(239)}😀 and this is still frustrating and unresolved.`
+    const { effect, momentLabels } = runUseCase({
+      session: makeSessionWithMessages([
+        message("user", "Can you help me update my billing email?"),
+        message("assistant", "Sure, open account settings and choose Profile."),
+        message("user", frustratedUserMessage),
+        message("assistant", "I'm sorry, I will correct that now."),
+      ]),
+      ai: {
+        generate: <T>(request: GenerateInput<T>) =>
+          Effect.succeed({
+            object: {
+              acceptedCandidateIds: candidatesFromPrompt(request.prompt).map((candidate) => candidate.id),
+            } as T,
+            tokens: 0,
+            duration: 0,
+          }) as Effect.Effect<GenerateResult<T>, never>,
+        embed: (input) => {
+          const text = input.text.toLowerCase()
+          if (text.includes("frustrat")) return Effect.succeed({ embedding: [1, 0] })
+          return Effect.succeed({ embedding: [-1, 0] })
+        },
+        rerank: () => Effect.die("rerank not used"),
+      },
+    })
+
+    await Effect.runPromise(effect)
+
+    const frustration = momentLabels.rows.find((label) => label.kind === "user_frustration")
+    expect(frustration).toBeDefined()
+    expect(frustration?.evidence.length).toBeLessThanOrEqual(240)
+    expect(frustration?.evidence).not.toMatch(LONE_SURROGATE_PATTERN)
+  })
+
   it("anchors user frustration labels to the rendered user message index", async () => {
     const frustratedUserMessage = "This is incredibly frustrating, you keep giving me the wrong answer."
     const renderedMessages = [

--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
@@ -57,7 +57,10 @@ import {
 import {
   analyzeSessionUseCase,
   clearConversationIntelligenceAnchorEmbeddingCacheForTesting,
+  middleTruncateForTesting,
 } from "./analyze-session.ts"
+
+const LONE_SURROGATE_PATTERN = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
 
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
@@ -1301,5 +1304,24 @@ describe("analyzeSessionUseCase", () => {
     const prompt = generated[0]?.prompt ?? ""
     expect(prompt.match(/<\/conversation_data>/g)).toHaveLength(1)
     expect(prompt).toContain("\\u003c/conversation_data\\u003e")
+  })
+})
+
+describe("middleTruncate", () => {
+  it("never leaves an unpaired UTF-16 surrogate at a truncation boundary", () => {
+    const value = "😀".repeat(50)
+    for (let maxLength = 0; maxLength <= value.length + 5; maxLength++) {
+      expect(middleTruncateForTesting(value, maxLength)).not.toMatch(LONE_SURROGATE_PATTERN)
+    }
+  })
+
+  it("still bounds the output length when truncating", () => {
+    const value = "😀".repeat(50)
+    expect(middleTruncateForTesting(value, 40).length).toBeLessThanOrEqual(40)
+  })
+
+  it("returns the original value unchanged when it already fits", () => {
+    const value = "😀".repeat(10)
+    expect(middleTruncateForTesting(value, value.length)).toBe(value)
   })
 })

--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
@@ -577,7 +577,9 @@ const detectEmbeddingAnchorMoments = (input: {
           }
         }
         if (!best) continue
-        const evidence = (messagesByIndex.get(best.turn.index)?.text ?? best.turn.content).slice(0, 240)
+        const evidence = stripLoneSurrogates(
+          (messagesByIndex.get(best.turn.index)?.text ?? best.turn.content).slice(0, 240),
+        )
         labels.push({
           kind: config.kind,
           firstMessageIndex: best.turn.index,

--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
@@ -22,6 +22,7 @@ import {
   type MessageEmbeddingUpsert,
   SessionRepository,
   sessionConversationMessages,
+  stripLoneSurrogates,
   TRACE_SEARCH_CHARS_PER_TOKEN_ESTIMATE,
   TraceSearchBudget,
 } from "@domain/spans"
@@ -128,11 +129,13 @@ const TRUNCATION_MARKER = "\n[...truncated...]\n"
 
 const middleTruncate = (value: string, maxLength: number): string => {
   if (value.length <= maxLength) return value
-  if (maxLength <= TRUNCATION_MARKER.length) return value.slice(0, maxLength)
+  if (maxLength <= TRUNCATION_MARKER.length) return stripLoneSurrogates(value.slice(0, maxLength))
   const head = Math.floor((maxLength - TRUNCATION_MARKER.length) / 2)
   const tail = maxLength - TRUNCATION_MARKER.length - head
-  return `${value.slice(0, head)}${TRUNCATION_MARKER}${value.slice(value.length - tail)}`
+  return `${stripLoneSurrogates(value.slice(0, head))}${TRUNCATION_MARKER}${stripLoneSurrogates(value.slice(value.length - tail))}`
 }
+
+export const middleTruncateForTesting = middleTruncate
 
 const escapePromptDelimiters = (value: string): string => value.replaceAll("<", "\\u003c").replaceAll(">", "\\u003e")
 

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -46,6 +46,7 @@ export {
   type MessageEmbeddingInput,
   type MessageEmbeddingRole,
 } from "./helpers/message-embedding.ts"
+export { normalizeLiteralPhrase, stripLoneSurrogates } from "./helpers/normalize-literal-phrase.ts"
 export {
   isLlmCompletionOperation,
   resolveLastLlmCompletionSpanId,


### PR DESCRIPTION
## What does this PR do?

Datadog scheduled triage surfaced a burst of 512 combined production errors on 2026-07-24 21:54–23:10 UTC, split across 4 Error Tracking issues that are actually **one incident** cascading through the call stack (same `first_seen`, same deploy SHA `e80aed6`):

- [`AI_APICallError`](https://app.datadoghq.eu/error-tracking/issue/4697cf5a-87aa-11f1-bcf2-da7ad0900005) (256×) — Bedrock rejects the request: `Failed to deserialize the JSON body into the target type: ?[1].content[0].text: Invalid 'messages': unexpected end of hex escape at line 1 column 9837`
- [`Error`](https://app.datadoghq.eu/error-tracking/issue/469bdd84-87aa-11f1-83a2-da7ad0900005) (128×) — `packages/platform/ai-vercel/src/ai.ts` wrapping the same failure after primary+fallback both fail
- [`AIError`](https://app.datadoghq.eu/error-tracking/issue/469e9e52-87aa-11f1-846e-da7ad0900005) (64×) — same failure, one layer further out
- [`MomentClassifierError`](https://app.datadoghq.eu/error-tracking/issue/46a24228-87aa-11f1-83a2-da7ad0900005) (64×) — `packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts:506`, the calling use-case

**Root cause:** `middleTruncate()` (`analyze-session.ts`) truncates session transcript text by raw UTF-16 code-unit count (`.slice()`) before it's sent as the moment-classifier prompt to Bedrock. Slicing at an arbitrary code-unit offset can land in the middle of a surrogate pair (e.g. an emoji), leaving an unpaired UTF-16 surrogate in the text handed to the model — the same defect class already fixed once for ClickHouse/Voyage via `stripLoneSurrogates` (see `packages/domain/spans/src/helpers/normalize-literal-phrase.ts`), just at a call site that fix didn't cover.

**Fix:** sanitize each truncated segment with the existing `stripLoneSurrogates` helper from `@domain/spans`, matching the codebase's established convention for this exact bug class, instead of inventing new logic.

**Note on confidence:** I verified `JSON.stringify` in this Node runtime always emits well-formed 4-hex-digit escapes for lone surrogates, so I can't fully rule out that the "unexpected end of hex escape" error itself originates one layer deeper, inside the beta `@ai-sdk/amazon-bedrock` / `@ai-sdk/provider-utils` request serialization (both pinned to `-beta` versions) rather than purely from this truncation. This fix removes a known-bad, generalizable input defect regardless, and is worth shipping on its own merits; I'll keep watching the issue's occurrence count after this deploys.

Two other high-volume issues from the same triage pass were already covered by prior triage comments and needed no new action (Class B/D, not code bugs): `50645210-…` (agentContext schema mismatch — already commented 2026-07-04, degrades gracefully) and `a1ed690a-…` (webhook transport failure — already commented 2026-07-20, transient network issue).

## Related issue (if applicable)

N/A — filed directly from scheduled Datadog triage, no linked GitHub issue.

## How was this tested?

- Added `middleTruncate` unit tests (`analyze-session.test.ts`) that exhaustively truncate a string built from surrogate-pair emoji at every possible cut length and assert no unpaired surrogate survives. Confirmed the new test **fails** without the fix (produces a lone surrogate/`�`) and **passes** with it.
- `pnpm --filter @domain/conversation-intelligence test` — 44/44 passing.
- `pnpm --filter @domain/conversation-intelligence typecheck` (tsgo) — clean.
- `pnpm exec biome check` on changed files — clean.

**Verification in production:** after deploy, occurrences of issue `4697cf5a-87aa-11f1-bcf2-da7ad0900005` (and its 3 sibling issues) should not recur under the same triggering conditions.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jsa4ZEck7yXqsz3noKDX1m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation to prevent malformed characters when cutting strings.
  * Ensured truncated output consistently respects the configured maximum length.
* **Tests**
  * Added coverage for surrogate-character safety, length limits, and unchanged short strings.
* **Improvements**
  * Expanded available text-normalization utilities for broader use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->