### PR TITLE
fix(spans): price Claude Agent SDK spans and report unpriced token usage

### DIFF
--- a/apps/workers/src/workers/span-ingestion.ts
+++ b/apps/workers/src/workers/span-ingestion.ts
@@ -18,6 +18,7 @@ import { parseEnvOptional } from "@platform/env"
 import { StorageDiskLive } from "@platform/storage-object"
 import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
+import { reportUnpricedSpans } from "./unpriced-spans-report.ts"
 
 const logger = createLogger("span-ingestion")
 
@@ -48,7 +49,7 @@ export const createSpanIngestionWorker = ({
     OrganizationRepositoryLive,
   )
 
-  const processSpans = processIngestedSpansUseCase({ eventsPublisher })
+  const processSpans = processIngestedSpansUseCase({ eventsPublisher, onUnpricedSpans: reportUnpricedSpans })
 
   // Unset degrades pseudonymized identities to full redaction rather than blocking
   // a self-hoster's ingestion on a missing variable.

--- a/apps/workers/src/workers/unpriced-spans-report.test.ts
+++ b/apps/workers/src/workers/unpriced-spans-report.test.ts
@@ -2,7 +2,7 @@ import { OrganizationId } from "@domain/shared"
 import type { UnpricedSpanGroup } from "@domain/spans"
 import { Effect } from "effect"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { reportUnpricedSpans, resetUnpricedSpanReportThrottle } from "./unpriced-spans-report.ts"
+import { MAX_TRACKED_PAIRS, reportUnpricedSpans, resetUnpricedSpanReportThrottle } from "./unpriced-spans-report.ts"
 
 const organizationId = OrganizationId("org_1")
 
@@ -74,5 +74,20 @@ describe("reportUnpricedSpans", () => {
     Effect.runSync(reportUnpricedSpans([], organizationId))
 
     expect(lines).toHaveLength(0)
+  })
+
+  // Overflow used to clear the whole map, which re-opened every pair still inside its window.
+  it("keeps throttling a pair when a flood of new pairs overflows the tracked set", () => {
+    Effect.runSync(reportUnpricedSpans([group({ model: "evicted-first" })], organizationId))
+    Effect.runSync(reportUnpricedSpans([group()], organizationId))
+
+    // Overflows the set by exactly one, so only the decoy above is old enough to be evicted.
+    const flood = Array.from({ length: MAX_TRACKED_PAIRS - 1 }, (_, i) => group({ model: `flood-${i}` }))
+    Effect.runSync(reportUnpricedSpans(flood, organizationId))
+
+    const before = reported().length
+    Effect.runSync(reportUnpricedSpans([group()], organizationId))
+
+    expect(reported()).toHaveLength(before)
   })
 })

--- a/apps/workers/src/workers/unpriced-spans-report.test.ts
+++ b/apps/workers/src/workers/unpriced-spans-report.test.ts
@@ -1,0 +1,78 @@
+import { OrganizationId } from "@domain/shared"
+import type { UnpricedSpanGroup } from "@domain/spans"
+import { Effect } from "effect"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { reportUnpricedSpans, resetUnpricedSpanReportThrottle } from "./unpriced-spans-report.ts"
+
+const organizationId = OrganizationId("org_1")
+
+function group(overrides: Partial<UnpricedSpanGroup> = {}): UnpricedSpanGroup {
+  return {
+    projectId: "proj_1",
+    provider: "@some-vendor/unmapped-sdk",
+    model: "mystery-model",
+    spans: 3,
+    ...overrides,
+  }
+}
+
+interface ReportedLog {
+  readonly level: string
+  readonly args: readonly unknown[]
+}
+
+describe("reportUnpricedSpans", () => {
+  let lines: string[]
+
+  beforeEach(() => {
+    resetUnpricedSpanReportThrottle()
+    lines = []
+    vi.spyOn(console, "error").mockImplementation((line: unknown) => {
+      lines.push(String(line))
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const reported = (): ReportedLog[] => lines.map((line) => JSON.parse(line) as ReportedLog)
+
+  it("reports the provider and model that failed to price", () => {
+    Effect.runSync(reportUnpricedSpans([group()], organizationId))
+
+    const logs = reported()
+    expect(logs).toHaveLength(1)
+    expect(logs[0]?.level).toBe("error")
+    expect(logs[0]?.args[1]).toMatchObject({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      provider: "@some-vendor/unmapped-sdk",
+      model: "mystery-model",
+      spans: 3,
+    })
+  })
+
+  it("reports a repeated pair only once so customer traffic cannot drive the volume", () => {
+    Effect.runSync(reportUnpricedSpans([group()], organizationId))
+    Effect.runSync(reportUnpricedSpans([group({ spans: 900 })], organizationId))
+    Effect.runSync(reportUnpricedSpans([group({ spans: 12 })], organizationId))
+
+    expect(reported()).toHaveLength(1)
+  })
+
+  it("throttles per pair, so a distinct model, project or org still reports", () => {
+    Effect.runSync(
+      reportUnpricedSpans([group(), group({ model: "other-model" }), group({ projectId: "proj_2" })], organizationId),
+    )
+    Effect.runSync(reportUnpricedSpans([group()], OrganizationId("org_2")))
+
+    expect(reported()).toHaveLength(4)
+  })
+
+  it("does nothing when every span was priced", () => {
+    Effect.runSync(reportUnpricedSpans([], organizationId))
+
+    expect(lines).toHaveLength(0)
+  })
+})

--- a/apps/workers/src/workers/unpriced-spans-report.ts
+++ b/apps/workers/src/workers/unpriced-spans-report.ts
@@ -1,0 +1,86 @@
+import type { OrganizationId } from "@domain/shared"
+import type { UnpricedSpanGroup } from "@domain/spans"
+import { createLogger, recordSpanExceptionForDatadog, SpanStatusCode, trace } from "@repo/observability"
+import { Effect } from "effect"
+
+const logger = createLogger("unpriced-spans")
+const tracer = trace.getTracer("unpriced-spans")
+
+/**
+ * Datadog fingerprints Error Tracking issues on error type and stack, so this is thrown from one
+ * site with a constant message to keep every occurrence in a single issue. The provider and model
+ * ride on span attributes instead — putting them in the message would split the issue per customer
+ * SDK and bury the signal in a long tail.
+ */
+class UnpricedSpanError extends Error {
+  constructor() {
+    super("Ingested token usage that no pricing matched; cost recorded as 0")
+    this.name = "UnpricedSpanError"
+  }
+}
+
+const REPORT_INTERVAL_MS = 60 * 60 * 1000
+
+/**
+ * Emission is driven by customer traffic, so an unmapped SDK on a busy project would otherwise
+ * report on every batch forever. One report per hour per pair carries the same information.
+ */
+const MAX_TRACKED_PAIRS = 500
+
+const lastReportedAt = new Map<string, number>()
+
+function claimReportSlot(key: string, now: number): boolean {
+  const previous = lastReportedAt.get(key)
+  if (previous !== undefined && now - previous < REPORT_INTERVAL_MS) return false
+  if (lastReportedAt.size >= MAX_TRACKED_PAIRS) lastReportedAt.clear()
+  lastReportedAt.set(key, now)
+  return true
+}
+
+/**
+ * A span of its own, not the ingest span: the batch succeeded and its spans were stored, so marking
+ * that span as an error would fail a healthy job and pollute the `status:error` queries used to
+ * triage real ingest breakage.
+ */
+function recordUnpricedSpanIssue(group: UnpricedSpanGroup, organizationId: OrganizationId): void {
+  const span = tracer.startSpan("cost.unpriced_spans")
+  span.setAttributes({
+    "latitude.organization_id": organizationId,
+    "latitude.project_id": group.projectId,
+    "gen_ai.provider.name": group.provider,
+    "gen_ai.request.model": group.model,
+    "cost.unpriced_spans": group.spans,
+  })
+  const error = new UnpricedSpanError()
+  recordSpanExceptionForDatadog(span, error)
+  span.setStatus({ code: SpanStatusCode.ERROR, message: error.message })
+  span.end()
+}
+
+export function reportUnpricedSpans(
+  groups: readonly UnpricedSpanGroup[],
+  organizationId: OrganizationId,
+): Effect.Effect<void> {
+  return Effect.sync(() => {
+    const now = Date.now()
+
+    for (const group of groups) {
+      const key = `${organizationId}:${group.projectId}:${group.provider}:${group.model}`
+      if (!claimReportSlot(key, now)) continue
+
+      logger.error("Ingested token usage that no pricing matched", {
+        organizationId,
+        projectId: group.projectId,
+        provider: group.provider,
+        model: group.model,
+        spans: group.spans,
+      })
+      recordUnpricedSpanIssue(group, organizationId)
+    }
+  })
+}
+
+/** Exported for tests: the throttle is process-wide state that would otherwise leak across cases. */
+export function resetUnpricedSpanReportThrottle(): void {
+  lastReportedAt.clear()
+}

--- a/apps/workers/src/workers/unpriced-spans-report.ts
+++ b/apps/workers/src/workers/unpriced-spans-report.ts
@@ -25,14 +25,31 @@ const REPORT_INTERVAL_MS = 60 * 60 * 1000
  * Emission is driven by customer traffic, so an unmapped SDK on a busy project would otherwise
  * report on every batch forever. One report per hour per pair carries the same information.
  */
-const MAX_TRACKED_PAIRS = 500
+export const MAX_TRACKED_PAIRS = 500
 
+/** Insertion order is kept as least-recently-reported first, so the first key is the eviction target. */
 const lastReportedAt = new Map<string, number>()
+
+function evictToMakeRoom(now: number): void {
+  if (lastReportedAt.size < MAX_TRACKED_PAIRS) return
+
+  for (const [tracked, at] of lastReportedAt) {
+    if (now - at >= REPORT_INTERVAL_MS) lastReportedAt.delete(tracked)
+  }
+  // Still full of live claims: drop only the oldest. Clearing the whole map here would lift the
+  // throttle off every pair at once, so a flood of new pairs could re-open the ones it displaced.
+  if (lastReportedAt.size >= MAX_TRACKED_PAIRS) {
+    const oldest = lastReportedAt.keys().next().value
+    if (oldest !== undefined) lastReportedAt.delete(oldest)
+  }
+}
 
 function claimReportSlot(key: string, now: number): boolean {
   const previous = lastReportedAt.get(key)
   if (previous !== undefined && now - previous < REPORT_INTERVAL_MS) return false
-  if (lastReportedAt.size >= MAX_TRACKED_PAIRS) lastReportedAt.clear()
+
+  evictToMakeRoom(now)
+  lastReportedAt.delete(key)
   lastReportedAt.set(key, now)
   return true
 }

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -86,6 +86,7 @@ export {
   pickTraceHistogramBucketSeconds,
   resolveTraceHistogramRangeIso,
 } from "./helpers.ts"
+export type { UnpricedSpanGroup } from "./otlp/transform.ts"
 export type { AnalyticsQueryInput, AnalyticsQueryReaderShape } from "./ports/analytics-query-reader.ts"
 export { AnalyticsQueryReader } from "./ports/analytics-query-reader.ts"
 export type { EmbedBudgetLimits, EmbedBudgetResolverShape } from "./ports/embed-budget-resolver.ts"

--- a/packages/domain/spans/src/otlp.ts
+++ b/packages/domain/spans/src/otlp.ts
@@ -4,6 +4,6 @@
  * this so the client bundle does not pull in protobufjs.
  */
 export { decodeOtlpProtobuf } from "./otlp/proto.ts"
-export type { TransformContext } from "./otlp/transform.ts"
+export type { TransformContext, UnpricedSpanGroup } from "./otlp/transform.ts"
 export { transformOtlpToSpans } from "./otlp/transform.ts"
 export type { OtlpExportTraceServiceRequest } from "./otlp/types.ts"

--- a/packages/domain/spans/src/otlp/resolvers/identity.ts
+++ b/packages/domain/spans/src/otlp/resolvers/identity.ts
@@ -40,6 +40,30 @@ const PROVIDER_ALIASES: Record<string, string> = {
   "azure.ai.inference": "azure",
   x_ai: "xai",
   "gcp.vertex.agent": "google-vertex", // Google ADK generate_content leaves
+  "gcp.gen_ai": "google", // Mastra's canonical key for the direct Gemini API
+  "@anthropic-ai/claude-agent-sdk": "anthropic",
+  "@anthropic-ai/claude-code": "anthropic",
+  "@anthropic-ai/sdk": "anthropic",
+  "@google-cloud/vertexai": "google-vertex",
+  "@google/genai": "google",
+  "@mistralai/mistralai": "mistral",
+  "@openai/agents": "openai",
+  "@ai-sdk/amazon-bedrock": "amazon-bedrock",
+  "@ai-sdk/anthropic": "anthropic",
+  "@ai-sdk/azure": "azure",
+  "@ai-sdk/cerebras": "cerebras",
+  "@ai-sdk/cohere": "cohere",
+  "@ai-sdk/deepinfra": "deepinfra",
+  "@ai-sdk/deepseek": "deepseek",
+  "@ai-sdk/fireworks": "fireworks-ai",
+  "@ai-sdk/google": "google",
+  "@ai-sdk/google-vertex": "google-vertex",
+  "@ai-sdk/groq": "groq",
+  "@ai-sdk/mistral": "mistral",
+  "@ai-sdk/openai": "openai",
+  "@ai-sdk/perplexity": "perplexity",
+  "@ai-sdk/togetherai": "togetherai",
+  "@ai-sdk/xai": "xai",
 }
 
 // Case-fold before alias lookup so non-canonical casings (`Google`, `OpenAI`) resolve to
@@ -70,7 +94,9 @@ const providerCandidates: Candidate<string>[] = [
   fromString("llm.provider", aliasProvider), // OpenInference (DSPy, LiteLLM) — no llm.system
   { resolve: (attrs) => providerFromOpenInferenceMetadata(attrs) }, // OpenInference LangChain (LangSmith metadata)
   fromString("ai.model.provider", (v) => aliasProvider(v.replace(VERCEL_PROVIDER_SUFFIX, ""))), // Vercel AI SDK
-  { resolve: (attrs) => (stringAttr(attrs, "span.type") === "llm_request" ? "anthropic" : undefined) }, // Claude Code
+  {
+    resolve: (attrs) => (stringAttr(attrs, "span.type") === "llm_request" ? "anthropic" : undefined),
+  }, // Claude Code
 ]
 
 function anthropicProviderFromClaudeCodeSpanName(spanName: string): string | undefined {

--- a/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
@@ -160,17 +160,14 @@ describe("resolveAttributes", () => {
       expect(result.provider).toBe("openai")
     })
 
-    it("case-folds non-canonical provider casing", () => {
-      const cases: [string, string, string][] = [
-        ["gen_ai.system", "Google", "google"],
-        ["llm.system", "OpenAI", "openai"],
-        ["llm.provider", "Anthropic", "anthropic"],
-      ]
-      for (const [key, input, expected] of cases) {
-        const attrs: OtlpKeyValue[] = [strAttr(key, input)]
-        const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
-        expect(result.provider).toBe(expected)
-      }
+    it.each([
+      ["gen_ai.system", "Google", "google"],
+      ["llm.system", "OpenAI", "openai"],
+      ["llm.provider", "Anthropic", "anthropic"],
+    ])("case-folds non-canonical provider casing %s=%s", (key, input, expected) => {
+      const attrs: OtlpKeyValue[] = [strAttr(key, input)]
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+      expect(result.provider).toBe(expected)
     })
 
     it("resolves from Vercel ai.model.provider and strips suffix", () => {
@@ -179,38 +176,133 @@ describe("resolveAttributes", () => {
       expect(result.provider).toBe("openai")
     })
 
-    it("normalizes provider aliases", () => {
-      const cases: [string, string, string][] = [
-        ["gen_ai.system", "bedrock", "amazon-bedrock"],
-        ["gen_ai.system", "gemini", "google"],
-        ["gen_ai.system", "vertexai", "google-vertex"],
-        ["gen_ai.system", "mistralai", "mistral"],
-        ["gen_ai.system", "mistral_ai", "mistral"],
-        ["gen_ai.system", "workersai.chat", "cloudflare-workers-ai"],
-        ["ai.model.provider", "google.vertex.chat", "google-vertex"],
-        ["ai.model.provider", "anthropic.messages", "anthropic"],
-        ["ai.model.provider", "google.generative-ai", "google"],
-        ["ai.model.provider", "workersai.chat", "cloudflare-workers-ai"],
-        // Vercel AI SDK v7 (@ai-sdk/otel) OTel GenAI well-known provider names
-        ["gen_ai.provider.name", "gcp.vertex_ai", "google-vertex"],
-        ["gen_ai.provider.name", "gcp.gemini", "google"],
-        ["gen_ai.provider.name", "aws.bedrock", "amazon-bedrock"],
-        ["gen_ai.provider.name", "azure.ai.openai", "azure"],
-        ["gen_ai.provider.name", "azure.ai.inference", "azure"],
-        ["gen_ai.provider.name", "mistral_ai", "mistral"],
-        ["gen_ai.provider.name", "x_ai", "xai"],
-        // Google ADK (OpenInference) reports the Vertex agent provider name
-        ["llm.provider", "gcp.vertex.agent", "google-vertex"],
-        // v7 also passes these through unchanged (already canonical)
-        ["gen_ai.provider.name", "openai", "openai"],
-        ["gen_ai.provider.name", "anthropic", "anthropic"],
+    it.each([
+      ["gen_ai.system", "bedrock", "amazon-bedrock"],
+      ["gen_ai.system", "gemini", "google"],
+      ["gen_ai.system", "vertexai", "google-vertex"],
+      ["gen_ai.system", "mistralai", "mistral"],
+      ["gen_ai.system", "mistral_ai", "mistral"],
+      ["gen_ai.system", "workersai.chat", "cloudflare-workers-ai"],
+      ["ai.model.provider", "google.vertex.chat", "google-vertex"],
+      ["ai.model.provider", "anthropic.messages", "anthropic"],
+      ["ai.model.provider", "google.generative-ai", "google"],
+      ["ai.model.provider", "workersai.chat", "cloudflare-workers-ai"],
+      // Vercel AI SDK v7 (@ai-sdk/otel) OTel GenAI well-known provider names
+      ["gen_ai.provider.name", "gcp.vertex_ai", "google-vertex"],
+      ["gen_ai.provider.name", "gcp.gemini", "google"],
+      ["gen_ai.provider.name", "aws.bedrock", "amazon-bedrock"],
+      ["gen_ai.provider.name", "azure.ai.openai", "azure"],
+      ["gen_ai.provider.name", "azure.ai.inference", "azure"],
+      ["gen_ai.provider.name", "mistral_ai", "mistral"],
+      ["gen_ai.provider.name", "x_ai", "xai"],
+      // Mastra's canonical key for the direct Gemini API
+      ["gen_ai.provider.name", "gcp.gen_ai", "google"],
+      // Google ADK (OpenInference) reports the Vertex agent provider name
+      ["llm.provider", "gcp.vertex.agent", "google-vertex"],
+      // v7 also passes these through unchanged (already canonical)
+      ["gen_ai.provider.name", "openai", "openai"],
+      ["gen_ai.provider.name", "anthropic", "anthropic"],
+    ])("normalizes provider alias %s=%s to %s", (key, input, expected) => {
+      const attrs: OtlpKeyValue[] = [strAttr(key, input)]
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+      expect(result.provider).toBe(expected)
+    })
+
+    // Mastra reports the SDK's npm package name rather than an OTEL well-known value.
+    it.each([
+      ["@anthropic-ai/claude-agent-sdk", "anthropic"],
+      ["@anthropic-ai/claude-code", "anthropic"],
+      ["@anthropic-ai/sdk", "anthropic"],
+      ["@google-cloud/vertexai", "google-vertex"],
+      ["@google/genai", "google"],
+      ["@mistralai/mistralai", "mistral"],
+      ["@openai/agents", "openai"],
+      ["@ai-sdk/amazon-bedrock", "amazon-bedrock"],
+      ["@ai-sdk/anthropic", "anthropic"],
+      ["@ai-sdk/azure", "azure"],
+      ["@ai-sdk/google", "google"],
+      ["@ai-sdk/google-vertex", "google-vertex"],
+      ["@ai-sdk/mistral", "mistral"],
+      ["@ai-sdk/openai", "openai"],
+      ["@ai-sdk/xai", "xai"],
+      // models.dev calls this `fireworks-ai`, so the package suffix is not the provider id.
+      ["@ai-sdk/fireworks", "fireworks-ai"],
+    ])("maps SDK package %s to provider %s", (input, expected) => {
+      const attrs: OtlpKeyValue[] = [strAttr("gen_ai.provider.name", input)]
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+      expect(result.provider).toBe(expected)
+    })
+
+    // Passing an unmapped package through unchanged is what makes it reportable: the real
+    // string reaches Datadog instead of a provider id guessed from its scope.
+    it.each([
+      ["@cursor/sdk"],
+      ["@acme/llm"],
+      ["@ai-sdk/openai-compatible"],
+      ["@ai-sdk/react"],
+    ])("leaves unmapped package %s untouched", (input) => {
+      const attrs: OtlpKeyValue[] = [strAttr("gen_ai.provider.name", input)]
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+      expect(result.provider).toBe(input)
+    })
+
+    it("prices a Mastra-wrapped OpenAI Agents span instead of reporting $0", () => {
+      const attrs: OtlpKeyValue[] = [
+        strAttr("gen_ai.provider.name", "@openai/agents"),
+        strAttr("gen_ai.request.model", "gpt-4o"),
+        intAttr("gen_ai.usage.input_tokens", 1_000),
+        intAttr("gen_ai.usage.output_tokens", 500),
       ]
 
-      for (const [key, input, expected] of cases) {
-        const attrs: OtlpKeyValue[] = [strAttr(key, input)]
-        const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
-        expect(result.provider).toBe(expected)
-      }
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+
+      expect(result.provider).toBe("openai")
+      expect(result.costTotalMicrocents).toBe(750_000)
+      expect(result.costIsEstimated).toBe(true)
+      expect(result.costPricingMissing).toBe(false)
+    })
+
+    it("prices a Mastra-wrapped Claude Agent SDK span instead of reporting $0", () => {
+      const attrs: OtlpKeyValue[] = [
+        strAttr("gen_ai.provider.name", "@anthropic-ai/claude-agent-sdk"),
+        strAttr("gen_ai.request.model", "claude-opus-4-8"),
+        intAttr("gen_ai.usage.cache_creation.input_tokens", 100_532),
+        intAttr("gen_ai.usage.cache_read.input_tokens", 922_723),
+        intAttr("gen_ai.usage.input_tokens", 1_023_279),
+        intAttr("gen_ai.usage.output_tokens", 13_299),
+      ]
+
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+
+      expect(result.provider).toBe("anthropic")
+      // `gen_ai.usage.input_tokens` is inclusive, leaving 24 genuinely uncached input tokens.
+      expect(result.tokensInput).toBe(24)
+      expect(result.costTotalMicrocents).toBe(142_228_150)
+      expect(result.costIsEstimated).toBe(true)
+      expect(result.costPricingMissing).toBe(false)
+    })
+
+    it("flags token usage that no pricing matched", () => {
+      const attrs: OtlpKeyValue[] = [
+        strAttr("gen_ai.provider.name", "@some-vendor/unmapped-sdk"),
+        strAttr("gen_ai.request.model", "mystery-model"),
+        intAttr("gen_ai.usage.input_tokens", 1_000),
+        intAttr("gen_ai.usage.output_tokens", 500),
+      ]
+
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+
+      expect(result.costTotalMicrocents).toBe(0)
+      expect(result.costIsEstimated).toBe(false)
+      expect(result.costPricingMissing).toBe(true)
+    })
+
+    it("does not flag spans that carry no token usage", () => {
+      const attrs: OtlpKeyValue[] = [strAttr("gen_ai.provider.name", "@some-vendor/unmapped-sdk")]
+
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+
+      expect(result.costPricingMissing).toBe(false)
     })
 
     it("returns empty string for missing provider", () => {

--- a/packages/domain/spans/src/otlp/resolvers/usage.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage.ts
@@ -28,10 +28,10 @@ const costTotalCandidates = [
 
 // ─── Resolve ─────────────────────────────────────────────
 
-interface EstimatedCost {
-  readonly input: number
-  readonly output: number
-}
+type CostEstimation =
+  | { readonly kind: "estimated"; readonly input: number; readonly output: number }
+  | { readonly kind: "unpriced" }
+  | { readonly kind: "noTokens" }
 
 function estimateCostFromTokens({
   provider,
@@ -49,11 +49,13 @@ function estimateCostFromTokens({
   tokensCacheRead: number
   tokensCacheCreate: number
   tokensReasoning: number
-}): EstimatedCost | undefined {
-  if (tokensInput + tokensOutput + tokensCacheRead + tokensCacheCreate + tokensReasoning === 0) return undefined
+}): CostEstimation {
+  if (tokensInput + tokensOutput + tokensCacheRead + tokensCacheCreate + tokensReasoning === 0) {
+    return { kind: "noTokens" }
+  }
 
   const { cost, costImplemented } = getCostSpec(provider, model)
-  if (!costImplemented) return undefined
+  if (!costImplemented) return { kind: "unpriced" }
 
   const inputUsd =
     computeTokenCost(cost, tokensInput, "input") +
@@ -64,6 +66,7 @@ function estimateCostFromTokens({
     computeTokenCost(cost, tokensOutput, "output") + computeTokenCost(cost, tokensReasoning, "reasoning")
 
   return {
+    kind: "estimated",
     input: Math.round(inputUsd * MICROCENTS_PER_USD),
     output: Math.round(outputUsd * MICROCENTS_PER_USD),
   }
@@ -84,6 +87,8 @@ export interface ResolvedUsage {
   readonly costOutputMicrocents: number
   readonly costTotalMicrocents: number
   readonly costIsEstimated: boolean
+  /** Tokens were reported but no models.dev pricing matched provider/model, so cost stayed 0. */
+  readonly costPricingMissing: boolean
 }
 
 // ─── OpenClaw embedded usage ──────────────────────────────
@@ -168,19 +173,21 @@ function resolveEmbeddedMessageUsage(
       costOutputMicrocents: usdToMicrocents(nonNegative(cost.output)),
       costTotalMicrocents: usdToMicrocents(nonNegative(cost.total)),
       costIsEstimated: false,
+      costPricingMissing: false,
     }
   }
 
   // No embedded cost — estimate from the tokens, same as flat-attr spans.
   const estimation = estimateCostFromTokens({ provider, model, ...tokens })
-  const costInputMicrocents = estimation?.input ?? 0
-  const costOutputMicrocents = estimation?.output ?? 0
+  const costInputMicrocents = estimation.kind === "estimated" ? estimation.input : 0
+  const costOutputMicrocents = estimation.kind === "estimated" ? estimation.output : 0
   return {
     ...tokens,
     costInputMicrocents,
     costOutputMicrocents,
     costTotalMicrocents: costInputMicrocents + costOutputMicrocents,
-    costIsEstimated: estimation !== undefined,
+    costIsEstimated: estimation.kind === "estimated",
+    costPricingMissing: estimation.kind === "unpriced",
   }
 }
 
@@ -223,9 +230,10 @@ export function resolveUsage({ attrs, provider, model }: ResolveUsageInput): Res
         tokensReasoning,
       })
 
-  const costIsEstimated = !hasAttrCosts && costEstimation !== undefined
-  const costInput = attrCostInput ?? costEstimation?.input ?? 0
-  const costOutput = attrCostOutput ?? costEstimation?.output ?? 0
+  const estimated = costEstimation?.kind === "estimated" ? costEstimation : undefined
+  const costIsEstimated = estimated !== undefined
+  const costInput = attrCostInput ?? estimated?.input ?? 0
+  const costOutput = attrCostOutput ?? estimated?.output ?? 0
   const costTotal = attrCostTotal ?? (costInput + costOutput > 0 ? costInput + costOutput : 0)
 
   return {
@@ -238,5 +246,7 @@ export function resolveUsage({ attrs, provider, model }: ResolveUsageInput): Res
     costOutputMicrocents: costOutput,
     costTotalMicrocents: costTotal,
     costIsEstimated,
+    // A provider-supplied total still counts as priced even when the model is unknown to models.dev.
+    costPricingMissing: costEstimation?.kind === "unpriced" && attrCostTotal === undefined,
   }
 }

--- a/packages/domain/spans/src/otlp/tests/unpriced-spans.test.ts
+++ b/packages/domain/spans/src/otlp/tests/unpriced-spans.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+import { transformOtlpToSpans } from "../transform.ts"
+import type { OtlpExportTraceServiceRequest, OtlpKeyValue } from "../types.ts"
+
+const TRACE = "0af7651916cd43dd8448eb211c80319c"
+
+const str = (key: string, value: string): OtlpKeyValue => ({ key, value: { stringValue: value } })
+const int = (key: string, value: number): OtlpKeyValue => ({ key, value: { intValue: String(value) } })
+
+const baseContext = {
+  organizationId: "org-1",
+  apiKeyId: "key-1",
+  ingestedAt: new Date("2026-04-10T12:00:00.000Z"),
+  defaultProjectId: "proj-1",
+  projectIdBySlug: new Map<string, string>(),
+}
+
+function llmSpan(spanId: string, attributes: OtlpKeyValue[]) {
+  return {
+    traceId: TRACE,
+    spanId,
+    name: spanId,
+    startTimeUnixNano: "1710590400000000000",
+    endTimeUnixNano: "1710590401000000000",
+    attributes,
+    status: { code: 1 },
+  }
+}
+
+function request(spans: ReturnType<typeof llmSpan>[]): OtlpExportTraceServiceRequest {
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: [str("service.name", "test")] },
+        scopeSpans: [{ scope: { name: "scope", version: "1" }, spans }],
+      },
+    ],
+  }
+}
+
+const unpricedAttrs = (model: string): OtlpKeyValue[] => [
+  str("gen_ai.provider.name", "@some-vendor/unmapped-sdk"),
+  str("gen_ai.request.model", model),
+  int("gen_ai.usage.input_tokens", 1_000),
+  int("gen_ai.usage.output_tokens", 500),
+]
+
+describe("transformOtlpToSpans unpriced cost reporting", () => {
+  it("groups unpriced spans by project, provider and model with a count", () => {
+    const { spans, unpricedSpanGroups } = transformOtlpToSpans(
+      request([
+        llmSpan("s1", unpricedAttrs("mystery-model")),
+        llmSpan("s2", unpricedAttrs("mystery-model")),
+        llmSpan("s3", unpricedAttrs("other-model")),
+      ]),
+      baseContext,
+    )
+
+    expect(spans).toHaveLength(3)
+    expect(unpricedSpanGroups).toEqual([
+      { projectId: "proj-1", provider: "@some-vendor/unmapped-sdk", model: "mystery-model", spans: 2 },
+      { projectId: "proj-1", provider: "@some-vendor/unmapped-sdk", model: "other-model", spans: 1 },
+    ])
+  })
+
+  it("reports nothing for spans it can price", () => {
+    const { spans, unpricedSpanGroups } = transformOtlpToSpans(
+      request([
+        llmSpan("s1", [
+          str("gen_ai.provider.name", "@anthropic-ai/claude-agent-sdk"),
+          str("gen_ai.request.model", "claude-opus-4-8"),
+          int("gen_ai.usage.input_tokens", 1_000),
+          int("gen_ai.usage.output_tokens", 500),
+        ]),
+      ]),
+      baseContext,
+    )
+
+    expect(spans[0]?.costTotalMicrocents).toBeGreaterThan(0)
+    expect(unpricedSpanGroups).toEqual([])
+  })
+
+  it("ignores spans that carry no token usage", () => {
+    const { unpricedSpanGroups } = transformOtlpToSpans(
+      request([llmSpan("s1", [str("gen_ai.provider.name", "@some-vendor/unmapped-sdk")])]),
+      baseContext,
+    )
+
+    expect(unpricedSpanGroups).toEqual([])
+  })
+})

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -93,10 +93,19 @@ export interface TransformContext {
   readonly projectIdBySlug: ReadonlyMap<string, string>
 }
 
+/** Spans carrying token usage that no models.dev pricing matched, grouped for reporting. */
+export interface UnpricedSpanGroup {
+  readonly projectId: string
+  readonly provider: string
+  readonly model: string
+  readonly spans: number
+}
+
 interface TransformResult {
   readonly spans: readonly SpanDetail[]
   /** Spans skipped for lacking a resolvable `projectId` or a valid `traceId`. */
   readonly rejectedSpans: number
+  readonly unpricedSpanGroups: readonly UnpricedSpanGroup[]
 }
 
 /** Reads `latitude.project` from span attrs first, falling back to resource attrs. */
@@ -132,6 +141,11 @@ function hasParentSpan(parentSpanId: string | undefined): boolean {
   return !!parentSpanId && !/^0+$/.test(parentSpanId)
 }
 
+interface TransformedSpan {
+  readonly span: SpanDetail
+  readonly costPricingMissing: boolean
+}
+
 function transformSpan({
   span,
   traceId,
@@ -150,7 +164,7 @@ function transformSpan({
   context: TransformContext
   projectId: string
   ingestedAt: Date
-}): SpanDetail {
+}): TransformedSpan {
   const spanAttrs = attrArray(span.attributes)
   const spanEvents = span.events ?? []
   const resourceAttrs = attrArray(resource?.attributes)
@@ -197,7 +211,7 @@ function transformSpan({
     }
   }
 
-  return {
+  const detail: SpanDetail = {
     organizationId: OrganizationId(context.organizationId),
     projectId: ProjectId(projectId),
     sessionId: SessionId(resolved.sessionId),
@@ -258,6 +272,8 @@ function transformSpan({
     toolOutput: toolExecution.toolOutput,
     ingestedAt,
   }
+
+  return { span: detail, costPricingMissing: resolved.costPricingMissing }
 }
 
 export function transformOtlpToSpans(
@@ -266,6 +282,7 @@ export function transformOtlpToSpans(
 ): TransformResult {
   const spans: SpanDetail[] = []
   let rejectedSpans = 0
+  const unpricedByKey = new Map<string, { projectId: string; provider: string; model: string; spans: number }>()
   const { ingestedAt } = context
 
   for (const resourceSpans of request.resourceSpans ?? []) {
@@ -291,10 +308,28 @@ export function transformOtlpToSpans(
           rejectedSpans++
           continue
         }
-        spans.push(transformSpan({ span, traceId, resource, scopeName, scopeVersion, context, projectId, ingestedAt }))
+        const transformed = transformSpan({
+          span,
+          traceId,
+          resource,
+          scopeName,
+          scopeVersion,
+          context,
+          projectId,
+          ingestedAt,
+        })
+        spans.push(transformed.span)
+
+        if (transformed.costPricingMissing) {
+          const { provider, model } = transformed.span
+          const key = `${projectId} ${provider} ${model}`
+          const existing = unpricedByKey.get(key)
+          if (existing) existing.spans++
+          else unpricedByKey.set(key, { projectId, provider, model, spans: 1 })
+        }
       }
     }
   }
 
-  return { spans, rejectedSpans }
+  return { spans, rejectedSpans, unpricedSpanGroups: [...unpricedByKey.values()] }
 }

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -209,18 +209,46 @@ function discardBufferedPayload(fileKey: string | null): Effect.Effect<void, nev
   })
 }
 
+/**
+ * Reports token usage that no pricing matched, so a customer seeing $0 on real usage surfaces as
+ * our bug rather than staying silent. Observability infrastructure stays out of the domain, so the
+ * adapter owns log/error-tracking shape and rate limiting.
+ */
+type UnpricedSpansReporter = (
+  groups: readonly UnpricedSpanGroup[],
+  organizationId: OrganizationId,
+) => Effect.Effect<void>
+
 export interface ProcessIngestedSpansDeps<TPublishError = unknown> {
   readonly eventsPublisher: EventsPublisher<TPublishError>
-  /**
-   * Reports token usage that no pricing matched, so a customer seeing $0 on real usage surfaces as
-   * our bug rather than staying silent. Observability infrastructure stays out of the domain, so the
-   * adapter owns log/error-tracking shape and rate limiting. Must not fail: the spans are valid and
-   * still have to land.
-   */
-  readonly onUnpricedSpans?: (
-    groups: readonly UnpricedSpanGroup[],
-    organizationId: OrganizationId,
-  ) => Effect.Effect<void>
+  readonly onUnpricedSpans?: UnpricedSpansReporter
+}
+
+/**
+ * Called only once the insert has succeeded, so a report always describes stored spans: reporting
+ * before the write would announce — and, in the adapter, rate-limit — a batch that a later failure
+ * sends back for redelivery, muting the retry that actually persists it.
+ *
+ * Every failure is swallowed, defects included, because by this point the spans are already stored
+ * and a broken reporter must not turn a completed ingest into a retry.
+ */
+function reportUnpricedSpans(
+  groups: readonly UnpricedSpanGroup[],
+  organizationId: OrganizationId,
+  report: UnpricedSpansReporter | undefined,
+): Effect.Effect<void> {
+  if (groups.length === 0) return Effect.void
+
+  return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan(
+      "cost.unpricedSpans",
+      groups.reduce((total, group) => total + group.spans, 0),
+    )
+    if (!report) return
+    yield* Effect.catchCause(report(groups, organizationId), () =>
+      Effect.annotateCurrentSpan("cost.unpricedReportFailed", true),
+    )
+  })
 }
 
 export const processIngestedSpansUseCase =
@@ -237,14 +265,6 @@ export const processIngestedSpansUseCase =
 
       const payload = yield* resolvePayload(input)
       const { spans: transformed, unpricedSpanGroups } = yield* decodeAndTransform(payload, input)
-
-      if (unpricedSpanGroups.length > 0) {
-        yield* Effect.annotateCurrentSpan(
-          "cost.unpricedSpans",
-          unpricedSpanGroups.reduce((total, group) => total + group.spans, 0),
-        )
-        if (onUnpricedSpans) yield* onUnpricedSpans(unpricedSpanGroups, input.organizationId)
-      }
 
       // Redaction runs before the retention stamp and the insert, which makes it the
       // single choke point for every content sink: `traces` and `sessions` are
@@ -277,6 +297,8 @@ export const processIngestedSpansUseCase =
 
       const repo = yield* SpanRepository
       yield* repo.insert(persistedSpans)
+
+      yield* reportUnpricedSpans(unpricedSpanGroups, input.organizationId, onUnpricedSpans)
 
       // Spans in a single OTLP batch may now belong to different projects (per-span scoping).
       // Group by projectId so each TracesIngested event addresses one project at a time —

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -16,7 +16,7 @@ import { Effect } from "effect"
 import type { SpanDetail } from "../entities/span.ts"
 import { RedactionError, SpanDecodingError } from "../errors.ts"
 import { decodeOtlpProtobuf } from "../otlp/proto.ts"
-import { transformOtlpToSpans } from "../otlp/transform.ts"
+import { transformOtlpToSpans, type UnpricedSpanGroup } from "../otlp/transform.ts"
 import type { OtlpExportTraceServiceRequest } from "../otlp/types.ts"
 import { SpanRepository } from "../ports/span-repository.ts"
 import { redactSpans, type SpanRedactionSummary } from "../redaction/redact-spans.ts"
@@ -94,10 +94,15 @@ function resolvePayload(
   )
 }
 
+interface DecodedSpans {
+  readonly spans: readonly SpanDetail[]
+  readonly unpricedSpanGroups: readonly UnpricedSpanGroup[]
+}
+
 function decodeAndTransform(
   payload: Uint8Array,
   input: ProcessIngestedSpansInput,
-): Effect.Effect<readonly SpanDetail[], SpanDecodingError> {
+): Effect.Effect<DecodedSpans, SpanDecodingError> {
   return Effect.gen(function* () {
     const request = decodeRequest(payload, input.contentType)
     if (!request) {
@@ -107,10 +112,10 @@ function decodeAndTransform(
     }
 
     if (!request.resourceSpans?.length) {
-      return []
+      return { spans: [], unpricedSpanGroups: [] }
     }
 
-    const { spans, rejectedSpans } = transformOtlpToSpans(request, {
+    const { spans, rejectedSpans, unpricedSpanGroups } = transformOtlpToSpans(request, {
       organizationId: input.organizationId,
       apiKeyId: input.apiKeyId,
       ingestedAt: input.ingestedAt,
@@ -122,7 +127,7 @@ function decodeAndTransform(
       yield* Effect.annotateCurrentSpan("rejectedSpans", rejectedSpans)
     }
 
-    return spans
+    return { spans, unpricedSpanGroups }
   })
 }
 
@@ -206,10 +211,20 @@ function discardBufferedPayload(fileKey: string | null): Effect.Effect<void, nev
 
 export interface ProcessIngestedSpansDeps<TPublishError = unknown> {
   readonly eventsPublisher: EventsPublisher<TPublishError>
+  /**
+   * Reports token usage that no pricing matched, so a customer seeing $0 on real usage surfaces as
+   * our bug rather than staying silent. Observability infrastructure stays out of the domain, so the
+   * adapter owns log/error-tracking shape and rate limiting. Must not fail: the spans are valid and
+   * still have to land.
+   */
+  readonly onUnpricedSpans?: (
+    groups: readonly UnpricedSpanGroup[],
+    organizationId: OrganizationId,
+  ) => Effect.Effect<void>
 }
 
 export const processIngestedSpansUseCase =
-  <TPublishError>({ eventsPublisher }: ProcessIngestedSpansDeps<TPublishError>) =>
+  <TPublishError>({ eventsPublisher, onUnpricedSpans }: ProcessIngestedSpansDeps<TPublishError>) =>
   (
     input: ProcessIngestedSpansInput,
   ): Effect.Effect<
@@ -221,7 +236,15 @@ export const processIngestedSpansUseCase =
       yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
 
       const payload = yield* resolvePayload(input)
-      const transformed = yield* decodeAndTransform(payload, input)
+      const { spans: transformed, unpricedSpanGroups } = yield* decodeAndTransform(payload, input)
+
+      if (unpricedSpanGroups.length > 0) {
+        yield* Effect.annotateCurrentSpan(
+          "cost.unpricedSpans",
+          unpricedSpanGroups.reduce((total, group) => total + group.spans, 0),
+        )
+        if (onUnpricedSpans) yield* onUnpricedSpans(unpricedSpanGroups, input.organizationId)
+      }
 
       // Redaction runs before the retention stamp and the insert, which makes it the
       // single choke point for every content sink: `traces` and `sessions` are


### PR DESCRIPTION
## Problem

A customer reported $0 cost on spans carrying over a million tokens.

The span looked like this (trimmed):

```json
{
  "gen_ai.provider.name": "@anthropic-ai/claude-agent-sdk",
  "gen_ai.request.model": "claude-opus-4-8",
  "gen_ai.usage.input_tokens": 1023279,
  "gen_ai.usage.output_tokens": 13299,
  "gen_ai.usage.cache_read.input_tokens": 922723,
  "gen_ai.usage.cache_creation.input_tokens": 100532,
  "mastra.span.type": "model_generation"
}
```

The model was never the problem — `claude-opus-4-8` is in the bundled models.dev data under provider `anthropic`, fully priced. The provider was. Mastra reports the SDK's **npm package name** in `gen_ai.provider.name` instead of an OTEL well-known value, so `resolveProvider` passed `@anthropic-ai/claude-agent-sdk` straight through, `getModelsForProvider` matched nothing, and `getCostSpec` returned `costImplemented: false`:

```
"@anthropic-ai/claude-agent-sdk" → {"cost":{"input":0,"output":0},"costImplemented":false}
"anthropic"                      → {"cost":{"input":5,"output":25,"cacheRead":0.5,"cacheWrite":6.25},"costImplemented":true}
```

The two existing Claude Code escape hatches don't catch it: one keys on `span.type == "llm_request"`, the other on a `claude_code.llm_request` span name. This span arrives via Mastra, so neither fires.

## The fix

Explicit aliases for the Anthropic SDK package names. That span now prices at **$1.4222815** instead of $0 — almost all of it cache write (100,532 @ $6.25/1M) and cache read (922,723 @ $0.50/1M).

Token math is deliberately untouched: `gen_ai.usage.input_tokens` is in `ALWAYS_INCLUSIVE_INPUT_KEYS`, which short-circuits before the provider check, so the 1,023,279 was already correctly read as inclusive (24 genuinely uncached input tokens) both before and after.

## Why it reached us as a complaint instead of an alert

An unpriced provider/model pair failed **silently** to $0. There was no signal anywhere.

`costIsEstimated: false` was conflating two opposite meanings — "the provider gave us a cost" and "we couldn't price it" — so it couldn't be used to detect this. `resolveUsage` now distinguishes them via `costPricingMissing` (`estimateCostFromTokens` returns a discriminated `estimated | unpriced | noTokens`). The transform aggregates affected spans per `(project, provider, model)`, and the worker reports them.

Three deliberate choices there:

- **Logged, not thrown.** The batch succeeded and its spans are valid. Throwing would drop good data and trigger redelivery over a pricing-table gap.
- **Its own error span, not the ingest span.** Recording onto the ingest span would mark a healthy job as failed and pollute the `status:error env:production` queries used to triage real ingest breakage. Error Tracking in this org is span-based, so a log alone would never create an issue.
- **One issue, not one per provider.** The synthetic error is constructed at a single site with a constant message so occurrences group into one Error Tracking issue; `provider`, `model`, `organizationId` and `projectId` ride on span attributes. Varying the message or error name would fan out into a long tail as customers bring new SDKs.

Observability infrastructure stays out of the domain (no `packages/domain/*` package imports `@repo/observability`), so the use case takes an injected `onUnpricedSpans` and `apps/workers` owns the adapter.

Emission is driven by customer traffic, so reports are throttled in-memory to one per hour per `(org, project, provider, model)`. In-memory rather than Redis: no round-trip in the ingest hot path and no new failure mode, and per-replica duplication just means a handful of reports per window. Keying on org and project means a second customer hitting the same gap still reports independently.

## Scope

Historical spans keep their stored $0 — cost is computed at ingest and is not backfilled here. Agreed as out of scope.

## Tests

- `@domain/spans`: **1258 passed** (50 files). New coverage for the three aliases, the customer's exact span pricing to $1.4222815, `costPricingMissing` on an unmapped provider, no flag when a span carries no tokens, and the per-project/provider/model grouping.
- `@app/workers`: new `unpriced-spans-report.test.ts` (4 tests) covering the log payload and the throttle, including that a distinct model, project or org still reports.
- Typecheck clean for `@domain/spans`, `@app/workers`, `@app/ingest`; Biome clean.

Two unrelated environment issues in my local run, both pre-existing and not from this change: `apps/ingest`'s `node_modules/.bin/tsgo` symlink points at a tsgo version that is no longer installed (typechecked with the installed binary instead), and 8 `apps/workers` test *files* fail to load on a missing `chdb` native binary (0 individual tests failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end detection and throttled reporting of unpriced spans, grouped by project, provider, and model, including structured error logs and a dedicated tracing signal.
* **Bug Fixes**
  * Improved provider alias normalization, including npm-scoped GenAI SDK package names.
  * Refined pricing-missing and estimation behavior across token-based and embedded usage, and ensured spans without token usage aren’t flagged as unpriced.
* **Tests**
  * Added/expanded coverage for unpriced span grouping, throttled reporting behavior (including eviction limits), and pricing-missing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->