### PR TITLE
fix: stop org selector from hiding other orgs after a switch

### DIFF
--- a/apps/web/src/routes/_authenticated/-components/nav-header.tsx
+++ b/apps/web/src/routes/_authenticated/-components/nav-header.tsx
@@ -105,6 +105,9 @@ export function NavHeader() {
         <Combobox
           autoHighlight
           modal
+          // No ComboboxInput here, so base-ui's internal query state goes stale after a selection and
+          // silently filters out other orgs on reopen; filter={null} disables that filtering entirely.
+          filter={null}
           value={selectedOrgOption}
           onValueChange={(picked: OrgOption | null) => {
             if (!picked) return


### PR DESCRIPTION
base-ui's Combobox keeps an internal query used to filter items, but the nav-header org switcher has no ComboboxInput to display or clear it. Once a different org is picked, that stale query persists and silently filters the list down to a single org the next time it's reopened. filter={null} disables that filtering, which this select-style trigger never needed anyway.

## What does this PR do?

<!-- Briefly describe the change for a reviewer with no prior context. -->

## Related issue (if applicable)

<!-- If this PR resolves an issue, link it so it auto-closes on merge, e.g. Closes #123 -->

Closes #

## How was this tested?

<!-- Describe the tests you ran or the steps to verify the change. -->

## Checklist

- [ ] Lint, type-checking, and tests pass locally
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the organization selector so previously hidden organizations appear correctly when reopening the menu.
  * Improved organization switching reliability after making a selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->