### PR TITLE
fix(analytics): forward Reddit click id on signup attribution

### DIFF
--- a/apps/web/src/lib/analytics/gtm.ts
+++ b/apps/web/src/lib/analytics/gtm.ts
@@ -15,6 +15,7 @@ export const TRACKING_PARAM_KEYS = [
   "ttclid",
   "li_fat_id",
   "msclkid",
+  "rdt_cid",
   "_gl",
   "utm_source",
   "utm_medium",

--- a/packages/domain/marketing/src/signup-attribution.test.ts
+++ b/packages/domain/marketing/src/signup-attribution.test.ts
@@ -32,9 +32,16 @@ describe("toMarketingAttribution", () => {
   it("forwards whitelisted UTM / click-id params and drops the rest", () => {
     expect(
       toMarketingAttribution({
-        trackingParams: { utm_source: "google", utm_medium: "cpc", gclid: "abc", _gl: "x", baker_anon_id: "y" },
+        trackingParams: {
+          utm_source: "google",
+          utm_medium: "cpc",
+          gclid: "abc",
+          rdt_cid: "rdt-1",
+          _gl: "x",
+          baker_anon_id: "y",
+        },
       }),
-    ).toEqual({ utm_source: "google", utm_medium: "cpc", gclid: "abc" })
+    ).toEqual({ utm_source: "google", utm_medium: "cpc", gclid: "abc", rdt_cid: "rdt-1" })
   })
 
   it("omits empty fields rather than emitting empty strings", () => {

--- a/packages/domain/marketing/src/signup-attribution.ts
+++ b/packages/domain/marketing/src/signup-attribution.ts
@@ -19,6 +19,7 @@ export type MarketingAttribution = {
   readonly ttclid?: string
   readonly li_fat_id?: string
   readonly msclkid?: string
+  readonly rdt_cid?: string
 }
 
 /** Raw signup attribution captured in the browser; stored transiently in the cache.
@@ -51,6 +52,7 @@ const FORWARDED_PARAM_KEYS = [
   "ttclid",
   "li_fat_id",
   "msclkid",
+  "rdt_cid",
 ] as const
 
 /** Maps captured attribution to PostHog property names (spread verbatim onto the event). */


### PR DESCRIPTION
## What does this PR do?

Adds `rdt_cid` — Reddit's click id — to the two lists that gate campaign params on their way to PostHog:

- `TRACKING_PARAM_KEYS` in `apps/web/src/lib/analytics/gtm.ts`, which `pickTrackingParams` uses to read params off the login URL
- `FORWARDED_PARAM_KEYS` in `packages/domain/marketing/src/signup-attribution.ts`, which `toMarketingAttribution` uses to spread params onto the server-side `UserSignedUp` capture

Reddit paid campaigns arrive with `rdt_cid`, but it was on neither list, so the click id was filtered out at the app boundary and never reached `UserSignedUp`. It's visible in PostHog today only as a substring of `$referrer` URLs, which nothing queries.

This is the app half of a two-repo fix. The other half (latitude-dev/latitude-llm-public#70) makes `latitude.so` forward campaign params onto outbound `console.latitude.so` links at all — without it the params never arrive for these lists to accept. Neither PR helps alone.

Context on why this matters: 26,045 tagged Reddit visitors landed on the home page since Jun 15 (the largest tagged source), and 0 signups are attributed to Reddit.

`_gl` and the `baker_*` keys are untouched.

## Related issue (if applicable)

N/A — found while investigating attribution coverage after #4205.

## How was this tested?

Extended the existing "forwards whitelisted UTM / click-id params and drops the rest" case in `signup-attribution.test.ts` to include `rdt_cid` in the input and expected output, alongside the `_gl` / `baker_anon_id` keys it already asserts are dropped.

**I could not run the suite.** `node_modules` isn't installed in this container and it has Node 22 against the repo's `>=25`. I did confirm by inspection that no existing test asserts an exhaustive key list — `gtm.test.ts` only checks `toContain("_gl")` — so nothing should break on the addition. CI is the real check here.

## Checklist

- [ ] Lint, type-checking, and tests pass locally — **not verified, see above**
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_019xzxiw4RYo14vsPsVHrhQz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing and forwarding the `rdt_cid` marketing attribution parameter during signup.
  * Signup attribution data now preserves this parameter for analytics and conversion tracking.

* **Tests**
  * Updated coverage to verify `rdt_cid` is retained while unsupported tracking parameters continue to be excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->