### PR TITLE
Resolves GUI-WVZV: Hide OAuth-only MCP tools from API-key sessions

### DIFF
--- a/.agents/skills/api-endpoints/SKILL.md
+++ b/.agents/skills/api-endpoints/SKILL.md
@@ -281,6 +281,26 @@ const internalReindex = widgetOperation({
 })
 ```
 
+## OAuth-only operations
+
+Some operations need a real acting user (`requireOAuthUserId`) and reject API-key callers with 403. Declare that on the operation so the live MCP transport can hide the tool from API-key sessions — otherwise agents discover a tool that always fails:
+
+```ts
+const createWidget = widgetOperation({
+  route: createRoute({ ... }),
+  access: "write",
+  authRequirement: "oauth", // ← omit from MCP tools/list when auth.method === "api-key"
+  rateLimitTier: "low",
+  execute: (input, ctx) =>
+    Effect.gen(function* () {
+      const userId = yield* requireOAuthUserId(ctx.auth)
+      // ...
+    }),
+})
+```
+
+Defaults to `"any"`. Only set `"oauth"` when the execute path calls `requireOAuthUserId`. The static `mcp.json` emits `authRequirement: "oauth"` for those tools; runtime `/v1/mcp` filters them per session.
+
 ## Verification checklist
 
 Run before opening the PR:

--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -7362,7 +7362,8 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false
-      }
+      },
+      "authRequirement": "oauth"
     },
     {
       "name": "updateSavedSearch",
@@ -16061,7 +16062,8 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": false
-      }
+      },
+      "authRequirement": "oauth"
     },
     {
       "name": "getMember",
@@ -16266,7 +16268,8 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true
-      }
+      },
+      "authRequirement": "oauth"
     },
     {
       "name": "removeMember",
@@ -16290,7 +16293,8 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true
-      }
+      },
+      "authRequirement": "oauth"
     },
     {
       "name": "listMonitors",

--- a/apps/api/scripts/emit-mcp.ts
+++ b/apps/api/scripts/emit-mcp.ts
@@ -42,6 +42,7 @@ const tools = collectToolDescriptors().map((tool) => ({
   // rely on `"outputSchema" in tool` to mean "structured output is available".
   ...(tool.output ? { outputSchema: z.toJSONSchema(tool.output.schema, { target: "draft-2020-12" }) } : {}),
   annotations: tool.annotations,
+  ...(tool.authRequirement !== "any" ? { authRequirement: tool.authRequirement } : {}),
 }))
 
 const manifest = { ...MCP_INFO, tools }

--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -8,6 +8,8 @@ import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
 import {
   type ApiTestContext,
+  createOAuthAuthHeaders,
+  createOAuthTenantSetup,
   createTenantSetup,
   setupTestApi,
   TEST_ENCRYPTION_KEY,
@@ -52,12 +54,16 @@ const insertProject = async (database: InMemoryPostgres, organizationId: string)
 
 const PROTOCOL_VERSION = "2025-03-26"
 
-const sendMcpRequest = async (app: ApiTestContext["app"], authToken: string, body: object): Promise<Response> => {
+const sendMcpRequest = async (
+  app: ApiTestContext["app"],
+  authHeaders: Record<string, string>,
+  body: object,
+): Promise<Response> => {
   return app.fetch(
     new Request("http://localhost/v1/mcp", {
       method: "POST",
       headers: {
-        ...createApiKeyAuthHeaders(authToken),
+        ...authHeaders,
         "Content-Type": "application/json",
         Accept: "application/json, text/event-stream",
       },
@@ -65,6 +71,11 @@ const sendMcpRequest = async (app: ApiTestContext["app"], authToken: string, bod
     }),
   )
 }
+
+const sendMcpApiKeyRequest = async (app: ApiTestContext["app"], apiKeyToken: string, body: object): Promise<Response> =>
+  sendMcpRequest(app, createApiKeyAuthHeaders(apiKeyToken), body)
+
+const OAUTH_ONLY_TOOLS = ["createSavedSearch", "inviteMember", "updateMember", "removeMember"] as const
 
 /**
  * The MCP streamable HTTP transport returns SSE for non-initialize responses
@@ -101,7 +112,7 @@ describe("/v1/mcp", () => {
 
   it<ApiTestContext>("initialize returns the server info + capabilities", async ({ app, database }) => {
     const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, {
       jsonrpc: "2.0",
       id: 1,
       method: "initialize",
@@ -117,7 +128,7 @@ describe("/v1/mcp", () => {
 
   it<ApiTestContext>("tools/list returns the registered API-key tools", async ({ app, database }) => {
     const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, {
       jsonrpc: "2.0",
       id: 2,
       method: "tools/list",
@@ -128,9 +139,38 @@ describe("/v1/mcp", () => {
     expect(toolNames).toEqual(expect.arrayContaining(["createApiKey", "listApiKeys", "revokeApiKey"]))
   })
 
+  it<ApiTestContext>("tools/list omits OAuth-only tools for API-key sessions", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/list",
+    })
+    expect(res.status).toBe(200)
+    const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
+    const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
+    expect(toolNames).toEqual(expect.arrayContaining(["listSavedSearches", "listMembers", "createApiKey"]))
+    for (const name of OAUTH_ONLY_TOOLS) {
+      expect(toolNames).not.toContain(name)
+    }
+  })
+
+  it<ApiTestContext>("tools/list includes OAuth-only tools for OAuth sessions", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, createOAuthAuthHeaders(tenant.oauthAccessToken), {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/list",
+    })
+    expect(res.status).toBe(200)
+    const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
+    const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
+    expect(toolNames).toEqual(expect.arrayContaining([...OAUTH_ONLY_TOOLS, "listSavedSearches", "createApiKey"]))
+  })
+
   it<ApiTestContext>("tools/list includes the tool-analytics tools", async ({ app, database }) => {
     const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 20, method: "tools/list" })
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 20, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -139,7 +179,7 @@ describe("/v1/mcp", () => {
 
   it<ApiTestContext>("tools/list includes the monitor tools", async ({ app, database }) => {
     const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 24, method: "tools/list" })
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 24, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -159,7 +199,7 @@ describe("/v1/mcp", () => {
 
   it<ApiTestContext>("tools/list includes the experiment tools", async ({ app, database }) => {
     const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 26, method: "tools/list" })
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 26, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -176,7 +216,7 @@ describe("/v1/mcp", () => {
 
   it<ApiTestContext>("tools/list includes the user-analytics tools", async ({ app, database }) => {
     const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 22, method: "tools/list" })
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 22, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -192,7 +232,7 @@ describe("/v1/mcp", () => {
     const tenant = await createTenantSetup(database)
     const project = await insertProject(database, tenant.organizationId)
 
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, {
       jsonrpc: "2.0",
       id: 23,
       method: "tools/call",
@@ -215,7 +255,7 @@ describe("/v1/mcp", () => {
     const tenant = await createTenantSetup(database)
     const project = await insertProject(database, tenant.organizationId)
 
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, {
       jsonrpc: "2.0",
       id: 21,
       method: "tools/call",
@@ -244,7 +284,7 @@ describe("/v1/mcp", () => {
     await insertApiKey(database, tenant.organizationId, generateApiKeyToken())
     await insertApiKey(database, tenant.organizationId, generateApiKeyToken())
 
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, {
       jsonrpc: "2.0",
       id: 3,
       method: "tools/call",
@@ -269,7 +309,7 @@ describe("/v1/mcp", () => {
     const tenant = await createTenantSetup(database)
     const project = await insertProject(database, tenant.organizationId)
 
-    const createRes = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const createRes = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, {
       jsonrpc: "2.0",
       id: 25,
       method: "tools/call",
@@ -301,7 +341,7 @@ describe("/v1/mcp", () => {
     expect(createdPayload.result?.structuredContent?.target?.stream).toBe("sessions")
     expect(createdPayload.result?.structuredContent?.target?.metric?.kind).toBe("count")
 
-    const listRes = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const listRes = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, {
       jsonrpc: "2.0",
       id: 26,
       method: "tools/call",
@@ -320,7 +360,7 @@ describe("/v1/mcp", () => {
     database,
   }) => {
     const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpApiKeyRequest(app, tenant.apiKeyToken, {
       jsonrpc: "2.0",
       id: 4,
       method: "tools/call",
@@ -350,7 +390,7 @@ describe("/v1/mcp", () => {
     const tenantB = await createTenantSetup(database)
     // Try to revoke tenant B's API key with tenant A's bearer — the inner
     // route's org-scoped repository returns 404, which surfaces as isError.
-    const res = await sendMcpRequest(app, tenantA.apiKeyToken, {
+    const res = await sendMcpApiKeyRequest(app, tenantA.apiKeyToken, {
       jsonrpc: "2.0",
       id: 5,
       method: "tools/call",

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -63,8 +63,11 @@ export const registerMcpRoute = ({
 
   routes.all("/mcp", async (c) => {
     const mcpServer = new McpServer(MCP_INFO, { instructions: MCP_INFO.instructions, capabilities: { tools: {} } })
+    const authMethod = c.get("auth").method
 
     for (const tool of toolDescriptors) {
+      if (tool.authRequirement === "oauth" && authMethod !== "oauth") continue
+
       // Capture each descriptor in the closure — the loop variable would
       // otherwise alias inside async callbacks once the iteration ends.
       const descriptor = tool

--- a/packages/operations/src/core/define-operation.test.ts
+++ b/packages/operations/src/core/define-operation.test.ts
@@ -55,6 +55,41 @@ describe("defineOperation", () => {
     expect(ep.tool).toBe(true)
   })
 
+  it("defaults `authRequirement` to `any` when not specified", () => {
+    const ep = endpoint({
+      route: createRoute({
+        method: "get",
+        path: "/x",
+        name: "x",
+        group: "test",
+        sdkMethod: "x",
+        description: "x",
+        responses: { 200: { description: "OK" } },
+      }),
+      access: "read-only",
+      handler: async (c) => c.body(null, 200),
+    })
+    expect(ep.authRequirement).toBe("any")
+  })
+
+  it("respects `authRequirement: oauth`", () => {
+    const ep = endpoint({
+      route: createRoute({
+        method: "post",
+        path: "/x",
+        name: "x",
+        group: "test",
+        sdkMethod: "x",
+        description: "x",
+        responses: { 200: { description: "OK" } },
+      }),
+      access: "write",
+      authRequirement: "oauth",
+      handler: async (c) => c.body(null, 200),
+    })
+    expect(ep.authRequirement).toBe("oauth")
+  })
+
   it("respects `tool: false`", () => {
     const ep = endpoint({
       route: createRoute({

--- a/packages/operations/src/core/define-operation.ts
+++ b/packages/operations/src/core/define-operation.ts
@@ -54,6 +54,16 @@ export type AppRouteConfig = Omit<RouteConfig, "operationId"> & {
 export type OperationAccess = "read-only" | "write" | "destructive"
 
 /**
+ * Which authentication methods may call the operation successfully.
+ *
+ * - `"any"` (default) — API-key and OAuth callers both work.
+ * - `"oauth"` — only OAuth (`loa_*`) callers succeed; API-key callers get 403
+ *   via `requireOAuthUserId`. The live MCP transport hides these tools from
+ *   API-key sessions so agents don't discover tools that always fail.
+ */
+export type OperationAuthRequirement = "any" | "oauth"
+
+/**
  * Internal MCP wire type — the `ToolAnnotations` shape registered on the MCP
  * server and emitted into `mcp.json`. Produced only by {@link accessToAnnotations};
  * operation authors declare {@link OperationAccess} instead.
@@ -97,6 +107,8 @@ interface Operation<R extends AppRouteConfig, E extends Env> {
   readonly handler: RouteHandler<R, E>
   /** What the operation does to org data — drives MCP annotations + toolset ceiling. */
   readonly access: OperationAccess
+  /** Auth methods that can call this operation. Defaults to `"any"`. */
+  readonly authRequirement: OperationAuthRequirement
   /** Transport-neutral implementation; present only for execute-form operations. */
   readonly execute?: ExecuteFn<R>
   /** Whether this operation should be exposed as an MCP tool. Defaults to `true`. */
@@ -124,6 +136,7 @@ interface Operation<R extends AppRouteConfig, E extends Env> {
 export interface AnyOperation {
   readonly route: AppRouteConfig
   readonly access: OperationAccess
+  readonly authRequirement: OperationAuthRequirement
   readonly tool: boolean
   readonly prefix: string
   readonly rateLimitTier?: RateLimitTier
@@ -137,6 +150,12 @@ type OperationArgs<R extends AppRouteConfig, E extends Env> = {
   route: R
   /** What the operation does to organization data. See {@link OperationAccess}. */
   access: OperationAccess
+  /**
+   * Auth methods that can call this operation. Defaults to `"any"`. Set to
+   * `"oauth"` when the execute path uses `requireOAuthUserId` so the live
+   * MCP transport can hide the tool from API-key sessions.
+   */
+  authRequirement?: OperationAuthRequirement
   /** Set to `false` to keep the operation HTTP-only (no MCP tool). Defaults to `true`. */
   tool?: boolean
   /** Rate-limit tier applied at HTTP mount time. Required once all modules declare it. */
@@ -204,7 +223,7 @@ type OperationArgs<R extends AppRouteConfig, E extends Env> = {
 export const defineOperation =
   <E extends Env>(prefix: string) =>
   <R extends AppRouteConfig>(args: OperationArgs<R, E>): Operation<R, E> => {
-    const { route, access, tool = true, rateLimitTier } = args
+    const { route, access, authRequirement = "any", tool = true, rateLimitTier } = args
     const handler = args.execute !== undefined ? executeToHandler<R, E>(route, args.execute) : args.handler
     if (handler === undefined) throw new Error(`Operation "${route.name}" must declare either handler or execute`)
     // Build the config handed to the OpenAPI generator as an order-preserving
@@ -231,6 +250,7 @@ export const defineOperation =
       route,
       handler,
       access,
+      authRequirement,
       tool,
       prefix: normalizedPrefix,
       ...(args.execute !== undefined ? { execute: args.execute } : {}),

--- a/packages/operations/src/core/registry.test.ts
+++ b/packages/operations/src/core/registry.test.ts
@@ -61,6 +61,23 @@ const deleteItem = itemEndpoint({
   handler: async (c) => c.body(null, 204),
 })
 
+const createItemOAuthOnly = itemEndpoint({
+  route: createRoute({
+    method: "post",
+    path: "/",
+    name: "createItem",
+    group: "test",
+    sdkMethod: "createItem",
+    description: "Create an item (OAuth only)",
+    responses: {
+      201: { content: { "application/json": { schema: ItemSchema } }, description: "Created" },
+    },
+  }),
+  access: "write",
+  authRequirement: "oauth",
+  handler: async (c) => c.json({ id: "new" }, 201),
+})
+
 const hiddenItem = itemEndpoint({
   route: createRoute({
     method: "get",
@@ -184,6 +201,16 @@ describe("registry", () => {
         readOnlyHint: false,
         destructiveHint: true,
       })
+    })
+
+    it("defaults authRequirement to any and carries oauth when declared", () => {
+      const sub = new OpenAPIHono<TestEnv>()
+      listItems.mountHttp(sub)
+      createItemOAuthOnly.mountHttp(sub)
+
+      const tools = collectToolDescriptors()
+      expect(tools.find((t) => t.name === "listItems")?.authRequirement).toBe("any")
+      expect(tools.find((t) => t.name === "createItem")?.authRequirement).toBe("oauth")
     })
 
     it("returns undefined `output` for routes whose success response has no body (204)", () => {

--- a/packages/operations/src/core/registry.ts
+++ b/packages/operations/src/core/registry.ts
@@ -1,4 +1,9 @@
-import { type AnyOperation, accessToAnnotations, type McpToolAnnotations } from "./define-operation.ts"
+import {
+  type AnyOperation,
+  accessToAnnotations,
+  type McpToolAnnotations,
+  type OperationAuthRequirement,
+} from "./define-operation.ts"
 import { type ExtractedOutput, extractOutputSchema } from "./extract-output.ts"
 import { type FlatInput, flattenRouteInputSchema } from "./flatten-input.ts"
 
@@ -57,6 +62,11 @@ interface ToolDescriptor {
   readonly description: string
   /** MCP tool annotations (read-only / destructive hints) declared at the endpoint. */
   readonly annotations: McpToolAnnotations
+  /**
+   * Auth methods that can call this tool. `"oauth"` tools are omitted from the
+   * live MCP `tools/list` for API-key sessions.
+   */
+  readonly authRequirement: OperationAuthRequirement
   /** Flattened Zod input schema + per-field source map for HTTP dispatch. */
   readonly input: FlatInput
   /**
@@ -79,12 +89,13 @@ interface ToolDescriptor {
  * route configuration mistakes surface at boot, not on a tool call.
  */
 export const collectToolDescriptors = (): ToolDescriptor[] =>
-  operationRegistry.map(({ route, access, prefix }) => {
+  operationRegistry.map(({ route, access, authRequirement, prefix }) => {
     return {
       name: route.name,
       title: route.summary ?? route.name,
       description: route.description ?? "",
       annotations: accessToAnnotations(access),
+      authRequirement,
       input: flattenRouteInputSchema(route),
       output: extractOutputSchema(route),
       routerPrefix: prefix,

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -4,6 +4,7 @@ export {
   type AppRouteConfig,
   defineOperation,
   type McpToolAnnotations,
+  type OperationAuthRequirement,
   type RateLimitTier,
 } from "./core/define-operation.ts"
 export type { ExecuteFn, OperationInput, OperationOutput } from "./core/execute.ts"

--- a/packages/operations/src/operations/members.ts
+++ b/packages/operations/src/operations/members.ts
@@ -194,6 +194,7 @@ const inviteMember = memberEndpoint({
     responses: typedResponses({ status: 201, schema: InvitedMemberSchema, description: "Invitation created" }),
   }),
   access: "write",
+  authRequirement: "oauth",
   rateLimitTier: "high",
   execute: (input, ctx) =>
     Effect.gen(function* () {
@@ -252,6 +253,7 @@ const updateMemberRole = memberEndpoint({
     }),
   }),
   access: "destructive",
+  authRequirement: "oauth",
   rateLimitTier: "low",
   execute: (input, ctx) =>
     Effect.gen(function* () {
@@ -291,6 +293,7 @@ const removeMember = memberEndpoint({
     responses: openApiNoContentResponses({ description: "Member removed" }),
   }),
   access: "destructive",
+  authRequirement: "oauth",
   rateLimitTier: "low",
   execute: (input, ctx) =>
     Effect.gen(function* () {

--- a/packages/operations/src/operations/saved-searches.ts
+++ b/packages/operations/src/operations/saved-searches.ts
@@ -180,6 +180,7 @@ const createSavedSearchEndpoint = savedSearchEndpoint({
     responses: typedResponses({ status: 201, schema: SavedSearchSchema, description: "Saved search created" }),
   }),
   access: "write",
+  authRequirement: "oauth",
   rateLimitTier: "low",
   execute: (input, ctx) =>
     Effect.gen(function* () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves GUI-WVZV

Signal [GUI-WVZV](https://console.latitude.so/projects/guilh-m/signals/GUI-WVZV) caught Claude Code calling `createSavedSearch` over MCP with an API key. That endpoint needs a real user (`requireOAuthUserId`), so the call always returned:

```json
{"error":"This endpoint requires OAuth authentication; API-key callers can't act on behalf of a specific user."}
```

The OAuth requirement is intentional. The bug was that `/v1/mcp` still listed those tools for API-key sessions, so agents discovered tools that could never succeed.

## Fix

Adds `authRequirement: "any" | "oauth"` on `defineOperation` (default `"any"`). The four ops that call `requireOAuthUserId` declare `"oauth"`:

- `createSavedSearch`
- `inviteMember`
- `updateMember`
- `removeMember`

The live MCP transport skips OAuth-only tools when `auth.method !== "oauth"`. HTTP/SDK behavior is unchanged (API-key callers still get 403). Static `mcp.json` emits `authRequirement: "oauth"` on those tools for docs.

## Tests

- Unit: `authRequirement` defaults and registry carry-through
- MCP integration: `tools/list` omits the four tools for API-key auth and includes them for OAuth
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b677a91-c39d-5b74-a5f3-8681163ee7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b677a91-c39d-5b74-a5f3-8681163ee7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

