### PR TITLE
fix(conversation-intelligence): sanitize lone surrogates in truncated LLM prompts

### DIFF
--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
@@ -1302,4 +1302,68 @@ describe("analyzeSessionUseCase", () => {
     expect(prompt.match(/<\/conversation_data>/g)).toHaveLength(1)
     expect(prompt).toContain("\\u003c/conversation_data\\u003e")
   })
+
+  // Bedrock/Anthropic reject a lone UTF-16 surrogate in the request body with
+  // "unexpected end of hex escape" while deserializing JSON. A short transcript
+  // takes the no-truncation early-return path, which must sanitize on its own.
+  it("sanitizes a raw lone surrogate in the classifier prompt even without truncation", async () => {
+    const frustratedMessage = "This is incredibly frustrating \uD83D, you keep giving me the wrong answer."
+    const { ai, generated } = createAdjudicationAi({
+      embeddingForText: (text) =>
+        text.includes("frustration annoyance or anger") || text.startsWith("user: This is incredibly frustrating")
+          ? [1, 0]
+          : [-1, 0],
+      acceptedCandidateIds: (prompt) => candidatesFromPrompt(prompt).map((candidate) => candidate.id),
+    })
+    const { effect } = runUseCase({
+      session: makeSessionWithMessages([
+        message("user", "Can you help me update my billing email?"),
+        message("assistant", "Sure, open account settings and choose Profile."),
+        message("user", frustratedMessage),
+        message("assistant", "I'm sorry, I will correct that now."),
+      ]),
+      ai,
+    })
+
+    await Effect.runPromise(effect)
+
+    const prompt = generated[0]?.prompt ?? ""
+    expect(prompt).toContain("frustrating")
+    expect(hasLoneSurrogate(prompt)).toBe(false)
+  })
+
+  // Same failure mode reaches the taxonomy projection embedding: `middleTruncate`
+  // slices by UTF-16 code unit, which can split a surrogate pair in half. The
+  // head cut here lands cleanly (even offset) but the tail cut lands mid-pair
+  // (odd offset), reproducing the exact truncation-split bug from production.
+  it("does not leave a lone surrogate when projection-text truncation splits a surrogate pair", async () => {
+    const embeds: string[] = []
+    const ai: AIShape = {
+      generate: <T>() =>
+        Effect.succeed({ object: { acceptedCandidateIds: [] } as T, tokens: 0, duration: 0 }) as Effect.Effect<
+          GenerateResult<T>,
+          never
+        >,
+      embed: (input) => {
+        embeds.push(input.text)
+        return Effect.succeed({ embedding: [1, 0] })
+      },
+      rerank: () => Effect.die("rerank not used"),
+    }
+    const { effect } = runUseCase({
+      session: makeSessionWithMessages([message("user", "😀".repeat(20_000)), message("assistant", "ok!")]),
+      ai,
+    })
+
+    await Effect.runPromise(effect)
+
+    const projectionText = embeds.find((text) => text.includes("[...truncated...]"))
+    expect(projectionText).toBeDefined()
+    expect(projectionText?.length).toBeLessThanOrEqual(24_000)
+    expect(hasLoneSurrogate(projectionText ?? "")).toBe(false)
+  })
 })
+
+function hasLoneSurrogate(text: string): boolean {
+  return /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(text)
+}

--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
@@ -22,6 +22,7 @@ import {
   type MessageEmbeddingUpsert,
   SessionRepository,
   sessionConversationMessages,
+  stripLoneSurrogates,
   TRACE_SEARCH_CHARS_PER_TOKEN_ESTIMATE,
   TraceSearchBudget,
 } from "@domain/spans"
@@ -126,12 +127,19 @@ const MOMENT_CLASSIFIER_CONTEXT_RADIUS = 3
 const TAXONOMY_DIRECT_PROJECTION_MAX_LENGTH = CONVERSATION_INTELLIGENCE_LLM_MAX_DOCUMENT_CHARS
 const TRUNCATION_MARKER = "\n[...truncated...]\n"
 
+// JS strings are UTF-16 and may contain unpaired surrogates — either from
+// malformed input or from a code-unit slice that splits a surrogate pair.
+// Bedrock/Anthropic reject them ("unexpected end of hex escape" while
+// deserializing the request body), so every lone surrogate is replaced with
+// U+FFFD before the text leaves this module — mirrors the identical
+// constraint handled by `stripLoneSurrogates` in `@domain/spans`'s trace
+// search document builder.
 const middleTruncate = (value: string, maxLength: number): string => {
-  if (value.length <= maxLength) return value
-  if (maxLength <= TRUNCATION_MARKER.length) return value.slice(0, maxLength)
+  if (value.length <= maxLength) return stripLoneSurrogates(value)
+  if (maxLength <= TRUNCATION_MARKER.length) return stripLoneSurrogates(value.slice(0, maxLength))
   const head = Math.floor((maxLength - TRUNCATION_MARKER.length) / 2)
   const tail = maxLength - TRUNCATION_MARKER.length - head
-  return `${value.slice(0, head)}${TRUNCATION_MARKER}${value.slice(value.length - tail)}`
+  return stripLoneSurrogates(`${value.slice(0, head)}${TRUNCATION_MARKER}${value.slice(value.length - tail)}`)
 }
 
 const escapePromptDelimiters = (value: string): string => value.replaceAll("<", "\\u003c").replaceAll(">", "\\u003e")
@@ -152,7 +160,7 @@ const renderMomentClassifierTranscript = (
 ): string | null => {
   const promptMessages = messages.map((message) => ({ ...message, text: escapePromptDelimiters(message.text) }))
   const fullTranscript = documentFromMessages(promptMessages)
-  if (fullTranscript.length <= maxLength) return fullTranscript
+  if (fullTranscript.length <= maxLength) return stripLoneSurrogates(fullTranscript)
 
   const contextIndexes = new Set<number>()
   for (const candidate of candidates) {


### PR DESCRIPTION
## What does this PR do?

Fixes a production regression where the conversation-intelligence moment classifier fails against Bedrock/Anthropic with `"unexpected end of hex escape"` JSON deserialization errors.

**Datadog issues addressed** (all `env:production`, `service:workflows`):
- [`AI_APICallError` — "unexpected end of hex escape"](https://app.datadoghq.eu/error-tracking/issue/4697cf5a-87aa-11f1-bcf2-da7ad0900005) — 320 occurrences, first seen 2026-07-24
- [`Error` — "Primary model ... failed: ... unexpected end of hex escape ..."](https://app.datadoghq.eu/error-tracking/issue/469bdd84-87aa-11f1-83a2-da7ad0900005) — 160 occurrences
- [`AIError` — "AI generation failed ... unexpected end of hex escape ..."](https://app.datadoghq.eu/error-tracking/issue/469e9e52-87aa-11f1-846e-da7ad0900005) — 80 occurrences
- [`MomentClassifierError` — "Moment classifier provider failed"](https://app.datadoghq.eu/error-tracking/issue/46a24228-87aa-11f1-83a2-da7ad0900005) — 80 occurrences

All four share the same `first_seen_version`/`last_seen_version` and are still firing in production. Combined they're ~640 occurrences over the last 7 days, the largest genuine-code-bug cluster among current production errors.

**Introducing commit:** [`9c0dc2f`](https://github.com/latitude-dev/latitude-llm/commit/9c0dc2f2ce9b56f8b2a0ed9f0f4bcbb6d324edce) ("Validate moment labels with contextual MiniMax classification", 2026-07-22), shipped in `v0.3.69` ([`e80aed6`](https://github.com/latitude-dev/latitude-llm/commit/e80aed65f6cb569900c7bd9024f2f5d3362c0ecb), 2026-07-24) — matches the issues' `first_seen`/`first_seen_version` exactly.

## Root cause

`middleTruncate` in `analyze-session.ts` slices conversation text by UTF-16 code unit count with no surrogate-pair awareness:

```ts
return `${value.slice(0, head)}${TRUNCATION_MARKER}${value.slice(value.length - tail)}`
```

When a cut lands inside an astral character (e.g. an emoji), it leaves a lone UTF-16 surrogate in the output. That text is sent straight into:
1. the moment classifier's `prompt` to Bedrock/Anthropic (`ai.ts` → `generateText`), which the provider's Rust/serde JSON deserializer rejects with `"unexpected end of hex escape"`, and
2. the taxonomy projection text used for topic embeddings.

This is the same constraint the domain's own trace-search-document builder already handles: `truncateMiddle` in `packages/domain/spans/src/use-cases/build-trace-search-document.ts` does the identical code-unit slice and is immediately followed by `stripLoneSurrogates` (because ClickHouse's JSON parser has the same rejection). `analyze-session.ts`'s `middleTruncate` was missing that sanitization step. A second sibling gap: `renderMomentClassifierTranscript`'s no-truncation early-return path also returned raw text unsanitized (a lone surrogate already present in the source conversation, not just one produced by truncation, would reach the model).

## Fix

Apply the existing shared `stripLoneSurrogates` helper (already exported from `@domain/spans`, used by `build-trace-search-document.ts` and the flaggers strategies) to every `middleTruncate` output and to the no-truncation early return, mirroring the established pattern instead of introducing a new one.

## How was this tested?

Added two regression tests to `analyze-session.test.ts`, both verified to fail without the fix and pass with it:
- A short conversation containing a raw lone surrogate character, asserting the classifier prompt (no-truncation path) is sanitized.
- A conversation long enough to trigger `middleTruncate`'s truncation, built so the tail cut lands mid-surrogate-pair (reproducing the exact production failure mode), asserting the taxonomy-projection embedding text is sanitized.

Also ran:
- `pnpm --filter @domain/conversation-intelligence test` — 43/43 passing
- `pnpm --filter @domain/conversation-intelligence typecheck` — clean (via `tsgo`)
- `pnpm exec biome check` on changed files — clean

**Verification in production:** after deploy, occurrences of the four issues above should drop to zero for new sessions containing astral characters (emoji, etc.) near a truncation boundary.

## Remaining risk

Low — the change only adds sanitization (replacing lone surrogates with U+FFFD) to existing truncation output; it does not change truncation behavior, token budgets, or prompt structure for well-formed text. Two other, unrelated production error clusters (a "prompt too long" truncation-limit issue and a "Grammar compilation timed out" issue) were investigated but ruled out of scope for this PR — the token-limit one likely needs a product decision on how to shrink the moment-classifier payload, and the grammar-timeout one looks provider-side.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows Conventional Commits
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_014YW8CVwxCapZiSYYQ12tpC)_