### PR TITLE
Resolves ATL-KP4T: prefer prose conversation over JSON-array sidecar chats

### DIFF
--- a/packages/domain/spans/src/helpers/resolve-last-llm-completion-span.test.ts
+++ b/packages/domain/spans/src/helpers/resolve-last-llm-completion-span.test.ts
@@ -110,4 +110,22 @@ describe("resolveLastLlmCompletionSpanId", () => {
     })
     expect(resolveLastLlmCompletionSpanId([s])).toBe(s.spanId)
   })
+
+  it("prefers the primary-model leaf over a later sidecar extractor model", () => {
+    const agentReply = baseSpan({
+      spanId: SpanId("a".repeat(16)),
+      operation: "chat",
+      model: "claude-opus-5",
+      startTime: new Date("2026-01-01T00:00:00Z"),
+      endTime: new Date("2026-01-01T00:00:04Z"),
+    })
+    const memoryExtract = baseSpan({
+      spanId: SpanId("b".repeat(16)),
+      operation: "chat",
+      model: "claude-haiku-4-5",
+      startTime: new Date("2026-01-01T00:00:05Z"),
+      endTime: new Date("2026-01-01T00:00:06Z"),
+    })
+    expect(resolveLastLlmCompletionSpanId([agentReply, memoryExtract])).toBe(agentReply.spanId)
+  })
 })

--- a/packages/domain/spans/src/helpers/resolve-last-llm-completion-span.ts
+++ b/packages/domain/spans/src/helpers/resolve-last-llm-completion-span.ts
@@ -10,21 +10,37 @@ export function isLlmCompletionOperation(operation: Operation): boolean {
   return operation === "chat" || operation === "text_completion" || operation === "generate_content"
 }
 
+function compareLlmCompletionSpans(a: Span, b: Span): number {
+  const byEnd = b.endTime.getTime() - a.endTime.getTime()
+  if (byEnd !== 0) return byEnd
+  const byStart = b.startTime.getTime() - a.startTime.getTime()
+  if (byStart !== 0) return byStart
+  return a.spanId.localeCompare(b.spanId)
+}
+
 /**
- * Picks the **latest** LLM completion span in a trace (by `endTime`, then `startTime`, then `spanId`).
- * Used when annotations are submitted with only `traceId` and optional `sessionId` / `spanId`.
+ * Picks the **latest user-facing** LLM completion span in a trace (by `endTime`,
+ * then `startTime`, then `spanId`).
+ *
+ * When the trace mixes models (agent reply on the primary model, then a sidecar
+ * extractor on another), prefer spans that share the earliest non-empty model so
+ * post-turn memory/fact extractors do not steal score/annotation pinning.
  */
 export function resolveLastLlmCompletionSpanId(spans: readonly Span[]): SpanId | undefined {
   const candidates = spans.filter((s) => isLlmCompletionOperation(s.operation))
   if (candidates.length === 0) {
     return undefined
   }
-  const sorted = [...candidates].sort((a, b) => {
-    const byEnd = b.endTime.getTime() - a.endTime.getTime()
-    if (byEnd !== 0) return byEnd
-    const byStart = b.startTime.getTime() - a.startTime.getTime()
-    if (byStart !== 0) return byStart
-    return a.spanId.localeCompare(b.spanId)
-  })
+
+  const primaryModel = [...candidates].sort((a, b) => a.startTime.getTime() - b.startTime.getTime()).find((s) => s.model !== "")
+    ?.model
+
+  const preferred =
+    primaryModel === undefined
+      ? candidates
+      : candidates.filter((s) => s.model === primaryModel || s.model === "")
+  const pool = preferred.length > 0 ? preferred : candidates
+
+  const sorted = [...pool].sort(compareLlmCompletionSpans)
   return sorted[0]?.spanId
 }

--- a/packages/domain/spans/src/helpers/resolve-last-llm-completion-span.ts
+++ b/packages/domain/spans/src/helpers/resolve-last-llm-completion-span.ts
@@ -32,13 +32,12 @@ export function resolveLastLlmCompletionSpanId(spans: readonly Span[]): SpanId |
     return undefined
   }
 
-  const primaryModel = [...candidates].sort((a, b) => a.startTime.getTime() - b.startTime.getTime()).find((s) => s.model !== "")
-    ?.model
+  const primaryModel = [...candidates]
+    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
+    .find((s) => s.model !== "")?.model
 
   const preferred =
-    primaryModel === undefined
-      ? candidates
-      : candidates.filter((s) => s.model === primaryModel || s.model === "")
+    primaryModel === undefined ? candidates : candidates.filter((s) => s.model === primaryModel || s.model === "")
   const pool = preferred.length > 0 ? preferred : candidates
 
   const sorted = [...pool].sort(compareLlmCompletionSpans)

--- a/packages/platform/db-clickhouse/clickhouse/.migration-lock
+++ b/packages/platform/db-clickhouse/clickhouse/.migration-lock
@@ -4,6 +4,6 @@
 # create migrations in parallel, preventing incompatible
 # migrations from being merged without conflict resolution.
 #
-# Generated: 2026-07-22T11:59:36.324Z
-# Hash: d8fea3a1-0349-4c17-9aef-6f2aed79aca9
+# Generated: 2026-07-29T09:35:21.433Z
+# Hash: ec8954b3-3605-44d8-b6b4-1c5dab47e755
 # Do not manually edit this file.

--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00055_prefer_prose_conversation_rollup.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00055_prefer_prose_conversation_rollup.sql
@@ -1,0 +1,221 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+-- Prefer user-facing prose replies over post-turn JSON-array sidecar chats
+-- (memory / fact extractors) when rolling up the "latest responsive" conversation.
+--
+-- 00040 gated conversation to model-call leaves so Vercel `invoke_agent`
+-- wrappers no longer steal the rollup. A later leaf `chat` that emits only a
+-- JSON array as its text part (`"content":"[]"` / `"content":"[{…}]"`) still
+-- wins plain `argMaxIf(..., end_time, …)` because it ends after the real reply.
+-- Evaluations, the session drawer, and getTrace then show the extractor turn —
+-- burying the recommendation inside a synthetic user blob with assistant `[]`.
+--
+-- Fix: keep the AggregateFunction signature (`argMaxIf(String, DateTime64, UInt8)`)
+-- and demote JSON-array outputs by collapsing their ranking time to epoch so any
+-- prior prose leaf wins. Extract-only traces still surface the extractor (all
+-- candidates share epoch). Redefines both MVs only — column types unchanged,
+-- existing aggregate states stay valid (new-data-only for the MV path; the
+-- span-sourced getTrace query is updated in application SQL separately).
+
+DROP VIEW IF EXISTS traces_mv ON CLUSTER default;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS traces_mv ON CLUSTER default TO traces
+AS SELECT
+    organization_id AS organization_id,
+    project_id AS project_id,
+    trace_id AS trace_id,
+    count() AS span_count,
+    countIf(status_code = 2) AS error_count,
+    min(start_time) AS min_start_time,
+    max(end_time) AS max_end_time,
+    min(if(time_to_first_token_ns > 0, addNanoseconds(start_time, toInt64(time_to_first_token_ns)), toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC'))) AS time_of_first_token,
+    sumIf(tokens_input, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_input,
+    sumIf(tokens_output, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_output,
+    sumIf(tokens_cache_read, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_cache_read,
+    sumIf(tokens_cache_create, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_cache_create,
+    sumIf(tokens_reasoning, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_reasoning,
+    sumIf(tokens_total, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_total,
+    sumIf(cost_input_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_input_microcents,
+    sumIf(cost_output_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_output_microcents,
+    sumIf(cost_total_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_total_microcents,
+    argMaxIfState(session_id, start_time, session_id != '') AS session_id,
+    argMaxIfState(user_id, start_time, user_id != '') AS user_id,
+    argMaxIfState(user_email, start_time, user_email != '') AS user_email,
+    groupUniqArrayArray(tags) AS tags,
+    maxMap(metadata) AS metadata,
+    argMaxIfState(simulation_id, start_time, simulation_id != '') AS simulation_id,
+    groupUniqArrayIfState(model, model != '') AS models,
+    groupUniqArrayIfState(provider, provider != '') AS providers,
+    groupUniqArrayIfState(service_name, service_name != '') AS service_names,
+    groupUniqArrayIfState(agent_name, agent_name != '') AS agent_names,
+    groupUniqArrayIfState(tool_name, operation = 'execute_tool' AND tool_name != '') AS tools,
+    groupUniqArrayArray(arrayFilter(n -> n != '', tool_names)) AS defined_tools,
+    argMinIfState(span_id, start_time, parent_span_id = '') AS root_span_id,
+    argMinIfState(name, start_time, parent_span_id = '') AS root_span_name,
+    argMinIfState(spans.input_messages, start_time, spans.input_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS input_messages,
+    argMaxIfState(spans.input_messages, if(match(spans.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), end_time), spans.output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages,
+    argMaxIfState(spans.output_messages, if(match(spans.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), end_time), spans.output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS output_messages,
+    argMinIfState(spans.system_instructions, start_time, spans.system_instructions != '' AND operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS system_instructions,
+    max(retention_days) AS retention_days
+FROM spans
+GROUP BY
+    organization_id,
+    project_id,
+    trace_id;
+
+DROP VIEW IF EXISTS sessions_mv ON CLUSTER default;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv ON CLUSTER default TO sessions
+AS SELECT
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id))         AS session_id,
+    uniqExactState(s.trace_id)                                       AS trace_count,
+    groupUniqArrayState(s.trace_id)                                  AS trace_ids,
+    count()                                                          AS span_count,
+    countIf(s.status_code = 2)                                       AS error_count,
+    min(s.start_time)                                                AS min_start_time,
+    max(s.end_time)                                                  AS max_end_time,
+    max(s.start_time)                                                AS max_start_time,
+    sum(if(((s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AND (s.end_time > s.start_time),
+           reinterpretAsInt64(s.end_time) - reinterpretAsInt64(s.start_time),
+           toInt64(0)))                                              AS duration_ns,
+    min(if(s.time_to_first_token_ns > 0,
+           addNanoseconds(s.start_time, toInt64(s.time_to_first_token_ns)),
+           toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC'))) AS time_of_first_token,
+    sumIf(s.tokens_input, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))         AS tokens_input,
+    sumIf(s.tokens_output, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))        AS tokens_output,
+    sumIf(s.tokens_cache_read, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))    AS tokens_cache_read,
+    sumIf(s.tokens_cache_create, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS tokens_cache_create,
+    sumIf(s.tokens_reasoning, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))     AS tokens_reasoning,
+    sumIf(s.tokens_total, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))         AS tokens_total,
+    sumIf(s.cost_input_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS cost_input_microcents,
+    sumIf(s.cost_output_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_output_microcents,
+    sumIf(s.cost_total_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS cost_total_microcents,
+    argMaxIfState(s.user_id, s.start_time, s.user_id != '')          AS user_id,
+    argMaxIfState(s.user_email, s.start_time, s.user_email != '')    AS user_email,
+    groupUniqArrayArray(s.tags)                                      AS tags,
+    maxMap(s.metadata)                                               AS metadata,
+    groupUniqArrayIfState(s.model, s.model != '')                    AS models,
+    groupUniqArrayIfState(s.provider, s.provider != '')              AS providers,
+    groupUniqArrayIfState(s.service_name, s.service_name != '')      AS service_names,
+    groupUniqArrayIfState(s.agent_name, s.agent_name != '')          AS agent_names,
+    groupUniqArrayIfState(s.tool_name, (s.operation = 'execute_tool') AND (s.tool_name != '')) AS tools,
+    groupUniqArrayArray(arrayFilter(n -> n != '', s.tool_names))     AS defined_tools,
+    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id,
+    argMinIfState(s.span_id, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_id,
+    argMinIfState(s.name, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_name,
+    argMinIfState(s.input_messages, s.start_time, s.input_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS input_messages,
+    argMaxIfState(s.input_messages, if(match(s.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), s.end_time), s.output_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages,
+    argMaxIfState(s.output_messages, if(match(s.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), s.end_time), s.output_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS output_messages,
+    argMinIfState(s.system_instructions, s.start_time, s.system_instructions != '' AND s.operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS system_instructions,
+    max(s.retention_days)                                            AS retention_days
+FROM spans AS s
+GROUP BY
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id));
+
+-- +goose Down
+
+-- Restore the 00049 traces_mv / 00048 sessions_mv definitions (end_time ranking).
+
+DROP VIEW IF EXISTS traces_mv ON CLUSTER default;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS traces_mv ON CLUSTER default TO traces
+AS SELECT
+    organization_id AS organization_id,
+    project_id AS project_id,
+    trace_id AS trace_id,
+    count() AS span_count,
+    countIf(status_code = 2) AS error_count,
+    min(start_time) AS min_start_time,
+    max(end_time) AS max_end_time,
+    min(if(time_to_first_token_ns > 0, addNanoseconds(start_time, toInt64(time_to_first_token_ns)), toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC'))) AS time_of_first_token,
+    sumIf(tokens_input, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_input,
+    sumIf(tokens_output, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_output,
+    sumIf(tokens_cache_read, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_cache_read,
+    sumIf(tokens_cache_create, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_cache_create,
+    sumIf(tokens_reasoning, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_reasoning,
+    sumIf(tokens_total, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_total,
+    sumIf(cost_input_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_input_microcents,
+    sumIf(cost_output_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_output_microcents,
+    sumIf(cost_total_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_total_microcents,
+    argMaxIfState(session_id, start_time, session_id != '') AS session_id,
+    argMaxIfState(user_id, start_time, user_id != '') AS user_id,
+    argMaxIfState(user_email, start_time, user_email != '') AS user_email,
+    groupUniqArrayArray(tags) AS tags,
+    maxMap(metadata) AS metadata,
+    argMaxIfState(simulation_id, start_time, simulation_id != '') AS simulation_id,
+    groupUniqArrayIfState(model, model != '') AS models,
+    groupUniqArrayIfState(provider, provider != '') AS providers,
+    groupUniqArrayIfState(service_name, service_name != '') AS service_names,
+    groupUniqArrayIfState(agent_name, agent_name != '') AS agent_names,
+    groupUniqArrayIfState(tool_name, operation = 'execute_tool' AND tool_name != '') AS tools,
+    groupUniqArrayArray(arrayFilter(n -> n != '', tool_names)) AS defined_tools,
+    argMinIfState(span_id, start_time, parent_span_id = '') AS root_span_id,
+    argMinIfState(name, start_time, parent_span_id = '') AS root_span_name,
+    argMinIfState(spans.input_messages, start_time, spans.input_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS input_messages,
+    argMaxIfState(spans.input_messages, end_time, spans.output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages,
+    argMaxIfState(spans.output_messages, end_time, spans.output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS output_messages,
+    argMinIfState(spans.system_instructions, start_time, spans.system_instructions != '' AND operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS system_instructions,
+    max(retention_days) AS retention_days
+FROM spans
+GROUP BY
+    organization_id,
+    project_id,
+    trace_id;
+
+DROP VIEW IF EXISTS sessions_mv ON CLUSTER default;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv ON CLUSTER default TO sessions
+AS SELECT
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id))         AS session_id,
+    uniqExactState(s.trace_id)                                       AS trace_count,
+    groupUniqArrayState(s.trace_id)                                  AS trace_ids,
+    count()                                                          AS span_count,
+    countIf(s.status_code = 2)                                       AS error_count,
+    min(s.start_time)                                                AS min_start_time,
+    max(s.end_time)                                                  AS max_end_time,
+    max(s.start_time)                                                AS max_start_time,
+    sum(if(((s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AND (s.end_time > s.start_time),
+           reinterpretAsInt64(s.end_time) - reinterpretAsInt64(s.start_time),
+           toInt64(0)))                                              AS duration_ns,
+    min(if(s.time_to_first_token_ns > 0,
+           addNanoseconds(s.start_time, toInt64(s.time_to_first_token_ns)),
+           toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC'))) AS time_of_first_token,
+    sumIf(s.tokens_input, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))         AS tokens_input,
+    sumIf(s.tokens_output, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))        AS tokens_output,
+    sumIf(s.tokens_cache_read, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))    AS tokens_cache_read,
+    sumIf(s.tokens_cache_create, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS tokens_cache_create,
+    sumIf(s.tokens_reasoning, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))     AS tokens_reasoning,
+    sumIf(s.tokens_total, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))         AS tokens_total,
+    sumIf(s.cost_input_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS cost_input_microcents,
+    sumIf(s.cost_output_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_output_microcents,
+    sumIf(s.cost_total_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS cost_total_microcents,
+    argMaxIfState(s.user_id, s.start_time, s.user_id != '')          AS user_id,
+    argMaxIfState(s.user_email, s.start_time, s.user_email != '')    AS user_email,
+    groupUniqArrayArray(s.tags)                                      AS tags,
+    maxMap(s.metadata)                                               AS metadata,
+    groupUniqArrayIfState(s.model, s.model != '')                    AS models,
+    groupUniqArrayIfState(s.provider, s.provider != '')              AS providers,
+    groupUniqArrayIfState(s.service_name, s.service_name != '')      AS service_names,
+    groupUniqArrayIfState(s.agent_name, s.agent_name != '')          AS agent_names,
+    groupUniqArrayIfState(s.tool_name, (s.operation = 'execute_tool') AND (s.tool_name != '')) AS tools,
+    groupUniqArrayArray(arrayFilter(n -> n != '', s.tool_names))     AS defined_tools,
+    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id,
+    argMinIfState(s.span_id, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_id,
+    argMinIfState(s.name, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_name,
+    argMinIfState(s.input_messages, s.start_time, s.input_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS input_messages,
+    argMaxIfState(s.input_messages, s.end_time, s.output_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages,
+    argMaxIfState(s.output_messages, s.end_time, s.output_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS output_messages,
+    argMinIfState(s.system_instructions, s.start_time, s.system_instructions != '' AND s.operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS system_instructions,
+    max(s.retention_days)                                            AS retention_days
+FROM spans AS s
+GROUP BY
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id));

--- a/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00055_prefer_prose_conversation_rollup.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00055_prefer_prose_conversation_rollup.sql
@@ -1,0 +1,221 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+-- Prefer user-facing prose replies over post-turn JSON-array sidecar chats
+-- (memory / fact extractors) when rolling up the "latest responsive" conversation.
+--
+-- 00040 gated conversation to model-call leaves so Vercel `invoke_agent`
+-- wrappers no longer steal the rollup. A later leaf `chat` that emits only a
+-- JSON array as its text part (`"content":"[]"` / `"content":"[{…}]"`) still
+-- wins plain `argMaxIf(..., end_time, …)` because it ends after the real reply.
+-- Evaluations, the session drawer, and getTrace then show the extractor turn —
+-- burying the recommendation inside a synthetic user blob with assistant `[]`.
+--
+-- Fix: keep the AggregateFunction signature (`argMaxIf(String, DateTime64, UInt8)`)
+-- and demote JSON-array outputs by collapsing their ranking time to epoch so any
+-- prior prose leaf wins. Extract-only traces still surface the extractor (all
+-- candidates share epoch). Redefines both MVs only — column types unchanged,
+-- existing aggregate states stay valid (new-data-only for the MV path; the
+-- span-sourced getTrace query is updated in application SQL separately).
+
+DROP VIEW IF EXISTS traces_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS traces_mv TO traces
+AS SELECT
+    organization_id AS organization_id,
+    project_id AS project_id,
+    trace_id AS trace_id,
+    count() AS span_count,
+    countIf(status_code = 2) AS error_count,
+    min(start_time) AS min_start_time,
+    max(end_time) AS max_end_time,
+    min(if(time_to_first_token_ns > 0, addNanoseconds(start_time, toInt64(time_to_first_token_ns)), toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC'))) AS time_of_first_token,
+    sumIf(tokens_input, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_input,
+    sumIf(tokens_output, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_output,
+    sumIf(tokens_cache_read, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_cache_read,
+    sumIf(tokens_cache_create, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_cache_create,
+    sumIf(tokens_reasoning, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_reasoning,
+    sumIf(tokens_total, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_total,
+    sumIf(cost_input_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_input_microcents,
+    sumIf(cost_output_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_output_microcents,
+    sumIf(cost_total_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_total_microcents,
+    argMaxIfState(session_id, start_time, session_id != '') AS session_id,
+    argMaxIfState(user_id, start_time, user_id != '') AS user_id,
+    argMaxIfState(user_email, start_time, user_email != '') AS user_email,
+    groupUniqArrayArray(tags) AS tags,
+    maxMap(metadata) AS metadata,
+    argMaxIfState(simulation_id, start_time, simulation_id != '') AS simulation_id,
+    groupUniqArrayIfState(model, model != '') AS models,
+    groupUniqArrayIfState(provider, provider != '') AS providers,
+    groupUniqArrayIfState(service_name, service_name != '') AS service_names,
+    groupUniqArrayIfState(agent_name, agent_name != '') AS agent_names,
+    groupUniqArrayIfState(tool_name, operation = 'execute_tool' AND tool_name != '') AS tools,
+    groupUniqArrayArray(arrayFilter(n -> n != '', tool_names)) AS defined_tools,
+    argMinIfState(span_id, start_time, parent_span_id = '') AS root_span_id,
+    argMinIfState(name, start_time, parent_span_id = '') AS root_span_name,
+    argMinIfState(spans.input_messages, start_time, spans.input_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS input_messages,
+    argMaxIfState(spans.input_messages, if(match(spans.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), end_time), spans.output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages,
+    argMaxIfState(spans.output_messages, if(match(spans.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), end_time), spans.output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS output_messages,
+    argMinIfState(spans.system_instructions, start_time, spans.system_instructions != '' AND operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS system_instructions,
+    max(retention_days) AS retention_days
+FROM spans
+GROUP BY
+    organization_id,
+    project_id,
+    trace_id;
+
+DROP VIEW IF EXISTS sessions_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv TO sessions
+AS SELECT
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id))         AS session_id,
+    uniqExactState(s.trace_id)                                       AS trace_count,
+    groupUniqArrayState(s.trace_id)                                  AS trace_ids,
+    count()                                                          AS span_count,
+    countIf(s.status_code = 2)                                       AS error_count,
+    min(s.start_time)                                                AS min_start_time,
+    max(s.end_time)                                                  AS max_end_time,
+    max(s.start_time)                                                AS max_start_time,
+    sum(if(((s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AND (s.end_time > s.start_time),
+           reinterpretAsInt64(s.end_time) - reinterpretAsInt64(s.start_time),
+           toInt64(0)))                                              AS duration_ns,
+    min(if(s.time_to_first_token_ns > 0,
+           addNanoseconds(s.start_time, toInt64(s.time_to_first_token_ns)),
+           toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC'))) AS time_of_first_token,
+    sumIf(s.tokens_input, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))         AS tokens_input,
+    sumIf(s.tokens_output, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))        AS tokens_output,
+    sumIf(s.tokens_cache_read, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))    AS tokens_cache_read,
+    sumIf(s.tokens_cache_create, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS tokens_cache_create,
+    sumIf(s.tokens_reasoning, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))     AS tokens_reasoning,
+    sumIf(s.tokens_total, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))         AS tokens_total,
+    sumIf(s.cost_input_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS cost_input_microcents,
+    sumIf(s.cost_output_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_output_microcents,
+    sumIf(s.cost_total_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS cost_total_microcents,
+    argMaxIfState(s.user_id, s.start_time, s.user_id != '')          AS user_id,
+    argMaxIfState(s.user_email, s.start_time, s.user_email != '')    AS user_email,
+    groupUniqArrayArray(s.tags)                                      AS tags,
+    maxMap(s.metadata)                                               AS metadata,
+    groupUniqArrayIfState(s.model, s.model != '')                    AS models,
+    groupUniqArrayIfState(s.provider, s.provider != '')              AS providers,
+    groupUniqArrayIfState(s.service_name, s.service_name != '')      AS service_names,
+    groupUniqArrayIfState(s.agent_name, s.agent_name != '')          AS agent_names,
+    groupUniqArrayIfState(s.tool_name, (s.operation = 'execute_tool') AND (s.tool_name != '')) AS tools,
+    groupUniqArrayArray(arrayFilter(n -> n != '', s.tool_names))     AS defined_tools,
+    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id,
+    argMinIfState(s.span_id, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_id,
+    argMinIfState(s.name, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_name,
+    argMinIfState(s.input_messages, s.start_time, s.input_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS input_messages,
+    argMaxIfState(s.input_messages, if(match(s.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), s.end_time), s.output_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages,
+    argMaxIfState(s.output_messages, if(match(s.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), s.end_time), s.output_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS output_messages,
+    argMinIfState(s.system_instructions, s.start_time, s.system_instructions != '' AND s.operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS system_instructions,
+    max(s.retention_days)                                            AS retention_days
+FROM spans AS s
+GROUP BY
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id));
+
+-- +goose Down
+
+-- Restore the 00049 traces_mv / 00048 sessions_mv definitions (end_time ranking).
+
+DROP VIEW IF EXISTS traces_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS traces_mv TO traces
+AS SELECT
+    organization_id AS organization_id,
+    project_id AS project_id,
+    trace_id AS trace_id,
+    count() AS span_count,
+    countIf(status_code = 2) AS error_count,
+    min(start_time) AS min_start_time,
+    max(end_time) AS max_end_time,
+    min(if(time_to_first_token_ns > 0, addNanoseconds(start_time, toInt64(time_to_first_token_ns)), toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC'))) AS time_of_first_token,
+    sumIf(tokens_input, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_input,
+    sumIf(tokens_output, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_output,
+    sumIf(tokens_cache_read, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_cache_read,
+    sumIf(tokens_cache_create, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_cache_create,
+    sumIf(tokens_reasoning, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_reasoning,
+    sumIf(tokens_total, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS tokens_total,
+    sumIf(cost_input_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_input_microcents,
+    sumIf(cost_output_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_output_microcents,
+    sumIf(cost_total_microcents, operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_total_microcents,
+    argMaxIfState(session_id, start_time, session_id != '') AS session_id,
+    argMaxIfState(user_id, start_time, user_id != '') AS user_id,
+    argMaxIfState(user_email, start_time, user_email != '') AS user_email,
+    groupUniqArrayArray(tags) AS tags,
+    maxMap(metadata) AS metadata,
+    argMaxIfState(simulation_id, start_time, simulation_id != '') AS simulation_id,
+    groupUniqArrayIfState(model, model != '') AS models,
+    groupUniqArrayIfState(provider, provider != '') AS providers,
+    groupUniqArrayIfState(service_name, service_name != '') AS service_names,
+    groupUniqArrayIfState(agent_name, agent_name != '') AS agent_names,
+    groupUniqArrayIfState(tool_name, operation = 'execute_tool' AND tool_name != '') AS tools,
+    groupUniqArrayArray(arrayFilter(n -> n != '', tool_names)) AS defined_tools,
+    argMinIfState(span_id, start_time, parent_span_id = '') AS root_span_id,
+    argMinIfState(name, start_time, parent_span_id = '') AS root_span_name,
+    argMinIfState(spans.input_messages, start_time, spans.input_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS input_messages,
+    argMaxIfState(spans.input_messages, end_time, spans.output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages,
+    argMaxIfState(spans.output_messages, end_time, spans.output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS output_messages,
+    argMinIfState(spans.system_instructions, start_time, spans.system_instructions != '' AND operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS system_instructions,
+    max(retention_days) AS retention_days
+FROM spans
+GROUP BY
+    organization_id,
+    project_id,
+    trace_id;
+
+DROP VIEW IF EXISTS sessions_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv TO sessions
+AS SELECT
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id))         AS session_id,
+    uniqExactState(s.trace_id)                                       AS trace_count,
+    groupUniqArrayState(s.trace_id)                                  AS trace_ids,
+    count()                                                          AS span_count,
+    countIf(s.status_code = 2)                                       AS error_count,
+    min(s.start_time)                                                AS min_start_time,
+    max(s.end_time)                                                  AS max_end_time,
+    max(s.start_time)                                                AS max_start_time,
+    sum(if(((s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AND (s.end_time > s.start_time),
+           reinterpretAsInt64(s.end_time) - reinterpretAsInt64(s.start_time),
+           toInt64(0)))                                              AS duration_ns,
+    min(if(s.time_to_first_token_ns > 0,
+           addNanoseconds(s.start_time, toInt64(s.time_to_first_token_ns)),
+           toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC'))) AS time_of_first_token,
+    sumIf(s.tokens_input, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))         AS tokens_input,
+    sumIf(s.tokens_output, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))        AS tokens_output,
+    sumIf(s.tokens_cache_read, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))    AS tokens_cache_read,
+    sumIf(s.tokens_cache_create, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS tokens_cache_create,
+    sumIf(s.tokens_reasoning, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))     AS tokens_reasoning,
+    sumIf(s.tokens_total, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))         AS tokens_total,
+    sumIf(s.cost_input_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS cost_input_microcents,
+    sumIf(s.cost_output_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker')) AS cost_output_microcents,
+    sumIf(s.cost_total_microcents, s.operation IN ('chat', 'text_completion', 'generate_content', 'embeddings', 'reranker'))  AS cost_total_microcents,
+    argMaxIfState(s.user_id, s.start_time, s.user_id != '')          AS user_id,
+    argMaxIfState(s.user_email, s.start_time, s.user_email != '')    AS user_email,
+    groupUniqArrayArray(s.tags)                                      AS tags,
+    maxMap(s.metadata)                                               AS metadata,
+    groupUniqArrayIfState(s.model, s.model != '')                    AS models,
+    groupUniqArrayIfState(s.provider, s.provider != '')              AS providers,
+    groupUniqArrayIfState(s.service_name, s.service_name != '')      AS service_names,
+    groupUniqArrayIfState(s.agent_name, s.agent_name != '')          AS agent_names,
+    groupUniqArrayIfState(s.tool_name, (s.operation = 'execute_tool') AND (s.tool_name != '')) AS tools,
+    groupUniqArrayArray(arrayFilter(n -> n != '', s.tool_names))     AS defined_tools,
+    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id,
+    argMinIfState(s.span_id, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_id,
+    argMinIfState(s.name, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_name,
+    argMinIfState(s.input_messages, s.start_time, s.input_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS input_messages,
+    argMaxIfState(s.input_messages, s.end_time, s.output_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages,
+    argMaxIfState(s.output_messages, s.end_time, s.output_messages != '' AND s.operation IN ('chat', 'text_completion', 'generate_content')) AS output_messages,
+    argMinIfState(s.system_instructions, s.start_time, s.system_instructions != '' AND s.operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS system_instructions,
+    max(s.retention_days)                                            AS retention_days
+FROM spans AS s
+GROUP BY
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id));

--- a/packages/platform/db-clickhouse/src/repositories/rollup-operation-gate.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/rollup-operation-gate.test.ts
@@ -30,6 +30,7 @@ const ORG_ID = OrganizationId("oooooooooooooooooooooooo")
 const PROJECT_ID = ProjectId("pppppppppppppppppppppppp")
 const VERCEL_TRACE = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as TraceId
 const ADK_TRACE = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as TraceId
+const MEMORY_EXTRACT_TRACE = "cccccccccccccccccccccccccccccccc" as TraceId
 
 const T0 = new Date("2026-06-18T10:00:00.000Z")
 const at = (ms: number) => new Date(T0.getTime() + ms)
@@ -45,6 +46,27 @@ const assistantToolCall = {
 }
 const toolResult = { role: "tool", parts: [{ type: "tool_call_response", id: "call_1", response: "sunny, 22C" }] }
 const assistantFinal = { role: "assistant", parts: [{ type: "text", content: "LEAF_FINAL: sunny, 22C in SF." }] }
+const agentRecommendation = {
+  role: "assistant",
+  parts: [
+    {
+      type: "text",
+      content:
+        "In Vienna under 90 EUR/night: Alfama Guesthouse at 58 EUR is the pick — ten minutes from the centre on foot.",
+    },
+  ],
+}
+const memoryExtractInput = {
+  role: "user",
+  parts: [
+    {
+      type: "text",
+      content:
+        "Traveler: Where should I stay in Vienna?\n\nAssistant: In Vienna under 90 EUR/night: Alfama Guesthouse at 58 EUR is the pick.",
+    },
+  ],
+}
+const memoryExtractOutput = { role: "assistant", parts: [{ type: "text", content: "[]" }] }
 // The Vercel wrapper's lossy summary: final text welded with an orphan tool_call
 // and no tool result — must never become the rolled-up conversation.
 const wrapperSummary = {
@@ -179,6 +201,38 @@ const VERCEL_SPANS: SpanRow[] = [
   }),
 ]
 
+// Agent reply followed by a later memory-extract `chat` leaf that returns only
+// a JSON array. Plain end_time ranking would pick the extractor; prose ranking
+// must keep the recommendation as the rolled-up conversation.
+const MEMORY_EXTRACT_SPANS: SpanRow[] = [
+  makeSpanRow({
+    traceId: MEMORY_EXTRACT_TRACE,
+    spanId: "bbbb111111111111",
+    operation: "chat",
+    startTime: at(0),
+    endTime: at(2_000),
+    tokensInput: 200,
+    tokensOutput: 80,
+    costTotalMicrocents: 900,
+    inputMessages: [userMsg],
+    outputMessages: [agentRecommendation],
+    systemInstructions: "You are Atlas, a travel planning assistant.",
+  }),
+  makeSpanRow({
+    traceId: MEMORY_EXTRACT_TRACE,
+    spanId: "bbbb222222222222",
+    operation: "chat",
+    startTime: at(2_100),
+    endTime: at(3_000), // ends LAST — would win un-gated / end_time-only ranking
+    tokensInput: 100,
+    tokensOutput: 12,
+    costTotalMicrocents: 50,
+    inputMessages: [memoryExtractInput],
+    outputMessages: [memoryExtractOutput],
+    systemInstructions: "You extract durable travel facts. Respond with only a JSON array.",
+  }),
+]
+
 // A Google-ADK-shaped trace: a single `generate_content` leaf (the real model
 // call) under an inert `invoke_agent` wrapper with no usage/conversation.
 const ADK_SPANS: SpanRow[] = [
@@ -226,7 +280,9 @@ describe("operation-gated rollup", () => {
 
   // Insert after the testkit's beforeEach TRUNCATE (registered first, so it runs first).
   beforeEach(async () => {
-    await Effect.runPromise(insertJsonEachRow(ch.client, "spans", [...VERCEL_SPANS, ...ADK_SPANS]))
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [...VERCEL_SPANS, ...ADK_SPANS, ...MEMORY_EXTRACT_SPANS]),
+    )
   })
 
   const runCh = <A, E>(effect: Effect.Effect<A, E, ChSqlClient | AI>) =>
@@ -276,6 +332,22 @@ describe("operation-gated rollup", () => {
       expect(serialize(detail.allMessages)).toContain("LEAF_FINAL")
       expect(detail.tokensInput).toBe(80)
       expect(detail.tokensOutput).toBe(40)
+    })
+
+    it("keeps the agent prose reply when a later memory-extract chat returns a JSON array", async () => {
+      const detail = await runCh(
+        traceRepo.findByTraceId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: MEMORY_EXTRACT_TRACE,
+        }),
+      )
+
+      const serialized = serialize(detail.allMessages)
+      expect(serialized).toContain("Alfama Guesthouse")
+      expect(serialized).not.toContain("Traveler:")
+      expect(serialize(detail.outputMessages)).toContain("Alfama Guesthouse")
+      expect(serialize(detail.outputMessages)).not.toContain('"content":"[]"')
     })
   })
 

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -94,18 +94,22 @@ const MESSAGE_OPERATION_FILTER = "operation IN ('chat', 'text_completion', 'gene
 const SYSTEM_INSTRUCTION_OPERATION_FILTER =
   "operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')"
 
+// Sidecar extractors emit a JSON array as the sole text part. Collapse their
+// ranking time to epoch so a prior prose leaf wins argMaxIf (same rule as MV 00055).
+const CONVERSATION_RANK_TIME = `if(match(output_messages, '"content":"\\\\[(\\\\]|\\\\{|\\\\\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), end_time)`
+
 const SPAN_MESSAGES_SELECT = `
   trace_id,
   argMinIf(input_messages, start_time, input_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS first_input_messages,
-  argMaxIf(input_messages, end_time, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS last_input_messages,
-  argMaxIf(output_messages, end_time, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS final_output_messages,
+  argMaxIf(input_messages, ${CONVERSATION_RANK_TIME}, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS last_input_messages,
+  argMaxIf(output_messages, ${CONVERSATION_RANK_TIME}, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS final_output_messages,
   argMinIf(system_instructions, start_time, system_instructions != '' AND ${SYSTEM_INSTRUCTION_OPERATION_FILTER}) AS first_system_instructions
 `
 
 const SPAN_METADATA_MESSAGES_SELECT = `
   trace_id,
   argMinIf(input_messages, start_time, input_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS first_input_messages,
-  argMaxIf(output_messages, end_time, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS final_output_messages,
+  argMaxIf(output_messages, ${CONVERSATION_RANK_TIME}, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS final_output_messages,
   argMinIf(system_instructions, start_time, system_instructions != '' AND ${SYSTEM_INSTRUCTION_OPERATION_FILTER}) AS first_system_instructions
 `
 
@@ -1669,8 +1673,8 @@ export const TraceRepositoryLive = Layer.effect(
                           FROM (
                             SELECT
                               argMinIf(system_instructions, start_time, system_instructions != '' AND ${SYSTEM_INSTRUCTION_OPERATION_FILTER}) AS system_instructions_json,
-                              argMaxIf(input_messages, end_time, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS last_input_messages_json,
-                              argMaxIf(output_messages, end_time, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS output_messages_json
+                              argMaxIf(input_messages, ${CONVERSATION_RANK_TIME}, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS last_input_messages_json,
+                              argMaxIf(output_messages, ${CONVERSATION_RANK_TIME}, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS output_messages_json
                             FROM ${dedupedSpanMessageRowsSubquery("trace_id = {traceId:FixedString(32)}")}
                             GROUP BY trace_id
                             LIMIT 1

--- a/packages/platform/testkit/src/clickhouse/schema.sql
+++ b/packages/platform/testkit/src/clickhouse/schema.sql
@@ -309,8 +309,8 @@ AS SELECT
     argMinIfState(s.span_id, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_id,
     argMinIfState(s.name, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_name,
     argMinIfState(s.input_messages, s.start_time, (s.input_messages != '') AND (s.operation IN ('chat', 'text_completion', 'generate_content'))) AS input_messages,
-    argMaxIfState(s.input_messages, s.end_time, (s.output_messages != '') AND (s.operation IN ('chat', 'text_completion', 'generate_content'))) AS last_input_messages,
-    argMaxIfState(s.output_messages, s.end_time, (s.output_messages != '') AND (s.operation IN ('chat', 'text_completion', 'generate_content'))) AS output_messages,
+    argMaxIfState(s.input_messages, if(match(s.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), s.end_time), (s.output_messages != '') AND (s.operation IN ('chat', 'text_completion', 'generate_content'))) AS last_input_messages,
+    argMaxIfState(s.output_messages, if(match(s.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), s.end_time), (s.output_messages != '') AND (s.operation IN ('chat', 'text_completion', 'generate_content'))) AS output_messages,
     argMinIfState(s.system_instructions, s.start_time, (s.system_instructions != '') AND (s.operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent'))) AS system_instructions,
     max(s.retention_days) AS retention_days
 FROM spans AS s
@@ -618,8 +618,8 @@ AS SELECT
     argMinIfState(span_id, start_time, parent_span_id = '') AS root_span_id,
     argMinIfState(name, start_time, parent_span_id = '') AS root_span_name,
     argMinIfState(spans.input_messages, start_time, (spans.input_messages != '') AND (operation IN ('chat', 'text_completion', 'generate_content'))) AS input_messages,
-    argMaxIfState(spans.input_messages, end_time, (spans.output_messages != '') AND (operation IN ('chat', 'text_completion', 'generate_content'))) AS last_input_messages,
-    argMaxIfState(spans.output_messages, end_time, (spans.output_messages != '') AND (operation IN ('chat', 'text_completion', 'generate_content'))) AS output_messages,
+    argMaxIfState(spans.input_messages, if(match(spans.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), end_time), (spans.output_messages != '') AND (operation IN ('chat', 'text_completion', 'generate_content'))) AS last_input_messages,
+    argMaxIfState(spans.output_messages, if(match(spans.output_messages, '"content":"\\[(\\]|\\{|\\\\)'), toDateTime64('1970-01-01 00:00:00.000000000', 9, 'UTC'), end_time), (spans.output_messages != '') AND (operation IN ('chat', 'text_completion', 'generate_content'))) AS output_messages,
     argMinIfState(spans.system_instructions, start_time, (spans.system_instructions != '') AND (operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent'))) AS system_instructions,
     max(retention_days) AS retention_days
 FROM spans


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves ATL-KP4T

## Problem

On traces like atlas-travel `c0dab59a3578c61f826b205fad940475`, a post-turn memory-extract `chat` leaf (Haiku returning `[]`) ends after the real agent reply. Conversation rollup used `argMaxIf(..., end_time, …)` over all model-call leaves, so getTrace / session conversation / evaluation context showed the extractor turn: the recommendation sat inside a synthetic user blob and the assistant output was `[]`. Nightly verbosity feedback then read the wrong slice.

## Fix

- Deprioritize outputs whose sole text part is a JSON array (`"content":"[]"` / `"content":"[{…}]"`) by collapsing their ranking time to epoch in span-sourced getTrace SQL and in `traces_mv` / `sessions_mv` (migration `00055`). AggregateFunction types are unchanged; MV path is new-data-only.
- Prefer the primary model when resolving the last LLM completion span for score/annotation pinning, so a later sidecar model does not win.

## Tests

- `rollup-operation-gate.test.ts`: agent prose + later memory-extract `[]` keeps the recommendation
- `resolve-last-llm-completion-span.test.ts`: primary-model leaf preferred over later extractor model

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c274255-5f97-5c3d-8825-e2bdf236a364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c274255-5f97-5c3d-8825-e2bdf236a364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

