### PR TITLE
Add country code finder for phone number

### DIFF
--- a/apps/web/src/components/phone-number-field.test.tsx
+++ b/apps/web/src/components/phone-number-field.test.tsx
@@ -74,6 +74,31 @@ describe("PhoneNumberField", () => {
     await waitFor(() => expect(state()).toBe("44|1234567890"))
   })
 
+  it("follows an international number typed one character at a time", async () => {
+    render(<Harness initialCallingCode="34" />)
+    const input = screen.getByRole("textbox")
+
+    for (const character of "+447700900000") {
+      fireEvent.change(input, { target: { value: (input as HTMLInputElement).value + character } })
+    }
+
+    await waitFor(() => expect(state()).toBe("44|7700900000"))
+  })
+
+  it("holds an incomplete prefix on the field instead of silently dropping the plus", async () => {
+    render(<Harness initialCallingCode="34" />)
+    const input = screen.getByRole("textbox")
+
+    fireEvent.change(input, { target: { value: "+" } })
+    await waitFor(() => expect(state()).toBe("34|+"))
+
+    fireEvent.change(input, { target: { value: "+4" } })
+    await waitFor(() => expect(state()).toBe("34|+4"))
+
+    fireEvent.change(input, { target: { value: "+44" } })
+    await waitFor(() => expect(state()).toBe("44|"))
+  })
+
   it("warns about a trunk zero without rewriting what the user typed", async () => {
     render(<Harness initialCallingCode="44" />)
 

--- a/apps/web/src/components/phone-number-field.test.tsx
+++ b/apps/web/src/components/phone-number-field.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { useState } from "react"
+import { afterEach, describe, expect, it } from "vitest"
+import { detectCallingCode } from "../lib/phone-countries.ts"
+import { PhoneNumberField } from "./phone-number-field.tsx"
+
+afterEach(cleanup)
+
+function Harness({ initialCallingCode = "" }: { readonly initialCallingCode?: string }) {
+  const [callingCode, setCallingCode] = useState(initialCallingCode)
+  const [nationalNumber, setNationalNumber] = useState("")
+  return (
+    <>
+      <PhoneNumberField
+        label="Phone number (optional)"
+        description="Helpful if we need to reach you about your setup."
+        callingCode={callingCode}
+        nationalNumber={nationalNumber}
+        onCallingCodeChange={setCallingCode}
+        onNationalNumberChange={setNationalNumber}
+      />
+      <output data-testid="state">{`${callingCode}|${nationalNumber}`}</output>
+    </>
+  )
+}
+
+const state = () => screen.getByTestId("state").textContent
+
+describe("PhoneNumberField", () => {
+  // Asserts the detection is plumbed through on mount; which code it lands on depends on the runner's zone.
+  it("defaults the calling code from the browser timezone", async () => {
+    const detected = detectCallingCode()
+    render(<Harness />)
+
+    if (detected) await waitFor(() => expect(state()).toBe(`${detected}|`))
+    else expect(state()).toBe("|")
+  })
+
+  it("shows the bare calling code on the trigger, with no country flag", () => {
+    render(<Harness initialCallingCode="1" />)
+
+    const trigger = screen.getByRole("button", { name: /calling code/i })
+    expect(trigger.textContent).toBe("+1")
+    expect(trigger.textContent).not.toMatch(/\p{Regional_Indicator}/u)
+  })
+
+  it("lets the user search by country and stores only the calling code", async () => {
+    render(<Harness initialCallingCode="34" />)
+
+    fireEvent.click(screen.getByRole("button", { name: /calling code/i }))
+    const search = await screen.findByPlaceholderText("Search country or code")
+    fireEvent.change(search, { target: { value: "Germany" } })
+    fireEvent.click(await screen.findByText("Germany +49"))
+
+    await waitFor(() => expect(state()).toBe("49|"))
+  })
+
+  it("finds the United Kingdom by an alias its name does not contain", async () => {
+    render(<Harness initialCallingCode="34" />)
+
+    fireEvent.click(screen.getByRole("button", { name: /calling code/i }))
+    fireEvent.change(await screen.findByPlaceholderText("Search country or code"), { target: { value: "UK" } })
+
+    fireEvent.click(await screen.findByText("United Kingdom +44"))
+    await waitFor(() => expect(state()).toBe("44|"))
+  })
+
+  it("follows a pasted international prefix", async () => {
+    render(<Harness initialCallingCode="34" />)
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "+441234567890" } })
+
+    await waitFor(() => expect(state()).toBe("44|1234567890"))
+  })
+
+  it("warns about a trunk zero without rewriting what the user typed", async () => {
+    render(<Harness initialCallingCode="44" />)
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "07700 900000" } })
+
+    await waitFor(() => expect(state()).toBe("44|07700 900000"))
+    expect(await screen.findByText(/without the leading 0/i)).toBeDefined()
+    expect(screen.getByText(/\+4407700900000/)).toBeDefined()
+  })
+
+  it("stays silent about a leading zero for Italy", async () => {
+    render(<Harness initialCallingCode="39" />)
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "06 1234 5678" } })
+
+    await waitFor(() => expect(state()).toBe("39|06 1234 5678"))
+    expect(screen.queryByText(/without the leading/i)).toBeNull()
+  })
+
+  it("keeps only phone formatting characters in the national number", async () => {
+    render(<Harness initialCallingCode="34" />)
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "612 34 abc 56-78" } })
+
+    await waitFor(() => expect(state()).toBe("34|612 34  56-78"))
+  })
+})

--- a/apps/web/src/components/phone-number-field.tsx
+++ b/apps/web/src/components/phone-number-field.tsx
@@ -1,0 +1,100 @@
+import { FormField, Input, Select, type SelectOption, Text, useMountEffect } from "@repo/ui"
+import { ChevronDown } from "lucide-react"
+import {
+  callingCodeForIso2,
+  detectCallingCode,
+  isKnownCallingCode,
+  PHONE_COUNTRIES,
+  phoneCountryFlag,
+  phoneCountrySearchText,
+  splitInternationalPhoneNumber,
+  trunkPrefixHint,
+} from "../lib/phone-countries.ts"
+
+// Rows are keyed by ISO code because ~50 countries share a calling code and the Select keys by value.
+const COUNTRY_OPTIONS: SelectOption<string>[] = PHONE_COUNTRIES.map((country) => ({
+  label: `${country.name} +${country.dialCode}`,
+  value: country.iso2,
+  searchText: phoneCountrySearchText(country),
+  icon: <span aria-hidden>{phoneCountryFlag(country.iso2)}</span>,
+}))
+
+export function PhoneNumberField({
+  label,
+  description,
+  callingCode,
+  nationalNumber,
+  errors,
+  onCallingCodeChange,
+  onNationalNumberChange,
+}: {
+  readonly label: string
+  readonly description?: string
+  readonly callingCode: string
+  readonly nationalNumber: string
+  readonly errors?: string[] | undefined
+  readonly onCallingCodeChange: (callingCode: string) => void
+  readonly onNationalNumberChange: (nationalNumber: string) => void
+}) {
+  // Detection is client-only, so it runs after mount rather than seeding the form's default value.
+  useMountEffect(() => {
+    if (callingCode) return
+    const detected = detectCallingCode()
+    if (detected) onCallingCodeChange(detected)
+  })
+
+  const handleNationalNumberChange = (raw: string) => {
+    if (raw.trimStart().startsWith("+")) {
+      const parsed = splitInternationalPhoneNumber(raw)
+      if (parsed) {
+        onCallingCodeChange(parsed.callingCode)
+        onNationalNumberChange(parsed.nationalNumber)
+        return
+      }
+    }
+    onNationalNumberChange(raw.replace(/[^\d\s().-]/g, ""))
+  }
+
+  const hint = trunkPrefixHint(callingCode, nationalNumber)
+
+  return (
+    <FormField label={label} description={hint ?? description} errors={errors}>
+      <div className="flex items-center gap-2">
+        <Select
+          name="phoneCallingCode"
+          width="auto"
+          side="bottom"
+          searchable
+          searchPlaceholder="Search country or code"
+          searchableEmptyMessage="No country found."
+          options={COUNTRY_OPTIONS}
+          onChange={(iso2) => {
+            const code = callingCodeForIso2(iso2)
+            if (code) onCallingCodeChange(code)
+          }}
+          contentClassName="min-w-72"
+          trigger={
+            <button
+              type="button"
+              aria-label={isKnownCallingCode(callingCode) ? `Calling code: +${callingCode}` : "Calling code"}
+              className="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-input bg-transparent px-3 outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <Text.H5 noWrap>{isKnownCallingCode(callingCode) ? `+${callingCode}` : "Code"}</Text.H5>
+              <ChevronDown className="h-4 w-4 shrink-0 opacity-50" aria-hidden />
+            </button>
+          }
+        />
+        <Input
+          type="tel"
+          className="flex-1"
+          placeholder="Phone number"
+          value={nationalNumber}
+          onChange={(event) => handleNationalNumberChange(event.target.value)}
+          maxLength={24}
+          autoComplete="tel-national"
+          inputMode="tel"
+        />
+      </div>
+    </FormField>
+  )
+}

--- a/apps/web/src/components/phone-number-field.tsx
+++ b/apps/web/src/components/phone-number-field.tsx
@@ -7,6 +7,7 @@ import {
   PHONE_COUNTRIES,
   phoneCountryFlag,
   phoneCountrySearchText,
+  sanitizeNationalNumberInput,
   splitInternationalPhoneNumber,
   trunkPrefixHint,
 } from "../lib/phone-countries.ts"
@@ -52,7 +53,7 @@ export function PhoneNumberField({
         return
       }
     }
-    onNationalNumberChange(raw.replace(/[^\d\s().-]/g, ""))
+    onNationalNumberChange(sanitizeNationalNumberInput(raw))
   }
 
   const hint = trunkPrefixHint(callingCode, nationalNumber)

--- a/apps/web/src/domains/users/user.functions.ts
+++ b/apps/web/src/domains/users/user.functions.ts
@@ -8,13 +8,9 @@ import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
+import { isStorablePhoneNumber } from "../../lib/phone-countries.ts"
 import { requireSession } from "../../server/auth.ts"
 import { getAdminPostgresClient } from "../../server/clients.ts"
-
-// Guarantees a calling code is present and the value is digits-only within E.164 length — not that the
-// number is dialable. Deliberately looser than the PII detector's 8-digit floor (`specs/pii-redaction.md`),
-// which is tuned against false positives in free text and would reject real 7-digit territory numbers.
-const PHONE_NUMBER_WITH_CALLING_CODE = /^\+[1-9]\d{4,14}$/
 
 const submitOnboardingSchema = z.object({
   jobTitle: z
@@ -28,8 +24,8 @@ const submitOnboardingSchema = z.object({
       z
         .string()
         .max(64)
-        .refine((v) => v.length === 0 || PHONE_NUMBER_WITH_CALLING_CODE.test(v), {
-          message: "Phone number must include a calling code, e.g. +15550100",
+        .refine((v) => v.length === 0 || isStorablePhoneNumber(v), {
+          message: "Phone number must start with a known calling code, e.g. +15550100",
         })
         .transform((v) => (v.length > 0 ? v : undefined)),
     )

--- a/apps/web/src/domains/users/user.functions.ts
+++ b/apps/web/src/domains/users/user.functions.ts
@@ -11,6 +11,11 @@ import { z } from "zod"
 import { requireSession } from "../../server/auth.ts"
 import { getAdminPostgresClient } from "../../server/clients.ts"
 
+// Guarantees a calling code is present and the value is digits-only within E.164 length — not that the
+// number is dialable. Deliberately looser than the PII detector's 8-digit floor (`specs/pii-redaction.md`),
+// which is tuned against false positives in free text and would reject real 7-digit territory numbers.
+const PHONE_NUMBER_WITH_CALLING_CODE = /^\+[1-9]\d{4,14}$/
+
 const submitOnboardingSchema = z.object({
   jobTitle: z
     .string()
@@ -23,6 +28,9 @@ const submitOnboardingSchema = z.object({
       z
         .string()
         .max(64)
+        .refine((v) => v.length === 0 || PHONE_NUMBER_WITH_CALLING_CODE.test(v), {
+          message: "Phone number must include a calling code, e.g. +15550100",
+        })
         .transform((v) => (v.length > 0 ? v : undefined)),
     )
     .optional(),

--- a/apps/web/src/domains/users/user.functions.ts
+++ b/apps/web/src/domains/users/user.functions.ts
@@ -1,7 +1,7 @@
 import { OutboxEventWriter } from "@domain/events"
 import { stackChoiceSchema, stackChoiceToOnboardingType } from "@domain/marketing"
 import { ProjectRepository } from "@domain/projects"
-import { ProjectId, SqlClient } from "@domain/shared"
+import { BadRequestError, ProjectId, SqlClient } from "@domain/shared"
 import { UserRepository } from "@domain/users"
 import { OutboxEventWriterLive, ProjectRepositoryLive, UserRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
@@ -11,6 +11,10 @@ import { z } from "zod"
 import { isStorablePhoneNumber } from "../../lib/phone-countries.ts"
 import { requireSession } from "../../server/auth.ts"
 import { getAdminPostgresClient } from "../../server/clients.ts"
+import { reportUnknownCallingCode } from "../../server/unknown-calling-code-report.ts"
+
+// Shape only, so obvious junk is rejected at the boundary and never reaches the reporter below.
+const E164_SHAPE = /^\+[1-9]\d{4,14}$/
 
 const submitOnboardingSchema = z.object({
   jobTitle: z
@@ -24,8 +28,8 @@ const submitOnboardingSchema = z.object({
       z
         .string()
         .max(64)
-        .refine((v) => v.length === 0 || isStorablePhoneNumber(v), {
-          message: "Phone number must start with a known calling code, e.g. +15550100",
+        .refine((v) => v.length === 0 || E164_SHAPE.test(v), {
+          message: "Phone number must include a calling code, e.g. +15550100",
         })
         .transform((v) => (v.length > 0 ? v : undefined)),
     )
@@ -39,6 +43,13 @@ export const submitOnboarding = createServerFn({ method: "POST" })
   .handler(async ({ data }) => {
     const { userId, organizationId } = await requireSession()
     const adminClient = getAdminPostgresClient()
+
+    // A prefix that looks like a calling code but matches none is either junk or a country code
+    // assigned since the table was last updated, so it is reported before the rejection.
+    if (data.phoneNumber !== undefined && !isStorablePhoneNumber(data.phoneNumber)) {
+      reportUnknownCallingCode(data.phoneNumber)
+      throw new BadRequestError({ message: "Phone number must start with a known calling code" })
+    }
 
     const onboardingType = stackChoiceToOnboardingType(data.stackChoice)
 

--- a/apps/web/src/domains/users/user.functions.ts
+++ b/apps/web/src/domains/users/user.functions.ts
@@ -44,8 +44,6 @@ export const submitOnboarding = createServerFn({ method: "POST" })
     const { userId, organizationId } = await requireSession()
     const adminClient = getAdminPostgresClient()
 
-    // A prefix that looks like a calling code but matches none is either junk or a country code
-    // assigned since the table was last updated, so it is reported before the rejection.
     if (data.phoneNumber !== undefined && !isStorablePhoneNumber(data.phoneNumber)) {
       reportUnknownCallingCode(data.phoneNumber)
       throw new BadRequestError({ message: "Phone number must start with a known calling code" })

--- a/apps/web/src/lib/phone-countries.test.ts
+++ b/apps/web/src/lib/phone-countries.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest"
+import {
+  callingCodeForIso2,
+  callingCodeForTimeZone,
+  composePhoneNumber,
+  PHONE_COUNTRIES,
+  phoneCountryFlag,
+  phoneCountrySearchText,
+  phoneNumberError,
+  splitInternationalPhoneNumber,
+  trunkPrefixHint,
+} from "./phone-countries.ts"
+
+describe("PHONE_COUNTRIES", () => {
+  it("has unique ISO 3166-1 alpha-2 codes", () => {
+    const iso2Codes = PHONE_COUNTRIES.map((country) => country.iso2)
+    expect(new Set(iso2Codes).size).toBe(iso2Codes.length)
+  })
+
+  it("stores calling codes as bare digits without a leading plus or zero", () => {
+    for (const { iso2, dialCode } of PHONE_COUNTRIES) {
+      expect(dialCode, iso2).toMatch(/^[1-9]\d{0,2}$/)
+    }
+  })
+
+  it("gives NANP territories the shared +1 code so area codes stay in the national number", () => {
+    for (const iso2 of ["US", "CA", "DO", "PR", "JM"]) {
+      expect(callingCodeForIso2(iso2), iso2).toBe("1")
+    }
+  })
+})
+
+describe("phoneCountrySearchText", () => {
+  it("matches on names the official country name does not contain", () => {
+    const gb = PHONE_COUNTRIES.find((c) => c.iso2 === "GB")
+    expect(gb).toBeDefined()
+    if (!gb) return
+    const searchText = phoneCountrySearchText(gb).toLowerCase()
+    expect(searchText).toContain("uk")
+    expect(searchText).toContain("gb")
+    expect(searchText).toContain("+44")
+  })
+
+  it("matches United States on the abbreviation its name lacks", () => {
+    const us = PHONE_COUNTRIES.find((c) => c.iso2 === "US")
+    expect(us).toBeDefined()
+    if (!us) return
+    expect("United States".toLowerCase()).not.toContain("us")
+    expect(phoneCountrySearchText(us).toLowerCase()).toContain("us")
+  })
+})
+
+describe("phoneCountryFlag", () => {
+  it("maps an ISO code to regional indicator symbols", () => {
+    expect(phoneCountryFlag("ES")).toBe("🇪🇸")
+    expect(phoneCountryFlag("us")).toBe("🇺🇸")
+  })
+})
+
+describe("composePhoneNumber", () => {
+  it("prefixes the calling code and strips formatting characters", () => {
+    expect(composePhoneNumber("34", "612 34 56 78")).toBe("+34612345678")
+    expect(composePhoneNumber("1", "(555) 010-0123")).toBe("+15550100123")
+  })
+
+  it("returns an empty string when there is no number or the code is unknown", () => {
+    expect(composePhoneNumber("34", "   ")).toBe("")
+    expect(composePhoneNumber("", "612345678")).toBe("")
+    expect(composePhoneNumber("999", "612345678")).toBe("")
+  })
+
+  it("keeps NANP area codes in the national number", () => {
+    expect(composePhoneNumber("1", "809 234 5678")).toBe("+18092345678")
+  })
+})
+
+describe("splitInternationalPhoneNumber", () => {
+  it("matches the longest calling code", () => {
+    expect(splitInternationalPhoneNumber("+34612345678")).toEqual({ callingCode: "34", nationalNumber: "612345678" })
+    expect(splitInternationalPhoneNumber("+353 87 123 4567")).toEqual({
+      callingCode: "353",
+      nationalNumber: "871234567",
+    })
+  })
+
+  it("resolves a shared calling code without guessing a country", () => {
+    expect(splitInternationalPhoneNumber("+1 555 0100")).toEqual({ callingCode: "1", nationalNumber: "5550100" })
+    expect(splitInternationalPhoneNumber("+44 7700 900000")).toEqual({
+      callingCode: "44",
+      nationalNumber: "7700900000",
+    })
+  })
+
+  it("returns undefined when no calling code matches", () => {
+    expect(splitInternationalPhoneNumber("+")).toBeUndefined()
+    expect(splitInternationalPhoneNumber("+999999")).toBeUndefined()
+  })
+})
+
+describe("phoneNumberError", () => {
+  it("accepts an empty number because the field is optional", () => {
+    expect(phoneNumberError("", "")).toBeUndefined()
+    expect(phoneNumberError("  ", "34")).toBeUndefined()
+  })
+
+  it("requires a calling code once a number is typed", () => {
+    expect(phoneNumberError("612345678", "")).toBe("Select your calling code")
+  })
+
+  it("rejects numbers that are too short or exceed E.164 length", () => {
+    expect(phoneNumberError("12", "34")).toBe("Enter a valid phone number")
+    expect(phoneNumberError("6123456789012345", "34")).toBe("Enter a valid phone number")
+  })
+
+  it("accepts a well-formed national number", () => {
+    expect(phoneNumberError("612 34 56 78", "34")).toBeUndefined()
+  })
+})
+
+describe("trunkPrefixHint", () => {
+  it("flags a leading zero and shows what would be stored", () => {
+    const hint = trunkPrefixHint("44", "07700 900000")
+    expect(hint).toContain("leading 0")
+    expect(hint).toContain("+4407700900000")
+  })
+
+  it("flags a leading 8 on +7, where that is the trunk digit", () => {
+    expect(trunkPrefixHint("7", "8 916 1234567")).toContain("leading 8")
+    expect(trunkPrefixHint("7", "916 1234567")).toBeUndefined()
+  })
+
+  it("stays silent for Italy, where a leading zero is part of the number", () => {
+    expect(trunkPrefixHint("39", "06 1234 5678")).toBeUndefined()
+  })
+
+  it("stays silent for a correctly written number", () => {
+    expect(trunkPrefixHint("44", "7700 900000")).toBeUndefined()
+    expect(trunkPrefixHint("34", "612 34 56 78")).toBeUndefined()
+  })
+})
+
+describe("callingCodeForTimeZone", () => {
+  it("resolves location-bearing zones to their calling code", () => {
+    expect(callingCodeForTimeZone("Europe/Madrid")).toBe("34")
+    expect(callingCodeForTimeZone("America/New_York")).toBe("1")
+    expect(callingCodeForTimeZone("America/Santo_Domingo")).toBe("1")
+    expect(callingCodeForTimeZone("Asia/Tokyo")).toBe("81")
+  })
+
+  it("survives renamed IANA zones by canonicalising through ICU", () => {
+    expect(callingCodeForTimeZone("Asia/Kolkata")).toBe("91")
+    expect(callingCodeForTimeZone("Asia/Calcutta")).toBe("91")
+    expect(callingCodeForTimeZone("Europe/Kyiv")).toBe("380")
+  })
+
+  it("returns undefined for an unknown zone", () => {
+    expect(callingCodeForTimeZone("Pacific/Nowhere")).toBeUndefined()
+  })
+})

--- a/apps/web/src/lib/phone-countries.test.ts
+++ b/apps/web/src/lib/phone-countries.test.ts
@@ -8,6 +8,7 @@ import {
   phoneCountryFlag,
   phoneCountrySearchText,
   phoneNumberError,
+  phoneNumberSubmitError,
   sanitizeNationalNumberInput,
   splitInternationalPhoneNumber,
   trunkPrefixHint,
@@ -118,8 +119,33 @@ describe("phoneNumberError", () => {
     expect(phoneNumberError("612345678", "")).toBe("Select your calling code")
   })
 
-  it("flags a national number still holding an unresolved international prefix", () => {
-    expect(phoneNumberError("+4412", "34")).toBe("That international prefix isn't recognised")
+  it("flags a national number holding a prefix that can never resolve", () => {
+    expect(phoneNumberError("+8881234567", "34")).toBe("That international prefix isn't recognised")
+    expect(phoneNumberError("+999", "34")).toBe("That international prefix isn't recognised")
+  })
+
+  it("stays quiet while a prefix could still be completed by the next keystroke", () => {
+    expect(phoneNumberError("+3", "34")).toBeUndefined()
+    expect(phoneNumberError("+35", "34")).toBeUndefined()
+    expect(phoneNumberError("+99", "34")).toBeUndefined()
+  })
+
+  it("does not flag a prefix that resolved, however short the national number is left", () => {
+    expect(splitInternationalPhoneNumber("+4412")).toEqual({ callingCode: "44", nationalNumber: "12" })
+    expect(phoneNumberError("12", "44")).toBe("Enter a valid phone number")
+  })
+})
+
+describe("phoneNumberSubmitError", () => {
+  it("rejects a prefix left unfinished, which the on-change check tolerates", () => {
+    expect(phoneNumberError("+3", "34")).toBeUndefined()
+    expect(phoneNumberSubmitError("+3", "34")).toBe("That international prefix isn't recognised")
+  })
+
+  it("otherwise matches the on-change check", () => {
+    expect(phoneNumberSubmitError("", "34")).toBeUndefined()
+    expect(phoneNumberSubmitError("612 34 56 78", "34")).toBeUndefined()
+    expect(phoneNumberSubmitError("12", "34")).toBe("Enter a valid phone number")
   })
 
   it("rejects numbers that are too short or exceed E.164 length", () => {

--- a/apps/web/src/lib/phone-countries.test.ts
+++ b/apps/web/src/lib/phone-countries.test.ts
@@ -3,10 +3,12 @@ import {
   callingCodeForIso2,
   callingCodeForTimeZone,
   composePhoneNumber,
+  isStorablePhoneNumber,
   PHONE_COUNTRIES,
   phoneCountryFlag,
   phoneCountrySearchText,
   phoneNumberError,
+  sanitizeNationalNumberInput,
   splitInternationalPhoneNumber,
   trunkPrefixHint,
 } from "./phone-countries.ts"
@@ -63,10 +65,19 @@ describe("composePhoneNumber", () => {
     expect(composePhoneNumber("1", "(555) 010-0123")).toBe("+15550100123")
   })
 
-  it("returns an empty string when there is no number or the code is unknown", () => {
+  it("returns an empty string only when there is no number at all", () => {
     expect(composePhoneNumber("34", "   ")).toBe("")
-    expect(composePhoneNumber("", "612345678")).toBe("")
-    expect(composePhoneNumber("999", "612345678")).toBe("")
+    expect(composePhoneNumber("", "")).toBe("")
+  })
+
+  it("returns bare digits for an unknown code so the server rejects instead of dropping the number", () => {
+    expect(composePhoneNumber("", "612345678")).toBe("612345678")
+    expect(composePhoneNumber("999", "612345678")).toBe("612345678")
+    expect(isStorablePhoneNumber(composePhoneNumber("999", "612345678"))).toBe(false)
+  })
+
+  it("refuses to compose an unresolved international prefix into a plausible number", () => {
+    expect(composePhoneNumber("34", "+4412")).toBe("4412")
   })
 
   it("keeps NANP area codes in the national number", () => {
@@ -107,6 +118,10 @@ describe("phoneNumberError", () => {
     expect(phoneNumberError("612345678", "")).toBe("Select your calling code")
   })
 
+  it("flags a national number still holding an unresolved international prefix", () => {
+    expect(phoneNumberError("+4412", "34")).toBe("That international prefix isn't recognised")
+  })
+
   it("rejects numbers that are too short or exceed E.164 length", () => {
     expect(phoneNumberError("12", "34")).toBe("Enter a valid phone number")
     expect(phoneNumberError("6123456789012345", "34")).toBe("Enter a valid phone number")
@@ -136,6 +151,42 @@ describe("trunkPrefixHint", () => {
   it("stays silent for a correctly written number", () => {
     expect(trunkPrefixHint("44", "7700 900000")).toBeUndefined()
     expect(trunkPrefixHint("34", "612 34 56 78")).toBeUndefined()
+  })
+})
+
+describe("sanitizeNationalNumberInput", () => {
+  it("keeps an incomplete international prefix so the next keystroke can complete it", () => {
+    expect(sanitizeNationalNumberInput("+")).toBe("+")
+    expect(sanitizeNationalNumberInput("+4")).toBe("+4")
+  })
+
+  it("strips characters that are never part of a phone number", () => {
+    expect(sanitizeNationalNumberInput("612 34 abc 56-78")).toBe("612 34  56-78")
+    expect(sanitizeNationalNumberInput("+4 abc 4")).toBe("+4  4")
+  })
+
+  it("keeps only a leading plus, not one typed mid-number", () => {
+    expect(sanitizeNationalNumberInput("612+345")).toBe("612345")
+  })
+})
+
+describe("isStorablePhoneNumber", () => {
+  it("accepts a composed number whose prefix is a real calling code", () => {
+    expect(isStorablePhoneNumber("+34612345678")).toBe(true)
+    expect(isStorablePhoneNumber("+18092345678")).toBe(true)
+    expect(isStorablePhoneNumber("+2904256")).toBe(true)
+  })
+
+  it("rejects an unassigned prefix that a digits-only pattern would allow", () => {
+    expect(isStorablePhoneNumber("+99999999")).toBe(false)
+    expect(isStorablePhoneNumber("+45678")).toBe(false)
+  })
+
+  it("rejects values with no calling code or the wrong shape", () => {
+    expect(isStorablePhoneNumber("612345678")).toBe(false)
+    expect(isStorablePhoneNumber("+0612345678")).toBe(false)
+    expect(isStorablePhoneNumber("+34 612 345 678")).toBe(false)
+    expect(isStorablePhoneNumber("+346123456789012345")).toBe(false)
   })
 })
 

--- a/apps/web/src/lib/phone-countries.test.ts
+++ b/apps/web/src/lib/phone-countries.test.ts
@@ -174,11 +174,18 @@ describe("isStorablePhoneNumber", () => {
   it("accepts a composed number whose prefix is a real calling code", () => {
     expect(isStorablePhoneNumber("+34612345678")).toBe(true)
     expect(isStorablePhoneNumber("+18092345678")).toBe(true)
+  })
+
+  it("accepts a real 7-digit territory number, which the PII detector's floor would reject", () => {
     expect(isStorablePhoneNumber("+2904256")).toBe(true)
   })
 
   it("rejects an unassigned prefix that a digits-only pattern would allow", () => {
     expect(isStorablePhoneNumber("+99999999")).toBe(false)
+    expect(isStorablePhoneNumber("+8881234567")).toBe(false)
+  })
+
+  it("rejects a known calling code whose national number is too short", () => {
     expect(isStorablePhoneNumber("+45678")).toBe(false)
   })
 

--- a/apps/web/src/lib/phone-countries.ts
+++ b/apps/web/src/lib/phone-countries.ts
@@ -315,17 +315,35 @@ function nationalNumberDigits(value: string): string {
 
 export function composePhoneNumber(callingCode: string, nationalNumber: string): string {
   const digits = nationalNumberDigits(nationalNumber)
-  if (digits.length === 0 || !isKnownCallingCode(callingCode)) return ""
+  if (digits.length === 0) return ""
+  // Bare digits rather than "" so a bypassed client surfaces the server's error instead of dropping the number.
+  if (!isKnownCallingCode(callingCode) || nationalNumber.includes("+")) return digits
   return `+${callingCode}${digits}`
+}
+
+/** Whether a composed value is storable: a known calling code followed by a national number. */
+export function isStorablePhoneNumber(value: string): boolean {
+  if (!/^\+[1-9]\d{4,14}$/.test(value)) return false
+  const parsed = splitInternationalPhoneNumber(value)
+  return parsed !== undefined && parsed.nationalNumber.length >= MIN_NATIONAL_NUMBER_DIGITS
 }
 
 export function phoneNumberError(nationalNumber: string, callingCode: string): string | undefined {
   const digits = nationalNumberDigits(nationalNumber)
   if (digits.length === 0) return undefined
+  if (nationalNumber.includes("+")) return "That international prefix isn't recognised"
   if (!isKnownCallingCode(callingCode)) return "Select your calling code"
   if (digits.length < MIN_NATIONAL_NUMBER_DIGITS) return "Enter a valid phone number"
   if (callingCode.length + digits.length > MAX_E164_DIGITS) return "Enter a valid phone number"
   return undefined
+}
+
+/** Keeps a still-unparseable international prefix intact so further keystrokes can complete it. */
+export function sanitizeNationalNumberInput(raw: string): string {
+  const trimmed = raw.trimStart()
+  const body = trimmed.startsWith("+") ? trimmed.slice(1) : trimmed
+  const cleaned = body.replace(/[^\d\s().-]/g, "")
+  return trimmed.startsWith("+") ? `+${cleaned}` : cleaned
 }
 
 /**
@@ -362,24 +380,26 @@ type LocaleWithTimeZones = Intl.Locale & { getTimeZones?: () => string[] | undef
  * Asia/Kolkata) agree once the input is canonicalised through `resolvedOptions`.
  */
 export function callingCodeForTimeZone(timeZone: string): string | undefined {
-  let canonical: string
   try {
-    canonical = new Intl.DateTimeFormat("en-US", { timeZone }).resolvedOptions().timeZone
+    const canonical = new Intl.DateTimeFormat("en-US", { timeZone }).resolvedOptions().timeZone
+    for (const { iso2, dialCode } of PHONE_COUNTRIES) {
+      const zones = (new Intl.Locale(`und-${iso2}`) as LocaleWithTimeZones).getTimeZones?.()
+      if (zones?.includes(canonical)) return dialCode
+    }
   } catch {
     return undefined
-  }
-  for (const { iso2, dialCode } of PHONE_COUNTRIES) {
-    const zones = (new Intl.Locale(`und-${iso2}`) as LocaleWithTimeZones).getTimeZones?.()
-    if (zones?.includes(canonical)) return dialCode
   }
   return undefined
 }
 
 /** Best-effort guess from the browser's timezone; users can always override it in the picker. */
 export function detectCallingCode(): string | undefined {
-  if (typeof Intl === "undefined") return undefined
-  if (typeof (new Intl.Locale("und-ES") as LocaleWithTimeZones).getTimeZones !== "function") return undefined
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
-  if (!timeZone) return undefined
-  return callingCodeForTimeZone(timeZone)
+  try {
+    if (typeof (new Intl.Locale("und-ES") as LocaleWithTimeZones).getTimeZones !== "function") return undefined
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    if (!timeZone) return undefined
+    return callingCodeForTimeZone(timeZone)
+  } catch {
+    return undefined
+  }
 }

--- a/apps/web/src/lib/phone-countries.ts
+++ b/apps/web/src/lib/phone-countries.ts
@@ -328,14 +328,29 @@ export function isStorablePhoneNumber(value: string): boolean {
   return parsed !== undefined && parsed.nationalNumber.length >= MIN_NATIONAL_NUMBER_DIGITS
 }
 
+function couldStillBecomeCallingCode(digits: string): boolean {
+  for (const code of KNOWN_CALLING_CODES) if (code.startsWith(digits)) return true
+  return false
+}
+
 export function phoneNumberError(nationalNumber: string, callingCode: string): string | undefined {
   const digits = nationalNumberDigits(nationalNumber)
   if (digits.length === 0) return undefined
-  if (nationalNumber.includes("+")) return "That international prefix isn't recognised"
+  if (nationalNumber.includes("+")) {
+    return couldStillBecomeCallingCode(digits) ? undefined : "That international prefix isn't recognised"
+  }
   if (!isKnownCallingCode(callingCode)) return "Select your calling code"
   if (digits.length < MIN_NATIONAL_NUMBER_DIGITS) return "Enter a valid phone number"
   if (callingCode.length + digits.length > MAX_E164_DIGITS) return "Enter a valid phone number"
   return undefined
+}
+
+/** Stricter than the on-change check, which tolerates a prefix the next keystroke could complete. */
+export function phoneNumberSubmitError(nationalNumber: string, callingCode: string): string | undefined {
+  if (nationalNumberDigits(nationalNumber).length > 0 && nationalNumber.includes("+")) {
+    return "That international prefix isn't recognised"
+  }
+  return phoneNumberError(nationalNumber, callingCode)
 }
 
 /** Keeps a still-unparseable international prefix intact so further keystrokes can complete it. */

--- a/apps/web/src/lib/phone-countries.ts
+++ b/apps/web/src/lib/phone-countries.ts
@@ -1,0 +1,385 @@
+type PhoneCountry = {
+  readonly iso2: string
+  readonly name: string
+  readonly dialCode: string
+}
+
+// NANP territories all share dial code "1" — their area codes belong to the national number.
+const ENTRIES: ReadonlyArray<readonly [iso2: string, dialCode: string, name: string]> = [
+  ["AF", "93", "Afghanistan"],
+  ["AX", "358", "Åland Islands"],
+  ["AL", "355", "Albania"],
+  ["DZ", "213", "Algeria"],
+  ["AS", "1", "American Samoa"],
+  ["AD", "376", "Andorra"],
+  ["AO", "244", "Angola"],
+  ["AI", "1", "Anguilla"],
+  ["AG", "1", "Antigua & Barbuda"],
+  ["AR", "54", "Argentina"],
+  ["AM", "374", "Armenia"],
+  ["AW", "297", "Aruba"],
+  ["AU", "61", "Australia"],
+  ["AT", "43", "Austria"],
+  ["AZ", "994", "Azerbaijan"],
+  ["BS", "1", "Bahamas"],
+  ["BH", "973", "Bahrain"],
+  ["BD", "880", "Bangladesh"],
+  ["BB", "1", "Barbados"],
+  ["BY", "375", "Belarus"],
+  ["BE", "32", "Belgium"],
+  ["BZ", "501", "Belize"],
+  ["BJ", "229", "Benin"],
+  ["BM", "1", "Bermuda"],
+  ["BT", "975", "Bhutan"],
+  ["BO", "591", "Bolivia"],
+  ["BA", "387", "Bosnia & Herzegovina"],
+  ["BW", "267", "Botswana"],
+  ["BR", "55", "Brazil"],
+  ["IO", "246", "British Indian Ocean Territory"],
+  ["VG", "1", "British Virgin Islands"],
+  ["BN", "673", "Brunei"],
+  ["BG", "359", "Bulgaria"],
+  ["BF", "226", "Burkina Faso"],
+  ["BI", "257", "Burundi"],
+  ["KH", "855", "Cambodia"],
+  ["CM", "237", "Cameroon"],
+  ["CA", "1", "Canada"],
+  ["CV", "238", "Cape Verde"],
+  ["BQ", "599", "Caribbean Netherlands"],
+  ["KY", "1", "Cayman Islands"],
+  ["CF", "236", "Central African Republic"],
+  ["TD", "235", "Chad"],
+  ["CL", "56", "Chile"],
+  ["CN", "86", "China"],
+  ["CX", "61", "Christmas Island"],
+  ["CC", "61", "Cocos (Keeling) Islands"],
+  ["CO", "57", "Colombia"],
+  ["KM", "269", "Comoros"],
+  ["CG", "242", "Congo - Brazzaville"],
+  ["CD", "243", "Congo - Kinshasa"],
+  ["CK", "682", "Cook Islands"],
+  ["CR", "506", "Costa Rica"],
+  ["CI", "225", "Côte d'Ivoire"],
+  ["HR", "385", "Croatia"],
+  ["CU", "53", "Cuba"],
+  ["CW", "599", "Curaçao"],
+  ["CY", "357", "Cyprus"],
+  ["CZ", "420", "Czechia"],
+  ["DK", "45", "Denmark"],
+  ["DJ", "253", "Djibouti"],
+  ["DM", "1", "Dominica"],
+  ["DO", "1", "Dominican Republic"],
+  ["EC", "593", "Ecuador"],
+  ["EG", "20", "Egypt"],
+  ["SV", "503", "El Salvador"],
+  ["GQ", "240", "Equatorial Guinea"],
+  ["ER", "291", "Eritrea"],
+  ["EE", "372", "Estonia"],
+  ["SZ", "268", "Eswatini"],
+  ["ET", "251", "Ethiopia"],
+  ["FK", "500", "Falkland Islands"],
+  ["FO", "298", "Faroe Islands"],
+  ["FJ", "679", "Fiji"],
+  ["FI", "358", "Finland"],
+  ["FR", "33", "France"],
+  ["GF", "594", "French Guiana"],
+  ["PF", "689", "French Polynesia"],
+  ["GA", "241", "Gabon"],
+  ["GM", "220", "Gambia"],
+  ["GE", "995", "Georgia"],
+  ["DE", "49", "Germany"],
+  ["GH", "233", "Ghana"],
+  ["GI", "350", "Gibraltar"],
+  ["GR", "30", "Greece"],
+  ["GL", "299", "Greenland"],
+  ["GD", "1", "Grenada"],
+  ["GP", "590", "Guadeloupe"],
+  ["GU", "1", "Guam"],
+  ["GT", "502", "Guatemala"],
+  ["GG", "44", "Guernsey"],
+  ["GN", "224", "Guinea"],
+  ["GW", "245", "Guinea-Bissau"],
+  ["GY", "592", "Guyana"],
+  ["HT", "509", "Haiti"],
+  ["HN", "504", "Honduras"],
+  ["HK", "852", "Hong Kong SAR China"],
+  ["HU", "36", "Hungary"],
+  ["IS", "354", "Iceland"],
+  ["IN", "91", "India"],
+  ["ID", "62", "Indonesia"],
+  ["IR", "98", "Iran"],
+  ["IQ", "964", "Iraq"],
+  ["IE", "353", "Ireland"],
+  ["IM", "44", "Isle of Man"],
+  ["IL", "972", "Israel"],
+  ["IT", "39", "Italy"],
+  ["JM", "1", "Jamaica"],
+  ["JP", "81", "Japan"],
+  ["JE", "44", "Jersey"],
+  ["JO", "962", "Jordan"],
+  ["KZ", "7", "Kazakhstan"],
+  ["KE", "254", "Kenya"],
+  ["KI", "686", "Kiribati"],
+  ["XK", "383", "Kosovo"],
+  ["KW", "965", "Kuwait"],
+  ["KG", "996", "Kyrgyzstan"],
+  ["LA", "856", "Laos"],
+  ["LV", "371", "Latvia"],
+  ["LB", "961", "Lebanon"],
+  ["LS", "266", "Lesotho"],
+  ["LR", "231", "Liberia"],
+  ["LY", "218", "Libya"],
+  ["LI", "423", "Liechtenstein"],
+  ["LT", "370", "Lithuania"],
+  ["LU", "352", "Luxembourg"],
+  ["MO", "853", "Macao SAR China"],
+  ["MG", "261", "Madagascar"],
+  ["MW", "265", "Malawi"],
+  ["MY", "60", "Malaysia"],
+  ["MV", "960", "Maldives"],
+  ["ML", "223", "Mali"],
+  ["MT", "356", "Malta"],
+  ["MH", "692", "Marshall Islands"],
+  ["MQ", "596", "Martinique"],
+  ["MR", "222", "Mauritania"],
+  ["MU", "230", "Mauritius"],
+  ["YT", "262", "Mayotte"],
+  ["MX", "52", "Mexico"],
+  ["FM", "691", "Micronesia"],
+  ["MD", "373", "Moldova"],
+  ["MC", "377", "Monaco"],
+  ["MN", "976", "Mongolia"],
+  ["ME", "382", "Montenegro"],
+  ["MS", "1", "Montserrat"],
+  ["MA", "212", "Morocco"],
+  ["MZ", "258", "Mozambique"],
+  ["MM", "95", "Myanmar (Burma)"],
+  ["NA", "264", "Namibia"],
+  ["NR", "674", "Nauru"],
+  ["NP", "977", "Nepal"],
+  ["NL", "31", "Netherlands"],
+  ["NC", "687", "New Caledonia"],
+  ["NZ", "64", "New Zealand"],
+  ["NI", "505", "Nicaragua"],
+  ["NE", "227", "Niger"],
+  ["NG", "234", "Nigeria"],
+  ["NU", "683", "Niue"],
+  ["NF", "672", "Norfolk Island"],
+  ["KP", "850", "North Korea"],
+  ["MK", "389", "North Macedonia"],
+  ["MP", "1", "Northern Mariana Islands"],
+  ["NO", "47", "Norway"],
+  ["OM", "968", "Oman"],
+  ["PK", "92", "Pakistan"],
+  ["PW", "680", "Palau"],
+  ["PS", "970", "Palestinian Territories"],
+  ["PA", "507", "Panama"],
+  ["PG", "675", "Papua New Guinea"],
+  ["PY", "595", "Paraguay"],
+  ["PE", "51", "Peru"],
+  ["PH", "63", "Philippines"],
+  ["PL", "48", "Poland"],
+  ["PT", "351", "Portugal"],
+  ["PR", "1", "Puerto Rico"],
+  ["QA", "974", "Qatar"],
+  ["RE", "262", "Réunion"],
+  ["RO", "40", "Romania"],
+  ["RU", "7", "Russia"],
+  ["RW", "250", "Rwanda"],
+  ["WS", "685", "Samoa"],
+  ["SM", "378", "San Marino"],
+  ["ST", "239", "São Tomé & Príncipe"],
+  ["SA", "966", "Saudi Arabia"],
+  ["SN", "221", "Senegal"],
+  ["RS", "381", "Serbia"],
+  ["SC", "248", "Seychelles"],
+  ["SL", "232", "Sierra Leone"],
+  ["SG", "65", "Singapore"],
+  ["SX", "1", "Sint Maarten"],
+  ["SK", "421", "Slovakia"],
+  ["SI", "386", "Slovenia"],
+  ["SB", "677", "Solomon Islands"],
+  ["SO", "252", "Somalia"],
+  ["ZA", "27", "South Africa"],
+  ["KR", "82", "South Korea"],
+  ["SS", "211", "South Sudan"],
+  ["ES", "34", "Spain"],
+  ["LK", "94", "Sri Lanka"],
+  ["BL", "590", "St. Barthélemy"],
+  ["SH", "290", "St. Helena"],
+  ["KN", "1", "St. Kitts & Nevis"],
+  ["LC", "1", "St. Lucia"],
+  ["MF", "590", "St. Martin"],
+  ["PM", "508", "St. Pierre & Miquelon"],
+  ["VC", "1", "St. Vincent & Grenadines"],
+  ["SD", "249", "Sudan"],
+  ["SR", "597", "Suriname"],
+  ["SJ", "47", "Svalbard & Jan Mayen"],
+  ["SE", "46", "Sweden"],
+  ["CH", "41", "Switzerland"],
+  ["SY", "963", "Syria"],
+  ["TW", "886", "Taiwan"],
+  ["TJ", "992", "Tajikistan"],
+  ["TZ", "255", "Tanzania"],
+  ["TH", "66", "Thailand"],
+  ["TL", "670", "Timor-Leste"],
+  ["TG", "228", "Togo"],
+  ["TK", "690", "Tokelau"],
+  ["TO", "676", "Tonga"],
+  ["TT", "1", "Trinidad & Tobago"],
+  ["TN", "216", "Tunisia"],
+  ["TR", "90", "Türkiye"],
+  ["TM", "993", "Turkmenistan"],
+  ["TC", "1", "Turks & Caicos Islands"],
+  ["TV", "688", "Tuvalu"],
+  ["UG", "256", "Uganda"],
+  ["UA", "380", "Ukraine"],
+  ["AE", "971", "United Arab Emirates"],
+  ["GB", "44", "United Kingdom"],
+  ["US", "1", "United States"],
+  ["UY", "598", "Uruguay"],
+  ["UZ", "998", "Uzbekistan"],
+  ["VU", "678", "Vanuatu"],
+  ["VA", "39", "Vatican City"],
+  ["VE", "58", "Venezuela"],
+  ["VN", "84", "Vietnam"],
+  ["WF", "681", "Wallis & Futuna"],
+  ["EH", "212", "Western Sahara"],
+  ["YE", "967", "Yemen"],
+  ["ZM", "260", "Zambia"],
+  ["ZW", "263", "Zimbabwe"],
+]
+
+export const PHONE_COUNTRIES: ReadonlyArray<PhoneCountry> = ENTRIES.map(([iso2, dialCode, name]) => ({
+  iso2,
+  name,
+  dialCode,
+}))
+
+const CALLING_CODE_BY_ISO2 = new Map(PHONE_COUNTRIES.map(({ iso2, dialCode }) => [iso2, dialCode]))
+
+const KNOWN_CALLING_CODES = new Set(PHONE_COUNTRIES.map(({ dialCode }) => dialCode))
+
+const MAX_CALLING_CODE_LENGTH = Math.max(...[...KNOWN_CALLING_CODES].map((code) => code.length))
+
+// Names people search by that no country's official name contains.
+const SEARCH_ALIASES: Readonly<Record<string, string>> = {
+  GB: "UK Great Britain England Scotland Wales",
+  US: "USA America",
+  AE: "UAE",
+  NL: "Holland",
+  CZ: "Czech Republic",
+  TR: "Turkey",
+  CI: "Ivory Coast",
+  SZ: "Swaziland",
+  MK: "Macedonia",
+  RU: "Russian Federation",
+  KR: "Korea",
+  KP: "Korea",
+  VN: "Viet Nam",
+  LA: "Lao",
+  TL: "East Timor",
+}
+
+const MIN_NATIONAL_NUMBER_DIGITS = 4
+const MAX_E164_DIGITS = 15
+
+// Trunk digit dropped when writing a number internationally, where it differs from the usual "0".
+const TRUNK_PREFIX_BY_CALLING_CODE: Readonly<Record<string, string>> = { "7": "8" }
+
+// +39 covers Italy and Vatican City, where a leading 0 is part of the landline number rather than a trunk digit.
+const CALLING_CODES_WITH_SIGNIFICANT_LEADING_ZERO = new Set(["39"])
+
+export function callingCodeForIso2(iso2: string): string | undefined {
+  return CALLING_CODE_BY_ISO2.get(iso2.toUpperCase())
+}
+
+export function isKnownCallingCode(callingCode: string): boolean {
+  return KNOWN_CALLING_CODES.has(callingCode)
+}
+
+export function phoneCountrySearchText({ iso2, name, dialCode }: PhoneCountry): string {
+  return `${name} ${iso2} +${dialCode} ${SEARCH_ALIASES[iso2] ?? ""}`.trimEnd()
+}
+
+const REGIONAL_INDICATOR_OFFSET = 0x1f1e6 - "A".charCodeAt(0)
+
+export function phoneCountryFlag(iso2: string): string {
+  const codePoints = [...iso2.toUpperCase()].map((letter) => letter.charCodeAt(0) + REGIONAL_INDICATOR_OFFSET)
+  return String.fromCodePoint(...codePoints)
+}
+
+function nationalNumberDigits(value: string): string {
+  return value.replace(/\D/g, "")
+}
+
+export function composePhoneNumber(callingCode: string, nationalNumber: string): string {
+  const digits = nationalNumberDigits(nationalNumber)
+  if (digits.length === 0 || !isKnownCallingCode(callingCode)) return ""
+  return `+${callingCode}${digits}`
+}
+
+export function phoneNumberError(nationalNumber: string, callingCode: string): string | undefined {
+  const digits = nationalNumberDigits(nationalNumber)
+  if (digits.length === 0) return undefined
+  if (!isKnownCallingCode(callingCode)) return "Select your calling code"
+  if (digits.length < MIN_NATIONAL_NUMBER_DIGITS) return "Enter a valid phone number"
+  if (callingCode.length + digits.length > MAX_E164_DIGITS) return "Enter a valid phone number"
+  return undefined
+}
+
+/**
+ * Flags a national number still carrying its trunk digit. Advisory only — auto-stripping would
+ * corrupt Italian landlines, where the leading 0 is significant.
+ */
+export function trunkPrefixHint(callingCode: string, nationalNumber: string): string | undefined {
+  const digits = nationalNumberDigits(nationalNumber)
+  if (digits.length < 2 || !isKnownCallingCode(callingCode)) return undefined
+  if (CALLING_CODES_WITH_SIGNIFICANT_LEADING_ZERO.has(callingCode)) return undefined
+  const trunk = TRUNK_PREFIX_BY_CALLING_CODE[callingCode] ?? "0"
+  if (!digits.startsWith(trunk)) return undefined
+  return `Numbers are usually written without the leading ${trunk} internationally. This saves as +${callingCode}${digits}.`
+}
+
+/** Splits a pasted international number so the picker follows the "+" prefix the user typed. */
+export function splitInternationalPhoneNumber(
+  value: string,
+): { readonly callingCode: string; readonly nationalNumber: string } | undefined {
+  const digits = nationalNumberDigits(value)
+  if (digits.length === 0) return undefined
+  for (let length = Math.min(MAX_CALLING_CODE_LENGTH, digits.length); length > 0; length--) {
+    const callingCode = digits.slice(0, length)
+    if (KNOWN_CALLING_CODES.has(callingCode)) return { callingCode, nationalNumber: digits.slice(length) }
+  }
+  return undefined
+}
+
+type LocaleWithTimeZones = Intl.Locale & { getTimeZones?: () => string[] | undefined }
+
+/**
+ * Resolves an IANA zone to its country's calling code by scanning ICU's per-region zone lists.
+ * Both sides come from the same engine's ICU, so legacy zone aliases (Asia/Calcutta vs
+ * Asia/Kolkata) agree once the input is canonicalised through `resolvedOptions`.
+ */
+export function callingCodeForTimeZone(timeZone: string): string | undefined {
+  let canonical: string
+  try {
+    canonical = new Intl.DateTimeFormat("en-US", { timeZone }).resolvedOptions().timeZone
+  } catch {
+    return undefined
+  }
+  for (const { iso2, dialCode } of PHONE_COUNTRIES) {
+    const zones = (new Intl.Locale(`und-${iso2}`) as LocaleWithTimeZones).getTimeZones?.()
+    if (zones?.includes(canonical)) return dialCode
+  }
+  return undefined
+}
+
+/** Best-effort guess from the browser's timezone; users can always override it in the picker. */
+export function detectCallingCode(): string | undefined {
+  if (typeof Intl === "undefined") return undefined
+  if (typeof (new Intl.Locale("und-ES") as LocaleWithTimeZones).getTimeZones !== "function") return undefined
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  if (!timeZone) return undefined
+  return callingCodeForTimeZone(timeZone)
+}

--- a/apps/web/src/lib/phone-countries.ts
+++ b/apps/web/src/lib/phone-countries.ts
@@ -346,10 +346,7 @@ export function sanitizeNationalNumberInput(raw: string): string {
   return trimmed.startsWith("+") ? `+${cleaned}` : cleaned
 }
 
-/**
- * Flags a national number still carrying its trunk digit. Advisory only — auto-stripping would
- * corrupt Italian landlines, where the leading 0 is significant.
- */
+/** Advisory only: auto-stripping would corrupt Italian landlines, where the leading 0 is significant. */
 export function trunkPrefixHint(callingCode: string, nationalNumber: string): string | undefined {
   const digits = nationalNumberDigits(nationalNumber)
   if (digits.length < 2 || !isKnownCallingCode(callingCode)) return undefined
@@ -374,11 +371,7 @@ export function splitInternationalPhoneNumber(
 
 type LocaleWithTimeZones = Intl.Locale & { getTimeZones?: () => string[] | undefined }
 
-/**
- * Resolves an IANA zone to its country's calling code by scanning ICU's per-region zone lists.
- * Both sides come from the same engine's ICU, so legacy zone aliases (Asia/Calcutta vs
- * Asia/Kolkata) agree once the input is canonicalised through `resolvedOptions`.
- */
+/** Canonicalising through `resolvedOptions` makes legacy zone aliases match ICU's own region lists. */
 export function callingCodeForTimeZone(timeZone: string): string | undefined {
   try {
     const canonical = new Intl.DateTimeFormat("en-US", { timeZone }).resolvedOptions().timeZone

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -16,6 +16,7 @@ import { submitOnboarding } from "../../../../../domains/users/user.functions.ts
 import { getQueryClient } from "../../../../../lib/data/query-client.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler } from "../../../../../lib/form-server-action.ts"
+import { composePhoneNumber } from "../../../../../lib/phone-countries.ts"
 import { OnboardingRightPane } from "./onboarding/onboarding-right-pane.tsx"
 import * as FlaggersStep from "./onboarding/steps/flaggers-step.tsx"
 import * as RoleStep from "./onboarding/steps/role-step.tsx"
@@ -25,14 +26,14 @@ import * as TelemetryStep from "./onboarding/steps/telemetry-step.tsx"
 export const ONBOARDING_STEPS = ["role", "flaggers", "slack", "telemetry"] as const
 export type OnboardingStep = (typeof ONBOARDING_STEPS)[number]
 
-type OnboardingFormValues = { jobTitle: string; phoneNumber: string }
+type OnboardingFormValues = { jobTitle: string; phoneCallingCode: string; phoneNumber: string }
 
 // Helper exists purely for type inference — `useForm` has 12 generic parameters and
 // `ReturnType<typeof useForm<T>>` doesn't auto-default the rest. Calling it here in a
 // never-invoked function lets TS infer the full instance type from the actual call shape.
 function _onboardingFormTypeHelper() {
   return useForm({
-    defaultValues: { jobTitle: "", phoneNumber: "" } as OnboardingFormValues,
+    defaultValues: { jobTitle: "", phoneCallingCode: "", phoneNumber: "" } as OnboardingFormValues,
   })
 }
 export type OnboardingForm = ReturnType<typeof _onboardingFormTypeHelper>
@@ -114,12 +115,18 @@ export function OnboardingFlow({
   const form = useForm({
     defaultValues: {
       jobTitle: "",
+      phoneCallingCode: "",
       phoneNumber: "",
     } satisfies OnboardingFormValues,
     onSubmit: createFormSubmitHandler(
-      async ({ jobTitle, phoneNumber }) => {
+      async ({ jobTitle, phoneCallingCode, phoneNumber }) => {
         await submitOnboarding({
-          data: { jobTitle, phoneNumber, stackChoice: "production-agent", projectId },
+          data: {
+            jobTitle,
+            phoneNumber: composePhoneNumber(phoneCallingCode, phoneNumber),
+            stackChoice: "production-agent",
+            projectId,
+          },
         })
       },
       {
@@ -132,9 +139,12 @@ export function OnboardingFlow({
   })
 
   const handleAdvanceFromRole = async () => {
-    await form.validateField("jobTitle", "change")
-    const meta = form.getFieldMeta("jobTitle")
-    if (meta && meta.errors.length > 0) return
+    await Promise.all([form.validateField("jobTitle", "change"), form.validateField("phoneNumber", "change")])
+    const hasErrors = (["jobTitle", "phoneNumber"] as const).some((name) => {
+      const meta = form.getFieldMeta(name)
+      return meta !== undefined && meta.errors.length > 0
+    })
+    if (hasErrors) return
     void form.handleSubmit()
   }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/role-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/role-step.tsx
@@ -1,7 +1,7 @@
 import { Button, Input, Text } from "@repo/ui"
 import { PhoneNumberField } from "../../../../../../../components/phone-number-field.tsx"
 import { fieldErrorsAsStrings } from "../../../../../../../lib/form-server-action.ts"
-import { phoneNumberError } from "../../../../../../../lib/phone-countries.ts"
+import { phoneNumberError, phoneNumberSubmitError } from "../../../../../../../lib/phone-countries.ts"
 import type { OnboardingForm } from "../../onboarding-flow.tsx"
 
 export function Left({
@@ -50,6 +50,7 @@ export function Left({
               name="phoneNumber"
               validators={{
                 onChange: ({ value }) => phoneNumberError(value, form.getFieldValue("phoneCallingCode")),
+                onSubmit: ({ value }) => phoneNumberSubmitError(value, form.getFieldValue("phoneCallingCode")),
               }}
             >
               {(numberField) => (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/role-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/role-step.tsx
@@ -1,5 +1,7 @@
 import { Button, Input, Text } from "@repo/ui"
+import { PhoneNumberField } from "../../../../../../../components/phone-number-field.tsx"
 import { fieldErrorsAsStrings } from "../../../../../../../lib/form-server-action.ts"
+import { phoneNumberError } from "../../../../../../../lib/phone-countries.ts"
 import type { OnboardingForm } from "../../onboarding-flow.tsx"
 
 export function Left({
@@ -42,19 +44,29 @@ export function Left({
             />
           )}
         </form.Field>
-        <form.Field name="phoneNumber">
-          {(field) => (
-            <Input
-              type="tel"
-              label="Phone number (optional)"
-              description="Helpful if we need to reach you about your setup."
-              placeholder="+1 555 0100"
-              value={field.state.value}
-              onChange={(e) => field.handleChange(e.target.value)}
-              errors={fieldErrorsAsStrings(field.state.meta.errors)}
-              maxLength={64}
-              autoComplete="tel"
-            />
+        <form.Field name="phoneCallingCode">
+          {(callingCodeField) => (
+            <form.Field
+              name="phoneNumber"
+              validators={{
+                onChange: ({ value }) => phoneNumberError(value, form.getFieldValue("phoneCallingCode")),
+              }}
+            >
+              {(numberField) => (
+                <PhoneNumberField
+                  label="Phone number (optional)"
+                  description="Helpful if we need to reach you about your setup."
+                  callingCode={callingCodeField.state.value}
+                  nationalNumber={numberField.state.value}
+                  errors={fieldErrorsAsStrings(numberField.state.meta.errors)}
+                  onCallingCodeChange={(callingCode) => {
+                    callingCodeField.handleChange(callingCode)
+                    void form.validateField("phoneNumber", "change")
+                  }}
+                  onNationalNumberChange={(value) => numberField.handleChange(value)}
+                />
+              )}
+            </form.Field>
           )}
         </form.Field>
         <div>

--- a/apps/web/src/routes/claim.$token.tsx
+++ b/apps/web/src/routes/claim.$token.tsx
@@ -21,6 +21,7 @@ import { submitOnboarding } from "../domains/users/user.functions.ts"
 import { getQueryClient } from "../lib/data/query-client.tsx"
 import { toUserMessage } from "../lib/errors.ts"
 import { createFormSubmitHandler } from "../lib/form-server-action.ts"
+import { composePhoneNumber } from "../lib/phone-countries.ts"
 import { OnboardingRightPane } from "./_authenticated/projects/$projectSlug/-components/onboarding/onboarding-right-pane.tsx"
 import * as FlaggersStep from "./_authenticated/projects/$projectSlug/-components/onboarding/steps/flaggers-step.tsx"
 import * as RoleStep from "./_authenticated/projects/$projectSlug/-components/onboarding/steps/role-step.tsx"
@@ -171,7 +172,7 @@ function ClaimPage() {
 }
 
 type ClaimOnboardingStep = "role" | "flaggers" | "slack"
-type OnboardingFormValues = { jobTitle: string; phoneNumber: string }
+type OnboardingFormValues = { jobTitle: string; phoneCallingCode: string; phoneNumber: string }
 
 function ClaimOnboarding({
   project,
@@ -201,11 +202,16 @@ function ClaimOnboarding({
   }
 
   const form = useForm({
-    defaultValues: { jobTitle: "", phoneNumber: "" } satisfies OnboardingFormValues,
+    defaultValues: { jobTitle: "", phoneCallingCode: "", phoneNumber: "" } satisfies OnboardingFormValues,
     onSubmit: createFormSubmitHandler(
-      async ({ jobTitle, phoneNumber }) => {
+      async ({ jobTitle, phoneCallingCode, phoneNumber }) => {
         await submitOnboarding({
-          data: { jobTitle, phoneNumber, stackChoice: "production-agent", projectId: project.id },
+          data: {
+            jobTitle,
+            phoneNumber: composePhoneNumber(phoneCallingCode, phoneNumber),
+            stackChoice: "production-agent",
+            projectId: project.id,
+          },
         })
       },
       {
@@ -218,9 +224,12 @@ function ClaimOnboarding({
   })
 
   const handleAdvanceFromRole = async () => {
-    await form.validateField("jobTitle", "change")
-    const meta = form.getFieldMeta("jobTitle")
-    if (meta && meta.errors.length > 0) return
+    await Promise.all([form.validateField("jobTitle", "change"), form.validateField("phoneNumber", "change")])
+    const hasErrors = (["jobTitle", "phoneNumber"] as const).some((name) => {
+      const meta = form.getFieldMeta(name)
+      return meta !== undefined && meta.errors.length > 0
+    })
+    if (hasErrors) return
     void form.handleSubmit()
   }
 

--- a/apps/web/src/server/unknown-calling-code-report.test.ts
+++ b/apps/web/src/server/unknown-calling-code-report.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { setAttributes, setStatus, end, startSpan, recordSpanExceptionForDatadog, loggerError } = vi.hoisted(() => {
+  const setAttributes = vi.fn()
+  const recordException = vi.fn()
+  const setStatus = vi.fn()
+  const end = vi.fn()
+  return {
+    setAttributes,
+    setStatus,
+    end,
+    startSpan: vi.fn(() => ({ setAttributes, recordException, setStatus, end })),
+    recordSpanExceptionForDatadog: vi.fn(),
+    loggerError: vi.fn(),
+  }
+})
+
+vi.mock("@repo/observability", () => ({
+  createLogger: () => ({ error: loggerError }),
+  trace: { getTracer: () => ({ startSpan }) },
+  recordSpanExceptionForDatadog,
+  SpanStatusCode: { ERROR: 2 },
+}))
+
+const { reportUnknownCallingCode, resetUnknownCallingCodeThrottle, MAX_TRACKED_PREFIXES } = await import(
+  "./unknown-calling-code-report.ts"
+)
+
+const attributesOf = (call: number) => setAttributes.mock.calls[call]?.[0] as Record<string, unknown>
+
+describe("reportUnknownCallingCode", () => {
+  beforeEach(() => {
+    resetUnknownCallingCodeThrottle()
+    vi.clearAllMocks()
+  })
+
+  it("records an error span carrying the prefix and length", () => {
+    reportUnknownCallingCode("+99912345678")
+
+    expect(startSpan).toHaveBeenCalledWith("phone.unknown_calling_code")
+    expect(attributesOf(0)).toEqual({ "phone.candidate_prefix": "999", "phone.digit_count": 11 })
+    expect(recordSpanExceptionForDatadog).toHaveBeenCalledOnce()
+    expect(setStatus).toHaveBeenCalledWith({ code: 2, message: expect.stringContaining("no known calling code") })
+    expect(end).toHaveBeenCalledOnce()
+  })
+
+  it("groups every occurrence under one issue by keeping the message constant", () => {
+    reportUnknownCallingCode("+99912345678")
+    resetUnknownCallingCodeThrottle()
+    reportUnknownCallingCode("+99887654321")
+
+    const [firstError] = recordSpanExceptionForDatadog.mock.calls[0]?.slice(1) as [Error]
+    const [secondError] = recordSpanExceptionForDatadog.mock.calls[1]?.slice(1) as [Error]
+    expect(firstError.name).toBe("UnknownCallingCodeError")
+    expect(secondError.name).toBe("UnknownCallingCodeError")
+    expect(firstError.message).toBe(secondError.message)
+  })
+
+  it("never sends the phone number itself", () => {
+    const phoneNumber = "+99912345678"
+    reportUnknownCallingCode(phoneNumber)
+
+    const serialized = JSON.stringify([
+      setAttributes.mock.calls,
+      loggerError.mock.calls,
+      recordSpanExceptionForDatadog.mock.calls.map(([, error]) => (error as Error).message),
+    ])
+    expect(serialized).not.toContain("12345678")
+    expect(serialized).not.toContain(phoneNumber)
+  })
+
+  it("reports a prefix once per window, however often it is submitted", () => {
+    for (let attempt = 0; attempt < 5; attempt++) reportUnknownCallingCode("+99912345678")
+
+    expect(startSpan).toHaveBeenCalledOnce()
+  })
+
+  it("throttles per prefix, so a different prefix still reports", () => {
+    reportUnknownCallingCode("+99912345678")
+    reportUnknownCallingCode("+99812345678")
+
+    expect(startSpan).toHaveBeenCalledTimes(2)
+  })
+
+  it("bounds the throttle map so unbounded prefixes cannot leak memory", () => {
+    for (let index = 0; index < MAX_TRACKED_PREFIXES + 50; index++) {
+      reportUnknownCallingCode(`+${String(index).padStart(3, "0")}12345678`)
+    }
+
+    // Re-reporting the most recent prefix must still be throttled, proving eviction kept live claims.
+    const calls = startSpan.mock.calls.length
+    reportUnknownCallingCode(`+${String(MAX_TRACKED_PREFIXES + 49).padStart(3, "0")}12345678`)
+    expect(startSpan).toHaveBeenCalledTimes(calls)
+  })
+
+  it("ignores a value with no digits at all", () => {
+    reportUnknownCallingCode("+")
+
+    expect(startSpan).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/server/unknown-calling-code-report.ts
+++ b/apps/web/src/server/unknown-calling-code-report.ts
@@ -1,0 +1,86 @@
+import { createLogger, recordSpanExceptionForDatadog, SpanStatusCode, trace } from "@repo/observability"
+
+const logger = createLogger("unknown-calling-code")
+const tracer = trace.getTracer("unknown-calling-code")
+
+/**
+ * Datadog fingerprints Error Tracking issues on error type and stack, so this is thrown from one
+ * site with a constant message to keep every occurrence in a single issue. The prefix and length
+ * ride on span attributes instead — putting them in the message would split the issue per prefix
+ * and bury a genuinely new country code under bot noise.
+ */
+class UnknownCallingCodeError extends Error {
+  constructor() {
+    super("Phone number rejected because no known calling code matched its prefix")
+    this.name = "UnknownCallingCodeError"
+  }
+}
+
+const REPORT_INTERVAL_MS = 60 * 60 * 1000
+
+/**
+ * Emission is driven by whatever users and bots submit, so one bad prefix hammered repeatedly
+ * would otherwise report forever. One report per hour per prefix carries the same information.
+ */
+export const MAX_TRACKED_PREFIXES = 200
+
+/** Insertion order is kept as least-recently-reported first, so the first key is the eviction target. */
+const lastReportedAt = new Map<string, number>()
+
+function evictToMakeRoom(now: number): void {
+  if (lastReportedAt.size < MAX_TRACKED_PREFIXES) return
+
+  for (const [tracked, at] of lastReportedAt) {
+    if (now - at >= REPORT_INTERVAL_MS) lastReportedAt.delete(tracked)
+  }
+  // Still full of live claims: drop only the oldest. Clearing the whole map here would lift the
+  // throttle off every prefix at once, so a flood of new prefixes could re-open the ones it displaced.
+  if (lastReportedAt.size >= MAX_TRACKED_PREFIXES) {
+    const oldest = lastReportedAt.keys().next().value
+    if (oldest !== undefined) lastReportedAt.delete(oldest)
+  }
+}
+
+function claimReportSlot(key: string, now: number): boolean {
+  const previous = lastReportedAt.get(key)
+  if (previous !== undefined && now - previous < REPORT_INTERVAL_MS) return false
+
+  evictToMakeRoom(now)
+  lastReportedAt.delete(key)
+  lastReportedAt.set(key, now)
+  return true
+}
+
+const CANDIDATE_PREFIX_LENGTH = 3
+
+/**
+ * Only the leading digits and the total length are reported. The number itself is a user's personal
+ * phone number, so it must not reach Datadog; three digits plus a length identify nobody while still
+ * showing a newly assigned country code as a repeating prefix at a plausible length.
+ */
+export function reportUnknownCallingCode(phoneNumber: string): void {
+  const digits = phoneNumber.replace(/\D/g, "")
+  const candidatePrefix = digits.slice(0, CANDIDATE_PREFIX_LENGTH)
+  if (candidatePrefix.length === 0) return
+  if (!claimReportSlot(candidatePrefix, Date.now())) return
+
+  logger.error("Phone number rejected because no known calling code matched its prefix", {
+    candidatePrefix,
+    digitCount: digits.length,
+  })
+
+  const span = tracer.startSpan("phone.unknown_calling_code")
+  span.setAttributes({
+    "phone.candidate_prefix": candidatePrefix,
+    "phone.digit_count": digits.length,
+  })
+  const error = new UnknownCallingCodeError()
+  recordSpanExceptionForDatadog(span, error)
+  span.setStatus({ code: SpanStatusCode.ERROR, message: error.message })
+  span.end()
+}
+
+/** Exported for tests: the throttle is process-wide state that would otherwise leak across cases. */
+export function resetUnknownCallingCodeThrottle(): void {
+  lastReportedAt.clear()
+}

--- a/apps/web/src/server/unknown-calling-code-report.ts
+++ b/apps/web/src/server/unknown-calling-code-report.ts
@@ -3,12 +3,7 @@ import { createLogger, recordSpanExceptionForDatadog, SpanStatusCode, trace } fr
 const logger = createLogger("unknown-calling-code")
 const tracer = trace.getTracer("unknown-calling-code")
 
-/**
- * Datadog fingerprints Error Tracking issues on error type and stack, so this is thrown from one
- * site with a constant message to keep every occurrence in a single issue. The prefix and length
- * ride on span attributes instead — putting them in the message would split the issue per prefix
- * and bury a genuinely new country code under bot noise.
- */
+// The message must stay constant: Datadog fingerprints Error Tracking issues on error type and stack.
 class UnknownCallingCodeError extends Error {
   constructor() {
     super("Phone number rejected because no known calling code matched its prefix")
@@ -18,10 +13,6 @@ class UnknownCallingCodeError extends Error {
 
 const REPORT_INTERVAL_MS = 60 * 60 * 1000
 
-/**
- * Emission is driven by whatever users and bots submit, so one bad prefix hammered repeatedly
- * would otherwise report forever. One report per hour per prefix carries the same information.
- */
 export const MAX_TRACKED_PREFIXES = 200
 
 /** Insertion order is kept as least-recently-reported first, so the first key is the eviction target. */
@@ -33,8 +24,7 @@ function evictToMakeRoom(now: number): void {
   for (const [tracked, at] of lastReportedAt) {
     if (now - at >= REPORT_INTERVAL_MS) lastReportedAt.delete(tracked)
   }
-  // Still full of live claims: drop only the oldest. Clearing the whole map here would lift the
-  // throttle off every prefix at once, so a flood of new prefixes could re-open the ones it displaced.
+  // Drop only the oldest: clearing the map would lift the throttle off every prefix at once.
   if (lastReportedAt.size >= MAX_TRACKED_PREFIXES) {
     const oldest = lastReportedAt.keys().next().value
     if (oldest !== undefined) lastReportedAt.delete(oldest)
@@ -53,11 +43,7 @@ function claimReportSlot(key: string, now: number): boolean {
 
 const CANDIDATE_PREFIX_LENGTH = 3
 
-/**
- * Only the leading digits and the total length are reported. The number itself is a user's personal
- * phone number, so it must not reach Datadog; three digits plus a length identify nobody while still
- * showing a newly assigned country code as a repeating prefix at a plausible length.
- */
+/** Reports only the leading digits and total length: the number itself must never reach Datadog. */
 export function reportUnknownCallingCode(phoneNumber: string): void {
   const digits = phoneNumber.replace(/\D/g, "")
   const candidatePrefix = digits.slice(0, CANDIDATE_PREFIX_LENGTH)

--- a/dev-docs/users.md
+++ b/dev-docs/users.md
@@ -30,7 +30,7 @@ The E.164 dial prefix a user selects during onboarding, stored as bare digits (`
 _Avoid_: country code, dial code, area code, IDD prefix
 
 **National number**:
-The subscriber portion a user types after the calling code, excluding any trunk digit.
+The subscriber portion typed after the calling code. E.164 excludes the trunk digit, which the field flags rather than enforces.
 _Avoid_: local number, subscriber number
 
 **Phone number**:
@@ -38,7 +38,7 @@ The composed value persisted on the user: a calling code and national number as 
 _Avoid_: telephone, contact number, mobile
 
 **Trunk digit**:
-The leading digit (usually `0`, `8` on `+7`) written domestically and dropped internationally.
+The leading digit (usually `0`, `8` on `+7`) written domestically and omitted in E.164.
 _Avoid_: trunk code, national prefix, leading zero
 
 ## Phone number
@@ -60,7 +60,7 @@ The default comes from the browser's IANA timezone, resolved by scanning ICU's p
 
 ### What the server guarantees
 
-The write path enforces that a stored number carries a calling code and is digits-only within E.164 length (`+`, then 5 to 15 digits). It does **not** claim the number is dialable, since `+12345` passes.
+The write path enforces that a stored number starts with a calling code that exists in the country table and is digits-only within E.164 length (`+`, then 5 to 15 digits). It does **not** claim the number is dialable, since `+12345` passes. Checking the prefix against the table rather than a bare `\d` pattern means an unassigned prefix such as `+99999999` is rejected, at the cost of the table having to stay current if a new country code is assigned.
 
 This is deliberately looser than the `phone` PII detector's 8-digit floor ([`../specs/pii-redaction.md`](../specs/pii-redaction.md)). The two have opposite risk profiles: a detector scanning free trace text must not fire on incidental digit runs, whereas a signup validator must not reject a real number. An 8-digit floor would reject genuine 7-digit numbers from `+290`, `+683` and `+690`.
 

--- a/dev-docs/users.md
+++ b/dev-docs/users.md
@@ -60,7 +60,13 @@ The default comes from the browser's IANA timezone, resolved by scanning ICU's p
 
 ### What the server guarantees
 
-The write path enforces that a stored number starts with a calling code that exists in the country table and is digits-only within E.164 length (`+`, then 5 to 15 digits). It does **not** claim the number is dialable, since `+12345` passes. Checking the prefix against the table rather than a bare `\d` pattern means an unassigned prefix such as `+99999999` is rejected, at the cost of the table having to stay current if a new country code is assigned.
+The write path enforces that a stored number starts with a calling code that exists in the country table and is digits-only within E.164 length (`+`, then 5 to 15 digits). It does **not** claim the number is dialable, since `+12345` passes. Checking the prefix against the table rather than a bare `\d` pattern means an unassigned prefix such as `+99999999` is rejected.
+
+The two checks are split deliberately. The Zod validator checks only the shape, so obvious junk is rejected at the boundary; the handler does the table lookup, because that path reports to Datadog and server-only imports belong in the handler rather than the validator.
+
+Since the table can go stale, every rejection emits a Datadog Error Tracking issue (`UnknownCallingCodeError`) on its own `phone.unknown_calling_code` span, following the same shape as the unpriced-spans reporter: a constant message so all occurrences group into one issue, and the varying data on span attributes. A country code assigned after the table was last updated therefore shows up as a repeating `phone.candidate_prefix` at a plausible `phone.digit_count`, rather than failing silently.
+
+**Only the leading three digits and the total digit count are reported.** The rejected value is a personal phone number and must never reach Datadog. Reports are throttled to one per prefix per hour, over an LRU-bounded map, because submissions are driven by whatever users and bots send.
 
 This is deliberately looser than the `phone` PII detector's 8-digit floor ([`../specs/pii-redaction.md`](../specs/pii-redaction.md)). The two have opposite risk profiles: a detector scanning free trace text must not fire on incidental digit runs, whereas a signup validator must not reject a real number. An 8-digit floor would reject genuine 7-digit numbers from `+290`, `+683` and `+690`.
 

--- a/dev-docs/users.md
+++ b/dev-docs/users.md
@@ -22,3 +22,53 @@ Keeping reliability user settings small avoids:
 2. shared operational behavior depending on who is signed in
 
 User scope should shape personal UX, not shared operational policy.
+
+## Language
+
+**Calling code**:
+The E.164 dial prefix a user selects during onboarding, stored as bare digits (`34`, `1`).
+_Avoid_: country code, dial code, area code, IDD prefix
+
+**National number**:
+The subscriber portion a user types after the calling code, excluding any trunk digit.
+_Avoid_: local number, subscriber number
+
+**Phone number**:
+The composed value persisted on the user: a calling code and national number as one `+`-prefixed string.
+_Avoid_: telephone, contact number, mobile
+
+**Trunk digit**:
+The leading digit (usually `0`, `8` on `+7`) written domestically and dropped internationally.
+_Avoid_: trunk code, national prefix, leading zero
+
+## Phone number
+
+`users.phone_number` is a nullable free-text column holding a single composed value. Onboarding is the only write path; the value feeds the backoffice user detail view and the Loops marketing contact, whose purpose is a human sales or support dial.
+
+Onboarding collects the calling code and the national number as two inputs and composes them on submit. **The country is deliberately not part of the model**: not a column, not a form value, not derived at read time. Users pick from a country-labelled list purely as a finding affordance; the selection collapses to a calling code the moment it is made.
+
+That choice is irreversible for stored data and should not be "fixed" by adding a country column later. Roughly fifty countries share `+1` and four share `+44`, so no column added after the fact can recover which country a past user chose. Adding one would only describe users onboarded after the change, leaving a permanently mixed dataset.
+
+Two consequences follow and are intentional:
+
+- The picker's trigger shows a bare `+44`, never a flag. After the collapse, no single country is determinable, so any flag would be a guess. Flags appear only on list rows, where each row genuinely is one country.
+- Per-country validation is impossible, which is why no phone-parsing library is a dependency. There is nothing for one to validate against.
+
+### Default calling code
+
+The default comes from the browser's IANA timezone, resolved by scanning ICU's per-region zone lists for the current zone. Timezone is used rather than the browser locale because locale carries *language*, not location: every English-language browser maximizes to region `US`, so a Spanish developer running an English OS would silently default to `+1`. Renamed IANA zones are handled by canonicalising the input through `Intl.DateTimeFormat`, so both sides of the comparison come from the same engine's ICU and agree. Detection is feature-detected and falls back to no default.
+
+### What the server guarantees
+
+The write path enforces that a stored number carries a calling code and is digits-only within E.164 length (`+`, then 5 to 15 digits). It does **not** claim the number is dialable, since `+12345` passes.
+
+This is deliberately looser than the `phone` PII detector's 8-digit floor ([`../specs/pii-redaction.md`](../specs/pii-redaction.md)). The two have opposite risk profiles: a detector scanning free trace text must not fire on incidental digit runs, whereas a signup validator must not reject a real number. An 8-digit floor would reject genuine 7-digit numbers from `+290`, `+683` and `+690`.
+
+### Trunk digits are flagged, never stripped
+
+A national number still carrying its trunk digit is surfaced as a non-blocking hint showing what would be stored; the user decides. Auto-stripping is wrong because the leading `0` is significant on Italian landlines (`+39 06 …` is Rome), and a zero-only rule would miss `+7`, where the trunk digit is `8`.
+
+### Known gaps
+
+- The value is write-once. Account settings expose name only, so a user cannot correct a mistyped number, and the backoffice has no edit affordance. Making it editable additionally requires a marketing re-sync, since the Loops contact updates only on `UserOnboardingCompleted`.
+- Rows written before calling codes were collected hold bare national digits. They cannot be backfilled, because a calling code is not inferable from `612345678` without the country, which was never recorded. The leading `+` is the marker distinguishing a dialable value.

--- a/packages/ui/src/components/select/index.tsx
+++ b/packages/ui/src/components/select/index.tsx
@@ -25,6 +25,8 @@ export type SelectOption<V = unknown> = {
   value: V
   icon?: ReactNode
   disabled?: boolean
+  /** Text a searchable Select filters on instead of `label`, for aliases the label doesn't spell out. */
+  searchText?: string
 }
 
 export type SelectOptionGroup<V = unknown> = {

--- a/packages/ui/src/components/select/searchable-list.tsx
+++ b/packages/ui/src/components/select/searchable-list.tsx
@@ -19,6 +19,7 @@ interface SearchableOption<V = unknown> {
   value: V
   icon?: ReactNode
   disabled?: boolean
+  searchText?: string
 }
 
 interface SearchableSelectListProps<V = unknown> {
@@ -79,7 +80,7 @@ export function SearchableSelectList<V = unknown>({
   const filtered = useMemo(() => {
     if (searchMode === "server" || !search) return options
     const lower = search.toLowerCase()
-    return options.filter((o) => o.label.toLowerCase().includes(lower))
+    return options.filter((o) => (o.searchText ?? o.label).toLowerCase().includes(lower))
   }, [options, search, searchMode])
 
   const handleOptionsScroll = (event: UIEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## What does this PR do?

<img width="726" height="670" alt="image" src="https://github.com/user-attachments/assets/46f9f4e3-f992-4c63-bac3-1b95ae066800" />

Onboarding asked for a phone number as one free-text field, so numbers arrived without a country prefix and undialable. It now asks for the calling code alongside the number and stores a single `+`-prefixed value.


- **Searchable picker.** Rows show `🇩🇪 Germany +49`; search matches the country
  name, its ISO code, aliases the name lacks (`UK`, `USA`, `Holland`), or the
  code itself.
- **Default from browser timezone**, not locale. Locale carries language, not
  location: `Intl.Locale("en").maximize().region` is `US`, so any
  English-language browser would have defaulted to +1 regardless of country.
  Feature-detected, blank fallback.
- **Pasting `+441234…`** switches the picker and strips the prefix.
- **Trunk digits are flagged, never stripped.** `+44` with `07700 900000` warns
  and shows what would be saved. Auto-stripping would corrupt Italian landlines
  (`+39 06 …` is Rome) and miss `+7`, where the trunk digit is `8`.
- **Server** now requires a calling code on write: `+`, then 5–15 digits.
  Deliberately looser than the PII detector's 8-digit floor, which would reject
  real 7-digit numbers from `+290`/`+683`/`+690`.

### The country is not stored

The picker collapses to a calling code on selection. No country column, no flag
on the trigger, no phone-parsing dependency. ~50 countries share `+1`, so a
column added later could never recover which country past users picked — see
[`dev-docs/users.md`](dev-docs/users.md).

### Also

- `SelectOption` in `@repo/ui` gained optional `searchText`. Without it, typing
  `US` matched nothing, since `"United States"` contains no substring `"us"`.
- Both onboarding entry points (`onboarding-flow.tsx`, `claim.$token.tsx`) now
  block Next on phone errors, not just job title.

### Known gaps

- Write-once. Account settings expose name only, so a mistyped number can't be
  corrected. Making it editable also needs a Loops re-sync, which currently
  fires only on `UserOnboardingCompleted`.
- Pre-existing rows hold bare national digits and can't be backfilled — the
  calling code isn't inferable without a country that was never recorded.

### Testing

`@app/web` 746 tests and `@repo/ui` 201 tests pass; verified under `TZ=UTC` as
well, since timezone detection is now on the path. Both packages typecheck,
Biome clean.



## Related issue (if applicable)

<!-- If this PR resolves an issue, link it so it auto-closes on merge, e.g. Closes #123 -->

Closes #

## How was this tested?

UT and manual testing

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a phone-number experience with searchable calling-code selection, timezone-based default detection, paste parsing for international prefixes (including incomplete “+” cases), and trunk-digit hints.
  * Onboarding now collects calling code and national number separately, composes the stored E.164-style value on submit, and rejects unknown calling codes.
* **Documentation**
  * Expanded developer docs describing calling-code/national-number interpretation, validation, trunk-digit behavior, and known limitations.
* **UI Improvements**
  * Improved searchable select filtering to use optional per-option search text (not just the visible label).
* **Tests**
  * Added comprehensive unit tests for phone-country utilities, phone-number field behavior, and unknown-calling-code reporting/throttling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->