### PR TITLE
Resolves LAT-LC6C: skip user-centric flaggers on taxonomy nested samples

### DIFF
--- a/dev-docs/flaggers.md
+++ b/dev-docs/flaggers.md
@@ -158,7 +158,7 @@ Context compaction mirrors the moments stance: the analyzed window is the last r
 
 Every production flagger LLM call is traced into the `latitude-flaggers` dogfood project, and the flaggers run on that project too. To bound recursion to one level (`src/reflag.ts`): a flagger running on a flagger-generated session stamps its own LLM output with the no-reflag tag, and screening skips any session whose tags carry it. Session tags are the union of span tags, and flagger telemetry sessions are effectively per-trace, so the union semantics are safe.
 
-User/input-centric strategies (`classifiesAssistantResponseOnly: false` — today `frustration`, `jailbreaking`, and `nsfw`) are also dropped on first-level flagger-generated sessions (`isUserCentricReflagInapplicable`). Their evidence includes Latitude prompt scaffolding that embeds nested evaluated content from the original session, which looks like a true positive for those categories. Assistant-response-centric strategies still run so reflag can catch bad classifications.
+User/input-centric strategies (`classifiesAssistantResponseOnly: false` — today `frustration`, `jailbreaking`, and `nsfw`) are dropped when session tags mark the user-role text as nested conversation samples (`isUserCentricReflagInapplicable`): first-level flagger-generated sessions (`flagger:classify` / `flagger:draft`) and taxonomy dogfood traces (`taxonomy:propose-themes`, `taxonomy:name-cluster`, `taxonomy:facet-extract`). In those cases the "user" message is scaffolding that embeds other conversations, which looks like a true positive for user-centric categories. Assistant-response-centric strategies still run so reflag / taxonomy self-observability can catch bad model outputs.
 
 ## Quality tooling
 

--- a/packages/domain/flaggers/src/reflag.test.ts
+++ b/packages/domain/flaggers/src/reflag.test.ts
@@ -62,13 +62,21 @@ describe("isUserCentricReflagInapplicable", () => {
     expect(isUserCentricReflagInapplicable([DRAFT], false)).toBe(true)
   })
 
-  it("still allows assistant-response-centric strategies on flagger-generated traces", () => {
+  it("skips user-centric strategies on taxonomy nested-sample traces", () => {
+    expect(isUserCentricReflagInapplicable(["taxonomy:propose-themes"], false)).toBe(true)
+    expect(isUserCentricReflagInapplicable(["taxonomy:name-cluster"], false)).toBe(true)
+    expect(isUserCentricReflagInapplicable(["taxonomy:facet-extract"], false)).toBe(true)
+  })
+
+  it("still allows assistant-response-centric strategies on nested-sample traces", () => {
     expect(isUserCentricReflagInapplicable([CLASSIFY], true)).toBe(false)
     expect(isUserCentricReflagInapplicable([CLASSIFY], undefined)).toBe(false)
+    expect(isUserCentricReflagInapplicable(["taxonomy:propose-themes"], true)).toBe(false)
   })
 
   it("does not skip user-centric strategies on ordinary production traces", () => {
     expect(isUserCentricReflagInapplicable([], false)).toBe(false)
     expect(isUserCentricReflagInapplicable(["live"], false)).toBe(false)
+    expect(isUserCentricReflagInapplicable(["eval:execute", "live"], false)).toBe(false)
   })
 })

--- a/packages/domain/flaggers/src/reflag.ts
+++ b/packages/domain/flaggers/src/reflag.ts
@@ -22,6 +22,18 @@ const FLAGGER_PROVENANCE_TAGS: readonly string[] = [
   ...AI_GENERATE_TELEMETRY_TAGS.flaggerDraft,
 ]
 
+/**
+ * Traces whose user-role messages are scaffolding that embeds other conversations
+ * (flagger evidence, taxonomy cluster samples, facet session text). User/input-
+ * centric strategies treat that nested wording as a real end-user and false-positive.
+ */
+const NESTED_CONVERSATION_SAMPLE_TAGS: readonly string[] = [
+  ...FLAGGER_PROVENANCE_TAGS,
+  ...AI_GENERATE_TELEMETRY_TAGS.taxonomyProposeThemes,
+  ...AI_GENERATE_TELEMETRY_TAGS.taxonomyNameCluster,
+  ...AI_GENERATE_TELEMETRY_TAGS.facetExtract,
+]
+
 const FLAGGER_NO_REFLAG_TAG: string = AI_GENERATE_TELEMETRY_TAGS.flaggerNoReflag[0]
 
 /**
@@ -30,6 +42,9 @@ const FLAGGER_NO_REFLAG_TAG: string = AI_GENERATE_TELEMETRY_TAGS.flaggerNoReflag
  */
 export const isFlaggerGeneratedTrace = (tags: readonly string[]): boolean =>
   tags.some((tag) => FLAGGER_PROVENANCE_TAGS.includes(tag))
+
+const hasNestedConversationSamples = (tags: readonly string[]): boolean =>
+  tags.some((tag) => NESTED_CONVERSATION_SAMPLE_TAGS.includes(tag))
 
 /**
  * True when the trace is explicitly marked "do not flag again" — emitted by a
@@ -45,7 +60,14 @@ export const isReflagSuppressed = (tags: readonly string[]): boolean => tags.inc
 export const reflagSuppressionTags = (inputTraceTags: readonly string[]): readonly string[] =>
   isFlaggerGeneratedTrace(inputTraceTags) ? AI_GENERATE_TELEMETRY_TAGS.flaggerNoReflag : []
 
+/**
+ * True when a user/input-centric strategy (`classifiesAssistantResponseOnly === false`)
+ * must not run: the session's user-role text embeds nested conversation samples, not a
+ * real end-user partner. Covers flagger.classify/draft reflag and taxonomy dogfood traces
+ * (`taxonomy:propose-themes`, `taxonomy:name-cluster`, `taxonomy:facet-extract`).
+ * Assistant-response-centric strategies still run.
+ */
 export const isUserCentricReflagInapplicable = (
   tags: readonly string[],
   classifiesAssistantResponseOnly: boolean | undefined,
-): boolean => isFlaggerGeneratedTrace(tags) && classifiesAssistantResponseOnly === false
+): boolean => hasNestedConversationSamples(tags) && classifiesAssistantResponseOnly === false

--- a/packages/domain/flaggers/src/reflag.ts
+++ b/packages/domain/flaggers/src/reflag.ts
@@ -22,11 +22,7 @@ const FLAGGER_PROVENANCE_TAGS: readonly string[] = [
   ...AI_GENERATE_TELEMETRY_TAGS.flaggerDraft,
 ]
 
-/**
- * Traces whose user-role messages are scaffolding that embeds other conversations
- * (flagger evidence, taxonomy cluster samples, facet session text). User/input-
- * centric strategies treat that nested wording as a real end-user and false-positive.
- */
+// Tags whose user-role text embeds nested conversation samples (see `dev-docs/flaggers.md`).
 const NESTED_CONVERSATION_SAMPLE_TAGS: readonly string[] = [
   ...FLAGGER_PROVENANCE_TAGS,
   ...AI_GENERATE_TELEMETRY_TAGS.taxonomyProposeThemes,
@@ -61,11 +57,8 @@ export const reflagSuppressionTags = (inputTraceTags: readonly string[]): readon
   isFlaggerGeneratedTrace(inputTraceTags) ? AI_GENERATE_TELEMETRY_TAGS.flaggerNoReflag : []
 
 /**
- * True when a user/input-centric strategy (`classifiesAssistantResponseOnly === false`)
- * must not run: the session's user-role text embeds nested conversation samples, not a
- * real end-user partner. Covers flagger.classify/draft reflag and taxonomy dogfood traces
- * (`taxonomy:propose-themes`, `taxonomy:name-cluster`, `taxonomy:facet-extract`).
- * Assistant-response-centric strategies still run.
+ * True when a user/input-centric strategy must not run on this session.
+ * Nested-sample tags only — assistant-response-centric strategies still run.
  */
 export const isUserCentricReflagInapplicable = (
   tags: readonly string[],

--- a/packages/domain/flaggers/src/use-cases/classify-session-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/classify-session-flagger.test.ts
@@ -97,13 +97,16 @@ describe("classifySessionFlaggerUseCase gating", () => {
     expect(result).toEqual({ matched: false })
   })
 
-  it("returns { matched: false } for frustration on a flagger.classify session without calling AI", async () => {
+  it.each([
+    { tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify], label: "flagger.classify" },
+    { tags: [...AI_GENERATE_TELEMETRY_TAGS.taxonomyProposeThemes], label: "taxonomy:propose-themes" },
+  ])("returns { matched: false } for frustration on a $label session without calling AI", async ({ tags }) => {
     const session = makeSessionDetail(
       [
-        user("no but read the memory first — nested correction inside classify evidence"),
+        user("I just honestly don't understand why you couldn't get this done for me — nested sample wording"),
         assistant('{"matched":true,"feedback":"task not completed","messageIndex":"2"}'),
       ],
-      { tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify] },
+      { tags },
     )
     const { repository: sessionRepo } = createFakeSessionRepository({
       findBySessionId: () => Effect.succeed(session),
@@ -125,7 +128,7 @@ describe("classifySessionFlaggerUseCase gating", () => {
         } as Flagger),
     })
     const { layer: aiLayer } = createFakeAI({
-      generate: () => Effect.die("AI must not be called for user-centric reflag"),
+      generate: () => Effect.die("AI must not be called for user-centric nested-sample traces"),
     })
 
     const result = await Effect.runPromise(

--- a/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
+++ b/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
@@ -243,6 +243,40 @@ describe("screenSessionFlaggersUseCase", () => {
     expect(scores.size).toBe(0)
   })
 
+  it("drops user-centric strategies on taxonomy:propose-themes (cluster samples are not a real user)", async () => {
+    const clusterSamples = [
+      "Samples:",
+      "0: User: I just honestly don't understand why you couldn't get this done for me.",
+      "Clearly there is something broke about you. Do not bother giving me a bunch of excuses.",
+    ].join("\n")
+    const session = makeSessionDetail(
+      [user(clusterSamples), assistant('{"themes":[{"name":"Project delivery failures"}]}')],
+      { tags: [...AI_GENERATE_TELEMETRY_TAGS.taxonomyProposeThemes] },
+    )
+    const { result, scores } = await runScreening({
+      session,
+      flaggers: [makeFlagger("frustration", 100), makeFlagger("laziness", 100)],
+      momentLabels: [makeMomentLabel("user_frustration"), makeMomentLabel("stalling")],
+      analyses: [analyzedAnalysis()],
+      deps: fakeDeps.deps,
+    })
+
+    expect(decisionFor(result.decisions, "frustration")).toEqual({
+      slug: "frustration",
+      action: "dropped",
+      reason: "missing-context",
+    })
+    expect(decisionFor(result.decisions, "laziness")).toEqual({
+      slug: "laziness",
+      action: "classify",
+      reason: "hinted",
+      hintKinds: ["moment:stalling"],
+    })
+    expect(result.classifications.some((c) => c.flaggerSlug === "frustration")).toBe(false)
+    expect(result.classifications.some((c) => c.flaggerSlug === "laziness")).toBe(true)
+    expect(scores.size).toBe(0)
+  })
+
   it("writes a session-anchored score with contentHash on a deterministic match", async () => {
     const session = makeSessionDetail([user("Please help me with this."), assistant("")])
     const { result, scores } = await runScreening({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves LAT-LC6C

## Signal

[LAT-LC6C — Repeats previously rejected output format despite claimed changes](https://console.latitude.so/projects/latitude-taxonomy/signals/LAT-LC6C) in **🧭 Taxonomy** (`latitude-taxonomy`).

- Source: `frustration` flagger
- Sample trace: `bae91448df6fbe3973920e2c5038d9f9` (`taxonomy:propose-themes`)
- Feedback quotes `"it did the SAME THING AGIAN"` from a Google Ads change-log conversation that only appears inside the cluster **Samples:** payload the naming model was asked to theme

The taxonomy assistant only returned JSON theme candidates. The frustration text is nested input, not behavior of the naming agent.

Same failure mode as [LAT-SF9R](https://console.latitude.so/projects/latitude-taxonomy/signals/LAT-SF9R) / #4207 (identical code change; this PR is the LAT-LC6C-linked copy so merge auto-resolves the signal). Also pushed as `fix/lat-lc6c-taxonomy-nested-frustration`.

## Fix

Extend `isUserCentricReflagInapplicable` so `frustration` / `jailbreaking` / `nsfw` also drop on `taxonomy:propose-themes`, `taxonomy:name-cluster`, and `taxonomy:facet-extract`. Assistant-response-centric strategies still run on those traces.

## Tests

- `reflag.test.ts` — taxonomy tags skip user-centric strategies
- `screen-session-flaggers.test.ts` — propose-themes drops frustration, keeps laziness
- `classify-session-flagger.test.ts` — classify short-circuits without calling AI

Do not mute or resolve LAT-LC6C from Latitude tools — verify after deploy that new `taxonomy:propose-themes` sessions no longer get frustration scores of this kind.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3011373-30d8-5566-9850-d4c2148f1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3011373-30d8-5566-9850-d4c2148f1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flagger screening for sessions containing nested conversation samples, with user-centric strategies now properly skipped for applicable taxonomy nested-sample traces.
  * Assistant-response-centric strategies continue to run normally.
* **Documentation**
  * Clarified when user-centric flagger strategies are suppressed and how “nested conversation samples” are identified as the evidence basis.
* **Tests**
  * Expanded coverage to validate skipping behavior for `taxonomy:propose-themes`, `taxonomy:name-cluster`, and `taxonomy:facet-extract`, and to confirm ordinary traces are not incorrectly skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->