### PR TITLE
feat(web): add MCP + per-integration command palette entries

### DIFF
--- a/apps/web/src/components/command-palette/commands/use-global-commands.tsx
+++ b/apps/web/src/components/command-palette/commands/use-global-commands.tsx
@@ -26,9 +26,10 @@ import type { PaletteCommand } from "../types.ts"
 const DOCS_URL = "https://docs.latitude.so"
 
 /**
- * Always-available global actions: theme toggle, create project/organization (open modals
- * owned by the provider), switch organization (a drill-down sub-page), docs, log out, and
- * backoffice (admins only). Mirrors the handlers already wired into the app header.
+ * Always-available global actions, independent of the current route: organization switching
+ * (a drill-down sub-page), theme, the create modals owned by the provider, links out to the
+ * docs, and account actions. Ordering convention: switch/navigate before create, Log out last;
+ * admin-only actions are gated on the user role.
  */
 export function useGlobalCommands(): readonly PaletteCommand[] {
   const router = useRouter()

--- a/apps/web/src/components/command-palette/commands/use-global-commands.tsx
+++ b/apps/web/src/components/command-palette/commands/use-global-commands.tsx
@@ -8,6 +8,7 @@ import {
   LinkIcon,
   LogOutIcon,
   MoonIcon,
+  PlugIcon,
   PlusIcon,
   ShieldAlertIcon,
   SunIcon,
@@ -123,6 +124,16 @@ export function useGlobalCommands(): readonly PaletteCommand[] {
         keywords: "docs help guide",
         perform: () => {
           window.open(DOCS_URL, "_blank", "noopener,noreferrer")
+        },
+      },
+      {
+        id: "action:mcp-docs",
+        title: "Connect via MCP",
+        icon: PlugIcon,
+        section: "actions",
+        keywords: "mcp model context protocol integrations add connect docs claude code cursor zed",
+        perform: () => {
+          window.open(`${DOCS_URL}/getting-started/mcp`, "_blank", "noopener,noreferrer")
         },
       },
     )

--- a/apps/web/src/components/command-palette/commands/use-navigation-commands.ts
+++ b/apps/web/src/components/command-palette/commands/use-navigation-commands.ts
@@ -1,5 +1,11 @@
+import { GithubIcon, SlackIcon } from "@repo/ui"
 import { useNavigate, useParams } from "@tanstack/react-router"
 import { useMemo } from "react"
+import {
+  AGENT_DISPATCH_KIND_ICONS,
+  AGENT_DISPATCH_KIND_LABELS,
+  type AgentDispatchKindKey,
+} from "../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
 import { useIsReadOnlyProjectScope } from "../../../domains/projects/project-scope.tsx"
 import {
   PROJECT_SETTINGS_SECTION,
@@ -8,11 +14,25 @@ import {
 } from "../../../domains/projects/project-sections.ts"
 import type { PaletteCommand } from "../types.ts"
 
+/** Integrations that live as sections on the Integrations page rather than their own route. */
+const INTEGRATION_PAGE_SECTIONS = [
+  { key: "slack", label: "Slack", icon: SlackIcon, keywords: "notifications channel workspace connect" },
+  { key: "github", label: "GitHub", icon: GithubIcon, keywords: "repository repo pull request connect" },
+] as const
+
+const AGENT_DISPATCH_KEYWORDS: Record<AgentDispatchKindKey, string> = {
+  cursor: "agent dispatch fix code connect",
+  claude_code: "agent dispatch claude fix code connect",
+  linear: "agent dispatch issue ticket connect",
+  webhook: "agent dispatch endpoint http connect",
+}
+
 /**
  * Navigation commands for the project the user is currently inside: top-level sections
- * (Search, Traces, Signals, …), the Settings entry, and every settings subsection. Returns
- * an empty list when not inside a project. Sourced from the shared `project-sections`
- * module so it never drifts from the sidebar.
+ * (Search, Traces, Signals, …), the Settings entry, every settings subsection, and each
+ * integration on the Integrations page. Returns an empty list when not inside a project.
+ * Sections and settings pages are sourced from the shared `project-sections` module, and
+ * agent-dispatch integrations from `agent-dispatch-kinds`, so neither drifts from the UI.
  */
 export function useNavigationCommands(): readonly PaletteCommand[] {
   const { projectSlug } = useParams({ strict: false })
@@ -58,6 +78,30 @@ export function useNavigationCommands(): readonly PaletteCommand[] {
             perform: () => navigate({ to: item.path(projectSlug) }),
           })
         }
+      }
+
+      for (const integration of INTEGRATION_PAGE_SECTIONS) {
+        commands.push({
+          id: `nav:integration:${integration.key}`,
+          title: integration.label,
+          subtitle: "Settings → Integrations",
+          icon: integration.icon,
+          section: "navigation",
+          keywords: integration.keywords,
+          perform: () => navigate({ to: `/projects/${projectSlug}/settings/integrations` }),
+        })
+      }
+
+      for (const [kind, label] of Object.entries(AGENT_DISPATCH_KIND_LABELS) as [AgentDispatchKindKey, string][]) {
+        commands.push({
+          id: `nav:integration:${kind}`,
+          title: label,
+          subtitle: "Settings → Integrations",
+          icon: AGENT_DISPATCH_KIND_ICONS[kind],
+          section: "navigation",
+          keywords: AGENT_DISPATCH_KEYWORDS[kind],
+          perform: () => navigate({ to: `/projects/${projectSlug}/settings/integrations/${kind}` }),
+        })
       }
     }
 

--- a/apps/web/src/components/command-palette/types.ts
+++ b/apps/web/src/components/command-palette/types.ts
@@ -1,5 +1,5 @@
-import type { LucideIcon } from "lucide-react"
-import type { ReactNode } from "react"
+import type { LucideProps } from "lucide-react"
+import type { ComponentType, ReactNode } from "react"
 
 /**
  * Groups commands into ordered, labelled sections. `context` commands are contributed by
@@ -17,7 +17,8 @@ interface BasePaletteCommand {
    * — it remains the value used by the text matcher and any plain-text contexts.
    */
   readonly titleNode?: ReactNode
-  readonly icon: LucideIcon
+  /** Matches `@repo/ui`'s `Icon` prop so brand marks (Slack, Linear, …) work, not just lucide icons. */
+  readonly icon: ComponentType<LucideProps>
   readonly section: CommandSection
   /** Sub-heading for contextual commands (e.g. "Signal", "Trace"). */
   readonly group?: string

--- a/apps/web/src/domains/agent-dispatch/agent-dispatch-kinds.ts
+++ b/apps/web/src/domains/agent-dispatch/agent-dispatch-kinds.ts
@@ -1,0 +1,18 @@
+import { ClaudeCodeIcon, CursorIcon, LinearIcon } from "@repo/ui"
+import { Webhook } from "lucide-react"
+
+export const AGENT_DISPATCH_KIND_LABELS = {
+  cursor: "Cursor",
+  claude_code: "Claude Code",
+  linear: "Linear",
+  webhook: "Webhook",
+} as const
+
+export type AgentDispatchKindKey = keyof typeof AGENT_DISPATCH_KIND_LABELS
+
+export const AGENT_DISPATCH_KIND_ICONS = {
+  cursor: CursorIcon,
+  claude_code: ClaudeCodeIcon,
+  linear: LinearIcon,
+  webhook: Webhook,
+} as const

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
@@ -7,11 +7,9 @@ import {
   Badge,
   Button,
   Checkbox,
-  ClaudeCodeIcon,
   CloseTrigger,
   CopyableText,
   CopyButton,
-  CursorIcon,
   Icon,
   InfiniteTable,
   type InfiniteTableColumn,
@@ -27,7 +25,7 @@ import { relativeTime } from "@repo/utils"
 import { useForm } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
-import { BookOpen, Copy, ExternalLink, FileText, type LucideProps, Plus, Settings, Webhook } from "lucide-react"
+import { BookOpen, Copy, ExternalLink, FileText, Plus, Settings } from "lucide-react"
 import { type ReactNode, useState } from "react"
 import { z } from "zod"
 import {
@@ -51,6 +49,11 @@ import {
   sendToDestinationsQueryKey,
   upsertOrgDefaultDispatchConfig,
 } from "../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
+import {
+  AGENT_DISPATCH_KIND_ICONS,
+  AGENT_DISPATCH_KIND_LABELS,
+  type AgentDispatchKindKey,
+} from "../../../../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../../lib/form-server-action.ts"
 import { useDebounce } from "../../../../../../lib/hooks/useDebounce.ts"
@@ -69,15 +72,6 @@ export interface DispatchConfigFormValues {
   readonly target: StoredAgentDispatchTarget
   readonly guardrails: { readonly maxDispatchesPerDay: number; readonly cooldownMinutes: number }
 }
-
-export const AGENT_DISPATCH_KIND_LABELS = {
-  cursor: "Cursor",
-  claude_code: "Claude Code",
-  linear: "Linear",
-  webhook: "Webhook",
-} as const
-
-export type AgentDispatchKindKey = keyof typeof AGENT_DISPATCH_KIND_LABELS
 
 const KIND_LABELS = AGENT_DISPATCH_KIND_LABELS
 
@@ -201,25 +195,6 @@ const TRIGGER_LABELS: Record<(typeof ACTIVE_DISPATCH_TRIGGERS)[number], { title:
 function isActiveDispatchTrigger(trigger: string): trigger is (typeof ACTIVE_DISPATCH_TRIGGERS)[number] {
   return ACTIVE_DISPATCH_TRIGGERS.some((activeTrigger) => activeTrigger === trigger)
 }
-
-function LinearIcon(props: LucideProps) {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" {...props}>
-      <circle cx="12" cy="12" r="10" fill="currentColor" />
-      <path d="M5.8 14.6L14.6 5.8" stroke="white" strokeLinecap="round" strokeWidth="2" />
-      <path d="M8.8 17.2L17.2 8.8" stroke="white" strokeLinecap="round" strokeWidth="2" />
-      <path d="M5.6 10.8L10.8 5.6" stroke="white" strokeLinecap="round" strokeWidth="2" />
-      <path d="M13.2 18.4L18.4 13.2" stroke="white" strokeLinecap="round" strokeWidth="2" />
-    </svg>
-  )
-}
-
-export const AGENT_DISPATCH_KIND_ICONS = {
-  cursor: CursorIcon,
-  claude_code: ClaudeCodeIcon,
-  linear: LinearIcon,
-  webhook: Webhook,
-} as const
 
 const INTEGRATION_ICONS = AGENT_DISPATCH_KIND_ICONS
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/project-dispatch-overrides.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/project-dispatch-overrides.tsx
@@ -9,13 +9,15 @@ import {
   sendToDestinationsQueryKey,
   upsertProjectDispatchOverride,
 } from "../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
+import {
+  AGENT_DISPATCH_KIND_ICONS,
+  AGENT_DISPATCH_KIND_LABELS,
+  type AgentDispatchKindKey,
+} from "../../../../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 import {
   AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY,
-  AGENT_DISPATCH_KIND_ICONS,
-  AGENT_DISPATCH_KIND_LABELS,
   AgentDispatchConfigFormInner,
-  type AgentDispatchKindKey,
   projectDispatchSettingsQueryKey,
 } from "./agent-dispatch-section.tsx"
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind.tsx
@@ -2,14 +2,14 @@ import { Button, Icon, Text, Tooltip } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
 import { ArrowLeftIcon } from "lucide-react"
-import { useProjectsCollection } from "../../../../../../domains/projects/projects.collection.ts"
-import { useRouteProject } from "../../-route-data.ts"
 import {
   AGENT_DISPATCH_KIND_ICONS,
   AGENT_DISPATCH_KIND_LABELS,
-  AgentDispatchIntegrationDetails,
   type AgentDispatchKindKey,
-} from "../-components/agent-dispatch-section.tsx"
+} from "../../../../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
+import { useProjectsCollection } from "../../../../../../domains/projects/projects.collection.ts"
+import { useRouteProject } from "../../-route-data.ts"
+import { AgentDispatchIntegrationDetails } from "../-components/agent-dispatch-section.tsx"
 import { SettingsPage } from "../-components/settings-page.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind")({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalSlug/-components/signal-dispatch-history.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalSlug/-components/signal-dispatch-history.tsx
@@ -6,6 +6,8 @@ import type { AgentDispatchRecord } from "../../../../../../../domains/agent-dis
 import {
   AGENT_DISPATCH_KIND_ICONS,
   AGENT_DISPATCH_KIND_LABELS,
+} from "../../../../../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
+import {
   DISPATCH_ERROR_TITLES,
   DISPATCH_TRIGGER_TITLES,
 } from "../../../settings/-components/agent-dispatch-section.tsx"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalSlug/-components/signal-send-to.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalSlug/-components/signal-send-to.tsx
@@ -34,12 +34,12 @@ import {
   setProjectDispatchRepo,
   signalAgentDispatchesQueryKey,
 } from "../../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
-import { toUserMessage } from "../../../../../../../lib/errors.ts"
 import {
   AGENT_DISPATCH_KIND_ICONS,
   AGENT_DISPATCH_KIND_LABELS,
-  projectDispatchSettingsQueryKey,
-} from "../../../settings/-components/agent-dispatch-section.tsx"
+} from "../../../../../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
+import { toUserMessage } from "../../../../../../../lib/errors.ts"
+import { projectDispatchSettingsQueryKey } from "../../../settings/-components/agent-dispatch-section.tsx"
 import { SignalDispatchHistory } from "./signal-dispatch-history.tsx"
 
 const MCP_DOCS_URL = "https://docs.latitude.so/getting-started/mcp"

--- a/dev-docs/command-palette.md
+++ b/dev-docs/command-palette.md
@@ -195,12 +195,14 @@ To add a section/settings page: add an entry with `{ key, label, icon, path(slug
 sidebar, the settings sub-nav, **and** the palette automatically — no palette-specific change.
 Do **not** hardcode a new nav command in the palette; that would duplicate the source of truth.
 
-Integrations are the one navigable surface that isn't a settings page, because they render as
-sections of the Integrations page rather than sidebar entries. Agent-dispatch integrations are
-derived in `use-navigation-commands.ts` from `AGENT_DISPATCH_KIND_LABELS` /
-`AGENT_DISPATCH_KIND_ICONS` (`domains/agent-dispatch/agent-dispatch-kinds.ts`), so a new dispatch
-kind surfaces in the palette with no palette change. Slack and GitHub have no per-integration
-route, so they are listed explicitly and point at the Integrations page.
+Individual integrations are the one navigable surface not modeled in `project-sections.ts`, since
+they sit under the Integrations settings page rather than being sidebar entries of their own.
+Agent-dispatch integrations (Cursor, Claude Code, Linear, Webhook) are route-backed — each has a
+`settings/integrations/$integrationKind` page — and their palette entries are derived in
+`use-navigation-commands.ts` from `AGENT_DISPATCH_KIND_LABELS` / `AGENT_DISPATCH_KIND_ICONS`
+(`domains/agent-dispatch/agent-dispatch-kinds.ts`), so a new dispatch kind surfaces with no palette
+change. Slack and GitHub render as sections of the Integrations page with no route of their own, so
+they are listed explicitly and point at that page.
 
 ### 2. New global action → `use-global-commands.tsx`
 

--- a/dev-docs/command-palette.md
+++ b/dev-docs/command-palette.md
@@ -57,7 +57,9 @@ The provider also holds:
   listing its child commands (keyboard drill-down).
 
 Shared fields: `id` (globally unique; also the cmdk item `value`), `title`, `icon`
-(`LucideIcon`), `section` (`"context" | "search" | "navigation" | "projects" | "actions"`),
+(`ComponentType<LucideProps>` — the same shape `@repo/ui`'s `Icon` accepts, so brand marks like
+`SlackIcon` / `LinearIcon` work alongside lucide icons),
+`section` (`"context" | "search" | "navigation" | "projects" | "actions"`),
 optional `leading` (overrides the icon, e.g. a project emoji), `subtitle`, `badge`,
 `keywords` (extra search terms), and `group` (sub-heading for contextual commands, e.g.
 `"Issue"`, `"Trace"`).
@@ -74,10 +76,12 @@ The palette merges, in render order:
 2. **In-project search results** (only when inside a project with a non-empty query):
    **Issues**, **Datasets**, **Saved searches**.
 3. **Central providers** (always available hooks):
-   - `useNavigationCommands` — the current project's sections + settings pages.
+   - `useNavigationCommands` — the current project's sections, settings pages, and each
+     integration (Slack/GitHub → the Integrations page; Cursor/Claude Code/Linear/Webhook →
+     their own `settings/integrations/$integrationKind` route).
    - `useProjectCommands` — switch to any project in the org.
    - `useGlobalCommands` — switch organization (drill-down), switch theme, create
-     project/org, docs, backoffice (admins), log out.
+     project/org, copy page link, docs + MCP setup, backoffice (admins), log out.
 4. **Traces fallback** — a single "Search traces for "…"" action, rendered last.
 
 `useCurrentProject` (`commands/use-current-project.ts`) resolves the active project from the
@@ -171,6 +175,7 @@ in the Projects group, which renders before the Actions group, so it already out
 | Monitor search | `apps/web/src/components/command-palette/commands/use-monitor-search-commands.ts` |
 | Experiment search | `apps/web/src/components/command-palette/commands/use-experiment-search-commands.ts` |
 | Shared project sections (source of truth) | `apps/web/src/domains/projects/project-sections.ts` |
+| Agent-dispatch kind labels + icons (source of truth) | `apps/web/src/domains/agent-dispatch/agent-dispatch-kinds.ts` |
 | Mount point + header button | `apps/web/src/routes/_authenticated.tsx` |
 
 ## Maintaining the palette
@@ -189,6 +194,13 @@ Project sections and settings pages are defined once in
 To add a section/settings page: add an entry with `{ key, label, icon, path(slug) }`. It then appears in the
 sidebar, the settings sub-nav, **and** the palette automatically — no palette-specific change.
 Do **not** hardcode a new nav command in the palette; that would duplicate the source of truth.
+
+Integrations are the one navigable surface that isn't a settings page, because they render as
+sections of the Integrations page rather than sidebar entries. Agent-dispatch integrations are
+derived in `use-navigation-commands.ts` from `AGENT_DISPATCH_KIND_LABELS` /
+`AGENT_DISPATCH_KIND_ICONS` (`domains/agent-dispatch/agent-dispatch-kinds.ts`), so a new dispatch
+kind surfaces in the palette with no palette change. Slack and GitHub have no per-integration
+route, so they are listed explicitly and point at the Integrations page.
 
 ### 2. New global action → `use-global-commands.tsx`
 

--- a/packages/ui/src/components/icons/custom-icons/brands/icons/linear.tsx
+++ b/packages/ui/src/components/icons/custom-icons/brands/icons/linear.tsx
@@ -1,0 +1,19 @@
+import type { LucideProps } from "lucide-react"
+import type { Ref } from "react"
+
+/**
+ * Linear brand mark. Accepts `LucideProps` so it's compatible with the
+ * shared `<Icon icon={LinearIcon} />` wrapper.
+ */
+export function LinearIcon({ ref, ...props }: LucideProps & { ref?: Ref<SVGSVGElement> | undefined }) {
+  return (
+    <svg ref={ref} aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" {...props}>
+      <title>Linear</title>
+      <circle cx="12" cy="12" r="10" fill="currentColor" />
+      <path d="M5.8 14.6L14.6 5.8" stroke="white" strokeLinecap="round" strokeWidth="2" />
+      <path d="M8.8 17.2L17.2 8.8" stroke="white" strokeLinecap="round" strokeWidth="2" />
+      <path d="M5.6 10.8L10.8 5.6" stroke="white" strokeLinecap="round" strokeWidth="2" />
+      <path d="M13.2 18.4L18.4 13.2" stroke="white" strokeLinecap="round" strokeWidth="2" />
+    </svg>
+  )
+}

--- a/packages/ui/src/components/icons/custom-icons/index.tsx
+++ b/packages/ui/src/components/icons/custom-icons/index.tsx
@@ -1,4 +1,5 @@
 export { GithubIcon } from "./brands/icons/github.tsx"
+export { LinearIcon } from "./brands/icons/linear.tsx"
 export { OpentelemetryIcon } from "./brands/icons/opentelemetry.tsx"
 export { SlackIcon } from "./brands/icons/slack.tsx"
 export { DatabaseAddIcon } from "./database-add.tsx"


### PR DESCRIPTION
Makes every integration reachable from Cmd+K by its own name.

## Changes

**Connect via MCP** action in global actions, opening [docs.latitude.so/getting-started/mcp](https://docs.latitude.so/getting-started/mcp). The MCP guide was previously linked only from the signal detail send-to panel.

**One navigation entry per integration**, since none of them answered a palette search for the tool's own name before:

| Entry | Destination |
| --- | --- |
| Cursor, Claude Code, Linear, Webhook | `settings/integrations/$integrationKind` |
| Slack, GitHub | `settings/integrations` (they render as sections of that page, with no route of their own) |

The four dispatch entries derive from `AGENT_DISPATCH_KIND_LABELS`, so a new kind surfaces in the palette with no palette-side change. They sit behind the same `isReadOnly` gate as the other settings entries, so the showcase demo does not get a path back into hidden pages.

## Supporting refactors

- **`AGENT_DISPATCH_KIND_LABELS` / `_ICONS` move** from the 1507-line `agent-dispatch-section.tsx` route component to `domains/agent-dispatch/agent-dispatch-kinds.ts`. The palette is mounted on every authenticated page, so importing them from the route component would have pulled the whole settings section into the always-loaded chunk. Four existing importers updated.
- **`LinearIcon` moves to `@repo/ui`** (`custom-icons/brands/icons/linear.tsx`) alongside `SlackIcon` / `GithubIcon`, instead of living as a local SVG in the settings component. Artwork unchanged.
- **`PaletteCommand.icon` widens** from `LucideIcon` to `ComponentType<LucideProps>` — the shape `@repo/ui`'s `Icon` already accepts — so brand marks work as command icons. Brand icons are plain function components, not `ForwardRefExoticComponent`, so the old type rejected them.

## Comment and doc updates

- The `useGlobalCommands` docstring enumerated an action list that had already drifted (it omitted "Copy link to this page") and claimed every action mirrors an app-header handler, which the docs links do not. Replaced with a description of the category and the ordering convention, so it stops going stale on each addition.
- `dev-docs/command-palette.md`: the `useNavigationCommands` / `useGlobalCommands` summaries, the `icon` type in the command model, a note in §1 on why integrations are the one navigable surface not driven by `project-sections.ts`, and a file-map row for the new module.

## Testing

- `pnpm --filter web typecheck`, `pnpm --filter @repo/ui typecheck`, `pnpm biome check`, and `pnpm knip` all pass.
- `pnpm --filter web test` — 770 tests across 84 files pass.
- No test covers the palette command list; the 7 Biome warnings in `apps/web/src` are pre-existing, in an unrelated memory test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global **“Connect via MCP”** command to the command palette, opening the MCP setup guide in a new browser tab.
  * Expanded **Cmd+K** navigation to include **Integrations** links within project settings, including entries driven by agent dispatch kinds.
  * Added support for a new brand icon used in command palette actions.
* **Documentation**
  * Updated the command palette specification to reflect the expanded command navigation and icon modeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->