### PR TITLE
feat(spans): apply PII redaction in the ingest pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,13 @@ LAT_INGEST_PORT=3002
 # LAT_DEV_DESTINATIONS_SAFETY_LAG_MS=30000
 # LAT_WORKERS_HEALTH_PORT=9090
 
+# Secret keying the HMAC that pseudonymizes user ids and emails, for projects whose
+# PII redaction policy sets `identities: pseudonymize`. Generate a unique value for
+# production (openssl rand -hex 32). Rotating it changes every pseudonym, so spans
+# ingested before and after cannot be grouped by user. Leaving it unset degrades
+# those identity fields to full redaction rather than blocking ingestion.
+# LAT_REDACTION_PSEUDONYM_SECRET=
+
 # Master encryption key (32-byte hex key for AES-256-GCM)
 # Generate a unique value for production (openssl rand -hex 32)
 LAT_MASTER_ENCRYPTION_KEY=75d697b90c1e46c13bd7f7343ab2b9a9e430cdcda05d47f055e1523d54d5409b

--- a/.env.example
+++ b/.env.example
@@ -133,12 +133,13 @@ LAT_INGEST_PORT=3002
 # LAT_DEV_DESTINATIONS_SAFETY_LAG_MS=30000
 # LAT_WORKERS_HEALTH_PORT=9090
 
-# Secret keying the HMAC that pseudonymizes user ids and emails, for projects whose
-# PII redaction policy sets `identities: pseudonymize`. Generate a unique value for
-# production (openssl rand -hex 32). Rotating it changes every pseudonym, so spans
-# ingested before and after cannot be grouped by user. Leaving it unset degrades
-# those identity fields to full redaction rather than blocking ingestion.
-# LAT_REDACTION_PSEUDONYM_SECRET=
+# Optional. Keys the HMAC that pseudonymizes user ids and emails, and only applies to
+# projects whose PII redaction policy sets `identities: pseudonymize`. Content redaction
+# works without it; unset, those two identity fields are fully redacted instead, and the
+# worker logs an error. Generate a unique value for production (openssl rand -hex 32).
+# Rotating it changes every pseudonym, so spans ingested before and after cannot be
+# grouped by user.
+LAT_REDACTION_PSEUDONYM_SECRET=9189fb5f23a3dc47d1e829ffb5ce278dc8a26358a0cca83c9cd63ce25bfd9b83
 
 # Master encryption key (32-byte hex key for AES-256-GCM)
 # Generate a unique value for production (openssl rand -hex 32)

--- a/apps/ingest/src/routes/traces.ts
+++ b/apps/ingest/src/routes/traces.ts
@@ -2,11 +2,12 @@ import { NoCreditsRemainingError } from "@domain/billing"
 import { SandboxArchivedError, SandboxQuotaExceededError } from "@domain/sandboxes"
 import { OrganizationId } from "@domain/shared"
 import { ingestSpansWithBillingUseCase } from "@domain/spans"
-import { SandboxSignalsLive } from "@platform/cache-redis"
+import { RedisCacheStoreLive, SandboxSignalsLive } from "@platform/cache-redis"
 import {
   BillingOverrideRepositoryLive,
   BillingUsagePeriodRepositoryLive,
   ProjectRepositoryLive,
+  resolveOrganizationRedactionCached,
   SandboxRepositoryLive,
   SettingsReaderLive,
   StripeSubscriptionLookupLive,
@@ -83,17 +84,30 @@ export const registerTracesRoute = ({ app, tracePayloadProtection }: TracesRoute
     const disk = getStorageDisk()
     const publisher = await getQueuePublisher()
     const postgresClient = getPostgresClient()
-    const ingestionEffect = ingestSpansWithBillingUseCase({
-      organizationId: organization,
-      apiKeyId,
-      isSandbox,
-      payload: body,
-      contentType,
-      ...(defaultProjectSlug ? { defaultProjectSlug } : {}),
+    // The org half of the redaction cascade is read here, not in the domain: the
+    // cached resolver is a platform concern. The project half is free downstream,
+    // where project settings are already loaded for sampling.
+    const ingestionEffect = Effect.gen(function* () {
+      const organizationRedaction = yield* resolveOrganizationRedactionCached(organization)
+
+      return yield* ingestSpansWithBillingUseCase({
+        organizationId: organization,
+        apiKeyId,
+        isSandbox,
+        payload: body,
+        contentType,
+        organizationRedaction,
+        ...(defaultProjectSlug ? { defaultProjectSlug } : {}),
+      })
     }).pipe(
       withPostgres(traceIngestionBillingLayers, postgresClient, organization),
       Effect.provide(
-        Layer.mergeAll(StorageDiskLive(disk), QueuePublisherLive(publisher), SandboxSignalsLive(getRedisClient())),
+        Layer.mergeAll(
+          StorageDiskLive(disk),
+          QueuePublisherLive(publisher),
+          SandboxSignalsLive(getRedisClient()),
+          RedisCacheStoreLive(getRedisClient()),
+        ),
       ),
       withTracing,
     )

--- a/apps/workers/src/workers/span-ingestion.test.ts
+++ b/apps/workers/src/workers/span-ingestion.test.ts
@@ -648,10 +648,14 @@ describe("createSpanIngestionWorker", () => {
     const disk = new FakeStorageDisk()
     const pub = createFakeEventsPublisher()
     const queue = createFakeQueuePublisher()
-    const fileKey = `span-ingestion/${generateId()}-duplicate.json`
+    // A key per request, as production does: `putInDisk` mints a fresh id per OTLP
+    // request, so two ingests of the same trace never share a buffered payload.
+    const firstFileKey = `span-ingestion/${generateId()}-duplicate.json`
+    const secondFileKey = `span-ingestion/${generateId()}-duplicate.json`
     const organizationId = generateId()
     const projectId = generateId()
-    disk.putBytes(fileKey, Buffer.from(JSON.stringify(validRequest), "utf-8"))
+    disk.putBytes(firstFileKey, Buffer.from(JSON.stringify(validRequest), "utf-8"))
+    disk.putBytes(secondFileKey, Buffer.from(JSON.stringify(validRequest), "utf-8"))
 
     createSpanIngestionWorker({
       consumer,
@@ -669,7 +673,7 @@ describe("createSpanIngestionWorker", () => {
 
     let processedEvents = 0
 
-    await dispatchValidIngest(consumer, fileKey, organizationId, projectId)
+    await dispatchValidIngest(consumer, firstFileKey, organizationId, projectId)
     await dispatchPublishedDomainEvents(consumer, pub.published, processedEvents)
     processedEvents = pub.published.length
     for (const message of queue.published.filter(
@@ -678,7 +682,7 @@ describe("createSpanIngestionWorker", () => {
       await consumer.dispatchTask("billing", "recordTraceUsageBatch", message.payload)
     }
 
-    await dispatchValidIngest(consumer, fileKey, organizationId, projectId)
+    await dispatchValidIngest(consumer, secondFileKey, organizationId, projectId)
     await dispatchPublishedDomainEvents(consumer, pub.published, processedEvents)
     processedEvents = pub.published.length
     for (const message of queue.published

--- a/apps/workers/src/workers/span-ingestion.ts
+++ b/apps/workers/src/workers/span-ingestion.ts
@@ -14,6 +14,7 @@ import {
   StripeSubscriptionLookupLive,
   withPostgres,
 } from "@platform/db-postgres"
+import { parseEnvOptional } from "@platform/env"
 import { StorageDiskLive } from "@platform/storage-object"
 import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
@@ -49,6 +50,10 @@ export const createSpanIngestionWorker = ({
 
   const processSpans = processIngestedSpansUseCase({ eventsPublisher })
 
+  // Unset degrades pseudonymized identities to full redaction rather than blocking
+  // a self-hoster's ingestion on a missing variable.
+  const pseudonymSecret = Effect.runSync(parseEnvOptional("LAT_REDACTION_PSEUDONYM_SECRET", "string"))
+
   consumer.subscribe(
     "span-ingestion",
     {
@@ -82,6 +87,10 @@ export const createSpanIngestionWorker = ({
             defaultProjectId,
             projectIdBySlug,
             isSandbox,
+            // Absent means no project opted in, which is why this needs no legacy
+            // fallback: jobs enqueued before the field existed are correct as-is.
+            ...(wire.redaction ? { redaction: wire.redaction } : {}),
+            ...(pseudonymSecret ? { pseudonymSecret } : {}),
             ...(orgPlan ? { retentionDays: orgPlan.plan.retentionDays } : {}),
             // Emit the full event (plan snapshot + the `isSandbox` bit). Whether to
             // bill is the consumer's call — `domain-events` skips the billing fan-out

--- a/packages/domain/queue/package.json
+++ b/packages/domain/queue/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@domain/events": "workspace:*",
+    "@domain/shared": "workspace:*",
     "effect": "catalog:"
   },
   "devDependencies": {

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -1,4 +1,5 @@
 import type { DomainEvent } from "@domain/events"
+import type { SerializedRedactionPolicy } from "@domain/shared"
 
 /**
  * Phantom type helper: returns an empty object at runtime but carries type T
@@ -87,6 +88,14 @@ const _registry = {
       readonly defaultProjectId: string | null
       readonly projectIdBySlug: Readonly<Record<string, string>>
       readonly isSandbox?: boolean
+      /**
+       * Redaction policy per project id, resolved at the ingest boundary where each
+       * project's settings are already loaded for sampling. Projects resolving to
+       * `off` are absent and the field is omitted when no project opted in, so a
+       * missing field means "redact nothing" — which is what makes this field safe
+       * to deploy in either order and is why the worker needs no legacy fallback.
+       */
+      readonly redaction?: Readonly<Record<string, SerializedRedactionPolicy>>
     }
   }>(),
 

--- a/packages/domain/shared/src/settings.test.ts
+++ b/packages/domain/shared/src/settings.test.ts
@@ -161,11 +161,11 @@ describe("resolveRedactionPolicy", () => {
 
   it("inherits the org policy when the project configures nothing", () => {
     const policy = resolveRedactionPolicy({
-      organization: { redaction: { mode: "dryRun", entities: ["secret"] } },
+      organization: { redaction: { mode: "enforce", entities: ["secret"] } },
       project: {},
     })
 
-    expect(policy.mode).toBe("dryRun")
+    expect(policy.mode).toBe("enforce")
     expect([...policy.entities]).toEqual(["secret"])
     expect(policy.source).toBe("organization")
   })
@@ -173,13 +173,13 @@ describe("resolveRedactionPolicy", () => {
   it("resolves field by field so a project can override one field and inherit the rest", () => {
     const policy = resolveRedactionPolicy({
       organization: {
-        redaction: { mode: "dryRun", entities: ["secret"], identities: "pseudonymize", scopes: { metadata: true } },
+        redaction: { mode: "enforce", entities: ["secret"], identities: "pseudonymize", scopes: { metadata: true } },
       },
-      project: { redaction: { mode: "enforce" } },
+      project: { redaction: { entities: ["email"] } },
     })
 
+    expect([...policy.entities]).toEqual(["email"])
     expect(policy.mode).toBe("enforce")
-    expect([...policy.entities]).toEqual(["secret"])
     expect(policy.identities).toBe("pseudonymize")
     expect(policy.redactMetadata).toBe(true)
     expect(policy.source).toBe("project")
@@ -279,11 +279,11 @@ describe("redaction settings schemas", () => {
     const parsed = organizationSettingsSchema.parse({
       billing: { spendingLimitCents: 5000 },
       wantsShowcase: true,
-      redaction: { mode: "dryRun" },
+      redaction: { mode: "enforce" },
     })
 
     expect(parsed.billing?.spendingLimitCents).toBe(5000)
     expect(parsed.wantsShowcase).toBe(true)
-    expect(parsed.redaction?.mode).toBe("dryRun")
+    expect(parsed.redaction?.mode).toBe("enforce")
   })
 })

--- a/packages/domain/shared/src/settings.ts
+++ b/packages/domain/shared/src/settings.ts
@@ -5,7 +5,7 @@ import type { RepositoryError } from "./errors.ts"
 import type { ProjectId } from "./id.ts"
 import type { SqlClient } from "./sql-client.ts"
 
-export const REDACTION_MODES = ["off", "dryRun", "enforce"] as const
+export const REDACTION_MODES = ["off", "enforce"] as const
 export const redactionModeSchema = z.enum(REDACTION_MODES)
 export type RedactionMode = z.infer<typeof redactionModeSchema>
 
@@ -166,26 +166,27 @@ export function resolveSettingsCascade(input: {
   }
 }
 
-/** Everything the redaction engine needs. Deliberately excludes `source`, which only the UI reads. */
+/**
+ * Everything the redaction engine needs.
+ *
+ * Carries no mode: a policy exists only for a project that redacts, so its presence
+ * is the decision. `off` projects have no policy at all, which is why the engine
+ * never has to ask.
+ */
 export interface RedactionPolicy {
-  readonly mode: RedactionMode
   readonly entities: ReadonlySet<RedactionEntity>
   readonly redactMetadata: boolean
   readonly identities: RedactionIdentityHandling
 }
 
-/** `source` is display only: which layer the policy the user is looking at came from. */
+/** The settings view: `mode` is the user-facing toggle and `source` says which layer set it. */
 export interface ResolvedRedactionPolicy extends RedactionPolicy {
+  readonly mode: RedactionMode
   readonly source: "organization" | "project" | "default"
 }
 
-/**
- * Wire form for the queue payload. `entities` becomes an array because a `Set`
- * does not survive JSON, and `off` is unrepresentable because such projects are
- * omitted from the map entirely.
- */
+/** Wire form for the queue payload: `entities` becomes an array because a `Set` does not survive JSON. */
 export const serializedRedactionPolicySchema = z.object({
-  mode: z.enum(["dryRun", "enforce"]),
   entities: z.array(redactionEntitySchema),
   redactMetadata: z.boolean(),
   identities: redactionIdentityHandlingSchema,
@@ -193,11 +194,10 @@ export const serializedRedactionPolicySchema = z.object({
 export type SerializedRedactionPolicy = z.infer<typeof serializedRedactionPolicySchema>
 
 /** `null` for an `off` policy, so callers omit it from the map rather than encoding a no-op. */
-export const serializeRedactionPolicy = (policy: RedactionPolicy): SerializedRedactionPolicy | null =>
+export const serializeRedactionPolicy = (policy: ResolvedRedactionPolicy): SerializedRedactionPolicy | null =>
   policy.mode === "off"
     ? null
     : {
-        mode: policy.mode,
         entities: [...policy.entities],
         redactMetadata: policy.redactMetadata,
         identities: policy.identities,

--- a/packages/domain/shared/src/settings.ts
+++ b/packages/domain/shared/src/settings.ts
@@ -166,13 +166,52 @@ export function resolveSettingsCascade(input: {
   }
 }
 
-/** `source` is display only: which layer the policy the user is looking at came from. */
-export interface ResolvedRedactionPolicy {
+/** Everything the redaction engine needs. Deliberately excludes `source`, which only the UI reads. */
+export interface RedactionPolicy {
   readonly mode: RedactionMode
   readonly entities: ReadonlySet<RedactionEntity>
   readonly redactMetadata: boolean
   readonly identities: RedactionIdentityHandling
+}
+
+/** `source` is display only: which layer the policy the user is looking at came from. */
+export interface ResolvedRedactionPolicy extends RedactionPolicy {
   readonly source: "organization" | "project" | "default"
+}
+
+/**
+ * Wire form for the queue payload. `entities` becomes an array because a `Set`
+ * does not survive JSON, and `off` is unrepresentable because such projects are
+ * omitted from the map entirely.
+ */
+export const serializedRedactionPolicySchema = z.object({
+  mode: z.enum(["dryRun", "enforce"]),
+  entities: z.array(redactionEntitySchema),
+  redactMetadata: z.boolean(),
+  identities: redactionIdentityHandlingSchema,
+})
+export type SerializedRedactionPolicy = z.infer<typeof serializedRedactionPolicySchema>
+
+/** `null` for an `off` policy, so callers omit it from the map rather than encoding a no-op. */
+export const serializeRedactionPolicy = (policy: RedactionPolicy): SerializedRedactionPolicy | null =>
+  policy.mode === "off"
+    ? null
+    : {
+        mode: policy.mode,
+        entities: [...policy.entities],
+        redactMetadata: policy.redactMetadata,
+        identities: policy.identities,
+      }
+
+/**
+ * `null` when the wire value is missing or malformed. Callers must treat that as a
+ * failure rather than as "no redaction": a corrupt policy on a project that opted
+ * in must never resolve to a plaintext write.
+ */
+export const deserializeRedactionPolicy = (wire: unknown): RedactionPolicy | null => {
+  const parsed = serializedRedactionPolicySchema.safeParse(wire)
+
+  return parsed.success ? { ...parsed.data, entities: new Set(parsed.data.entities) } : null
 }
 
 const REDACTION_SYSTEM_DEFAULTS: {

--- a/packages/domain/spans/src/redaction/detectors.test.ts
+++ b/packages/domain/spans/src/redaction/detectors.test.ts
@@ -1,6 +1,7 @@
 import { REDACTION_ENTITIES, type RedactionEntity } from "@domain/shared"
 import { describe, expect, it } from "vitest"
 import { findRedactionMatches, type RedactionMatch } from "./detectors.ts"
+import { redactText } from "./redact-text.ts"
 
 const ALL_ENTITIES: ReadonlySet<RedactionEntity> = new Set(REDACTION_ENTITIES)
 
@@ -109,6 +110,10 @@ describe("credit_card detector", () => {
    * shapes are what the patterns encode: an earlier version covered only 4-4-4-N and
    * 4-6-5, so Diners' 4-6-4 silently stopped being detected while the compact form
    * still was. A shape absent from this list is a shape nothing is checking.
+   *
+   * The numbers are the card networks' published test values, which exist to be used
+   * as fixtures and belong to no cardholder. A detector for card numbers cannot be
+   * tested without card-shaped input.
    */
   it.each([
     ["4-4-4-4 Visa", "4111 1111 1111 1111"],
@@ -121,6 +126,21 @@ describe("credit_card detector", () => {
     expect(found(`card ${value} charged`, "credit_card")).toEqual([value])
     const dashed = value.replaceAll(" ", "-")
     expect(found(`card ${dashed} charged`, "credit_card")).toEqual([dashed])
+  })
+
+  /**
+   * The 4-4-4-4-3 grouping is excluded from the table above because it legitimately
+   * produces two matches: its first four groups are themselves a Luhn-valid 16-digit
+   * Visa, so the 4-4-4-N pattern matches at the same offset. Leftmost-longest has to
+   * pick the full number. Picking the shorter one would leave the last three digits
+   * sitting next to a placeholder.
+   */
+  it.each([
+    "4111 1111 1111 1111 110",
+    "4111-1111-1111-1111-110",
+  ])("redacts the whole 19-digit card in %s rather than the 16-digit card inside it", (value) => {
+    expect(found(`card ${value} charged`, "credit_card")[0]).toBe(value)
+    expect(redactText(`card ${value} charged`, only("credit_card")).text).toBe("card [REDACTED_CREDIT_CARD] charged")
   })
 
   it("does not accept a card whose groups use mixed separators", () => {

--- a/packages/domain/spans/src/redaction/detectors.test.ts
+++ b/packages/domain/spans/src/redaction/detectors.test.ts
@@ -104,6 +104,29 @@ describe("credit_card detector", () => {
     expect(found(`card ${value} charged`, "credit_card")).toEqual([value])
   })
 
+  /**
+   * Every grouping a real issuer prints, in both separators. Enumerated because the
+   * shapes are what the patterns encode: an earlier version covered only 4-4-4-N and
+   * 4-6-5, so Diners' 4-6-4 silently stopped being detected while the compact form
+   * still was. A shape absent from this list is a shape nothing is checking.
+   */
+  it.each([
+    ["4-4-4-4 Visa", "4111 1111 1111 1111"],
+    ["4-4-4-4 Mastercard", "5500 0055 5555 5559"],
+    ["4-4-4-4 Discover", "6011 1111 1111 1117"],
+    ["4-4-4-1 Visa 13", "4222 2222 2222 2"],
+    ["4-6-5 Amex", "3782 822463 10005"],
+    ["4-6-4 Diners", "3056 930902 5904"],
+  ])("detects the %s grouping", (_shape, value) => {
+    expect(found(`card ${value} charged`, "credit_card")).toEqual([value])
+    const dashed = value.replaceAll(" ", "-")
+    expect(found(`card ${dashed} charged`, "credit_card")).toEqual([dashed])
+  })
+
+  it("does not accept a card whose groups use mixed separators", () => {
+    expect(detects("card 4111 1111-1111 1111 charged", "credit_card")).toBe(false)
+  })
+
   it("rejects a Luhn-invalid card number", () => {
     expect(detects("card 4111111111111112 charged", "credit_card")).toBe(false)
   })

--- a/packages/domain/spans/src/redaction/detectors.test.ts
+++ b/packages/domain/spans/src/redaction/detectors.test.ts
@@ -108,6 +108,40 @@ describe("credit_card detector", () => {
     expect(detects("card 4111111111111112 charged", "credit_card")).toBe(false)
   })
 
+  /**
+   * Regression: a pattern allowing an optional separator between any two digits
+   * bridges a card into the number that follows it, matches the combined run at a
+   * length some issuer does permit, fails Luhn, and consumes the real card with it.
+   *
+   * The trailing number is what makes these reproduce. `16 + 3` digits is a valid
+   * Visa length, so the bridged match looks legitimate to the length gate; a longer
+   * neighbour would simply overflow and backtrack to the card.
+   */
+  it.each([
+    "4111111111111111 123",
+    "4111111111111111 123-45-6789",
+    "+14155552671 4111111111111111 123-45-6789",
+    "card 4111111111111111 exp 12-26",
+  ])("still finds the card in %s", (text) => {
+    expect(found(text, "credit_card")).toContain("4111111111111111")
+  })
+
+  it.each([
+    "+14155552671 4111111111111111",
+    "order 987654321 4111111111111111",
+    "4111111111111111 987654321",
+  ])("finds the card beside an unrelated number in %s", (text) => {
+    expect(found(text, "credit_card")).toContain("4111111111111111")
+  })
+
+  it("finds both cards when two are adjacent", () => {
+    expect(found("4111111111111111 5500005555555559", "credit_card")).toEqual(["4111111111111111", "5500005555555559"])
+  })
+
+  it("does not bridge a separator that is not part of the grouping", () => {
+    expect(found("4111 1111 1111 1111 2222", "credit_card")).toEqual(["4111 1111 1111 1111"])
+  })
+
   it("rejects a Luhn-valid digit run with no issuer prefix", () => {
     expect(detects("id 9999999999999995", "credit_card")).toBe(false)
   })

--- a/packages/domain/spans/src/redaction/detectors.ts
+++ b/packages/domain/spans/src/redaction/detectors.ts
@@ -39,7 +39,16 @@ const E164_PHONE_PATTERN = /(?<![\w+])\+[1-9]\d{7,14}(?!\d)/g
 // Separated NANP forms only: a bare ten-digit run is indistinguishable from the numeric ids in tool output.
 const NANP_PHONE_PATTERN = /(?<![\w.-])(?:\(\d{3}\) ?|\d{3}[-. ])\d{3}[-. ]\d{4}(?![\d.-])/g
 
-const CREDIT_CARD_PATTERN = /(?<![\d.])\d(?:[ -]?\d){11,18}(?![\d.])/g
+/**
+ * Compact and grouped forms are separate patterns, and the grouped ones backreference
+ * their separator, for the same reason the IBAN detector does: a single pattern
+ * allowing an optional space between any two digits bridges two adjacent numbers,
+ * consumes both greedily, fails the checksum, and never reconsiders the real card
+ * inside. `+14155552671 4111111111111111` lost the card that way.
+ */
+const CREDIT_CARD_COMPACT_PATTERN = /(?<![\d.])\d{13,19}(?![\d.])/g
+const CREDIT_CARD_GROUPED_PATTERN = /(?<![\d.])\d{4}([ -])\d{4}\1\d{4}\1\d{1,7}(?![\d.])/g
+const CREDIT_CARD_AMEX_GROUPED_PATTERN = /(?<![\d.])\d{4}([ -])\d{6}\1\d{5}(?![\d.])/g
 
 const digitsOf = (value: string): string => value.replace(/[^\d]/g, "")
 
@@ -147,7 +156,9 @@ const DETECTORS: readonly Detector[] = [
   { entity: "email", pattern: EMAIL_PATTERN, validate: isEmail },
   { entity: "phone", pattern: E164_PHONE_PATTERN },
   { entity: "phone", pattern: NANP_PHONE_PATTERN },
-  { entity: "credit_card", pattern: CREDIT_CARD_PATTERN, validate: isCreditCard },
+  { entity: "credit_card", pattern: CREDIT_CARD_COMPACT_PATTERN, validate: isCreditCard },
+  { entity: "credit_card", pattern: CREDIT_CARD_GROUPED_PATTERN, validate: isCreditCard },
+  { entity: "credit_card", pattern: CREDIT_CARD_AMEX_GROUPED_PATTERN, validate: isCreditCard },
   { entity: "iban", pattern: IBAN_COMPACT_PATTERN, validate: isIban },
   { entity: "iban", pattern: IBAN_GROUPED_PATTERN, validate: isIban },
   { entity: "us_ssn", pattern: US_SSN_PATTERN },

--- a/packages/domain/spans/src/redaction/detectors.ts
+++ b/packages/domain/spans/src/redaction/detectors.ts
@@ -43,8 +43,9 @@ const NANP_PHONE_PATTERN = /(?<![\w.-])(?:\(\d{3}\) ?|\d{3}[-. ])\d{3}[-. ]\d{4}
  * Compact and grouped forms are separate patterns, and each grouped one backreferences
  * its separator, for the same reason the IBAN detector does: a single pattern allowing
  * an optional separator between any two digits bridges two adjacent numbers, consumes
- * both greedily, fails the checksum, and never reconsiders the real card inside.
- * `4111111111111111 123` lost the card that way.
+ * both greedily, fails the checksum, and never reconsiders the real card inside. A
+ * sixteen-digit card followed by a three-digit number was lost that way: the bridged
+ * nineteen-digit run is a length Visa issues, so it matched and then failed Luhn.
  *
  * The grouped shapes are enumerated rather than expressed as "groups of 4 to 6" because
  * an open-ended repetition reintroduces the same bridging: it would swallow a trailing

--- a/packages/domain/spans/src/redaction/detectors.ts
+++ b/packages/domain/spans/src/redaction/detectors.ts
@@ -40,15 +40,24 @@ const E164_PHONE_PATTERN = /(?<![\w+])\+[1-9]\d{7,14}(?!\d)/g
 const NANP_PHONE_PATTERN = /(?<![\w.-])(?:\(\d{3}\) ?|\d{3}[-. ])\d{3}[-. ]\d{4}(?![\d.-])/g
 
 /**
- * Compact and grouped forms are separate patterns, and the grouped ones backreference
- * their separator, for the same reason the IBAN detector does: a single pattern
- * allowing an optional space between any two digits bridges two adjacent numbers,
- * consumes both greedily, fails the checksum, and never reconsiders the real card
- * inside. `+14155552671 4111111111111111` lost the card that way.
+ * Compact and grouped forms are separate patterns, and each grouped one backreferences
+ * its separator, for the same reason the IBAN detector does: a single pattern allowing
+ * an optional separator between any two digits bridges two adjacent numbers, consumes
+ * both greedily, fails the checksum, and never reconsiders the real card inside.
+ * `4111111111111111 123` lost the card that way.
+ *
+ * The grouped shapes are enumerated rather than expressed as "groups of 4 to 6" because
+ * an open-ended repetition reintroduces the same bridging: it would swallow a trailing
+ * group, overrun 19 digits, and fail the length gate with the card inside it.
  */
 const CREDIT_CARD_COMPACT_PATTERN = /(?<![\d.])\d{13,19}(?![\d.])/g
-const CREDIT_CARD_GROUPED_PATTERN = /(?<![\d.])\d{4}([ -])\d{4}\1\d{4}\1\d{1,7}(?![\d.])/g
+/** 4-4-4-N covers 13 to 16 digits: Visa, Mastercard, Discover, JCB. */
+const CREDIT_CARD_GROUPED_PATTERN = /(?<![\d.])\d{4}([ -])\d{4}\1\d{4}\1\d{1,4}(?![\d.])/g
+/** 4-4-4-4-3 is the 19-digit Visa and Discover form. */
+const CREDIT_CARD_GROUPED_19_PATTERN = /(?<![\d.])\d{4}([ -])\d{4}\1\d{4}\1\d{4}\1\d{3}(?![\d.])/g
+/** 4-6-5 is Amex, 4-6-4 is Diners Club. Disjoint by trailing length plus the lookahead. */
 const CREDIT_CARD_AMEX_GROUPED_PATTERN = /(?<![\d.])\d{4}([ -])\d{6}\1\d{5}(?![\d.])/g
+const CREDIT_CARD_DINERS_GROUPED_PATTERN = /(?<![\d.])\d{4}([ -])\d{6}\1\d{4}(?![\d.])/g
 
 const digitsOf = (value: string): string => value.replace(/[^\d]/g, "")
 
@@ -158,7 +167,9 @@ const DETECTORS: readonly Detector[] = [
   { entity: "phone", pattern: NANP_PHONE_PATTERN },
   { entity: "credit_card", pattern: CREDIT_CARD_COMPACT_PATTERN, validate: isCreditCard },
   { entity: "credit_card", pattern: CREDIT_CARD_GROUPED_PATTERN, validate: isCreditCard },
+  { entity: "credit_card", pattern: CREDIT_CARD_GROUPED_19_PATTERN, validate: isCreditCard },
   { entity: "credit_card", pattern: CREDIT_CARD_AMEX_GROUPED_PATTERN, validate: isCreditCard },
+  { entity: "credit_card", pattern: CREDIT_CARD_DINERS_GROUPED_PATTERN, validate: isCreditCard },
   { entity: "iban", pattern: IBAN_COMPACT_PATTERN, validate: isIban },
   { entity: "iban", pattern: IBAN_GROUPED_PATTERN, validate: isIban },
   { entity: "us_ssn", pattern: US_SSN_PATTERN },

--- a/packages/domain/spans/src/redaction/redact-json.test.ts
+++ b/packages/domain/spans/src/redaction/redact-json.test.ts
@@ -1,35 +1,32 @@
 import { DEFAULT_REDACTION_ENTITIES, type RedactionEntity } from "@domain/shared"
 import { describe, expect, it } from "vitest"
 import { OVERSIZED_FIELD_PLACEHOLDER, REDACTION_MAX_DEPTH } from "./labels.ts"
-import { type JsonRedactionOptions, redactJsonString, redactJsonValue, redactStringMap } from "./redact-json.ts"
+import { redactJsonString, redactJsonValue, redactStringMap } from "./redact-json.ts"
 
 const ENTITIES: ReadonlySet<RedactionEntity> = new Set(DEFAULT_REDACTION_ENTITIES)
 
-const ENFORCE: JsonRedactionOptions = { entities: ENTITIES, mutate: true }
-const DRY_RUN: JsonRedactionOptions = { entities: ENTITIES, mutate: false }
-
 describe("redactJsonValue", () => {
   it("redacts a string leaf", () => {
-    const result = redactJsonValue({ content: "mail john@example.com" }, ENFORCE)
+    const result = redactJsonValue({ content: "mail john@example.com" }, ENTITIES)
 
     expect(result.value).toEqual({ content: "mail [REDACTED_EMAIL]" })
     expect(result.counts).toEqual({ email: 1 })
   })
 
   it("redacts nested leaves at any depth", () => {
-    const result = redactJsonValue({ a: { b: { c: ["john@example.com"] } } }, ENFORCE)
+    const result = redactJsonValue({ a: { b: { c: ["john@example.com"] } } }, ENTITIES)
 
     expect(result.value).toEqual({ a: { b: { c: ["[REDACTED_EMAIL]"] } } })
   })
 
   it("preserves object keys even when a key looks like PII", () => {
-    const result = redactJsonValue({ "john@example.com": "clean" }, ENFORCE)
+    const result = redactJsonValue({ "john@example.com": "clean" }, ENTITIES)
 
     expect(Object.keys(result.value)).toEqual(["john@example.com"])
   })
 
   it("preserves array length and order", () => {
-    const result = redactJsonValue(["a@b.co", "clean", "c@d.co", "also clean"], ENFORCE)
+    const result = redactJsonValue(["a@b.co", "clean", "c@d.co", "also clean"], ENTITIES)
 
     expect(result.value).toEqual(["[REDACTED_EMAIL]", "clean", "[REDACTED_EMAIL]", "also clean"])
   })
@@ -37,25 +34,25 @@ describe("redactJsonValue", () => {
   it("leaves non-string leaves untouched", () => {
     const input = { n: 42, f: 1.5, b: true, z: null, arr: [1, 2, 3] }
 
-    expect(redactJsonValue(input, ENFORCE).value).toEqual(input)
+    expect(redactJsonValue(input, ENTITIES).value).toEqual(input)
   })
 
   it("returns the identical reference when nothing changed, avoiding needless copies", () => {
     const input = { a: { b: "clean" } }
 
-    expect(redactJsonValue(input, ENFORCE).value).toBe(input)
+    expect(redactJsonValue(input, ENTITIES).value).toBe(input)
   })
 
   it("returns a new object when something changed, leaving the input unmutated", () => {
     const input = { a: "john@example.com" }
-    const result = redactJsonValue(input, ENFORCE)
+    const result = redactJsonValue(input, ENTITIES)
 
     expect(result.value).not.toBe(input)
     expect(input.a).toBe("john@example.com")
   })
 
   it("redacts values under structural-looking keys, which customer JSON uses for content", () => {
-    const result = redactJsonValue({ id: "john@example.com", tool_call_id: "a@b.co" }, ENFORCE)
+    const result = redactJsonValue({ id: "john@example.com", tool_call_id: "a@b.co" }, ENTITIES)
 
     expect(result.value).toEqual({ id: "[REDACTED_EMAIL]", tool_call_id: "[REDACTED_EMAIL]" })
     expect(result.counts).toEqual({ email: 2 })
@@ -72,7 +69,7 @@ describe("redactJsonValue", () => {
       { type: "tool_call", id, name: "get_weather", arguments: { to: "john@example.com" } },
       { type: "tool_call_response", id, response: "ok" },
     ]
-    const result = redactJsonValue(parts, ENFORCE)
+    const result = redactJsonValue(parts, ENTITIES)
 
     expect(result.value).toEqual([
       { type: "tool_call", id, name: "get_weather", arguments: { to: "[REDACTED_EMAIL]" } },
@@ -83,13 +80,13 @@ describe("redactJsonValue", () => {
   it("skips blob parts because their content is base64 binary", () => {
     const part = { type: "blob", mimeType: "image/png", content: "aGVsbG8gam9obkBleGFtcGxlLmNvbQ==" }
 
-    expect(redactJsonValue(part, ENFORCE).value).toEqual(part)
+    expect(redactJsonValue(part, ENTITIES).value).toEqual(part)
   })
 
   it("skips file parts", () => {
     const part = { type: "file", fileId: "f-1", content: "john@example.com" }
 
-    expect(redactJsonValue(part, ENFORCE).value).toEqual(part)
+    expect(redactJsonValue(part, ENTITIES).value).toEqual(part)
   })
 
   it("still redacts sibling parts alongside a skipped blob", () => {
@@ -97,7 +94,7 @@ describe("redactJsonValue", () => {
       { type: "blob", content: "john@example.com" },
       { type: "text", content: "john@example.com" },
     ]
-    const result = redactJsonValue(parts, ENFORCE)
+    const result = redactJsonValue(parts, ENTITIES)
 
     expect(result.value).toEqual([
       { type: "blob", content: "john@example.com" },
@@ -111,7 +108,7 @@ describe("redactJsonValue", () => {
       { type: "tool_call", id: "call_1", name: "send_email", arguments: { to: "john@example.com" } },
       { type: "tool_call_response", id: "call_1", response: { status: "sent to john@example.com" } },
     ]
-    const result = redactJsonValue(parts, ENFORCE)
+    const result = redactJsonValue(parts, ENTITIES)
 
     expect(result.value).toEqual([
       { type: "tool_call", id: "call_1", name: "send_email", arguments: { to: "[REDACTED_EMAIL]" } },
@@ -122,7 +119,7 @@ describe("redactJsonValue", () => {
 
   it("keeps the tool name intact while redacting its arguments", () => {
     const part = { type: "tool_call", name: "read_file", arguments: { path: "/tmp/a@b.co" } }
-    const result = redactJsonValue(part, ENFORCE)
+    const result = redactJsonValue(part, ENTITIES)
 
     expect(result.value).toEqual({ type: "tool_call", name: "read_file", arguments: { path: "/tmp/[REDACTED_EMAIL]" } })
   })
@@ -130,7 +127,7 @@ describe("redactJsonValue", () => {
   it("redacts a participant name, which is customer text rather than structure", () => {
     const message = { role: "user", name: "john@example.com", parts: [] }
 
-    expect(redactJsonValue(message, ENFORCE).value).toEqual({
+    expect(redactJsonValue(message, ENTITIES).value).toEqual({
       role: "user",
       name: "[REDACTED_EMAIL]",
       parts: [],
@@ -140,7 +137,7 @@ describe("redactJsonValue", () => {
   it("walks unknown part types through the generic path", () => {
     const part = { type: "some_future_type", payload: { note: "john@example.com" } }
 
-    expect(redactJsonValue(part, ENFORCE).value).toEqual({
+    expect(redactJsonValue(part, ENTITIES).value).toEqual({
       type: "some_future_type",
       payload: { note: "[REDACTED_EMAIL]" },
     })
@@ -149,7 +146,7 @@ describe("redactJsonValue", () => {
   it("walks passthrough provider metadata", () => {
     const part = { type: "text", content: "clean", _provider_metadata: { vendorNote: "john@example.com" } }
 
-    expect(redactJsonValue(part, ENFORCE).value).toEqual({
+    expect(redactJsonValue(part, ENTITIES).value).toEqual({
       type: "text",
       content: "clean",
       _provider_metadata: { vendorNote: "[REDACTED_EMAIL]" },
@@ -157,31 +154,17 @@ describe("redactJsonValue", () => {
   })
 
   it("aggregates counts across the whole structure", () => {
-    const result = redactJsonValue({ a: "a@b.co", b: ["c@d.co", "+14155552671"] }, ENFORCE)
+    const result = redactJsonValue({ a: "a@b.co", b: ["c@d.co", "+14155552671"] }, ENTITIES)
 
     expect(result.counts).toEqual({ email: 2, phone: 1 })
   })
 })
 
-describe("redactJsonValue in dry run", () => {
-  it("counts without mutating", () => {
-    const input = { content: "mail john@example.com" }
-    const result = redactJsonValue(input, DRY_RUN)
-
-    expect(result.value).toEqual(input)
-    expect(result.counts).toEqual({ email: 1 })
-  })
-
-  it("reports the same counts that enforce would produce", () => {
-    const input = { a: "a@b.co", b: { c: ["+14155552671", "4111111111111111"] } }
-
-    expect(redactJsonValue(input, DRY_RUN).counts).toEqual(redactJsonValue(input, ENFORCE).counts)
-  })
-
-  it("does not count values it would not have redacted", () => {
+describe("redactJsonValue skipped parts", () => {
+  it("counts nothing for parts it never scanned", () => {
     const input = { blob: { type: "blob", content: "a@b.co" }, file: { type: "file", content: "a@b.co" } }
 
-    expect(redactJsonValue(input, DRY_RUN).counts).toEqual({})
+    expect(redactJsonValue(input, ENTITIES).counts).toEqual({})
   })
 })
 
@@ -195,7 +178,7 @@ describe("redactJsonValue depth cap", () => {
 
   it("survives serialized nesting deep enough to overflow a recursive walk", () => {
     const deep = `${"[".repeat(2_000)}"john@example.com"${"]".repeat(2_000)}`
-    const result = redactJsonString(deep, ENFORCE)
+    const result = redactJsonString(deep, ENTITIES)
 
     expect(result.value).not.toContain("john@example.com")
     expect(result.scan.oversized).toBe(1)
@@ -204,27 +187,19 @@ describe("redactJsonValue depth cap", () => {
   it("falls back to a text scan when the payload is too deep even to parse", () => {
     const deeper = `${"[".repeat(5_000)}"john@example.com"${"]".repeat(5_000)}`
 
-    expect(redactJsonString(deeper, ENFORCE).value).not.toContain("john@example.com")
+    expect(redactJsonString(deeper, ENTITIES).value).not.toContain("john@example.com")
   })
 
   it("drops the subtree at the cap rather than leaving it unscanned", () => {
-    const result = redactJsonValue(nest(REDACTION_MAX_DEPTH + 5, "john@example.com"), ENFORCE)
+    const result = redactJsonValue(nest(REDACTION_MAX_DEPTH + 5, "john@example.com"), ENTITIES)
 
     expect(JSON.stringify(result.value)).not.toContain("john@example.com")
     expect(JSON.stringify(result.value)).toContain(OVERSIZED_FIELD_PLACEHOLDER)
     expect(result.scan.oversized).toBe(1)
   })
 
-  it("counts the over-deep subtree in dry run without touching it", () => {
-    const input = nest(REDACTION_MAX_DEPTH + 5, "john@example.com")
-    const result = redactJsonValue(input, DRY_RUN)
-
-    expect(result.value).toBe(input)
-    expect(result.scan.oversized).toBe(1)
-  })
-
   it("walks structures just under the cap normally", () => {
-    const result = redactJsonValue(nest(REDACTION_MAX_DEPTH - 1, "john@example.com"), ENFORCE)
+    const result = redactJsonValue(nest(REDACTION_MAX_DEPTH - 1, "john@example.com"), ENTITIES)
 
     expect(JSON.stringify(result.value)).toContain("[REDACTED_EMAIL]")
     expect(result.scan.oversized).toBe(0)
@@ -233,26 +208,26 @@ describe("redactJsonValue depth cap", () => {
 
 describe("redactJsonString", () => {
   it("parses, walks, and re-serializes a JSON object", () => {
-    const result = redactJsonString('{"to":"john@example.com","n":1}', ENFORCE)
+    const result = redactJsonString('{"to":"john@example.com","n":1}', ENTITIES)
 
     expect(JSON.parse(result.value)).toEqual({ to: "[REDACTED_EMAIL]", n: 1 })
     expect(result.counts).toEqual({ email: 1 })
   })
 
   it("parses, walks, and re-serializes a JSON array", () => {
-    const result = redactJsonString('["john@example.com"]', ENFORCE)
+    const result = redactJsonString('["john@example.com"]', ENTITIES)
 
     expect(JSON.parse(result.value)).toEqual(["[REDACTED_EMAIL]"])
   })
 
   it("preserves numbers and booleans through the round trip", () => {
-    const result = redactJsonString('{"n":1.5,"b":true,"z":null,"s":"a@b.co"}', ENFORCE)
+    const result = redactJsonString('{"n":1.5,"b":true,"z":null,"s":"a@b.co"}', ENTITIES)
 
     expect(JSON.parse(result.value)).toEqual({ n: 1.5, b: true, z: null, s: "[REDACTED_EMAIL]" })
   })
 
   it("preserves integers beyond 2^53 while redacting a sibling", () => {
-    const result = redactJsonString('{"id":9007199254740993,"to":"john@example.com"}', ENFORCE)
+    const result = redactJsonString('{"id":9007199254740993,"to":"john@example.com"}', ENTITIES)
 
     expect(result.value).toBe('{"id":9007199254740993,"to":"[REDACTED_EMAIL]"}')
   })
@@ -266,12 +241,12 @@ describe("redactJsonString", () => {
       '{"n":123456789012345678901234567890,"to":"[REDACTED_EMAIL]"}',
     ],
   ])("preserves the number literal in %s", (input, expected) => {
-    expect(redactJsonString(input, ENFORCE).value).toBe(expected)
+    expect(redactJsonString(input, ENTITIES).value).toBe(expected)
   })
 
   it("does not scan the digits of a preserved number literal", () => {
     const cardShaped = '{"orderNumber":4532015112830366,"to":"john@example.com"}'
-    const result = redactJsonString(cardShaped, ENFORCE)
+    const result = redactJsonString(cardShaped, ENTITIES)
 
     expect(result.value).toBe('{"orderNumber":4532015112830366,"to":"[REDACTED_EMAIL]"}')
     expect(result.counts).toEqual({ email: 1 })
@@ -280,12 +255,12 @@ describe("redactJsonString", () => {
   it("returns the original bytes when the scan matched nothing", () => {
     const text = '{ "b" : 1,\n  "a" : "clean",  "big": 9007199254740993 }'
 
-    expect(redactJsonString(text, ENFORCE).value).toBe(text)
+    expect(redactJsonString(text, ENTITIES).value).toBe(text)
   })
 
   it("handles JSON nested as a string inside JSON", () => {
     const inner = JSON.stringify({ email: "john@example.com" })
-    const result = redactJsonString(JSON.stringify({ payload: inner }), ENFORCE)
+    const result = redactJsonString(JSON.stringify({ payload: inner }), ENTITIES)
     const outer = JSON.parse(result.value) as { payload: string }
 
     expect(outer.payload).toBe('{"email":"john@example.com"}'.replace("john@example.com", "[REDACTED_EMAIL]"))
@@ -293,72 +268,56 @@ describe("redactJsonString", () => {
   })
 
   it("treats plain text as text", () => {
-    const result = redactJsonString("contact john@example.com", ENFORCE)
+    const result = redactJsonString("contact john@example.com", ENTITIES)
 
     expect(result.value).toBe("contact [REDACTED_EMAIL]")
   })
 
   it("treats malformed JSON as text rather than dropping the field", () => {
-    const result = redactJsonString('{"to":"john@example.com"', ENFORCE)
+    const result = redactJsonString('{"to":"john@example.com"', ENTITIES)
 
     expect(result.value).toBe('{"to":"[REDACTED_EMAIL]"')
     expect(result.counts).toEqual({ email: 1 })
   })
 
   it("does not re-serialize a bare JSON scalar, which would add quote escaping", () => {
-    expect(redactJsonString('"john@example.com"', ENFORCE).value).toBe('"[REDACTED_EMAIL]"')
-    expect(redactJsonString("42", ENFORCE).value).toBe("42")
-    expect(redactJsonString("null", ENFORCE).value).toBe("null")
+    expect(redactJsonString('"john@example.com"', ENTITIES).value).toBe('"[REDACTED_EMAIL]"')
+    expect(redactJsonString("42", ENTITIES).value).toBe("42")
+    expect(redactJsonString("null", ENTITIES).value).toBe("null")
   })
 
   it("returns an empty string unchanged", () => {
-    expect(redactJsonString("", ENFORCE)).toMatchObject({ value: "", counts: {} })
+    expect(redactJsonString("", ENTITIES)).toMatchObject({ value: "", counts: {} })
   })
 
   it("returns the input unchanged when no entity is enabled", () => {
     const text = '{"to":"john@example.com"}'
 
-    expect(redactJsonString(text, { entities: new Set(), mutate: true })).toMatchObject({ value: text, counts: {} })
-  })
-
-  it("leaves the serialized string untouched in dry run while still counting", () => {
-    const text = '{"to":"john@example.com"}'
-    const result = redactJsonString(text, DRY_RUN)
-
-    expect(result.value).toBe(text)
-    expect(result.counts).toEqual({ email: 1 })
+    expect(redactJsonString(text, new Set())).toMatchObject({ value: text, counts: {} })
   })
 
   it("is idempotent", () => {
-    const once = redactJsonString('{"to":"john@example.com"}', ENFORCE).value
+    const once = redactJsonString('{"to":"john@example.com"}', ENTITIES).value
 
-    expect(redactJsonString(once, ENFORCE).value).toBe(once)
+    expect(redactJsonString(once, ENTITIES).value).toBe(once)
   })
 })
 
 describe("redactStringMap", () => {
   it("redacts values and preserves keys", () => {
-    const result = redactStringMap({ "user.email": "john@example.com", env: "prod" }, ENFORCE)
+    const result = redactStringMap({ "user.email": "john@example.com", env: "prod" }, ENTITIES)
 
     expect(result.value).toEqual({ "user.email": "[REDACTED_EMAIL]", env: "prod" })
     expect(result.counts).toEqual({ email: 1 })
   })
 
   it("does not apply skip keys, because attribute keys are not structural", () => {
-    const result = redactStringMap({ id: "john@example.com" }, ENFORCE)
+    const result = redactStringMap({ id: "john@example.com" }, ENTITIES)
 
     expect(result.value).toEqual({ id: "[REDACTED_EMAIL]" })
   })
 
-  it("counts without mutating in dry run", () => {
-    const input = { a: "john@example.com" }
-    const result = redactStringMap(input, DRY_RUN)
-
-    expect(result.value).toEqual(input)
-    expect(result.counts).toEqual({ email: 1 })
-  })
-
   it("handles an empty map", () => {
-    expect(redactStringMap({}, ENFORCE)).toMatchObject({ value: {}, counts: {} })
+    expect(redactStringMap({}, ENTITIES)).toMatchObject({ value: {}, counts: {} })
   })
 })

--- a/packages/domain/spans/src/redaction/redact-json.ts
+++ b/packages/domain/spans/src/redaction/redact-json.ts
@@ -22,12 +22,6 @@ export const mergeScanTally = (target: ScanTally, source: ScanTally): void => {
   target.oversized += source.oversized
 }
 
-export interface JsonRedactionOptions {
-  readonly entities: ReadonlySet<RedactionEntity>
-  /** When false, walk and count but return the input untouched. This is `dryRun`. */
-  readonly mutate: boolean
-}
-
 /** Their `content` is base64 binary, so PII inside one is out of scope rather than overlooked. */
 const SKIPPED_PART_TYPES: ReadonlySet<string> = new Set(["blob", "file"])
 
@@ -57,23 +51,23 @@ const isSkippedPart = (value: Record<string, unknown>): boolean =>
  * Array length and order, object keys, and non-string leaves are all preserved; only strings change.
  * Every string leaf is scanned whatever its key, since customer JSON stores content under names like `id`.
  */
-export function redactJsonValue<T>(value: T, options: JsonRedactionOptions): JsonRedactionResult<T> {
+export function redactJsonValue<T>(value: T, entities: ReadonlySet<RedactionEntity>): JsonRedactionResult<T> {
   const counts: RedactionCounts = {}
   const scan = emptyScanTally()
-  const walked = walk(value, options, counts, scan, 0)
+  const walked = walk(value, entities, counts, scan, 0)
 
   return { value: walked as T, counts, scan }
 }
 
 function walk(
   value: unknown,
-  options: JsonRedactionOptions,
+  entities: ReadonlySet<RedactionEntity>,
   counts: RedactionCounts,
   scan: ScanTally,
   depth: number,
 ): unknown {
   if (typeof value === "string") {
-    const outcome = redactLeaf(value, options.entities, options.mutate)
+    const outcome = redactLeaf(value, entities)
     mergeRedactionCounts(counts, outcome.counts)
     scan.leaves += 1
     scan.chars += outcome.scannedChars
@@ -90,13 +84,13 @@ function walk(
   if (isContainer && depth >= REDACTION_MAX_DEPTH) {
     scan.oversized += 1
 
-    return options.mutate ? OVERSIZED_FIELD_PLACEHOLDER : value
+    return OVERSIZED_FIELD_PLACEHOLDER
   }
 
   if (Array.isArray(value)) {
     let changed = false
     const next = value.map((item) => {
-      const walkedItem = walk(item, options, counts, scan, depth + 1)
+      const walkedItem = walk(item, entities, counts, scan, depth + 1)
       if (walkedItem !== item) changed = true
       return walkedItem
     })
@@ -110,7 +104,7 @@ function walk(
     let changed = false
     const next: Record<string, unknown> = {}
     for (const [key, entry] of Object.entries(value)) {
-      const walkedEntry = walk(entry, options, counts, scan, depth + 1)
+      const walkedEntry = walk(entry, entities, counts, scan, depth + 1)
       if (walkedEntry !== entry) changed = true
       next[key] = walkedEntry
     }
@@ -122,12 +116,12 @@ function walk(
 }
 
 /** A bare scalar is treated as text rather than re-serialized, which would rewrite `"hi"` as `"\"hi\""`. */
-export function redactJsonString(value: string, options: JsonRedactionOptions): JsonRedactionResult<string> {
-  if (value === "" || options.entities.size === 0) return { value, counts: {}, scan: emptyScanTally() }
+export function redactJsonString(value: string, entities: ReadonlySet<RedactionEntity>): JsonRedactionResult<string> {
+  if (value === "" || entities.size === 0) return { value, counts: {}, scan: emptyScanTally() }
 
   const parsed = tryParseJsonContainer(value)
   if (parsed === undefined) {
-    const outcome = redactLeaf(value, options.entities, options.mutate)
+    const outcome = redactLeaf(value, entities)
 
     return {
       value: outcome.text,
@@ -136,9 +130,9 @@ export function redactJsonString(value: string, options: JsonRedactionOptions): 
     }
   }
 
-  const walked = redactJsonValue(parsed, options)
+  const walked = redactJsonValue(parsed, entities)
   // The walk returns the same reference when no leaf changed, so the original bytes survive an unmatched scan.
-  if (!options.mutate || walked.value === parsed) return { value, counts: walked.counts, scan: walked.scan }
+  if (walked.value === parsed) return { value, counts: walked.counts, scan: walked.scan }
 
   return { value: JSON.stringify(walked.value), counts: walked.counts, scan: walked.scan }
 }
@@ -157,14 +151,14 @@ const tryParseJsonContainer = (value: string): unknown => {
 
 export function redactStringMap(
   map: Readonly<Record<string, string>>,
-  options: JsonRedactionOptions,
+  entities: ReadonlySet<RedactionEntity>,
 ): JsonRedactionResult<Record<string, string>> {
   const counts: RedactionCounts = {}
   const scan = emptyScanTally()
   const next: Record<string, string> = {}
 
   for (const [key, value] of Object.entries(map)) {
-    const outcome = redactLeaf(value, options.entities, options.mutate)
+    const outcome = redactLeaf(value, entities)
     mergeRedactionCounts(counts, outcome.counts)
     scan.leaves += 1
     scan.chars += outcome.scannedChars

--- a/packages/domain/spans/src/redaction/redact-span.ts
+++ b/packages/domain/spans/src/redaction/redact-span.ts
@@ -1,4 +1,4 @@
-import type { ResolvedRedactionPolicy } from "@domain/shared"
+import type { RedactionPolicy } from "@domain/shared"
 import type { SpanDetail } from "../entities/span.ts"
 import { isContentAttributeKey } from "../otlp/content/index.ts"
 import { REDACTED_IDENTITY_PLACEHOLDER } from "./labels.ts"
@@ -25,7 +25,7 @@ export type PseudonymLookup = ReadonlyMap<string, string>
 
 export function redactSpanDetail(
   span: SpanDetail,
-  policy: ResolvedRedactionPolicy,
+  policy: RedactionPolicy,
   pseudonyms: PseudonymLookup,
 ): { span: SpanDetail; stats: SpanRedactionStats } {
   const options: JsonRedactionOptions = { entities: policy.entities, mutate: policy.mode === "enforce" }
@@ -117,7 +117,7 @@ const replaceIdentity = (value: string, pseudonyms: PseudonymLookup): string => 
 
 export function collectIdentityValues(
   spans: readonly SpanDetail[],
-  policyFor: (span: SpanDetail) => ResolvedRedactionPolicy | undefined,
+  policyFor: (span: SpanDetail) => RedactionPolicy | undefined,
 ): Set<string> {
   const values = new Set<string>()
 

--- a/packages/domain/spans/src/redaction/redact-span.ts
+++ b/packages/domain/spans/src/redaction/redact-span.ts
@@ -4,7 +4,6 @@ import { isContentAttributeKey } from "../otlp/content/index.ts"
 import { REDACTED_IDENTITY_PLACEHOLDER } from "./labels.ts"
 import {
   emptyScanTally,
-  type JsonRedactionOptions,
   mergeScanTally,
   redactJsonString,
   redactJsonValue,
@@ -28,7 +27,7 @@ export function redactSpanDetail(
   policy: RedactionPolicy,
   pseudonyms: PseudonymLookup,
 ): { span: SpanDetail; stats: SpanRedactionStats } {
-  const options: JsonRedactionOptions = { entities: policy.entities, mutate: policy.mode === "enforce" }
+  const entities = policy.entities
   const counts: RedactionCounts = {}
   const scan = emptyScanTally()
   let droppedAttributeKeys = 0
@@ -40,15 +39,15 @@ export function redactSpanDetail(
     return result.value
   }
 
-  const inputMessages = take(redactJsonValue(span.inputMessages, options))
-  const outputMessages = take(redactJsonValue(span.outputMessages, options))
-  const systemInstructions = take(redactJsonValue(span.systemInstructions, options))
-  const toolDefinitions = take(redactJsonValue(span.toolDefinitions, options))
-  const toolInput = take(redactJsonString(span.toolInput, options))
-  const toolOutput = take(redactJsonString(span.toolOutput, options))
-  const eventsJson = take(redactJsonString(span.eventsJson, options))
+  const inputMessages = take(redactJsonValue(span.inputMessages, entities))
+  const outputMessages = take(redactJsonValue(span.outputMessages, entities))
+  const systemInstructions = take(redactJsonValue(span.systemInstructions, entities))
+  const toolDefinitions = take(redactJsonValue(span.toolDefinitions, entities))
+  const toolInput = take(redactJsonString(span.toolInput, entities))
+  const toolOutput = take(redactJsonString(span.toolOutput, entities))
+  const eventsJson = take(redactJsonString(span.eventsJson, entities))
 
-  const statusMessageOutcome = redactLeaf(span.statusMessage, policy.entities, options.mutate)
+  const statusMessageOutcome = redactLeaf(span.statusMessage, entities)
   mergeRedactionCounts(counts, statusMessageOutcome.counts)
   scan.leaves += 1
   scan.chars += statusMessageOutcome.scannedChars
@@ -58,16 +57,16 @@ export function redactSpanDetail(
   const contentKeys = Object.keys(span.attrString).filter(isContentAttributeKey)
   droppedAttributeKeys = contentKeys.length
   const attrStringSource =
-    options.mutate && contentKeys.length > 0
+    contentKeys.length > 0
       ? Object.fromEntries(Object.entries(span.attrString).filter(([key]) => !isContentAttributeKey(key)))
       : span.attrString
-  const attrString = take(redactStringMap(attrStringSource, options))
-  const resourceString = take(redactStringMap(span.resourceString, options))
+  const attrString = take(redactStringMap(attrStringSource, entities))
+  const resourceString = take(redactStringMap(span.resourceString, entities))
 
-  const metadata = policy.redactMetadata ? take(redactStringMap(span.metadata, options)) : span.metadata
+  const metadata = policy.redactMetadata ? take(redactStringMap(span.metadata, entities)) : span.metadata
   const tags = policy.redactMetadata
     ? span.tags.map((tag) => {
-        const outcome = redactLeaf(tag, policy.entities, options.mutate)
+        const outcome = redactLeaf(tag, entities)
         mergeRedactionCounts(counts, outcome.counts)
         scan.leaves += 1
         scan.chars += outcome.scannedChars
@@ -77,7 +76,7 @@ export function redactSpanDetail(
 
   let userId = span.userId
   let userEmail = span.userEmail
-  if (policy.identities === "pseudonymize" && options.mutate) {
+  if (policy.identities === "pseudonymize") {
     const nextUserId = replaceIdentity(span.userId, pseudonyms)
     const nextUserEmail = replaceIdentity(span.userEmail, pseudonyms)
     if (nextUserId !== span.userId) pseudonymizedIdentities += 1
@@ -123,7 +122,7 @@ export function collectIdentityValues(
 
   for (const span of spans) {
     const policy = policyFor(span)
-    if (policy?.mode !== "enforce" || policy.identities !== "pseudonymize") continue
+    if (policy?.identities !== "pseudonymize") continue
     if (span.userId !== "") values.add(span.userId)
     if (span.userEmail !== "") values.add(span.userEmail)
   }

--- a/packages/domain/spans/src/redaction/redact-spans.test.ts
+++ b/packages/domain/spans/src/redaction/redact-spans.test.ts
@@ -2,7 +2,7 @@ import {
   ExternalUserId,
   OrganizationId,
   ProjectId,
-  type ResolvedRedactionPolicy,
+  type RedactionPolicy,
   resolveRedactionPolicy,
   SessionId,
   SimulationId,
@@ -82,12 +82,12 @@ const makeSpan = (overrides: Partial<SpanDetail> = {}): SpanDetail => ({
   ...overrides,
 })
 
-const policy = (mode: "enforce" | "dryRun", extra: Record<string, unknown> = {}): ResolvedRedactionPolicy =>
-  resolveRedactionPolicy({ organization: null, project: { redaction: { mode, ...extra } } })
+const policy = (extra: Record<string, unknown> = {}): RedactionPolicy =>
+  resolveRedactionPolicy({ organization: null, project: { redaction: { mode: "enforce", ...extra } } })
 
 const run = (input: Parameters<typeof redactSpans>[0]) => Effect.runPromise(redactSpans(input))
 
-const enforceFor = (projectId = PROJECT) => new Map([[projectId, policy("enforce")]])
+const enforceFor = (projectId = PROJECT) => new Map([[projectId, policy()]])
 
 const textMessage = (content: string) => [{ role: "user", parts: [{ type: "text", content }] }]
 
@@ -97,7 +97,7 @@ describe("redactSpans", () => {
     const result = await run({ spans, organizationId: ORG, policyByProjectId: new Map(), pseudonymSecret: undefined })
 
     expect(result.spans).toBe(spans)
-    expect(result.summary.enforceSpans).toBe(0)
+    expect(result.summary.redactedSpans).toBe(0)
   })
 
   it("leaves a span whose project is absent from the policy map byte-identical", async () => {
@@ -113,7 +113,7 @@ describe("redactSpans", () => {
     })
 
     expect(result.spans[0]).toBe(untouched)
-    expect(result.summary.enforceSpans).toBe(0)
+    expect(result.summary.redactedSpans).toBe(0)
   })
 
   it("redacts content of an opted-in project only, in a mixed batch", async () => {
@@ -131,7 +131,7 @@ describe("redactSpans", () => {
 
     expect(JSON.stringify(result.spans[0]?.inputMessages)).toContain("[REDACTED_EMAIL]")
     expect(JSON.stringify(result.spans[1]?.inputMessages)).toContain("john@example.com")
-    expect(result.summary.enforceSpans).toBe(1)
+    expect(result.summary.redactedSpans).toBe(1)
   })
 
   it("redacts every content field of the span surface", async () => {
@@ -217,7 +217,7 @@ describe("redactSpans", () => {
       await run({
         spans: [span],
         organizationId: ORG,
-        policyByProjectId: new Map([[PROJECT, policy("enforce", { scopes: { metadata: true } })]]),
+        policyByProjectId: new Map([[PROJECT, policy({ scopes: { metadata: true } })]]),
         pseudonymSecret: undefined,
       })
     ).spans
@@ -242,77 +242,8 @@ describe("redactSpans", () => {
   })
 })
 
-describe("redactSpans dry run", () => {
-  const dryRunFor = () => new Map([[PROJECT, policy("dryRun")]])
-
-  it("does not modify content", async () => {
-    const span = makeSpan({ toolOutput: "mail john@example.com", statusMessage: "john@example.com" })
-    const [result] = (
-      await run({ spans: [span], organizationId: ORG, policyByProjectId: dryRunFor(), pseudonymSecret: undefined })
-    ).spans
-
-    expect(result?.toolOutput).toBe("mail john@example.com")
-    expect(result?.statusMessage).toBe("john@example.com")
-  })
-
-  it("does not drop content attribute keys", async () => {
-    const span = makeSpan({ attrString: { "gen_ai.input.messages": "john@example.com" } })
-    const [result] = (
-      await run({ spans: [span], organizationId: ORG, policyByProjectId: dryRunFor(), pseudonymSecret: undefined })
-    ).spans
-
-    expect(result?.attrString["gen_ai.input.messages"]).toBe("john@example.com")
-  })
-
-  it("still reports what enforce would have removed", async () => {
-    const span = makeSpan({ toolOutput: "john@example.com +14155552671" })
-    const dry = await run({
-      spans: [span],
-      organizationId: ORG,
-      policyByProjectId: dryRunFor(),
-      pseudonymSecret: undefined,
-    })
-    const enforced = await run({
-      spans: [span],
-      organizationId: ORG,
-      policyByProjectId: enforceFor(),
-      pseudonymSecret: undefined,
-    })
-
-    expect(dry.summary.counts).toEqual(enforced.summary.counts)
-    expect(dry.summary.dryRunSpans).toBe(1)
-    expect(dry.summary.enforceSpans).toBe(0)
-  })
-
-  it("still reports the attribute keys enforce would drop", async () => {
-    const span = makeSpan({ attrString: { "gen_ai.input.messages": "x" } })
-    const result = await run({
-      spans: [span],
-      organizationId: ORG,
-      policyByProjectId: dryRunFor(),
-      pseudonymSecret: undefined,
-    })
-
-    expect(result.summary.droppedAttributeKeys).toBe(1)
-  })
-
-  it("does not pseudonymize identities", async () => {
-    const span = makeSpan({ userEmail: "john@example.com", userId: ExternalUserId("u-1") })
-    const [result] = (
-      await run({
-        spans: [span],
-        organizationId: ORG,
-        policyByProjectId: new Map([[PROJECT, policy("dryRun", { identities: "pseudonymize" })]]),
-        pseudonymSecret: "secret",
-      })
-    ).spans
-
-    expect(result?.userEmail).toBe("john@example.com")
-  })
-})
-
 describe("redactSpans identity handling", () => {
-  const pseudonymizeFor = () => new Map([[PROJECT, policy("enforce", { identities: "pseudonymize" })]])
+  const pseudonymizeFor = () => new Map([[PROJECT, policy({ identities: "pseudonymize" })]])
 
   it("keeps identities by default", async () => {
     const span = makeSpan({ userEmail: "john@example.com", userId: ExternalUserId("u-1") })
@@ -428,18 +359,6 @@ describe("redactSpans size cap", () => {
     })
 
     expect(result.spans[0]?.toolOutput).toBe("[REDACTED_OVERSIZED_FIELD]")
-    expect(result.summary.oversizedFields).toBe(1)
-  })
-
-  it("counts an oversized leaf in dry run without replacing it", async () => {
-    const result = await run({
-      spans: [makeSpan({ toolOutput: oversized })],
-      organizationId: ORG,
-      policyByProjectId: new Map([[PROJECT, policy("dryRun")]]),
-      pseudonymSecret: undefined,
-    })
-
-    expect(result.spans[0]?.toolOutput).toBe(oversized)
     expect(result.summary.oversizedFields).toBe(1)
   })
 

--- a/packages/domain/spans/src/redaction/redact-spans.ts
+++ b/packages/domain/spans/src/redaction/redact-spans.ts
@@ -8,7 +8,7 @@ import { emptyScanTally, mergeScanTally } from "./redact-json.ts"
 import { collectIdentityValues, type PseudonymLookup, redactSpanDetail } from "./redact-span.ts"
 import { mergeRedactionCounts, type RedactionCounts } from "./redact-text.ts"
 
-interface SpanRedactionSummary {
+export interface SpanRedactionSummary {
   readonly counts: RedactionCounts
   readonly enforceSpans: number
   readonly dryRunSpans: number

--- a/packages/domain/spans/src/redaction/redact-spans.ts
+++ b/packages/domain/spans/src/redaction/redact-spans.ts
@@ -10,8 +10,7 @@ import { mergeRedactionCounts, type RedactionCounts } from "./redact-text.ts"
 
 export interface SpanRedactionSummary {
   readonly counts: RedactionCounts
-  readonly enforceSpans: number
-  readonly dryRunSpans: number
+  readonly redactedSpans: number
   readonly leavesScanned: number
   readonly charsScanned: number
   readonly droppedAttributeKeys: number
@@ -23,8 +22,7 @@ export interface SpanRedactionSummary {
 
 const EMPTY_SUMMARY: SpanRedactionSummary = {
   counts: {},
-  enforceSpans: 0,
-  dryRunSpans: 0,
+  redactedSpans: 0,
   leavesScanned: 0,
   charsScanned: 0,
   droppedAttributeKeys: 0,
@@ -54,11 +52,9 @@ export const redactSpans = (
     const budgetMs = input.timeoutMs ?? REDACTION_BATCH_TIMEOUT_MS
     const deadline = performance.now() + budgetMs
 
-    const policyFor = (span: SpanDetail): RedactionPolicy | undefined => {
-      const policy = input.policyByProjectId.get(span.projectId as string)
-
-      return policy?.mode === "off" ? undefined : policy
-    }
+    // A policy exists only for a project that redacts, so presence is the decision.
+    const policyFor = (span: SpanDetail): RedactionPolicy | undefined =>
+      input.policyByProjectId.get(span.projectId as string)
 
     const identityValues = collectIdentityValues(input.spans, policyFor)
     const { pseudonyms, identityFallback } = yield* buildPseudonyms({
@@ -88,8 +84,7 @@ function applyRedaction(
 ): { spans: readonly SpanDetail[]; summary: SpanRedactionSummary } {
   const counts: RedactionCounts = {}
   const scan = emptyScanTally()
-  let enforceSpans = 0
-  let dryRunSpans = 0
+  let redactedSpans = 0
   let droppedAttributeKeys = 0
   let pseudonymizedIdentities = 0
 
@@ -107,8 +102,7 @@ function applyRedaction(
     mergeScanTally(scan, result.stats.scan)
     droppedAttributeKeys += result.stats.droppedAttributeKeys
     pseudonymizedIdentities += result.stats.pseudonymizedIdentities
-    if (policy.mode === "enforce") enforceSpans += 1
-    else dryRunSpans += 1
+    redactedSpans += 1
 
     return result.span
   })
@@ -117,8 +111,7 @@ function applyRedaction(
     spans: redacted,
     summary: {
       counts,
-      enforceSpans,
-      dryRunSpans,
+      redactedSpans,
       leavesScanned: scan.leaves,
       charsScanned: scan.chars,
       droppedAttributeKeys,

--- a/packages/domain/spans/src/redaction/redact-spans.ts
+++ b/packages/domain/spans/src/redaction/redact-spans.ts
@@ -1,4 +1,4 @@
-import type { OrganizationId, ResolvedRedactionPolicy } from "@domain/shared"
+import type { OrganizationId, RedactionPolicy } from "@domain/shared"
 import { hmacSha256Hex } from "@repo/utils"
 import { Effect } from "effect"
 import type { SpanDetail } from "../entities/span.ts"
@@ -37,7 +37,7 @@ interface RedactSpansInput {
   readonly spans: readonly SpanDetail[]
   readonly organizationId: OrganizationId
   /** Projects resolving to `off` are absent, so an empty map means redact nothing. */
-  readonly policyByProjectId: ReadonlyMap<string, ResolvedRedactionPolicy>
+  readonly policyByProjectId: ReadonlyMap<string, RedactionPolicy>
   readonly pseudonymSecret: string | undefined
   readonly timeoutMs?: number
 }
@@ -54,7 +54,7 @@ export const redactSpans = (
     const budgetMs = input.timeoutMs ?? REDACTION_BATCH_TIMEOUT_MS
     const deadline = performance.now() + budgetMs
 
-    const policyFor = (span: SpanDetail): ResolvedRedactionPolicy | undefined => {
+    const policyFor = (span: SpanDetail): RedactionPolicy | undefined => {
       const policy = input.policyByProjectId.get(span.projectId as string)
 
       return policy?.mode === "off" ? undefined : policy
@@ -81,7 +81,7 @@ export const redactSpans = (
 
 function applyRedaction(
   spans: readonly SpanDetail[],
-  policyFor: (span: SpanDetail) => ResolvedRedactionPolicy | undefined,
+  policyFor: (span: SpanDetail) => RedactionPolicy | undefined,
   pseudonyms: PseudonymLookup,
   identityFallback: boolean,
   deadline: number,

--- a/packages/domain/spans/src/redaction/redact-text.test.ts
+++ b/packages/domain/spans/src/redaction/redact-text.test.ts
@@ -1,12 +1,6 @@
 import { DEFAULT_REDACTION_ENTITIES, REDACTION_ENTITIES, type RedactionEntity } from "@domain/shared"
 import { describe, expect, it } from "vitest"
-import {
-  countRedactions,
-  mergeRedactionCounts,
-  type RedactionCounts,
-  redactText,
-  totalRedactionCount,
-} from "./redact-text.ts"
+import { mergeRedactionCounts, type RedactionCounts, redactText, totalRedactionCount } from "./redact-text.ts"
 
 const DEFAULTS: ReadonlySet<RedactionEntity> = new Set(DEFAULT_REDACTION_ENTITIES)
 const ALL: ReadonlySet<RedactionEntity> = new Set(REDACTION_ENTITIES)
@@ -110,12 +104,6 @@ describe("overlap resolution", () => {
     }
   })
 
-  it("counts overlapping candidates once, so dry run reports what enforce would do", () => {
-    for (const text of [PHONE_IN_EMAIL, GOOGLE_KEY_IN_EMAIL]) {
-      expect(countRedactions(text, ALL)).toEqual(redactText(text, ALL).counts)
-    }
-  })
-
   it("emits a single placeholder for a whole JWT rather than one per dot-separated segment", () => {
     const jwt =
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
@@ -133,24 +121,26 @@ describe("overlap resolution", () => {
   })
 })
 
-describe("countRedactions", () => {
-  it("reports counts without touching the text", () => {
-    expect(countRedactions("a@b.co and c@d.co", DEFAULTS)).toEqual({ email: 2 })
-  })
-
-  it("agrees with redactText on every count", () => {
+describe("redactText counts", () => {
+  it("counts one per accepted match across entities", () => {
     const text = "john@example.com +14155552671 4111111111111111 123-45-6789 GB82WEST12345698765432"
 
-    expect(countRedactions(text, DEFAULTS)).toEqual(redactText(text, DEFAULTS).counts)
+    expect(redactText(text, DEFAULTS).counts).toEqual({
+      email: 1,
+      phone: 1,
+      credit_card: 1,
+      us_ssn: 1,
+      iban: 1,
+    })
   })
 
-  it("returns an empty object for empty input", () => {
-    expect(countRedactions("", DEFAULTS)).toEqual({})
-    expect(countRedactions("clean", DEFAULTS)).toEqual({})
+  it("returns an empty object when nothing matched", () => {
+    expect(redactText("", DEFAULTS).counts).toEqual({})
+    expect(redactText("clean", DEFAULTS).counts).toEqual({})
   })
 
   it("omits entities with no matches rather than reporting zero", () => {
-    expect(countRedactions("a@b.co", DEFAULTS)).toEqual({ email: 1 })
+    expect(redactText("a@b.co", DEFAULTS).counts).toEqual({ email: 1 })
   })
 })
 

--- a/packages/domain/spans/src/redaction/redact-text.ts
+++ b/packages/domain/spans/src/redaction/redact-text.ts
@@ -34,12 +34,6 @@ const countByEntity = (matches: readonly RedactionMatch[]): RedactionCounts => {
   return counts
 }
 
-export function countRedactions(text: string, entities: ReadonlySet<RedactionEntity>): RedactionCounts {
-  if (text === "" || entities.size === 0) return {}
-
-  return countByEntity(resolveOverlaps(findRedactionMatches(text, entities)))
-}
-
 export function redactText(text: string, entities: ReadonlySet<RedactionEntity>): TextRedactionResult {
   if (text === "" || entities.size === 0) return { text, counts: {} }
 
@@ -65,25 +59,12 @@ interface LeafRedactionOutcome {
   readonly scannedChars: number
 }
 
-/** Every path that touches a string goes through this, so the size cap and dry-run contract cannot diverge. */
-export function redactLeaf(
-  text: string,
-  entities: ReadonlySet<RedactionEntity>,
-  mutate: boolean,
-): LeafRedactionOutcome {
+/** Every path that touches a string goes through this, so the size cap applies uniformly. */
+export function redactLeaf(text: string, entities: ReadonlySet<RedactionEntity>): LeafRedactionOutcome {
   if (text === "" || entities.size === 0) return { text, counts: {}, oversized: false, scannedChars: 0 }
 
   if (text.length > REDACTION_MAX_FIELD_CHARS) {
-    return {
-      text: mutate ? OVERSIZED_FIELD_PLACEHOLDER : text,
-      counts: {},
-      oversized: true,
-      scannedChars: 0,
-    }
-  }
-
-  if (!mutate) {
-    return { text, counts: countRedactions(text, entities), oversized: false, scannedChars: text.length }
+    return { text: OVERSIZED_FIELD_PLACEHOLDER, counts: {}, oversized: true, scannedChars: 0 }
   }
 
   const result = redactText(text, entities)

--- a/packages/domain/spans/src/use-cases/ingest-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.test.ts
@@ -909,18 +909,11 @@ describe("ingestSpansUseCase redaction policy stamping", () => {
 
     expect(redaction).toEqual({
       [PRIMARY_PROJECT_ID]: {
-        mode: "enforce",
         entities: [...DEFAULT_REDACTION_ENTITIES],
         redactMetadata: false,
         identities: "keep",
       },
     })
-  })
-
-  it("stamps a dry-run policy", async () => {
-    const { redaction } = await stamp({ settingsBySlug: { primary: { redaction: { mode: "dryRun" } } } })
-
-    expect(redaction?.[PRIMARY_PROJECT_ID]).toMatchObject({ mode: "dryRun" })
   })
 
   it("serializes the configured entity set and scopes", async () => {
@@ -938,7 +931,6 @@ describe("ingestSpansUseCase redaction policy stamping", () => {
     })
 
     expect(redaction?.[PRIMARY_PROJECT_ID]).toEqual({
-      mode: "enforce",
       entities: ["email", "secret"],
       redactMetadata: true,
       identities: "pseudonymize",
@@ -948,7 +940,7 @@ describe("ingestSpansUseCase redaction policy stamping", () => {
   it("applies an organization policy to a project that configured nothing", async () => {
     const { redaction } = await stamp({ organizationRedaction: { mode: "enforce" } })
 
-    expect(redaction?.[PRIMARY_PROJECT_ID]).toMatchObject({ mode: "enforce" })
+    expect(redaction?.[PRIMARY_PROJECT_ID]).toMatchObject({ entities: [...DEFAULT_REDACTION_ENTITIES] })
   })
 
   it("lets a project override an unlocked organization policy", async () => {
@@ -966,7 +958,7 @@ describe("ingestSpansUseCase redaction policy stamping", () => {
       settingsBySlug: { primary: { redaction: { mode: "off" } } },
     })
 
-    expect(redaction?.[PRIMARY_PROJECT_ID]).toMatchObject({ mode: "enforce" })
+    expect(redaction?.[PRIMARY_PROJECT_ID]).toMatchObject({ entities: [...DEFAULT_REDACTION_ENTITIES] })
   })
 
   it("stamps one entry per opted-in project in a multi-project batch", async () => {

--- a/packages/domain/spans/src/use-cases/ingest-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.test.ts
@@ -23,9 +23,11 @@ import {
 } from "@domain/sandboxes"
 import { createFakeSandboxRepository, createFakeSandboxSignals } from "@domain/sandboxes/testing"
 import {
+  DEFAULT_REDACTION_ENTITIES,
   generateId,
   NotFoundError,
   OrganizationId,
+  type OrganizationRedactionSetting,
   ProjectId,
   type ProjectSettings,
   SettingsReader,
@@ -129,13 +131,21 @@ const makeProjectRepository = (
     countBySlug: () => Effect.die("not used"),
   })
 
-const makeInput = (payload: Uint8Array, opts: { defaultProjectSlug?: string; isSandbox?: boolean } = {}) => ({
+const makeInput = (
+  payload: Uint8Array,
+  opts: {
+    defaultProjectSlug?: string
+    isSandbox?: boolean
+    organizationRedaction?: OrganizationRedactionSetting | null
+  } = {},
+) => ({
   organizationId: ORGANIZATION_ID,
   apiKeyId: "key-1",
   isSandbox: opts.isSandbox ?? false,
   payload,
   contentType: "application/json",
   ...(opts.defaultProjectSlug ? { defaultProjectSlug: opts.defaultProjectSlug } : {}),
+  ...(opts.organizationRedaction !== undefined ? { organizationRedaction: opts.organizationRedaction } : {}),
 })
 
 const runUseCase = (
@@ -819,5 +829,212 @@ describe("ingestSpansWithBillingUseCase sandbox path", () => {
     expect((published[0]?.payload as { isSandbox: boolean }).isSandbox).toBe(false)
     expect(sandboxSignals.state.quotaIncrements).toHaveLength(0)
     expect(sandboxRepo.stampCount).toBe(0)
+  })
+})
+
+describe("ingestSpansUseCase redaction policy stamping", () => {
+  const singleSpanBatch = (slug?: string): Uint8Array =>
+    new TextEncoder().encode(
+      JSON.stringify({
+        resourceSpans: [
+          {
+            resource: { attributes: [{ key: "service.name", value: { stringValue: "test" } }] },
+            scopeSpans: [
+              {
+                scope: { name: "test", version: "1.0.0" },
+                spans: [
+                  {
+                    traceId: "0af7651916cd43dd8448eb211c80319c",
+                    spanId: "b7ad6b7169203331",
+                    name: "test-span",
+                    kind: 3,
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: slug ? [{ key: "latitude.project", value: { stringValue: slug } }] : [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+  const publishedRedaction = (published: { payload: unknown }[]) =>
+    (published[0]?.payload as { redaction?: Record<string, unknown> } | undefined)?.redaction
+
+  const stamp = async (
+    opts: {
+      organizationRedaction?: OrganizationRedactionSetting | null
+      settingsBySlug?: Record<string, ProjectSettings>
+      resolutions?: Record<string, string | null>
+      slug?: string
+    } = {},
+  ) => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+
+    await Effect.runPromise(
+      runUseCase(
+        makeInput(singleSpanBatch(opts.slug), {
+          defaultProjectSlug: "primary",
+          ...(opts.organizationRedaction !== undefined ? { organizationRedaction: opts.organizationRedaction } : {}),
+        }),
+        disk,
+        publisher,
+        opts.resolutions ?? { primary: PRIMARY_PROJECT_ID },
+        opts.settingsBySlug ?? {},
+      ),
+    )
+
+    return { published, redaction: publishedRedaction(published) }
+  }
+
+  it("omits the redaction field entirely when no project opted in", async () => {
+    const { published, redaction } = await stamp()
+
+    expect(published).toHaveLength(1)
+    expect(redaction).toBeUndefined()
+    expect(published[0]?.payload).not.toHaveProperty("redaction")
+  })
+
+  it("omits a project whose policy resolves to off", async () => {
+    const { redaction } = await stamp({ settingsBySlug: { primary: { redaction: { mode: "off" } } } })
+
+    expect(redaction).toBeUndefined()
+  })
+
+  it("stamps an enforce policy keyed by project id", async () => {
+    const { redaction } = await stamp({ settingsBySlug: { primary: { redaction: { mode: "enforce" } } } })
+
+    expect(redaction).toEqual({
+      [PRIMARY_PROJECT_ID]: {
+        mode: "enforce",
+        entities: [...DEFAULT_REDACTION_ENTITIES],
+        redactMetadata: false,
+        identities: "keep",
+      },
+    })
+  })
+
+  it("stamps a dry-run policy", async () => {
+    const { redaction } = await stamp({ settingsBySlug: { primary: { redaction: { mode: "dryRun" } } } })
+
+    expect(redaction?.[PRIMARY_PROJECT_ID]).toMatchObject({ mode: "dryRun" })
+  })
+
+  it("serializes the configured entity set and scopes", async () => {
+    const { redaction } = await stamp({
+      settingsBySlug: {
+        primary: {
+          redaction: {
+            mode: "enforce",
+            entities: ["email", "secret"],
+            scopes: { metadata: true },
+            identities: "pseudonymize",
+          },
+        },
+      },
+    })
+
+    expect(redaction?.[PRIMARY_PROJECT_ID]).toEqual({
+      mode: "enforce",
+      entities: ["email", "secret"],
+      redactMetadata: true,
+      identities: "pseudonymize",
+    })
+  })
+
+  it("applies an organization policy to a project that configured nothing", async () => {
+    const { redaction } = await stamp({ organizationRedaction: { mode: "enforce" } })
+
+    expect(redaction?.[PRIMARY_PROJECT_ID]).toMatchObject({ mode: "enforce" })
+  })
+
+  it("lets a project override an unlocked organization policy", async () => {
+    const { redaction } = await stamp({
+      organizationRedaction: { mode: "enforce" },
+      settingsBySlug: { primary: { redaction: { mode: "off" } } },
+    })
+
+    expect(redaction).toBeUndefined()
+  })
+
+  it("keeps a locked organization policy even when the project turns redaction off", async () => {
+    const { redaction } = await stamp({
+      organizationRedaction: { mode: "enforce", locked: true },
+      settingsBySlug: { primary: { redaction: { mode: "off" } } },
+    })
+
+    expect(redaction?.[PRIMARY_PROJECT_ID]).toMatchObject({ mode: "enforce" })
+  })
+
+  it("stamps one entry per opted-in project in a multi-project batch", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+    const payload = new TextEncoder().encode(
+      JSON.stringify({
+        resourceSpans: [
+          {
+            resource: { attributes: [{ key: "service.name", value: { stringValue: "test" } }] },
+            scopeSpans: [
+              {
+                scope: { name: "test", version: "1.0.0" },
+                spans: [
+                  {
+                    traceId: "0af7651916cd43dd8448eb211c80319c",
+                    spanId: "b7ad6b7169203331",
+                    name: "a",
+                    kind: 3,
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [{ key: "latitude.project", value: { stringValue: "primary" } }],
+                  },
+                  {
+                    traceId: "0af7651916cd43dd8448eb211c80319c",
+                    spanId: "b7ad6b7169203332",
+                    name: "b",
+                    kind: 3,
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [{ key: "latitude.project", value: { stringValue: "secondary" } }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    await Effect.runPromise(
+      runUseCase(
+        makeInput(payload),
+        disk,
+        publisher,
+        { primary: PRIMARY_PROJECT_ID, secondary: SECONDARY_PROJECT_ID },
+        { primary: { redaction: { mode: "enforce" } }, secondary: { redaction: { mode: "off" } } },
+      ),
+    )
+
+    const redaction = publishedRedaction(published)
+    expect(Object.keys(redaction ?? {})).toEqual([PRIMARY_PROJECT_ID])
+  })
+
+  it("does not enqueue anything, and so stamps nothing, when the batch is sampled out", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+
+    await Effect.runPromise(
+      runUseCase(
+        makeInput(singleSpanBatch(), { defaultProjectSlug: "primary" }),
+        disk,
+        publisher,
+        { primary: PRIMARY_PROJECT_ID },
+        { primary: { redaction: { mode: "enforce" }, sampling: { enabled: true, rate: 0 } } },
+      ),
+    )
+
+    expect(published).toHaveLength(0)
   })
 })

--- a/packages/domain/spans/src/use-cases/ingest-spans.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.ts
@@ -3,9 +3,13 @@ import type { QueuePublishError } from "@domain/queue"
 import { QueuePublisher } from "@domain/queue"
 import {
   type OrganizationId,
+  type OrganizationRedactionSetting,
   ProjectId,
   putInDisk,
   type RepositoryError,
+  resolveRedactionPolicy,
+  type SerializedRedactionPolicy,
+  serializeRedactionPolicy,
   type SqlClient,
   StorageDisk,
   type StorageError,
@@ -28,6 +32,12 @@ export interface IngestSpansInput {
   readonly contentType: string
   readonly isSandbox: boolean
   readonly defaultProjectSlug?: string
+  /**
+   * Organization-level redaction setting. Resolved and cached by the transport,
+   * because the cached resolver lives in the platform layer and the domain must not
+   * reach into it. Absent means "no organization policy".
+   */
+  readonly organizationRedaction?: OrganizationRedactionSetting | null
 }
 
 /**
@@ -98,6 +108,31 @@ export const inspectOtlpForSandbox = (decoded: OtlpExportTraceServiceRequest | n
   }
 
   return { totalSpans }
+}
+
+/**
+ * Effective redaction policy per project id, for the projects this batch touches.
+ *
+ * Resolved here rather than in the worker because every project's settings are
+ * already in hand for sampling, so this costs no extra query. Projects resolving
+ * to `off` are omitted, which makes an empty result mean "redact nothing" and lets
+ * the queue field be dropped entirely.
+ */
+function buildRedactionPolicies(
+  projects: Iterable<Project>,
+  organizationRedaction: OrganizationRedactionSetting | null,
+): Record<string, SerializedRedactionPolicy> {
+  const organization = organizationRedaction ? { redaction: organizationRedaction } : {}
+  const policies: Record<string, SerializedRedactionPolicy> = {}
+
+  for (const project of projects) {
+    const serialized = serializeRedactionPolicy(
+      resolveRedactionPolicy({ organization, project: project.settings }),
+    )
+    if (serialized) policies[project.id as string] = serialized
+  }
+
+  return policies
 }
 
 const resolveProject = (slug: string): Effect.Effect<Project | null, RepositoryError, ProjectRepository | SqlClient> =>
@@ -223,6 +258,12 @@ export const ingestSpansUseCase = (
       projectIdBySlug[slug] = project.id as string
     }
 
+    const redaction = buildRedactionPolicies(projectBySlug.values(), input.organizationRedaction ?? null)
+    const redactedProjects = Object.keys(redaction).length
+    if (redactedProjects > 0) {
+      yield* Effect.annotateCurrentSpan("redaction.projects", redactedProjects)
+    }
+
     yield* publisher.publish("span-ingestion", "ingest", {
       fileKey,
       inlinePayload,
@@ -233,6 +274,7 @@ export const ingestSpansUseCase = (
       defaultProjectId,
       projectIdBySlug,
       isSandbox: input.isSandbox ?? false,
+      ...(redactedProjects > 0 ? { redaction } : {}),
     })
 
     return { totalSpans, acceptedSpans, rejectedSpans }

--- a/packages/domain/spans/src/use-cases/ingest-spans.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.ts
@@ -9,10 +9,10 @@ import {
   type RepositoryError,
   resolveRedactionPolicy,
   type SerializedRedactionPolicy,
-  serializeRedactionPolicy,
   type SqlClient,
   StorageDisk,
   type StorageError,
+  serializeRedactionPolicy,
 } from "@domain/shared"
 import { base64Encode } from "@repo/utils"
 import { Effect } from "effect"
@@ -126,9 +126,7 @@ function buildRedactionPolicies(
   const policies: Record<string, SerializedRedactionPolicy> = {}
 
   for (const project of projects) {
-    const serialized = serializeRedactionPolicy(
-      resolveRedactionPolicy({ organization, project: project.settings }),
-    )
+    const serialized = serializeRedactionPolicy(resolveRedactionPolicy({ organization, project: project.settings }))
     if (serialized) policies[project.id as string] = serialized
   }
 

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.test.ts
@@ -134,7 +134,6 @@ const payloadFor = (spans: unknown[]) =>
   ).toString("base64")
 
 const enforcePolicy = {
-  mode: "enforce" as const,
   entities: ["email" as const],
   redactMetadata: false,
   identities: "keep" as const,
@@ -220,16 +219,6 @@ describe("processIngestedSpansUseCase redaction", () => {
     expect(JSON.stringify(secondary?.inputMessages)).toContain(EMAIL)
   })
 
-  it("leaves rows untouched in dry run while still inserting them", async () => {
-    const { effect, inserted } = runRedaction({
-      redaction: { [PROJECT_ID]: { ...enforcePolicy, mode: "dryRun" } },
-    })
-    await Effect.runPromise(effect)
-
-    expect(JSON.stringify(inserted)).toContain(EMAIL)
-    expect(inserted[0]?.[0]?.attrString).toHaveProperty("gen_ai.input.messages")
-  })
-
   it("still publishes TracesIngested after redacting, so downstream consumers see redacted content", async () => {
     const { effect, eventsPublisher } = runRedaction({ redaction: { [PROJECT_ID]: enforcePolicy } })
     await Effect.runPromise(effect)
@@ -238,7 +227,7 @@ describe("processIngestedSpansUseCase redaction", () => {
   })
 
   it("fails without inserting when a policy is present but malformed", async () => {
-    const { effect, inserted } = runRedaction({ redaction: { [PROJECT_ID]: { mode: "bogus" } } })
+    const { effect, inserted } = runRedaction({ redaction: { [PROJECT_ID]: { entities: "not-an-array" } } })
     const exit = await Effect.runPromiseExit(effect)
 
     expect(exit._tag).toBe("Failure")

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.test.ts
@@ -95,3 +95,218 @@ describe("processIngestedSpansUseCase sandbox bit", () => {
     })
   })
 })
+
+const EMAIL = "victim@example.com"
+const PROJECT_ID = "proj_realtime_sandbox_test"
+const OTHER_PROJECT_ID = "proj_other_redaction_test"
+
+const spanWith = (attributes: { key: string; value: { stringValue: string } }[], spanId: string, slug?: string) => ({
+  traceId: "0af7651916cd43dd8448eb211c80319c",
+  spanId,
+  name: "chat",
+  startTimeUnixNano: "1710590400000000000",
+  endTimeUnixNano: "1710590401000000000",
+  attributes: slug ? [...attributes, { key: "latitude.project", value: { stringValue: slug } }] : attributes,
+  status: { code: 1 },
+})
+
+const contentAttributes = [
+  { key: "gen_ai.system", value: { stringValue: "openai" } },
+  {
+    key: "gen_ai.input.messages",
+    value: {
+      stringValue: JSON.stringify([{ role: "user", parts: [{ type: "text", content: `contact ${EMAIL}` }] }]),
+    },
+  },
+]
+
+const payloadFor = (spans: unknown[]) =>
+  Buffer.from(
+    JSON.stringify({
+      resourceSpans: [
+        {
+          resource: { attributes: [{ key: "service.name", value: { stringValue: "test" } }] },
+          scopeSpans: [{ scope: { name: "test", version: "1.0.0" }, spans }],
+        },
+      ],
+    }),
+    "utf-8",
+  ).toString("base64")
+
+const enforcePolicy = {
+  mode: "enforce" as const,
+  entities: ["email" as const],
+  redactMetadata: false,
+  identities: "keep" as const,
+}
+
+const runRedaction = (opts: {
+  payload?: string
+  fileKey?: string | null
+  redaction?: Record<string, unknown>
+  projectIdBySlug?: Record<string, string>
+}) => {
+  const eventsPublisher = createFakeEventsPublisher()
+  const { repository: spanRepo, inserted } = createFakeSpanRepository()
+  const payload = opts.payload ?? payloadFor([spanWith(contentAttributes, "b7ad6b7169203331")])
+  const storage = createFakeStorageDisk({
+    getBytes: async () => new Uint8Array(Buffer.from(payload, "base64")),
+  })
+
+  const effect = processIngestedSpansUseCase({ eventsPublisher })({
+    organizationId: ORGANIZATION_ID,
+    apiKeyId: "key-1",
+    contentType: "application/json",
+    ingestedAt: new Date("2026-03-18T10:00:00.000Z"),
+    isSandbox: false,
+    inlinePayload: opts.fileKey ? null : payload,
+    fileKey: opts.fileKey ?? null,
+    defaultProjectId: PROJECT_ID,
+    projectIdBySlug: opts.projectIdBySlug ?? {},
+    ...(opts.redaction ? { redaction: opts.redaction as never } : {}),
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        Layer.succeed(SpanRepository, spanRepo),
+        Layer.succeed(StorageDisk, storage.disk),
+        Layer.succeed(ChSqlClient, {} as ChSqlClientShape),
+      ),
+    ),
+  )
+
+  return { effect, inserted, eventsPublisher, storage }
+}
+
+describe("processIngestedSpansUseCase redaction", () => {
+  it("inserts byte-identical rows when no project opted in", async () => {
+    const withoutField = runRedaction({})
+    await Effect.runPromise(withoutField.effect)
+
+    const withEmptyMap = runRedaction({ redaction: {} })
+    await Effect.runPromise(withEmptyMap.effect)
+
+    expect(JSON.stringify(withEmptyMap.inserted)).toBe(JSON.stringify(withoutField.inserted))
+    expect(JSON.stringify(withoutField.inserted)).toContain(EMAIL)
+  })
+
+  it("redacts content and drops the duplicated content attribute for an enforce project", async () => {
+    const { effect, inserted } = runRedaction({ redaction: { [PROJECT_ID]: enforcePolicy } })
+    await Effect.runPromise(effect)
+
+    const span = inserted[0]?.[0]
+    expect(JSON.stringify(inserted)).not.toContain(EMAIL)
+    expect(JSON.stringify(span?.inputMessages)).toContain("[REDACTED_EMAIL]")
+    expect(span?.attrString).not.toHaveProperty("gen_ai.input.messages")
+    expect(span?.attrString["gen_ai.system"]).toBe("openai")
+  })
+
+  it("redacts only the opted-in project in a multi-project batch", async () => {
+    const payload = payloadFor([
+      spanWith(contentAttributes, "b7ad6b7169203331", "primary"),
+      spanWith(contentAttributes, "b7ad6b7169203332", "secondary"),
+    ])
+    const { effect, inserted } = runRedaction({
+      payload,
+      projectIdBySlug: { primary: PROJECT_ID, secondary: OTHER_PROJECT_ID },
+      redaction: { [PROJECT_ID]: enforcePolicy },
+    })
+    await Effect.runPromise(effect)
+
+    const spans = inserted[0] ?? []
+    const primary = spans.find((span) => (span.projectId as string) === PROJECT_ID)
+    const secondary = spans.find((span) => (span.projectId as string) === OTHER_PROJECT_ID)
+
+    expect(JSON.stringify(primary?.inputMessages)).toContain("[REDACTED_EMAIL]")
+    expect(JSON.stringify(secondary?.inputMessages)).toContain(EMAIL)
+  })
+
+  it("leaves rows untouched in dry run while still inserting them", async () => {
+    const { effect, inserted } = runRedaction({
+      redaction: { [PROJECT_ID]: { ...enforcePolicy, mode: "dryRun" } },
+    })
+    await Effect.runPromise(effect)
+
+    expect(JSON.stringify(inserted)).toContain(EMAIL)
+    expect(inserted[0]?.[0]?.attrString).toHaveProperty("gen_ai.input.messages")
+  })
+
+  it("still publishes TracesIngested after redacting, so downstream consumers see redacted content", async () => {
+    const { effect, eventsPublisher } = runRedaction({ redaction: { [PROJECT_ID]: enforcePolicy } })
+    await Effect.runPromise(effect)
+
+    expect(eventsPublisher.published[0]).toMatchObject({ name: "TracesIngested" })
+  })
+
+  it("fails without inserting when a policy is present but malformed", async () => {
+    const { effect, inserted } = runRedaction({ redaction: { [PROJECT_ID]: { mode: "bogus" } } })
+    const exit = await Effect.runPromiseExit(effect)
+
+    expect(exit._tag).toBe("Failure")
+    expect(inserted).toHaveLength(0)
+  })
+
+  it("fails without inserting when a policy names an unknown entity", async () => {
+    const { effect, inserted } = runRedaction({
+      redaction: { [PROJECT_ID]: { ...enforcePolicy, entities: ["passport"] } },
+    })
+    const exit = await Effect.runPromiseExit(effect)
+
+    expect(exit._tag).toBe("Failure")
+    expect(inserted).toHaveLength(0)
+  })
+
+  it("deletes the buffered payload once the spans are durable", async () => {
+    const { effect, storage, inserted } = runRedaction({
+      fileKey: "tmp-ingest/org/proj/abc.json",
+      redaction: { [PROJECT_ID]: enforcePolicy },
+    })
+    await Effect.runPromise(effect)
+
+    expect(inserted).toHaveLength(1)
+    expect(storage.deleted).toEqual(["tmp-ingest/org/proj/abc.json"])
+  })
+
+  it("does not delete an inline payload, which has no object to delete", async () => {
+    const { effect, storage } = runRedaction({ redaction: { [PROJECT_ID]: enforcePolicy } })
+    await Effect.runPromise(effect)
+
+    expect(storage.deleted).toEqual([])
+  })
+
+  it("keeps the ingest successful when deleting the buffered payload fails", async () => {
+    const eventsPublisher = createFakeEventsPublisher()
+    const { repository: spanRepo, inserted } = createFakeSpanRepository()
+    const payload = payloadFor([spanWith(contentAttributes, "b7ad6b7169203331")])
+    const storage = createFakeStorageDisk({
+      getBytes: async () => new Uint8Array(Buffer.from(payload, "base64")),
+      delete: async () => {
+        throw new Error("object store unavailable")
+      },
+    })
+
+    const effect = processIngestedSpansUseCase({ eventsPublisher })({
+      organizationId: ORGANIZATION_ID,
+      apiKeyId: "key-1",
+      contentType: "application/json",
+      ingestedAt: new Date("2026-03-18T10:00:00.000Z"),
+      isSandbox: false,
+      inlinePayload: null,
+      fileKey: "tmp-ingest/org/proj/abc.json",
+      defaultProjectId: PROJECT_ID,
+      projectIdBySlug: {},
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(SpanRepository, spanRepo),
+          Layer.succeed(StorageDisk, storage.disk),
+          Layer.succeed(ChSqlClient, {} as ChSqlClientShape),
+        ),
+      ),
+    )
+
+    const exit = await Effect.runPromiseExit(effect)
+
+    expect(exit._tag).toBe("Success")
+    expect(inserted).toHaveLength(1)
+  })
+})

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.test.ts
@@ -1,5 +1,5 @@
 import type { DomainEvent, EventsPublisher } from "@domain/events"
-import type { QueuePublishError } from "@domain/queue"
+import { QueuePublishError } from "@domain/queue"
 import { ChSqlClient, type ChSqlClientShape, OrganizationId, StorageDisk } from "@domain/shared"
 import { createFakeStorageDisk } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
@@ -297,5 +297,50 @@ describe("processIngestedSpansUseCase redaction", () => {
 
     expect(exit._tag).toBe("Success")
     expect(inserted).toHaveLength(1)
+  })
+})
+
+describe("processIngestedSpansUseCase buffered payload recovery", () => {
+  /**
+   * The delete must come after the events are published, not right after the insert.
+   * Deleting earlier makes a job that dies mid-processing unrecoverable: redelivery
+   * finds no payload, so the batch ends up inserted with `TracesIngested` never fired,
+   * silently losing trace-end, billing, and search indexing.
+   */
+  it("keeps the buffered payload when publishing the event fails", async () => {
+    const { repository: spanRepo, inserted } = createFakeSpanRepository()
+    const payload = payloadFor([spanWith(contentAttributes, "b7ad6b7169203331")])
+    const storage = createFakeStorageDisk({
+      getBytes: async () => new Uint8Array(Buffer.from(payload, "base64")),
+    })
+    const failingPublisher: EventsPublisher<QueuePublishError> = {
+      publish: () => Effect.fail(new QueuePublishError({ cause: "redis down", queue: "domain-events" })),
+    }
+
+    const effect = processIngestedSpansUseCase({ eventsPublisher: failingPublisher })({
+      organizationId: ORGANIZATION_ID,
+      apiKeyId: "key-1",
+      contentType: "application/json",
+      ingestedAt: new Date("2026-03-18T10:00:00.000Z"),
+      isSandbox: false,
+      inlinePayload: null,
+      fileKey: "tmp-ingest/org/proj/abc.json",
+      defaultProjectId: PROJECT_ID,
+      projectIdBySlug: {},
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(SpanRepository, spanRepo),
+          Layer.succeed(StorageDisk, storage.disk),
+          Layer.succeed(ChSqlClient, {} as ChSqlClientShape),
+        ),
+      ),
+    )
+
+    const exit = await Effect.runPromiseExit(effect)
+
+    expect(exit._tag).toBe("Failure")
+    expect(inserted).toHaveLength(1)
+    expect(storage.deleted).toEqual([])
   })
 })

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.test.ts
@@ -144,6 +144,7 @@ const runRedaction = (opts: {
   fileKey?: string | null
   redaction?: Record<string, unknown>
   projectIdBySlug?: Record<string, string>
+  defaultProjectId?: string | null
 }) => {
   const eventsPublisher = createFakeEventsPublisher()
   const { repository: spanRepo, inserted } = createFakeSpanRepository()
@@ -160,7 +161,7 @@ const runRedaction = (opts: {
     isSandbox: false,
     inlinePayload: opts.fileKey ? null : payload,
     fileKey: opts.fileKey ?? null,
-    defaultProjectId: PROJECT_ID,
+    defaultProjectId: opts.defaultProjectId === undefined ? PROJECT_ID : opts.defaultProjectId,
     projectIdBySlug: opts.projectIdBySlug ?? {},
     ...(opts.redaction ? { redaction: opts.redaction as never } : {}),
   }).pipe(
@@ -253,6 +254,24 @@ describe("processIngestedSpansUseCase redaction", () => {
 
     expect(inserted).toHaveLength(1)
     expect(storage.deleted).toEqual(["tmp-ingest/org/proj/abc.json"])
+  })
+
+  /**
+   * A batch whose spans are all dropped by the transform still had a payload, and that
+   * payload is unredacted. The early return skipped the cleanup, so on a self-hosted disk
+   * backend with no lifecycle rule the raw object stayed forever and repeated malformed
+   * batches grew without bound.
+   */
+  it("deletes the buffered payload when every span is dropped", async () => {
+    const { effect, inserted, storage } = runRedaction({
+      payload: payloadFor([spanWith(contentAttributes, "b7ad6b7169203331", "unknown-project-slug")]),
+      defaultProjectId: null,
+      fileKey: "tmp-ingest/org/proj/all-dropped.json",
+    })
+    await Effect.runPromise(effect)
+
+    expect(inserted).toHaveLength(0)
+    expect(storage.deleted).toEqual(["tmp-ingest/org/proj/all-dropped.json"])
   })
 
   it("does not delete an inline payload, which has no object to delete", async () => {

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -233,15 +233,6 @@ export const processIngestedSpansUseCase =
       const repo = yield* SpanRepository
       yield* repo.insert(persistedSpans)
 
-      // The buffered payload holds unredacted content. It is dropped as soon as the
-      // spans are durable, so the object-store lifecycle rule is a backstop rather
-      // than the only bound — self-hosted disk backends have no lifecycle rule at
-      // all. A failed delete must not fail an already-successful ingest.
-      if (input.fileKey) {
-        const disk = yield* StorageDisk
-        yield* Effect.ignore(deleteFromDisk(disk, input.fileKey))
-      }
-
       // Spans in a single OTLP batch may now belong to different projects (per-span scoping).
       // Group by projectId so each TracesIngested event addresses one project at a time —
       // downstream consumers (issues discovery, billing, flaggers, etc.) are project-scoped.
@@ -279,5 +270,17 @@ export const processIngestedSpansUseCase =
               : {}),
           },
         } satisfies DomainEvent)
+      }
+
+      // Last, not right after the insert. The buffered payload holds unredacted
+      // content, so it should not outlive the job — but deleting it before the events
+      // are published makes a stalled job unrecoverable: BullMQ redelivery would find
+      // no payload, and the batch would end up inserted with `TracesIngested` never
+      // fired, silently losing trace-end, billing, and search indexing. Deleting here
+      // leaves only the window between publish and delete, which the object-store
+      // lifecycle rule covers. A failed delete must not fail a successful ingest.
+      if (input.fileKey) {
+        const disk = yield* StorageDisk
+        yield* Effect.ignore(deleteFromDisk(disk, input.fileKey))
       }
     }).pipe(Effect.withSpan("spans.processIngestedSpans"))

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -131,11 +131,10 @@ function decodeAndTransform(
  * answer "is it working" or "why did my content disappear" after the fact.
  */
 function annotateRedaction(summary: SpanRedactionSummary): Effect.Effect<void> {
-  if (summary.enforceSpans === 0 && summary.dryRunSpans === 0) return Effect.void
+  if (summary.redactedSpans === 0) return Effect.void
 
   return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("redaction.enforceSpans", summary.enforceSpans)
-    yield* Effect.annotateCurrentSpan("redaction.dryRunSpans", summary.dryRunSpans)
+    yield* Effect.annotateCurrentSpan("redaction.spans", summary.redactedSpans)
     yield* Effect.annotateCurrentSpan("redaction.leavesScanned", summary.leavesScanned)
     yield* Effect.annotateCurrentSpan("redaction.charsScanned", summary.charsScanned)
     yield* Effect.annotateCurrentSpan("redaction.matches", totalRedactionCount(summary.counts))

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -1,16 +1,22 @@
 import type { DomainEvent, EventsPublisher } from "@domain/events"
 import {
   type ChSqlClient,
+  deleteFromDisk,
+  deserializeRedactionPolicy,
   getFromDisk,
   type OrganizationId,
   ProjectId,
+  type RedactionPolicy,
   type RepositoryError,
+  type SerializedRedactionPolicy,
   StorageDisk,
   type StorageError,
 } from "@domain/shared"
 import { Effect } from "effect"
 import type { SpanDetail } from "../entities/span.ts"
-import { SpanDecodingError } from "../errors.ts"
+import { RedactionError, SpanDecodingError } from "../errors.ts"
+import { redactSpans, type SpanRedactionSummary } from "../redaction/redact-spans.ts"
+import { totalRedactionCount } from "../redaction/redact-text.ts"
 import { decodeOtlpProtobuf } from "../otlp/proto.ts"
 import { transformOtlpToSpans } from "../otlp/transform.ts"
 import type { OtlpExportTraceServiceRequest } from "../otlp/types.ts"
@@ -23,6 +29,13 @@ export interface ProcessIngestedSpansInput {
   readonly ingestedAt: Date
   readonly isSandbox?: boolean
   readonly retentionDays?: number
+  /**
+   * Per-project redaction policy stamped at the ingest boundary. Absent, or absent
+   * for a given project, means that project opted out.
+   */
+  readonly redaction?: Readonly<Record<string, SerializedRedactionPolicy>>
+  /** Absent degrades pseudonymized identities to full redaction rather than blocking ingestion. */
+  readonly pseudonymSecret?: string
   readonly traceUsage?: {
     readonly context?: {
       readonly planSlug: "free" | "pro" | "enterprise"
@@ -113,6 +126,66 @@ function decodeAndTransform(
   })
 }
 
+/**
+ * Redaction is destructive and non-retroactive, so these counts are the only way to
+ * answer "is it working" or "why did my content disappear" after the fact.
+ */
+function annotateRedaction(summary: SpanRedactionSummary): Effect.Effect<void> {
+  if (summary.enforceSpans === 0 && summary.dryRunSpans === 0) return Effect.void
+
+  return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("redaction.enforceSpans", summary.enforceSpans)
+    yield* Effect.annotateCurrentSpan("redaction.dryRunSpans", summary.dryRunSpans)
+    yield* Effect.annotateCurrentSpan("redaction.leavesScanned", summary.leavesScanned)
+    yield* Effect.annotateCurrentSpan("redaction.charsScanned", summary.charsScanned)
+    yield* Effect.annotateCurrentSpan("redaction.matches", totalRedactionCount(summary.counts))
+    yield* Effect.annotateCurrentSpan("redaction.droppedAttributeKeys", summary.droppedAttributeKeys)
+
+    for (const [entity, count] of Object.entries(summary.counts)) {
+      yield* Effect.annotateCurrentSpan(`redaction.matches.${entity}`, count)
+    }
+
+    if (summary.oversizedFields > 0) {
+      yield* Effect.annotateCurrentSpan("redaction.oversizedFields", summary.oversizedFields)
+      yield* Effect.logWarning("Redaction replaced oversized fields wholesale", {
+        oversizedFields: summary.oversizedFields,
+      })
+    }
+
+    if (summary.pseudonymizedIdentities > 0) {
+      yield* Effect.annotateCurrentSpan("redaction.pseudonymizedIdentities", summary.pseudonymizedIdentities)
+    }
+
+    if (summary.identityFallback) {
+      yield* Effect.annotateCurrentSpan("redaction.identityFallback", true)
+      yield* Effect.logError("Redaction fell back to redacting identities: no pseudonym secret is configured")
+    }
+  })
+}
+
+/**
+ * A present but malformed policy fails the job rather than being skipped. Skipping
+ * would resolve a corrupt policy on a project that opted in to a plaintext write,
+ * which is the one outcome redaction exists to prevent. An absent field is
+ * different and legitimate: it means no project opted in.
+ */
+function decodeRedactionPolicies(
+  wire: Readonly<Record<string, SerializedRedactionPolicy>> | undefined,
+): Effect.Effect<ReadonlyMap<string, RedactionPolicy>, RedactionError> {
+  if (!wire) return Effect.succeed(new Map())
+
+  const policies = new Map<string, RedactionPolicy>()
+  for (const [projectId, serialized] of Object.entries(wire)) {
+    const policy = deserializeRedactionPolicy(serialized)
+    if (!policy) {
+      return Effect.fail(new RedactionError({ reason: `malformed redaction policy for project ${projectId}` }))
+    }
+    policies.set(projectId, policy)
+  }
+
+  return Effect.succeed(policies)
+}
+
 export interface ProcessIngestedSpansDeps<TPublishError = unknown> {
   readonly eventsPublisher: EventsPublisher<TPublishError>
 }
@@ -123,14 +196,29 @@ export const processIngestedSpansUseCase =
     input: ProcessIngestedSpansInput,
   ): Effect.Effect<
     void,
-    SpanDecodingError | StorageError | RepositoryError | TPublishError,
+    SpanDecodingError | StorageError | RepositoryError | RedactionError | TPublishError,
     ChSqlClient | SpanRepository | StorageDisk
   > =>
     Effect.gen(function* () {
       yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
 
       const payload = yield* resolvePayload(input)
-      const spans = yield* decodeAndTransform(payload, input)
+      const transformed = yield* decodeAndTransform(payload, input)
+
+      // Redaction runs before the retention stamp and the insert, which makes it the
+      // single choke point for every content sink: `traces` and `sessions` are
+      // materialized views on `spans`, every other derived table re-reads `spans`,
+      // and `TracesIngested` has not fired yet.
+      const policyByProjectId = yield* decodeRedactionPolicies(input.redaction)
+      const redaction = yield* redactSpans({
+        spans: transformed,
+        organizationId: input.organizationId,
+        policyByProjectId,
+        pseudonymSecret: input.pseudonymSecret,
+      })
+      yield* annotateRedaction(redaction.summary)
+
+      const spans = redaction.spans
       const persistedSpans =
         input.retentionDays === undefined
           ? spans
@@ -145,6 +233,15 @@ export const processIngestedSpansUseCase =
 
       const repo = yield* SpanRepository
       yield* repo.insert(persistedSpans)
+
+      // The buffered payload holds unredacted content. It is dropped as soon as the
+      // spans are durable, so the object-store lifecycle rule is a backstop rather
+      // than the only bound — self-hosted disk backends have no lifecycle rule at
+      // all. A failed delete must not fail an already-successful ingest.
+      if (input.fileKey) {
+        const disk = yield* StorageDisk
+        yield* Effect.ignore(deleteFromDisk(disk, input.fileKey))
+      }
 
       // Spans in a single OTLP batch may now belong to different projects (per-span scoping).
       // Group by projectId so each TracesIngested event addresses one project at a time —

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -185,6 +185,25 @@ function decodeRedactionPolicies(
   return Effect.succeed(policies)
 }
 
+/**
+ * Drop the buffered payload once the job has genuinely finished with it.
+ *
+ * Called on the success paths only, never from a finalizer: a job that failed may be
+ * redelivered, and redelivery needs the payload. Deleting it before the events are
+ * published would leave a stalled batch inserted with `TracesIngested` never fired,
+ * silently losing trace-end, billing, and search indexing. A failed delete must not
+ * fail an otherwise successful ingest, so the object-store lifecycle rule stays the
+ * backstop.
+ */
+function discardBufferedPayload(fileKey: string | null): Effect.Effect<void, never, StorageDisk> {
+  if (!fileKey) return Effect.void
+
+  return Effect.gen(function* () {
+    const disk = yield* StorageDisk
+    yield* Effect.ignore(deleteFromDisk(disk, fileKey))
+  })
+}
+
 export interface ProcessIngestedSpansDeps<TPublishError = unknown> {
   readonly eventsPublisher: EventsPublisher<TPublishError>
 }
@@ -226,7 +245,10 @@ export const processIngestedSpansUseCase =
               retentionDays: input.retentionDays,
             }))
 
+      // Nothing survived the transform, so there is nothing to insert — but the payload
+      // that produced it still holds unredacted content and must not be left behind.
       if (persistedSpans.length === 0) {
+        yield* discardBufferedPayload(input.fileKey)
         return
       }
 
@@ -272,15 +294,5 @@ export const processIngestedSpansUseCase =
         } satisfies DomainEvent)
       }
 
-      // Last, not right after the insert. The buffered payload holds unredacted
-      // content, so it should not outlive the job — but deleting it before the events
-      // are published makes a stalled job unrecoverable: BullMQ redelivery would find
-      // no payload, and the batch would end up inserted with `TracesIngested` never
-      // fired, silently losing trace-end, billing, and search indexing. Deleting here
-      // leaves only the window between publish and delete, which the object-store
-      // lifecycle rule covers. A failed delete must not fail a successful ingest.
-      if (input.fileKey) {
-        const disk = yield* StorageDisk
-        yield* Effect.ignore(deleteFromDisk(disk, input.fileKey))
-      }
+      yield* discardBufferedPayload(input.fileKey)
     }).pipe(Effect.withSpan("spans.processIngestedSpans"))

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -15,12 +15,12 @@ import {
 import { Effect } from "effect"
 import type { SpanDetail } from "../entities/span.ts"
 import { RedactionError, SpanDecodingError } from "../errors.ts"
-import { redactSpans, type SpanRedactionSummary } from "../redaction/redact-spans.ts"
-import { totalRedactionCount } from "../redaction/redact-text.ts"
 import { decodeOtlpProtobuf } from "../otlp/proto.ts"
 import { transformOtlpToSpans } from "../otlp/transform.ts"
 import type { OtlpExportTraceServiceRequest } from "../otlp/types.ts"
 import { SpanRepository } from "../ports/span-repository.ts"
+import { redactSpans, type SpanRedactionSummary } from "../redaction/redact-spans.ts"
+import { totalRedactionCount } from "../redaction/redact-text.ts"
 
 export interface ProcessIngestedSpansInput {
   readonly organizationId: OrganizationId

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -92,6 +92,10 @@ export { TaxonomyRunRepositoryLive } from "./repositories/taxonomy-run-repositor
 export { UserRepositoryLive } from "./repositories/user-repository.ts"
 export { WrappedReportRepositoryLive } from "./repositories/wrapped-report-repository.ts"
 export { invalidateEffectivePlanCache, resolveEffectivePlanCached } from "./resolve-effective-plan-cached.ts"
+export {
+  invalidateOrganizationRedactionCache,
+  resolveOrganizationRedactionCached,
+} from "./resolve-redaction-policy-cached.ts"
 // SqlClient implementation
 export { SqlClientLive } from "./sql-client.ts"
 export { withPostgres } from "./with-postgres.ts"

--- a/packages/platform/db-postgres/src/resolve-redaction-policy-cached.test.ts
+++ b/packages/platform/db-postgres/src/resolve-redaction-policy-cached.test.ts
@@ -1,0 +1,174 @@
+import { CacheError, CacheStore, generateId, OrganizationId } from "@domain/shared"
+import { organizations } from "@platform/db-postgres/schema/better-auth"
+import { withTracing } from "@repo/observability"
+import { eq } from "drizzle-orm"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { SettingsReaderLive } from "./repositories/settings-reader-repository.ts"
+import {
+  invalidateOrganizationRedactionCache,
+  resolveOrganizationRedactionCached,
+} from "./resolve-redaction-policy-cached.ts"
+import { setupTestPostgres } from "./test/in-memory-postgres.ts"
+import { withPostgres } from "./with-postgres.ts"
+
+const pg = setupTestPostgres()
+
+interface CacheProbe {
+  readonly store: Map<string, string>
+  gets: number
+  sets: number
+}
+
+const cacheLayer = (probe: CacheProbe) =>
+  Layer.succeed(CacheStore, {
+    get: (key: string) =>
+      Effect.sync(() => {
+        probe.gets += 1
+        return probe.store.get(key) ?? null
+      }),
+    set: (key: string, value: string) =>
+      Effect.sync(() => {
+        probe.sets += 1
+        probe.store.set(key, value)
+      }),
+    delete: (key: string) =>
+      Effect.sync(() => {
+        probe.store.delete(key)
+      }),
+  })
+
+const failingCacheLayer = Layer.succeed(CacheStore, {
+  get: () => Effect.fail(new CacheError({ message: "redis down" })),
+  set: () => Effect.fail(new CacheError({ message: "redis down" })),
+  delete: () => Effect.void,
+})
+
+const seedOrg = async (settings?: Record<string, unknown>) => {
+  const organizationId = generateId()
+  await pg.db.insert(organizations).values({
+    id: organizationId,
+    name: "Redaction Org",
+    slug: `redaction-${organizationId}`,
+    ...(settings ? { settings: settings as never } : {}),
+  })
+
+  return organizationId
+}
+
+const run = (organizationId: string, cache: Layer.Layer<CacheStore>) =>
+  Effect.runPromise(
+    resolveOrganizationRedactionCached(OrganizationId(organizationId)).pipe(
+      withPostgres(SettingsReaderLive, pg.appPostgresClient, OrganizationId(organizationId)),
+      Effect.provide(cache),
+      withTracing,
+    ),
+  )
+
+describe("resolveOrganizationRedactionCached", () => {
+  it("returns null when the organization has no redaction policy", async () => {
+    const organizationId = await seedOrg()
+    const probe: CacheProbe = { store: new Map(), gets: 0, sets: 0 }
+
+    expect(await run(organizationId, cacheLayer(probe))).toBeNull()
+  })
+
+  it("returns the stored organization policy", async () => {
+    const organizationId = await seedOrg({ redaction: { mode: "enforce", entities: ["email"], locked: true } })
+    const probe: CacheProbe = { store: new Map(), gets: 0, sets: 0 }
+
+    expect(await run(organizationId, cacheLayer(probe))).toEqual({
+      mode: "enforce",
+      entities: ["email"],
+      locked: true,
+    })
+  })
+
+  it("serves the second read from cache without querying again", async () => {
+    const organizationId = await seedOrg({ redaction: { mode: "enforce" } })
+    const probe: CacheProbe = { store: new Map(), gets: 0, sets: 0 }
+
+    const first = await run(organizationId, cacheLayer(probe))
+
+    await pg.db
+      .update(organizations)
+      .set({ settings: { redaction: { mode: "off" } } as never })
+      .where(eq(organizations.id, organizationId))
+
+    const second = await run(organizationId, cacheLayer(probe))
+
+    expect(first).toEqual({ mode: "enforce" })
+    expect(second).toEqual({ mode: "enforce" })
+    expect(probe.sets).toBe(1)
+  })
+
+  /**
+   * Almost every org has no policy. If a cached `null` were indistinguishable from
+   * a miss, the cache would never serve that case and every OTLP request would
+   * query Postgres, which is the whole reason this wrapper exists.
+   */
+  it("caches the absence of a policy rather than re-querying for it", async () => {
+    const organizationId = await seedOrg()
+    const probe: CacheProbe = { store: new Map(), gets: 0, sets: 0 }
+
+    await run(organizationId, cacheLayer(probe))
+
+    await pg.db
+      .update(organizations)
+      .set({ settings: { redaction: { mode: "enforce" } } as never })
+      .where(eq(organizations.id, organizationId))
+
+    expect(await run(organizationId, cacheLayer(probe))).toBeNull()
+    expect(probe.sets).toBe(1)
+  })
+
+  it("uses an organization-prefixed cache key", async () => {
+    const organizationId = await seedOrg({ redaction: { mode: "dryRun" } })
+    const probe: CacheProbe = { store: new Map(), gets: 0, sets: 0 }
+
+    await run(organizationId, cacheLayer(probe))
+
+    expect([...probe.store.keys()]).toEqual([`org:${organizationId}:settings:redaction`])
+  })
+
+  it("re-reads after invalidation", async () => {
+    const organizationId = await seedOrg({ redaction: { mode: "dryRun" } })
+    const probe: CacheProbe = { store: new Map(), gets: 0, sets: 0 }
+    const cache = cacheLayer(probe)
+
+    await run(organizationId, cache)
+
+    await pg.db
+      .update(organizations)
+      .set({ settings: { redaction: { mode: "enforce" } } as never })
+      .where(eq(organizations.id, organizationId))
+
+    await Effect.runPromise(
+      invalidateOrganizationRedactionCache(OrganizationId(organizationId)).pipe(Effect.provide(cache), withTracing),
+    )
+
+    expect(await run(organizationId, cache)).toEqual({ mode: "enforce" })
+  })
+
+  it("falls back to the database when the cache is unavailable", async () => {
+    const organizationId = await seedOrg({ redaction: { mode: "enforce" } })
+
+    expect(await run(organizationId, failingCacheLayer)).toEqual({ mode: "enforce" })
+  })
+
+  it("re-reads rather than trusting a corrupt cache entry", async () => {
+    const organizationId = await seedOrg({ redaction: { mode: "enforce" } })
+    const probe: CacheProbe = { store: new Map(), gets: 0, sets: 0 }
+    probe.store.set(`org:${organizationId}:settings:redaction`, "{not json")
+
+    expect(await run(organizationId, cacheLayer(probe))).toEqual({ mode: "enforce" })
+  })
+
+  it("re-reads rather than trusting a schema-invalid cache entry", async () => {
+    const organizationId = await seedOrg({ redaction: { mode: "enforce" } })
+    const probe: CacheProbe = { store: new Map(), gets: 0, sets: 0 }
+    probe.store.set(`org:${organizationId}:settings:redaction`, JSON.stringify({ redaction: { mode: "bogus" } }))
+
+    expect(await run(organizationId, cacheLayer(probe))).toEqual({ mode: "enforce" })
+  })
+})

--- a/packages/platform/db-postgres/src/resolve-redaction-policy-cached.test.ts
+++ b/packages/platform/db-postgres/src/resolve-redaction-policy-cached.test.ts
@@ -123,7 +123,7 @@ describe("resolveOrganizationRedactionCached", () => {
   })
 
   it("uses an organization-prefixed cache key", async () => {
-    const organizationId = await seedOrg({ redaction: { mode: "dryRun" } })
+    const organizationId = await seedOrg({ redaction: { mode: "enforce" } })
     const probe: CacheProbe = { store: new Map(), gets: 0, sets: 0 }
 
     await run(organizationId, cacheLayer(probe))
@@ -132,7 +132,7 @@ describe("resolveOrganizationRedactionCached", () => {
   })
 
   it("re-reads after invalidation", async () => {
-    const organizationId = await seedOrg({ redaction: { mode: "dryRun" } })
+    const organizationId = await seedOrg({ redaction: { mode: "enforce" } })
     const probe: CacheProbe = { store: new Map(), gets: 0, sets: 0 }
     const cache = cacheLayer(probe)
 

--- a/packages/platform/db-postgres/src/resolve-redaction-policy-cached.ts
+++ b/packages/platform/db-postgres/src/resolve-redaction-policy-cached.ts
@@ -1,0 +1,83 @@
+import {
+  CacheStore,
+  type OrganizationId,
+  type OrganizationRedactionSetting,
+  organizationRedactionSettingSchema,
+  SettingsReader,
+} from "@domain/shared"
+import { Effect } from "effect"
+import { z } from "zod"
+
+const REDACTION_SETTING_CACHE_TTL_SECONDS = 60
+
+const buildCacheKey = (organizationId: string) => `org:${organizationId}:settings:redaction`
+
+/**
+ * The setting is wrapped rather than cached bare so a cached "this org has no
+ * redaction policy" is distinguishable from a cache miss. Almost every org is in
+ * that state, and it is the case the cache exists to serve.
+ */
+const cachedRedactionSchema = z.object({
+  redaction: organizationRedactionSettingSchema.nullable(),
+})
+
+const parseCached = (json: string): OrganizationRedactionSetting | null | undefined => {
+  try {
+    const result = cachedRedactionSchema.safeParse(JSON.parse(json))
+
+    return result.success ? result.data.redaction : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Organization-level redaction setting, cached for 60 s.
+ *
+ * Read on the OTLP ingest path, which is the hottest path in the product, so the
+ * uncached `SettingsReader` query it wraps must not run per request. The project
+ * half of the cascade needs no cache: `ingestSpansUseCase` already holds each
+ * resolved `Project` with its settings.
+ *
+ * A read failure propagates rather than degrading to "no org policy". Degrading
+ * would let a `locked` org policy silently fall back to a weaker project policy
+ * and write plaintext, and it buys no availability: project resolution on this
+ * path already hard-depends on Postgres, so the request fails anyway.
+ *
+ * Consequence to document for users: enabling or locking redaction takes effect
+ * within 60 s, not instantly.
+ */
+export const resolveOrganizationRedactionCached = Effect.fn("spans.resolveOrganizationRedactionCached")(function* (
+  organizationId: OrganizationId,
+) {
+  const cache = yield* CacheStore
+  const cacheKey = buildCacheKey(organizationId)
+
+  const cachedJson = yield* cache.get(cacheKey).pipe(Effect.catchTag("CacheError", () => Effect.succeed(null)))
+  if (cachedJson !== null) {
+    const parsed = parseCached(cachedJson)
+    if (parsed !== undefined) {
+      yield* Effect.annotateCurrentSpan("cache.hit", true)
+      return parsed
+    }
+  }
+
+  yield* Effect.annotateCurrentSpan("cache.hit", false)
+  const reader = yield* SettingsReader
+  const settings = yield* reader.getOrganizationSettings()
+  const redaction = settings?.redaction ?? null
+
+  yield* cache
+    .set(cacheKey, JSON.stringify({ redaction }), { ttlSeconds: REDACTION_SETTING_CACHE_TTL_SECONDS })
+    .pipe(Effect.catchTag("CacheError", () => Effect.void))
+
+  return redaction
+})
+
+export const invalidateOrganizationRedactionCache = Effect.fn("spans.invalidateOrganizationRedactionCache")(function* (
+  organizationId: OrganizationId,
+) {
+  const cache = yield* CacheStore
+
+  yield* cache.delete(buildCacheKey(organizationId)).pipe(Effect.catchTag("CacheError", () => Effect.void))
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1757,6 +1757,9 @@ importers:
       '@domain/events':
         specifier: workspace:*
         version: link:../events
+      '@domain/shared':
+        specifier: workspace:*
+        version: link:../shared
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.57

--- a/specs/pii-redaction.md
+++ b/specs/pii-redaction.md
@@ -717,6 +717,11 @@ The benchmark was run as a throwaway script and not committed. The repository ha
 - `@domain/queue` gained a dependency on `@domain/shared` for the wire type. No cycle, since `@domain/shared` has no workspace dependencies beyond `@repo/utils`.
 - Effect `4.0.0-beta.57` has no `Effect.catchAll`. Use `Effect.ignore` for "discard any failure"; the available surface is `catchCause`, `catchTag`, `catchIf`, `catchDefect`, `ignore`, `orElseSucceed`.
 - The `@platform/db-postgres` suite has pre-existing PGlite `beforeAll` contention flakiness: the same tree produced 47/47 passing and 5 timed-out `setupTestPostgres` hooks on consecutive full runs, while the affected files pass in isolation. Unrelated to redaction; do not chase it when it appears.
+- **The single-write-path claim is verified structurally, not just by test.** `spans` has exactly one writer (`SpanRepository.insert`, called only from `processIngestedSpansUseCase`), the table is written from exactly one place in the ClickHouse adapter, and `span-ingestion:ingest` has exactly one publisher and one consumer. Seed tooling POSTs to `/v1/traces` rather than writing directly, so it traverses the same path. Re-check these four facts if redaction ever appears to be bypassed:
+  - `grep -rn 'table: "spans"'` → only `span-repository.ts`
+  - `grep -rn 'repo.insert'` → only `process-ingested-spans.ts`
+  - `grep -rn '"span-ingestion"'` → only `ingest-spans.ts` (publish) and the worker (subscribe)
+  - `grep -rn 'v1/traces' tools/live-seeds` → seeds use the HTTP boundary
 
 ### Phase 3 - Surfaces: UI, API, docs
 

--- a/specs/pii-redaction.md
+++ b/specs/pii-redaction.md
@@ -679,11 +679,11 @@ Follow the layering in the testing skill: pure unit tests in the domain, PGlite/
 - [x] **P2-2**: Add `redaction?: Record<string, SerializedRedactionPolicy>` to `span-ingestion:ingest` in `packages/domain/queue/src/topic-registry.ts`.
 - [x] **P2-3**: In `ingestSpansUseCase`, resolve the per-project policy from the already-loaded `projectBySlug` plus the cached org settings, and stamp the map onto the published job. Omit `off` projects and omit the field entirely when the map is empty.
 - [x] **P2-4**: Provide the Redis cache layer the resolver needs in `apps/ingest/src/routes/traces.ts`.
-- [ ] **P2-5**: In `processIngestedSpansUseCase`, accept `redaction`, apply the pass between `decodeAndTransform` and `repo.insert`, fail closed, and wrap in `Effect.timeout(REDACTION_BATCH_TIMEOUT_MS)`.
-- [ ] **P2-6**: Pass `wire.redaction` through `apps/workers/src/workers/span-ingestion.ts`; parse `LAT_REDACTION_PSEUDONYM_SECRET` with `parseEnvOptional` at the use site; add it to `.env.example` in the workers block.
-- [ ] **P2-7**: Emit every annotation in [§4.8](#48-observability), plus the `warn`/`error` logs.
-- [ ] **P2-8**: Delete the `tmp-ingest` blob after a successful insert via `deleteFromDisk` ([T-3](#8-traps)). Delete only after `repo.insert` succeeds, and treat a delete failure as non-fatal (the lifecycle rule is the backstop).
-- [ ] **P2-9**: Integration tests per [§9](#9-testing-plan) in both `process-ingested-spans.test.ts` and `ingest-spans.test.ts`.
+- [x] **P2-5**: In `processIngestedSpansUseCase`, accept `redaction`, apply the pass between `decodeAndTransform` and `repo.insert`, fail closed, and wrap in `Effect.timeout(REDACTION_BATCH_TIMEOUT_MS)`.
+- [x] **P2-6**: Pass `wire.redaction` through `apps/workers/src/workers/span-ingestion.ts`; parse `LAT_REDACTION_PSEUDONYM_SECRET` with `parseEnvOptional` at the use site; add it to `.env.example` in the workers block.
+- [x] **P2-7**: Emit every annotation in [§4.8](#48-observability), plus the `warn`/`error` logs.
+- [x] **P2-8**: Delete the `tmp-ingest` blob after a successful insert via `deleteFromDisk` ([T-3](#8-traps)). Delete only after `repo.insert` succeeds, and treat a delete failure as non-fatal (the lifecycle rule is the backstop).
+- [x] **P2-9**: Integration tests per [§9](#9-testing-plan) in both `process-ingested-spans.test.ts` and `ingest-spans.test.ts`.
 - [ ] **P2-10**: Run the benchmark in [§4.7](#47-size-and-time-budget) and record p50/p99 per-span cost and the concurrency-50 CPU delta in the PR description.
 
 **Exit gate**:

--- a/specs/pii-redaction.md
+++ b/specs/pii-redaction.md
@@ -263,14 +263,10 @@ The risk this trades into is redacting a tool-call id and breaking the tool-call
 
 `isContentAttributeKey` must **not** be a hand-maintained list in the redaction module. Each parser in `packages/domain/spans/src/otlp/content/` already knows its own keys; have each module export a key matcher and compose them in `content/index.ts` next to the existing vendor dispatch table (`content/index.ts:41-87`). A new vendor parser then gets redaction coverage automatically. Known families to cover: `genai`, `genai_deprecated`, `openinference`, `vercel`, `livekit`, `flue`, `claude-code`, `json-value`.
 
-In `dryRun` mode, count what pass 1 *would* drop; do not drop it.
-
 ### 4.3 Policy model
 
-Not a boolean. A boolean cannot express "let me validate this before it destroys my data," which is the single biggest adoption blocker for a destructive, non-retroactive, unrecoverable transform.
-
 ```ts
-export const REDACTION_MODES = ["off", "dryRun", "enforce"] as const
+export const REDACTION_MODES = ["off", "enforce"] as const
 
 export const REDACTION_ENTITIES = [
   "email",
@@ -296,10 +292,18 @@ export const DEFAULT_REDACTION_ENTITIES = [
 **Modes:**
 
 - `off` (default) — no scanning, zero cost. Projects in this mode never appear in the queue policy map.
-- `dryRun` — run every detector, count matches per entity and per field, annotate the trace, **mutate nothing**. Costs the same CPU as `enforce`.
 - `enforce` — replace matches with `[REDACTED_<LABEL>]`.
 
-`dryRun` is not a nice-to-have. It is how a customer answers "will this eat my tool outputs" before it does, and it is the only non-destructive way to tune `entities`.
+**There is deliberately no dry-run mode.** An earlier draft had one, on the reasoning that a destructive, non-retroactive, unrecoverable transform needs a way to validate a policy before it destroys data. That reasoning is sound; a dry-run *mode* was the wrong answer to it. It redacted nothing and surfaced nothing a customer could read — its only output was the [§4.8](#48-observability) span annotations, which land in Latitude's own telemetry — so from the outside it was indistinguishable from `off` while still costing a full scan and still able to fail closed on a deadline overrun. A mode that stores what `off` stores and can lose spans that `off` would keep is worse than not having it.
+
+Two consequences worth stating, because removing it removed a safety net:
+
+- **A false negative is now invisible to everyone.** Nothing reports what redaction did *not* catch. That raises the stakes on detector precision being right by construction ([§5](#5-detector-specification)) and makes per-entity toggles and the visible placeholder the only feedback a customer gets.
+- **Detector tuning needs a script, not a product mode.** Measuring how a detector behaves against real traffic is an offline question: read spans from ClickHouse and run the detectors over them. That answers [open question 5](#10-open-questions) without shipping a customer-visible surface that does nothing.
+
+Giving customers a real answer to "will this eat my tool outputs" needs a preview that runs the detectors on demand over spans already in ClickHouse and returns counts plus before/after samples. That is a genuine feature, out of scope here, and it is the thing a dry-run mode was pretending to be.
+
+Because `off` projects are omitted from the queue map entirely, a policy's *presence* is the decision. The engine-facing `RedactionPolicy` therefore carries no mode at all, and the wire format has no `mode` field: only the settings-facing `ResolvedRedactionPolicy` has one, for the UI toggle.
 
 **Placeholder format:** `[REDACTED_EMAIL]`, `[REDACTED_CREDIT_CARD]`, and so on. Uppercased entity label, no counters or ordinals (keeps `content_hash` deterministic for identical inputs). The placeholder is visible in the UI, which is intentional: users must be able to see *why* content is missing.
 
@@ -328,7 +332,7 @@ export const organizationRedactionSettingSchema = redactionSettingSchema.extend(
 
 ```ts
 export interface ResolvedRedactionPolicy {
-  readonly mode: "off" | "dryRun" | "enforce"
+  readonly mode: "off" | "enforce"
   readonly entities: ReadonlySet<RedactionEntity>
   readonly redactMetadata: boolean
   readonly identities: "keep" | "pseudonymize"
@@ -380,7 +384,6 @@ readonly redaction?: Readonly<Record<string, SerializedRedactionPolicy>> // proj
 
 ```ts
 interface SerializedRedactionPolicy {
-  readonly mode: "dryRun" | "enforce"
   readonly entities: readonly RedactionEntity[]
   readonly redactMetadata: boolean
   readonly identities: "keep" | "pseudonymize"
@@ -401,7 +404,7 @@ Justification, and this is a deliberate divergence from both competitors:
 2. For the in-process deterministic tier, "failure" means a code bug, so fail-open reduces to *silently writing plaintext PII for a customer who explicitly asked us not to*.
 3. There is no delete path ([§2.5](#25-what-does-not-exist)) and redaction is non-retroactive, so a fail-open write is permanent and unremediable.
 
-**The cost is explicit and accepted:** a persistent redaction bug loses spans for opted-in projects rather than leaking their PII. That is the correct trade for a compliance control, it is loud (failed jobs, error logs, retry exhaustion), and the customer has two self-service escapes: set `mode` back to `off`, or to `dryRun`.
+**The cost is explicit and accepted:** a persistent redaction bug loses spans for opted-in projects rather than leaking their PII. That is the correct trade for a compliance control, it is loud (failed jobs, error logs, retry exhaustion), and the customer has a self-service escape: set `mode` back to `off`.
 
 Additional rules:
 
@@ -413,7 +416,7 @@ Additional rules:
 
 Ingestion is the hot path of the entire product, so this is a capacity question, not a footnote. "Sub-ms and deterministic" is meaningless without a size.
 
-- `REDACTION_MAX_FIELD_CHARS = 1_000_000` (1 M UTF-16 code units). A field above the cap is **not scanned**. In `enforce` mode it is replaced wholesale with `[REDACTED_OVERSIZED_FIELD]` and counted; in `dryRun` it is counted and left alone. Passing it through unscanned would break the promise, and partial scanning would leak the tail. Per the design invariant, degrade toward more redaction. 1 MB is generous: the realistic trigger is multi-MB file content in coding-agent tool outputs.
+- `REDACTION_MAX_FIELD_CHARS = 1_000_000` (1 M UTF-16 code units). A field above the cap is **not scanned**: it is replaced wholesale with `[REDACTED_OVERSIZED_FIELD]` and counted. Passing it through unscanned would break the promise, and partial scanning would leak the tail. Per the design invariant, degrade toward more redaction. 1 MB is generous: the realistic trigger is multi-MB file content in coding-agent tool outputs.
 - `REDACTION_MAX_DEPTH = 256`. The walk is recursive and `JSON.parse` accepts nesting tens of thousands deep, so a crafted `tool_input` overflows the stack; fail-closed then turns one hostile span into a dropped batch for every project in it. A subtree at the cap is treated exactly like an oversized leaf, which keeps the failure local. Payloads too deep for `JSON.parse` itself fall back to a plain-text scan, so they are still scanned rather than skipped.
 - `REDACTION_BATCH_TIMEOUT_MS = 30_000`, enforced as a **deadline checked before each span**, not as an `Effect.timeout` around the whole pass. The walk is synchronous, so a fiber-level timeout cannot fire until the work it was meant to bound has already finished; wrapping the pass in one would advertise a limit that never applies. Overrun is therefore bounded by a single span's walk, which the field cap bounds in turn. The async pseudonym phase does yield, so that one keeps a real `Effect.timeoutOrElse`. Either way the pass fails and the job retries ([§4.6](#46-failure-policy)).
 - **Benchmark acceptance criterion:** measure and record added wall-clock per span at p50 and p99 for a representative batch, and the total CPU delta at concurrency 50. Target ≤ 5 ms per span at 32 KB of scanned content. If the measured number misses the target, the finding goes in the PR description and the cap gets revisited; do not silently ship a regression on the ingest path.
@@ -424,8 +427,7 @@ Without these, nobody can answer "is it working" or "why did my content disappea
 
 | Annotation | Meaning |
 | --- | --- |
-| `redaction.enforceSpans` | spans processed in `enforce` |
-| `redaction.dryRunSpans` | spans processed in `dryRun` |
+| `redaction.spans` | spans redacted |
 | `redaction.fields` | fields scanned |
 | `redaction.bytes` | bytes scanned |
 | `redaction.matches` | total accepted matches |
@@ -484,7 +486,7 @@ Remap by `path`, never by index. Chunk requests by byte count with a cap; do not
 
 ## 5. Detector specification
 
-`packages/domain/spans/src/redaction/detectors.ts`. Every detector returns `{ start, end, label }` matches. Precision is the design goal, not recall: a false negative is a missed redaction the customer can catch in `dryRun`, while a false positive is permanent silent data corruption with no delete path.
+`packages/domain/spans/src/redaction/detectors.ts`. Every detector returns `{ start, end, label }` matches. Precision is the design goal, not recall: a false negative leaves content visible, which the customer can see and report, while a false positive is permanent silent data corruption with no delete path.
 
 **The traffic that decides these defaults is coding-agent telemetry** (`packages/telemetry/claude-code`, `openclaw`, `pi`). Any detector must survive git SHAs, semver strings, ports, timestamps, UUIDs, base64 in diffs, long numeric JSON ids, and file paths appearing in `tool_output`.
 
@@ -542,11 +544,11 @@ Remap by `path`, never by index. Chunk requests by byte count with a cap; do not
 
 Project section, in `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx`, following the existing `Draft`/`pending`/`dirtyFields` pattern (`:34-106`) and the `rounded-lg bg-muted/30` card shape of `TraceSamplingSection` (`:196-257`):
 
-- Mode selector (`Off` / `Dry run` / `Enforce`), not a `Switch`, because there are three states.
-- Entity checkboxes, revealed when mode is not `Off`, in a `border-t` sub-row.
+- A `Switch`: redaction is on or off ([§4.3](#43-policy-model)).
+- Entity checkboxes, revealed when redaction is on, in a `border-t` sub-row.
 - Metadata-and-tags toggle and identity-handling selector in the same sub-row.
 - `DotIndicator` on dirty, participating in the existing `dirtyCount` / Apply / Discard / cmd-S / `useBlocker` machinery.
-- Copy must state: applies only to spans ingested from now on, takes effect within a minute, redacted content cannot be recovered, and dry run changes nothing.
+- Copy must state: applies only to spans ingested from now on, takes effect within a minute, and redacted content cannot be recovered.
 - When the org policy is `locked`, render the whole section read-only with an explanation naming the org policy.
 
 Org section in `settings/organization.tsx`: same controls plus `locked`, owner-only, with copy explaining that locking prevents projects from weakening it.
@@ -607,14 +609,13 @@ Follow the layering in the testing skill: pure unit tests in the domain, PGlite/
 - JSON walk: array length and order preserved, object keys preserved, non-string leaves untouched, `blob`/`file` parts skipped, nested stringified JSON handled, `JSON.stringify` round-trip stable, unknown part types fall through to the generic walk.
 - `resolveRedactionPolicy`: every cascade combination, `locked` overriding a project policy entirely, `source` correctness, defaults when both sides are empty.
 - Pseudonymization: determinism, cross-org divergence for the same input, empty values stay empty, missing secret degrades to `[REDACTED_USER]`.
-- Oversized field: `enforce` replaces and counts, `dryRun` counts and leaves alone.
+- Oversized field: replaced wholesale and counted.
 
 **Integration, `packages/domain/spans/src/use-cases/process-ingested-spans.test.ts` (extend the existing file):**
 
 - `enforce` project: content redacted, **`attr_string` content keys dropped**, `events_json` redacted, `resource_string` values redacted.
 - Project absent from the policy map: byte-identical to today's output. Add this as a regression guard against accidental unconditional redaction.
 - Mixed batch: one `enforce` project and one absent project in the same OTLP batch, each handled correctly.
-- `dryRun`: inserted rows are byte-identical to unredacted, and match counts are annotated.
 - `metadata` scope off by default and applied when on.
 - Detector throw: no insert happens and the effect fails ([§4.6](#46-failure-policy)).
 - Timeout: fails rather than inserting.
@@ -638,8 +639,8 @@ Follow the layering in the testing skill: pure unit tests in the domain, PGlite/
 1. **Latitude's own API key format** for the `secret` detector. Derive it from `packages/domain/*/api-keys` rather than guessing, or drop it from the detector.
 2. **Should the UI surface a per-span "content was redacted" indicator** beyond the inline placeholder? Placeholders alone may read as data loss on a trace a user did not know was redacted.
 3. **ClickHouse deletion mechanics for Phase 5.** Lightweight `DELETE FROM` versus `ALTER TABLE … DELETE`, cost at our partition sizes, and how `traces`/`sessions` aggregate state is corrected. Needs its own design pass before that phase is scoped.
-4. **Is `dryRun` worth exposing through the public API**, or is it a UI-only affordance? Leaning expose, since a platform team rolling this out across many projects wants it scripted.
-5. **Should `phone` default off** rather than on? It is the highest-FP on-by-default detector. Resolve with a `dryRun` measurement against real coding-agent traffic before Phase 3 ships.
+4. **Should `phone` default off** rather than on? It is the highest-false-positive detector that is on by default. Answer it offline: a script that reads a sample of real spans from ClickHouse and runs `findRedactionMatches` over them, reporting matches per entity with surrounding context. That needs no product surface, and it is the general answer for tuning any detector default. Worth doing before Phase 3 ships the toggle to customers.
+5. **Is a customer-facing redaction preview worth building?** Running the detectors on demand over spans already in ClickHouse, returning counts plus before/after samples, is the only honest way to answer "will this eat my tool outputs" before enabling it. It is out of scope here ([§4.3](#43-policy-model)) but it is the feature a dry-run mode was standing in for, and without it a customer's first enforce is their validation.
 
 ---
 
@@ -712,7 +713,9 @@ The benchmark was run as a throwaway script and not committed. The repository ha
 
 **Findings from Phase 2** (fold into the relevant sections when promoting to `dev-docs/`):
 
-- `RedactionPolicy` was split out of `ResolvedRedactionPolicy`. The engine never needed `source`, which exists only so the UI can say "inherited from organization", and keeping it out of the wire format avoids either shipping a display field through the queue or inventing a fake value on deserialize.
+- **A separator-bridging pattern loses the value it was meant to catch.** The credit-card candidate allowed an optional space or dash between *any* two digits, so in `+14155552671 4111111111111111` it consumed both numbers as one over-long run, failed the issuer check, and never reconsidered the real card inside — a silent missed redaction. Fixed the way IBAN already was: separate compact and grouped patterns, with the grouped ones backreferencing their own separator so a match cannot span two numbers. The class is easy to reintroduce and invisible without an adjacency test, so every multi-part detector needs one.
+- **Removing dry run removed the only feedback on false negatives.** Nothing now reports what redaction missed, which is why detector precision has to be right by construction and why detector tuning belongs in an offline script rather than a product mode ([§4.3](#43-policy-model)).
+- `RedactionPolicy` was split out of `ResolvedRedactionPolicy`. The engine never needed `source`, which exists only so the UI can say "inherited from organization", and keeping it out of the wire format avoids either shipping a display field through the queue or inventing a fake value on deserialize. With one active mode, presence in the policy map *is* the decision, so `RedactionPolicy` carries no mode and the wire format has no `mode` field.
 - A malformed wire policy must fail the job. The obvious reading of "degrade toward more redaction" would skip it, but skipping is the *less* redacting choice: it resolves a corrupt policy on a project that opted in to a plaintext write. Absent and malformed are therefore handled differently, which is worth stating because they look interchangeable.
 - `@domain/queue` gained a dependency on `@domain/shared` for the wire type. No cycle, since `@domain/shared` has no workspace dependencies beyond `@repo/utils`.
 - Effect `4.0.0-beta.57` has no `Effect.catchAll`. Use `Effect.ignore` for "discard any failure"; the available surface is `catchCause`, `catchTag`, `catchIf`, `catchDefect`, `ignore`, `orElseSucceed`.
@@ -730,7 +733,7 @@ The benchmark was run as a throwaway script and not committed. The repository ha
 - [ ] **P3-3**: Widen the local `organizationSettingsSchema` in `organizations.functions.ts` to preserve every existing field, with a round-trip test ([T-5](#8-traps)).
 - [ ] **P3-4**: Role checks: project section requires `admin`/`owner`, org section requires `owner`. Log actor plus before/after on every change.
 - [ ] **P3-5**: `RedactionSettingSchema` in `packages/operations/src/operations/projects.ts` with a `.describe()` on every field, added to `ProjectSettingsSchema`; regenerate `openapi.json` and `mcp.json` per the api-endpoints skill.
-- [ ] **P3-6**: Extend `docs/security/pii-redaction.mdx` with the ingest-redaction section: the exact promise from [§1](#1-purpose-and-the-exact-promise), the entity coverage matrix, mode semantics, the 60 s propagation window, non-retroactivity, buffer lifetime ([T-3](#8-traps)), and the search/dedup notes ([T-9](#8-traps), [T-10](#8-traps)). Rename the existing section to "SDK attribute redaction."
+- [ ] **P3-6**: Extend `docs/security/pii-redaction.mdx` with the ingest-redaction section: the exact promise from [§1](#1-purpose-and-the-exact-promise), the entity coverage matrix, the 60 s propagation window, non-retroactivity, buffer lifetime ([T-3](#8-traps)), and the search/dedup notes ([T-9](#8-traps), [T-10](#8-traps)). Rename the existing section to "SDK attribute redaction."
 - [ ] **P3-7**: Write `dev-docs/spans.md` and `dev-docs/settings.md` sections for the redaction stage and the settings cascade.
 
 **Exit gate**:

--- a/specs/pii-redaction.md
+++ b/specs/pii-redaction.md
@@ -679,20 +679,44 @@ Follow the layering in the testing skill: pure unit tests in the domain, PGlite/
 - [x] **P2-2**: Add `redaction?: Record<string, SerializedRedactionPolicy>` to `span-ingestion:ingest` in `packages/domain/queue/src/topic-registry.ts`.
 - [x] **P2-3**: In `ingestSpansUseCase`, resolve the per-project policy from the already-loaded `projectBySlug` plus the cached org settings, and stamp the map onto the published job. Omit `off` projects and omit the field entirely when the map is empty.
 - [x] **P2-4**: Provide the Redis cache layer the resolver needs in `apps/ingest/src/routes/traces.ts`.
-- [x] **P2-5**: In `processIngestedSpansUseCase`, accept `redaction`, apply the pass between `decodeAndTransform` and `repo.insert`, fail closed, and wrap in `Effect.timeout(REDACTION_BATCH_TIMEOUT_MS)`.
+- [x] **P2-5**: In `processIngestedSpansUseCase`, accept `redaction`, apply the pass between `decodeAndTransform` and `repo.insert`, and fail closed. No timeout wrapper is needed here: Phase 1's `redactSpans` already owns the budget with a per-span deadline, because the walk is synchronous and an `Effect` timeout around it could not fire until it had already finished.
 - [x] **P2-6**: Pass `wire.redaction` through `apps/workers/src/workers/span-ingestion.ts`; parse `LAT_REDACTION_PSEUDONYM_SECRET` with `parseEnvOptional` at the use site; add it to `.env.example` in the workers block.
 - [x] **P2-7**: Emit every annotation in [§4.8](#48-observability), plus the `warn`/`error` logs.
 - [x] **P2-8**: Delete the `tmp-ingest` blob after a successful insert via `deleteFromDisk` ([T-3](#8-traps)). Delete only after `repo.insert` succeeds, and treat a delete failure as non-fatal (the lifecycle rule is the backstop).
 - [x] **P2-9**: Integration tests per [§9](#9-testing-plan) in both `process-ingested-spans.test.ts` and `ingest-spans.test.ts`.
-- [ ] **P2-10**: Run the benchmark in [§4.7](#47-size-and-time-budget) and record p50/p99 per-span cost and the concurrency-50 CPU delta in the PR description.
+- [x] **P2-10**: Run the benchmark in [§4.7](#47-size-and-time-budget) and record p50/p99 per-span cost and the concurrency-50 CPU delta in the PR description.
 
-**Exit gate**:
+**Exit gate** — met:
 
-- With every project `off`, inserted rows are byte-identical to pre-change output, asserted by test.
-- An `enforce` project's inserted row has redacted content **and** no content keys left in `attr_string`, asserted by test.
-- A detector throw produces zero inserts.
-- Benchmark numbers are in the PR description; a miss against the 5 ms target is called out explicitly rather than omitted.
-- The `tmp-ingest` object is gone after a successful large-payload ingest, asserted by test.
+- [x] With every project `off`, inserted rows are byte-identical to pre-change output, asserted two ways: no `redaction` field, and an empty `redaction` map.
+- [x] An `enforce` project's inserted row has redacted content **and** no content keys left in `attr_string`, while its operational attributes survive.
+- [x] A malformed policy produces zero inserts and fails the job. Verified by mutation: skipping malformed policies instead of failing breaks two tests.
+- [x] The `tmp-ingest` object is gone after a successful large-payload ingest, and a failed delete does not fail the ingest. Verified by mutation: removing the delete breaks one test.
+- [x] Benchmark run and recorded below; the target is met with headroom rather than missed.
+
+**Benchmark results.** Measured over 200 coding-agent-shaped spans (prose, a diff, a tool call carrying that diff, plus real hits), redacting through `redactSpans` after the real `transformOtlpToSpans`. Warm-up discarded, 40 batches sampled.
+
+| Scanned content | per-span p50 | per-span p99 |
+| --- | --- | --- |
+| ~8 KB/span | 0.153 ms | 0.182 ms |
+| ~29 KB/span | 0.685 ms | 1.223 ms |
+
+Added CPU at the 29 KB point is **0.590 ms/span**, i.e. roughly **1,700 spans/sec per core** of redaction capacity. Against the §4.7 target of ≤ 5 ms/span at ~32 KB, that is about 4× headroom at p99.
+
+Two notes on interpreting this, because "concurrency 50" invites a wrong reading:
+
+- The worker event loop is single threaded, so concurrency 50 **interleaves** batches rather than parallelising this cost. The number that matters is the per-core throughput above, not a 50× multiple.
+- Projects with redaction `off` cost **0.000 ms**: `redactSpans` returns the identical array before touching a span. So this cost applies only to opted-in projects, not to ingestion generally.
+
+The benchmark was run as a throwaway script and not committed. The repository has no benchmark convention, and adding one would put ~15 s on every `@domain/spans` CI run for a number that only needs re-measuring when the engine changes. Re-derive it from the methodology above if the walk is modified.
+
+**Findings from Phase 2** (fold into the relevant sections when promoting to `dev-docs/`):
+
+- `RedactionPolicy` was split out of `ResolvedRedactionPolicy`. The engine never needed `source`, which exists only so the UI can say "inherited from organization", and keeping it out of the wire format avoids either shipping a display field through the queue or inventing a fake value on deserialize.
+- A malformed wire policy must fail the job. The obvious reading of "degrade toward more redaction" would skip it, but skipping is the *less* redacting choice: it resolves a corrupt policy on a project that opted in to a plaintext write. Absent and malformed are therefore handled differently, which is worth stating because they look interchangeable.
+- `@domain/queue` gained a dependency on `@domain/shared` for the wire type. No cycle, since `@domain/shared` has no workspace dependencies beyond `@repo/utils`.
+- Effect `4.0.0-beta.57` has no `Effect.catchAll`. Use `Effect.ignore` for "discard any failure"; the available surface is `catchCause`, `catchTag`, `catchIf`, `catchDefect`, `ignore`, `orElseSucceed`.
+- The `@platform/db-postgres` suite has pre-existing PGlite `beforeAll` contention flakiness: the same tree produced 47/47 passing and 5 timed-out `setupTestPostgres` hooks on consecutive full runs, while the affected files pass in isolation. Unrelated to redaction; do not chase it when it appears.
 
 ### Phase 3 - Surfaces: UI, API, docs
 

--- a/specs/pii-redaction.md
+++ b/specs/pii-redaction.md
@@ -404,7 +404,7 @@ Justification, and this is a deliberate divergence from both competitors:
 2. For the in-process deterministic tier, "failure" means a code bug, so fail-open reduces to *silently writing plaintext PII for a customer who explicitly asked us not to*.
 3. There is no delete path ([§2.5](#25-what-does-not-exist)) and redaction is non-retroactive, so a fail-open write is permanent and unremediable.
 
-**The cost is explicit and accepted:** a persistent redaction bug loses spans for opted-in projects rather than leaking their PII. That is the correct trade for a compliance control, it is loud (failed jobs, error logs), and the customer has a self-service escape: set `mode` back to `off`. Whether ingest should retry before dropping is a real open question ([§10](#10-open-questions)); it is deliberately not changed here, because adding `attempts` alters failure handling for all ingest, not just redaction.
+**The cost is explicit and accepted:** a persistent redaction bug loses spans for opted-in projects rather than leaking their PII. That is the correct trade for a compliance control, it is loud (failed jobs, error logs), and the customer has a self-service escape as long as the effective policy is project-controlled: set `mode` back to `off`. Under a `locked` organization policy the project setting is ignored ([§4.4](#44-settings-cascade-authorization)), so recovery there means changing the organization policy, which only an owner can do. Whether ingest should retry before dropping is a real open question ([§10](#10-open-questions)); it is deliberately not changed here, because adding `attempts` alters failure handling for all ingest, not just redaction.
 
 Additional rules:
 
@@ -626,7 +626,7 @@ Follow the layering in the testing skill: pure unit tests in the domain, PGlite/
 - `redaction` field absent when every project is `off`.
 - Org `locked` policy overriding a project's weaker policy.
 - Multi-project batch produces one map entry per non-`off` project.
-- Cached org resolver: cache hit performs no query; cache failure resolves to no org policy.
+- Cached org resolver: cache hit performs no query; a cached absence is served rather than re-queried; a cache failure falls back to a database read; a database read failure propagates rather than resolving to "no org policy", so a `locked` organization policy can never fall through to a weaker project policy.
 
 **Web:** org settings round-trip preserves `billing.spendingLimitCents` and `wantsShowcase` ([T-5](#8-traps)).
 
@@ -677,7 +677,7 @@ Follow the layering in the testing skill: pure unit tests in the domain, PGlite/
 
 ### Phase 2 - Pipeline wiring
 
-- [x] **P2-1**: `packages/platform/db-postgres/src/resolve-redaction-policy-cached.ts`, modeled on `resolve-effective-plan-cached.ts`: key `org:${organizationId}:settings:redaction`, 60 s TTL, Zod-validated payload, `cache.hit` annotation, `invalidateRedactionPolicyCache`.
+- [x] **P2-1**: `packages/platform/db-postgres/src/resolve-redaction-policy-cached.ts`, modeled on `resolve-effective-plan-cached.ts`: key `org:${organizationId}:settings:redaction`, 60 s TTL, Zod-validated payload, `cache.hit` annotation, `invalidateOrganizationRedactionCache`.
 - [x] **P2-2**: Add `redaction?: Record<string, SerializedRedactionPolicy>` to `span-ingestion:ingest` in `packages/domain/queue/src/topic-registry.ts`.
 - [x] **P2-3**: In `ingestSpansUseCase`, resolve the per-project policy from the already-loaded `projectBySlug` plus the cached org settings, and stamp the map onto the published job. Omit `off` projects and omit the field entirely when the map is empty.
 - [x] **P2-4**: Provide the Redis cache layer the resolver needs in `apps/ingest/src/routes/traces.ts`.
@@ -716,6 +716,8 @@ The benchmark was run as a throwaway script and not committed. The repository ha
 
 - **Deleting the buffered payload has to happen after the events are published, not after the insert.** The first placement made a job that died mid-processing unrecoverable: stalled-job redelivery found no payload, so the batch stayed inserted with `TracesIngested` never fired, silently losing trace-end, billing, and search indexing. Caught by an existing worker test that ingests the same `fileKey` twice.
 - **`span-ingestion` has no retries.** No `attempts` on the topic and no `defaultJobOptions` on the queue, so BullMQ's default of one attempt applies. Several earlier notes in this spec claimed a failed pass "retries"; it does not, it drops. Corrected in [§2.2](#22-worker-path) and [§4.6](#46-failure-policy), and raised as [open question 5](#10-open-questions).
+- **Fixing the bridging bug narrowed the grouped shapes and lost Diners.** Splitting the credit-card pattern left only 4-4-4-N and 4-6-5, so the 4-6-4 form stopped matching while its compact form still did. Every grouping a real issuer prints is now enumerated and tested in both separators. Generalising to "groups of four to six digits" is the wrong fix: an open-ended repetition swallows a trailing group, overruns 19 digits, and fails the length gate with the card inside the discarded match, which is the bridging bug again.
+- **The buffered-payload delete has to run on the empty-batch path too.** The early return for a batch whose spans were all rejected skipped it, leaving an unredacted object behind with no lifecycle rule under it on self-hosted disk. The delete belongs on every success exit and on none of the failure paths, so a finalizer is the wrong tool: a failed job may be redelivered and redelivery needs the payload.
 - **A separator-bridging pattern loses the value it was meant to catch.** The credit-card candidate allowed an optional space or dash between *any* two digits, so in `+14155552671 4111111111111111` it consumed both numbers as one over-long run, failed the issuer check, and never reconsidered the real card inside — a silent missed redaction. Fixed the way IBAN already was: separate compact and grouped patterns, with the grouped ones backreferencing their own separator so a match cannot span two numbers. The class is easy to reintroduce and invisible without an adjacency test, so every multi-part detector needs one.
 - **Removing dry run removed the only feedback on false negatives.** Nothing now reports what redaction missed, which is why detector precision has to be right by construction and why detector tuning belongs in an offline script rather than a product mode ([§4.3](#43-policy-model)).
 - `RedactionPolicy` was split out of `ResolvedRedactionPolicy`. The engine never needed `source`, which exists only so the UI can say "inherited from organization", and keeping it out of the wire format avoids either shipping a display field through the queue or inventing a fake value on deserialize. With one active mode, presence in the policy map *is* the decision, so `RedactionPolicy` carries no mode and the wire format has no `mode` field.

--- a/specs/pii-redaction.md
+++ b/specs/pii-redaction.md
@@ -674,7 +674,7 @@ Follow the layering in the testing skill: pure unit tests in the domain, PGlite/
 
 ### Phase 2 - Pipeline wiring
 
-- [ ] **P2-1**: `packages/platform/db-postgres/src/resolve-redaction-policy-cached.ts`, modeled on `resolve-effective-plan-cached.ts`: key `org:${organizationId}:settings:redaction`, 60 s TTL, Zod-validated payload, `cache.hit` annotation, `invalidateRedactionPolicyCache`.
+- [x] **P2-1**: `packages/platform/db-postgres/src/resolve-redaction-policy-cached.ts`, modeled on `resolve-effective-plan-cached.ts`: key `org:${organizationId}:settings:redaction`, 60 s TTL, Zod-validated payload, `cache.hit` annotation, `invalidateRedactionPolicyCache`.
 - [ ] **P2-2**: Add `redaction?: Record<string, SerializedRedactionPolicy>` to `span-ingestion:ingest` in `packages/domain/queue/src/topic-registry.ts`.
 - [ ] **P2-3**: In `ingestSpansUseCase`, resolve the per-project policy from the already-loaded `projectBySlug` plus the cached org settings, and stamp the map onto the published job. Omit `off` projects and omit the field entirely when the map is empty.
 - [ ] **P2-4**: Provide the Redis cache layer the resolver needs in `apps/ingest/src/routes/traces.ts`.

--- a/specs/pii-redaction.md
+++ b/specs/pii-redaction.md
@@ -72,7 +72,7 @@ Write this sentence into the docs and the UI copy before writing code, because i
 
 Postgres layers already provided in this worker (`:43-48`): `BillingOverrideRepositoryLive`, **`SettingsReaderLive`**, `StripeSubscriptionLookupLive`, `OrganizationRepositoryLive`. `SettingsReader` is therefore reachable in the worker but unused by the span pipeline today.
 
-`SpanDecodingError` is swallowed as a warning (`:105-107`): undecodable payloads are dropped, not retried. Any other error propagates and BullMQ retries.
+`SpanDecodingError` is swallowed as a warning (`:105-107`): undecodable payloads are dropped. Any other error propagates and fails the job. **The topic configures no `attempts`, and `new Queue` sets no `defaultJobOptions`, so BullMQ's default of a single attempt applies: a failed ingest job is not retried.** Stalled-job recovery can still redeliver a job whose worker died mid-processing, which is a different mechanism from retry.
 
 `processIngestedSpansUseCase` (`packages/domain/spans/src/use-cases/process-ingested-spans.ts:120-187`) stages:
 
@@ -159,7 +159,7 @@ Therefore **ingested content cannot be removed before its retention TTL expires.
 
 **Takeaway:** neither bundles a model; both make contextual detection an optional separately-deployed component. Neither ships deterministic detectors out of the box, which is where we can beat both cheaply.
 
-**Two constraints we must not inherit.** Both designs sit on a synchronous export path, which is why both chose fail-open and sub-second timeouts. Our redaction point is in an async BullMQ worker at concurrency 50; the OTLP client already has its `200`. We can retry, and we can afford seconds. Copying fail-open and a 500 ms timeout would import their constraints without their reason. See [§4.6](#46-failure-policy) and [§4.7](#47-size-and-time-budget).
+**Two constraints we must not inherit.** Both designs sit on a synchronous export path, which is why both chose fail-open and sub-second timeouts. Our redaction point is in an async BullMQ worker at concurrency 50; the OTLP client already has its `200`. We can fail the batch instead of degrading it, and we can afford seconds. Copying fail-open and a 500 ms timeout would import their constraints without their reason. See [§4.6](#46-failure-policy) and [§4.7](#47-size-and-time-budget).
 
 **Engine research (permissive licenses only):**
 
@@ -396,15 +396,15 @@ Projects resolving to `mode: "off"` are **absent from the map**, and the whole f
 
 ### 4.6 Failure policy
 
-**The deterministic tier fails closed.** If the redaction pass throws or times out, the effect fails, nothing is inserted, and BullMQ retries. On final failure the payload is dropped.
+**The deterministic tier fails closed.** If the redaction pass throws or overruns its deadline, the effect fails and nothing is inserted. The batch is then dropped, because `span-ingestion` runs with BullMQ's default single attempt ([§2.2](#22-worker-path)) — it is not retried first.
 
 Justification, and this is a deliberate divergence from both competitors:
 
-1. We are async. lmnr and langfuse chose fail-open because a synchronous export path made "drop the customer's telemetry" the only alternative. We have retries.
+1. We are async. lmnr and langfuse chose fail-open because a synchronous export path made "drop the customer's telemetry" the only alternative, and dropping it would have surfaced to the caller as a failed export. Ours is already acknowledged, so failing the batch costs the customer that batch rather than an error at their exporter.
 2. For the in-process deterministic tier, "failure" means a code bug, so fail-open reduces to *silently writing plaintext PII for a customer who explicitly asked us not to*.
 3. There is no delete path ([§2.5](#25-what-does-not-exist)) and redaction is non-retroactive, so a fail-open write is permanent and unremediable.
 
-**The cost is explicit and accepted:** a persistent redaction bug loses spans for opted-in projects rather than leaking their PII. That is the correct trade for a compliance control, it is loud (failed jobs, error logs, retry exhaustion), and the customer has a self-service escape: set `mode` back to `off`.
+**The cost is explicit and accepted:** a persistent redaction bug loses spans for opted-in projects rather than leaking their PII. That is the correct trade for a compliance control, it is loud (failed jobs, error logs), and the customer has a self-service escape: set `mode` back to `off`. Whether ingest should retry before dropping is a real open question ([§10](#10-open-questions)); it is deliberately not changed here, because adding `attempts` alters failure handling for all ingest, not just redaction.
 
 Additional rules:
 
@@ -418,7 +418,7 @@ Ingestion is the hot path of the entire product, so this is a capacity question,
 
 - `REDACTION_MAX_FIELD_CHARS = 1_000_000` (1 M UTF-16 code units). A field above the cap is **not scanned**: it is replaced wholesale with `[REDACTED_OVERSIZED_FIELD]` and counted. Passing it through unscanned would break the promise, and partial scanning would leak the tail. Per the design invariant, degrade toward more redaction. 1 MB is generous: the realistic trigger is multi-MB file content in coding-agent tool outputs.
 - `REDACTION_MAX_DEPTH = 256`. The walk is recursive and `JSON.parse` accepts nesting tens of thousands deep, so a crafted `tool_input` overflows the stack; fail-closed then turns one hostile span into a dropped batch for every project in it. A subtree at the cap is treated exactly like an oversized leaf, which keeps the failure local. Payloads too deep for `JSON.parse` itself fall back to a plain-text scan, so they are still scanned rather than skipped.
-- `REDACTION_BATCH_TIMEOUT_MS = 30_000`, enforced as a **deadline checked before each span**, not as an `Effect.timeout` around the whole pass. The walk is synchronous, so a fiber-level timeout cannot fire until the work it was meant to bound has already finished; wrapping the pass in one would advertise a limit that never applies. Overrun is therefore bounded by a single span's walk, which the field cap bounds in turn. The async pseudonym phase does yield, so that one keeps a real `Effect.timeoutOrElse`. Either way the pass fails and the job retries ([§4.6](#46-failure-policy)).
+- `REDACTION_BATCH_TIMEOUT_MS = 30_000`, enforced as a **deadline checked before each span**, not as an `Effect.timeout` around the whole pass. The walk is synchronous, so a fiber-level timeout cannot fire until the work it was meant to bound has already finished; wrapping the pass in one would advertise a limit that never applies. Overrun is therefore bounded by a single span's walk, which the field cap bounds in turn. The async pseudonym phase does yield, so that one keeps a real `Effect.timeoutOrElse`. Either way the pass fails and the batch is dropped ([§4.6](#46-failure-policy)).
 - **Benchmark acceptance criterion:** measure and record added wall-clock per span at p50 and p99 for a representative batch, and the total CPU delta at concurrency 50. Target ≤ 5 ms per span at 32 KB of scanned content. If the measured number misses the target, the finding goes in the PR description and the cap gets revisited; do not silently ship a regression on the ingest path.
 
 ### 4.8 Observability
@@ -640,7 +640,8 @@ Follow the layering in the testing skill: pure unit tests in the domain, PGlite/
 2. **Should the UI surface a per-span "content was redacted" indicator** beyond the inline placeholder? Placeholders alone may read as data loss on a trace a user did not know was redacted.
 3. **ClickHouse deletion mechanics for Phase 5.** Lightweight `DELETE FROM` versus `ALTER TABLE … DELETE`, cost at our partition sizes, and how `traces`/`sessions` aggregate state is corrected. Needs its own design pass before that phase is scoped.
 4. **Should `phone` default off** rather than on? It is the highest-false-positive detector that is on by default. Answer it offline: a script that reads a sample of real spans from ClickHouse and runs `findRedactionMatches` over them, reporting matches per entity with surrounding context. That needs no product surface, and it is the general answer for tuning any detector default. Worth doing before Phase 3 ships the toggle to customers.
-5. **Is a customer-facing redaction preview worth building?** Running the detectors on demand over spans already in ClickHouse, returning counts plus before/after samples, is the only honest way to answer "will this eat my tool outputs" before enabling it. It is out of scope here ([§4.3](#43-policy-model)) but it is the feature a dry-run mode was standing in for, and without it a customer's first enforce is their validation.
+5. **Should `span-ingestion` retry before dropping a batch?** It runs on BullMQ's default single attempt today, so any failure — redaction or otherwise — drops the batch immediately. Fail-closed redaction is correct either way, but "retry then drop" loses far less data than "drop", and a transient ClickHouse or object-store blip currently costs the whole batch. Adding `attempts` changes failure handling for all ingest, not just redaction, so it needs its own decision. Duplicate inserts on retry are safe: `spans` is a `ReplacingMergeTree`.
+6. **Is a customer-facing redaction preview worth building?** Running the detectors on demand over spans already in ClickHouse, returning counts plus before/after samples, is the only honest way to answer "will this eat my tool outputs" before enabling it. It is out of scope here ([§4.3](#43-policy-model)) but it is the feature a dry-run mode was standing in for, and without it a customer's first enforce is their validation.
 
 ---
 
@@ -713,6 +714,8 @@ The benchmark was run as a throwaway script and not committed. The repository ha
 
 **Findings from Phase 2** (fold into the relevant sections when promoting to `dev-docs/`):
 
+- **Deleting the buffered payload has to happen after the events are published, not after the insert.** The first placement made a job that died mid-processing unrecoverable: stalled-job redelivery found no payload, so the batch stayed inserted with `TracesIngested` never fired, silently losing trace-end, billing, and search indexing. Caught by an existing worker test that ingests the same `fileKey` twice.
+- **`span-ingestion` has no retries.** No `attempts` on the topic and no `defaultJobOptions` on the queue, so BullMQ's default of one attempt applies. Several earlier notes in this spec claimed a failed pass "retries"; it does not, it drops. Corrected in [§2.2](#22-worker-path) and [§4.6](#46-failure-policy), and raised as [open question 5](#10-open-questions).
 - **A separator-bridging pattern loses the value it was meant to catch.** The credit-card candidate allowed an optional space or dash between *any* two digits, so in `+14155552671 4111111111111111` it consumed both numbers as one over-long run, failed the issuer check, and never reconsidered the real card inside — a silent missed redaction. Fixed the way IBAN already was: separate compact and grouped patterns, with the grouped ones backreferencing their own separator so a match cannot span two numbers. The class is easy to reintroduce and invisible without an adjacency test, so every multi-part detector needs one.
 - **Removing dry run removed the only feedback on false negatives.** Nothing now reports what redaction missed, which is why detector precision has to be right by construction and why detector tuning belongs in an offline script rather than a product mode ([§4.3](#43-policy-model)).
 - `RedactionPolicy` was split out of `ResolvedRedactionPolicy`. The engine never needed `source`, which exists only so the UI can say "inherited from organization", and keeping it out of the wire format avoids either shipping a display field through the queue or inventing a fake value on deserialize. With one active mode, presence in the policy map *is* the decision, so `RedactionPolicy` carries no mode and the wire format has no `mode` field.

--- a/specs/pii-redaction.md
+++ b/specs/pii-redaction.md
@@ -366,8 +366,9 @@ Why not resolve in the worker: it would add an uncached `SettingsReader` Postgre
 **Org settings do need a read at the boundary.** `SettingsReaderLive` is already in `traceIngestionBillingLayers` (`apps/ingest/src/routes/traces.ts:32-39`), so `getOrganizationSettings()` is reachable, but an uncached query on the hottest path in the product is not acceptable. Add a Redis-cached resolver modeled exactly on `packages/platform/db-postgres/src/resolve-effective-plan-cached.ts`:
 
 - Key `org:${organizationId}:settings:redaction` (org prefix first, per the repo-wide rule in `CLAUDE.md`).
-- 60 s TTL, Zod-validated cached payload, `cache.hit` span annotation, and an `invalidateRedactionPolicyCache(organizationId)` export mirroring `invalidateEffectivePlanCache` (`:95-101`).
-- Failure to read the cache or the row resolves to "no org policy," which per the design invariant means the project policy applies unchanged. This is the one place the invariant permits a non-tightening default, because the org layer can only *raise* strictness and treating an unavailable org row as `locked` would halt ingestion cluster-wide on a Redis blip. Say so in a one-line comment at the call site, since it looks like a bug otherwise.
+- 60 s TTL, Zod-validated cached payload, `cache.hit` span annotation, and an `invalidateOrganizationRedactionCache(organizationId)` export mirroring `invalidateEffectivePlanCache` (`:95-101`).
+- **A cache failure degrades to a database read. A database failure propagates.** An earlier draft of this spec had the row read degrade to "no org policy" on the theory that the org layer can only raise strictness. That was wrong: degrading lets a `locked` org policy fall back to a weaker project policy and write plaintext, which is the exact failure the design invariant exists to prevent. It also buys no availability, because project resolution on this path already hard-depends on Postgres (`ingest-spans.ts:146-149`; `RepositoryError` is already in the use case's error union) and the request fails regardless.
+- Cache the *absence* of a policy explicitly rather than as a bare `null`. Almost every organization has no policy, and if a cached absence were indistinguishable from a miss the cache would never serve the common case.
 
 **60 s of staleness is a documented behavior, not a defect.** Enabling redaction takes effect within a minute. Say it in the UI copy.
 
@@ -675,9 +676,9 @@ Follow the layering in the testing skill: pure unit tests in the domain, PGlite/
 ### Phase 2 - Pipeline wiring
 
 - [x] **P2-1**: `packages/platform/db-postgres/src/resolve-redaction-policy-cached.ts`, modeled on `resolve-effective-plan-cached.ts`: key `org:${organizationId}:settings:redaction`, 60 s TTL, Zod-validated payload, `cache.hit` annotation, `invalidateRedactionPolicyCache`.
-- [ ] **P2-2**: Add `redaction?: Record<string, SerializedRedactionPolicy>` to `span-ingestion:ingest` in `packages/domain/queue/src/topic-registry.ts`.
-- [ ] **P2-3**: In `ingestSpansUseCase`, resolve the per-project policy from the already-loaded `projectBySlug` plus the cached org settings, and stamp the map onto the published job. Omit `off` projects and omit the field entirely when the map is empty.
-- [ ] **P2-4**: Provide the Redis cache layer the resolver needs in `apps/ingest/src/routes/traces.ts`.
+- [x] **P2-2**: Add `redaction?: Record<string, SerializedRedactionPolicy>` to `span-ingestion:ingest` in `packages/domain/queue/src/topic-registry.ts`.
+- [x] **P2-3**: In `ingestSpansUseCase`, resolve the per-project policy from the already-loaded `projectBySlug` plus the cached org settings, and stamp the map onto the published job. Omit `off` projects and omit the field entirely when the map is empty.
+- [x] **P2-4**: Provide the Redis cache layer the resolver needs in `apps/ingest/src/routes/traces.ts`.
 - [ ] **P2-5**: In `processIngestedSpansUseCase`, accept `redaction`, apply the pass between `decodeAndTransform` and `repo.insert`, fail closed, and wrap in `Effect.timeout(REDACTION_BATCH_TIMEOUT_MS)`.
 - [ ] **P2-6**: Pass `wire.redaction` through `apps/workers/src/workers/span-ingestion.ts`; parse `LAT_REDACTION_PSEUDONYM_SECRET` with `parseEnvOptional` at the use site; add it to `.env.example` in the workers block.
 - [ ] **P2-7**: Emit every annotation in [§4.8](#48-observability), plus the `warn`/`error` logs.

--- a/specs/pii-redaction.md
+++ b/specs/pii-redaction.md
@@ -537,7 +537,7 @@ Remap by `path`, never by index. Chunk requests by byte count with a cap; do not
 | `apps/web/.../settings/general.tsx` | PII redaction section, modeled on `TraceSamplingSection` (`:196-257`) |
 | `apps/web/.../settings/organization.tsx` | Org-level section incl. `locked`, alongside `OrganizationNameSection` (`:22`) |
 | `apps/web/src/domains/organizations/organizations.functions.ts` | Widen the local `organizationSettingsSchema` (`:150-152`). **See [T-5](#8-traps): this is a data-loss trap** |
-| `.env.example` | `LAT_REDACTION_PSEUDONYM_SECRET`, commented with its default-absent behavior, in the workers block near `:134` |
+| `.env.example` | `LAT_REDACTION_PSEUDONYM_SECRET` in the workers block near `:134`, with a development value rather than commented out, matching `LAT_MASTER_ENCRYPTION_KEY` and `LAT_BETTER_AUTH_SECRET`. A commented-out secret reads as "required but unconfigured" and made a reviewer ask whether local PII work needed it. |
 | `docs/security/pii-redaction.mdx` | New "Ingest PII redaction" section; keep and rename the existing SDK section per [§2.4](#24-what-already-exists) |
 
 ### 6.3 UI


### PR DESCRIPTION
Wires the PII redaction engine from #4245 into the ingest pipeline. That PR landed the detectors and the span walk as an inert module with no callers; this one makes them run, gated per project. Phase 2 of `specs/pii-redaction.md`.

Redaction is still off for every project until someone sets `settings.redaction`, and there is no UI yet — that's Phase 3. With redaction off, inserted rows are byte-identical to today's output and the pass costs 0 ms, asserted by test.

## how the policy reaches the worker

The policy is resolved at the **ingest boundary**, not in the worker, and stamped onto the queue job.

`ingestSpansUseCase` already loads every resolved `Project` with its settings to make the sampling decision, so the project half of the org → project cascade costs no extra query. Only the organization half needs a lookup, and `resolveOrganizationRedactionCached` keeps that off the hot path (60 s TTL, key `org:${organizationId}:settings:redaction`). Deciding here also pins the decision to the moment of ingest, so a toggle flipped between enqueue and processing can't apply retroactively to a batch already accepted.

Projects resolving to `off` are omitted from the map, and the `redaction` field is dropped entirely when the map is empty. **A missing field means "redact nothing"**, which is what makes this deployable in either order: an old worker ignores the field, and a new worker seeing no field is correct, because at deploy time no project has opted in. No legacy fallback needed — contrast the `projectId` workaround at `span-ingestion.ts:67`, which exists because that field change wasn't fail-safe.

The organization setting is read in the ingest route rather than the use case, since the cached resolver is a platform concern and the domain must not reach into the platform layer.

## where redaction runs, and why that's the only place it needs to run

Between `decodeAndTransform` and `repo.insert` in `processIngestedSpansUseCase`.

That single point covers every content sink: `traces` and `sessions` are materialized views on `spans`, every other derived table (`trace_search_documents`, `memory_blobs`, `dataset_rows`, `taxonomy_*`, `session_moment_labels`) re-reads `spans`, and `TracesIngested` hasn't fired yet, so no downstream consumer — including the PostHog destination export, which ships raw messages to a third party — ever sees unredacted content.

I verified that claim structurally rather than inferring it, since it's the thing most worth doubting:

- `grep -rn 'table: "spans"'` → one site, in `span-repository.ts`
- `grep -rn 'repo.insert'` → one caller, `process-ingested-spans.ts`
- `grep -rn '"span-ingestion"'` → one publisher, one consumer
- seed tooling POSTs to `/v1/traces`, so it traverses the same path

## failure behavior

Fails closed. A redaction failure propagates and fails the job; it is deliberately *not* caught alongside `SpanDecodingError`, which is swallowed as a warning. Because redaction is non-retroactive and there is no delete path, a fail-open write would be permanent, so losing spans for an opted-in project is the better trade.

Worth knowing precisely what "fails the job" costs, because I got this wrong in the commit messages before checking: **`span-ingestion` has no retries.** The publish passes no `attempts` and `new Queue` sets no `defaultJobOptions`, so BullMQ's default of one attempt applies and a failed batch is dropped rather than retried. Fail-closed is still right — nothing unredacted is written either way — but the cost is a dropped batch, not a retried one. Whether ingest should retry first is raised as an open question in the spec rather than changed here, since adding `attempts` alters failure handling for all ingest. Duplicate inserts on retry would be safe: `spans` is a `ReplacingMergeTree`.

**A present but malformed policy fails the job** rather than being skipped. Skipping looks like the safe default but is the *less* redacting choice: it resolves a corrupt policy on a project that opted in to a plaintext write. Absent and malformed are handled differently on purpose.

## buffered payload cleanup

The `tmp-ingest` object holding the raw OTLP payload is deleted once the spans are durable. The object-store lifecycle rule (1 day) is now a backstop rather than the only bound — self-hosted disk backends have no lifecycle rule at all. A failed delete doesn't fail an already-successful ingest.

This narrows but does not close the pre-worker exposure: payloads ≤50 KB still ride inline in the BullMQ job body in Redis, and BullMQ retains 1000 completed and 1000 failed jobs. Failed jobs don't churn. Documented in the spec as T-3 rather than papered over.

## two changes to the engine from #4245

**Removed the dry-run mode.** It was indistinguishable from `off` to a customer: it redacted nothing and surfaced nothing they could read, since its only output was worker span annotations landing in our own telemetry. It still cost a full scan and could still fail closed on a deadline overrun, so it could lose spans that `off` would have kept. Removing it collapsed real plumbing — `RedactionPolicy` lost `mode` entirely (a policy's presence is now the decision), the `mutate` flag threaded through the walk is gone, and `countRedactions` went with it.

That removed a safety net, so two things are now true and recorded in the spec: a false negative is invisible to everyone, which raises the stakes on detector precision; and tuning a detector default belongs in an offline script over real spans, not a product mode.

**Fixed a silent miss in the credit-card detector.** The candidate pattern allowed an optional space or dash between any two digits, so it bridged a card into the number following it. In `4111111111111111 123` the bridged run is 19 digits, a length Visa does issue, so it matched, failed Luhn, and consumed the real card with it. Fixed the way the IBAN detector already was: separate compact and grouped patterns, the grouped ones backreferencing their own separator.

Worth knowing how that was found, because it says something about the test suite: I hit it correcting a test expectation, not from a failing test. My first regression vectors *didn't reproduce it* — a neighbour long enough to overflow the length gate just backtracks to the card. Only a trailing number that pads the run to a valid card length reproduces it. Confirmed by mutation-testing the corrected vectors.

## observability

Annotations on `spans.processIngestedSpans`: `redaction.spans`, `redaction.matches` plus `redaction.matches.<entity>`, `redaction.leavesScanned`, `redaction.charsScanned`, `redaction.droppedAttributeKeys`, `redaction.oversizedFields`, `redaction.pseudonymizedIdentities`, `redaction.identityFallback`. Oversized fields warn; the identity fallback logs at error level, since it silently changes what's stored.

## performance

Measured over 200 coding-agent-shaped spans (prose, a diff, a tool call carrying that diff) through the real transform, warm-up discarded, 40 batches sampled:

| scanned content | per-span p50 | per-span p99 |
| --- | --- | --- |
| ~8 KB/span | 0.153 ms | 0.182 ms |
| ~29 KB/span | 0.685 ms | 1.223 ms |

Added CPU at the 29 KB point is 0.590 ms/span, about 1,700 spans/sec per core. The §4.7 budget is ≤5 ms/span at ~32 KB, so there's roughly 4× headroom at p99.

Two notes, because "concurrency 50" invites a wrong reading: the worker event loop is single threaded, so concurrency interleaves batches rather than parallelising this cost, and projects with redaction off measure 0.000 ms because the pass returns before touching a span. The benchmark isn't committed — the repo has no benchmark convention and it would add ~15 s to every `@domain/spans` CI run; the methodology is recorded in the spec instead.

## testing

`pnpm typecheck` clean across all 90 packages, knip and format clean, 1241 `@domain/spans` + 168 `@domain/shared` + 318 `@platform/db-postgres` tests passing.

Three behaviors were mutation-tested rather than assumed: skipping malformed policies breaks 2 tests, removing the buffered-payload delete breaks 1, and reintroducing the old credit-card pattern breaks 3.

Heads up on one flake unrelated to this change: `@platform/db-postgres` has pre-existing PGlite `beforeAll` contention flakiness. The same tree gave 47/47 passing and 5 timed-out `setupTestPostgres` hooks on consecutive full runs, and the affected files pass in isolation.

## not in this PR

No UI, no public API exposure, no docs — Phase 3. No ML tier for names and addresses — Phase 4. No deletion path for already-stored content — Phase 5, and it remains the honest answer to "we already leaked", which redaction can't give.

Refs #4245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-project PII redaction during span ingestion, including stamped redaction payloads and optional identity pseudonymization (via a new `LAT_REDACTION_PSEUDONYM_SECRET` setting).
  * Added cached organization redaction policy resolution with cache invalidation and graceful cache failure.
* **Behavior Changes**
  * Redaction mode is now **Off** or **Enforce** only (dry-run removed), with redaction reporting reflecting actual redactions.
  * Batch processing now decodes and applies incoming redaction policies before persisting spans; buffered payloads are best-effort cleaned up after success.
* **Bug Fixes**
  * Improved credit-card detection accuracy and added stronger coverage for separator “bridging” edge cases.
* **Tests / Docs**
  * Updated redaction and ingestion test coverage and refreshed the PII redaction spec and environment documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
