### PR TITLE
fix(ai): alias openai verbosity to the SDK's textVerbosity option

### DIFF
--- a/packages/core/src/services/ai/providers/rules/all.test.ts
+++ b/packages/core/src/services/ai/providers/rules/all.test.ts
@@ -75,6 +75,77 @@ describe('rules', () => {
     })
   })
 
+  it('aliases openai verbosity to the name the AI SDK expects', () => {
+    const result = applyAllRules({
+      providerType: Providers.OpenAI,
+      messages: [],
+      config: {
+        model: 'gpt-5.1',
+        verbosity: 'low',
+      },
+    })
+
+    expect(result.config.providerOptions.openai).toEqual({
+      model: 'gpt-5.1',
+      textVerbosity: 'low',
+    })
+  })
+
+  it('aliases openai verbosity for Azure too', () => {
+    const result = applyAllRules({
+      providerType: Providers.Azure,
+      messages: [],
+      config: {
+        model: 'gpt-5.1',
+        reasoning_effort: 'medium',
+        verbosity: 'low',
+        azure: { resourceName: 'my-resource' },
+      },
+    })
+
+    expect(result.config.providerOptions.openai).toEqual({
+      model: 'gpt-5.1',
+      reasoningEffort: 'medium',
+      textVerbosity: 'low',
+      azure: { resourceName: 'my-resource' },
+    })
+  })
+
+  it('keeps an explicit textVerbosity over the aliased verbosity', () => {
+    const result = applyAllRules({
+      providerType: Providers.OpenAI,
+      messages: [],
+      config: {
+        model: 'gpt-5.1',
+        verbosity: 'low',
+        text_verbosity: 'high',
+      },
+    })
+
+    expect(result.config.providerOptions.openai).toEqual({
+      model: 'gpt-5.1',
+      textVerbosity: 'high',
+    })
+  })
+
+  it('does not alias verbosity for providers without openai options', () => {
+    const result = applyAllRules({
+      providerType: Providers.Google,
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      ] as Message[],
+      config: {
+        model: 'gemini-2.5-pro',
+        verbosity: 'low',
+      },
+    })
+
+    expect(result.config.providerOptions.google).toEqual({
+      model: 'gemini-2.5-pro',
+      verbosity: 'low',
+    })
+  })
+
   it('camelCase all providerOptions', () => {
     expect(
       applyAllRules({

--- a/packages/core/src/services/ai/providers/rules/all.ts
+++ b/packages/core/src/services/ai/providers/rules/all.ts
@@ -23,6 +23,49 @@ const translator = new Translator({
   providerMetadata: 'preserve',
 })
 
+/**
+ * Config attributes named after the provider's public API that the Vercel AI
+ * SDK exposes under a different name. The SDK validates provider options with
+ * a zod schema that silently drops unknown keys, so without these aliases the
+ * attribute never reaches the provider.
+ *
+ * Keys are the metadata keys from PROVIDER_TO_METADATA_KEY, not provider names,
+ * so aliases apply to every provider sharing an SDK adapter (e.g. OpenAI and
+ * Azure).
+ */
+const PROVIDER_OPTIONS_ALIASES: Record<string, Record<string, string>> = {
+  openai: {
+    // https://platform.openai.com/docs/api-reference/chat/create#chat_create-verbosity
+    verbosity: 'textVerbosity',
+  },
+}
+
+function aliasProviderOptions({
+  providerKey,
+  providerOptions,
+}: {
+  providerKey: string
+  providerOptions: Record<string, JSONValue>
+}): Record<string, JSONValue> {
+  const aliases = PROVIDER_OPTIONS_ALIASES[providerKey]
+  if (!aliases) return providerOptions
+
+  return Object.entries(providerOptions).reduce(
+    (acc, [key, value]) => {
+      const alias = aliases[key]
+      if (!alias) {
+        acc[key] = value
+        return acc
+      }
+
+      if (acc[alias] === undefined) acc[alias] = value
+
+      return acc
+    },
+    {} as Record<string, JSONValue>,
+  )
+}
+
 function convertLatitudeMessagesToVercelFormat({
   messages,
   provider,
@@ -57,7 +100,10 @@ export function applyAllRules({ providerType, messages, config }: Props) {
   })
 
   const providerKey = getProviderMetadataKey(providerType)
-  const providerOptions = toCamelCaseDeep(config)
+  const providerOptions = aliasProviderOptions({
+    providerKey,
+    providerOptions: toCamelCaseDeep(config) as Record<string, JSONValue>,
+  })
 
   return {
     ...rules,


### PR DESCRIPTION
## Problem

A customer reported that OpenAI's `verbosity` param has no effect in Latitude:

```yaml
---
provider: azure-www-sd-insights
model: gpt-5.1
reasoning_effort: medium
maxTokens: 100000
verbosity: low   # <- silently ignored
---
```

It is not Azure-specific — it affects the OpenAI provider too.

`applyAllRules` camelCases the whole prompt config into `providerOptions[providerKey]`, so `verbosity: low` arrives as `providerOptions.openai.verbosity`. But `@ai-sdk/openai` validates provider options against a zod schema whose field is **`textVerbosity`** (which it then serializes to `verbosity` for chat completions, `text.verbosity` for responses). Zod strips unknown keys, so the attribute was dropped with no error and no warning anywhere.

Worth noting the customer wasn't misreading anything: `verbosity` is the correct name in [OpenAI's own API](https://platform.openai.com/docs/api-reference/chat/create#chat_create-verbosity). Only the SDK calls it something else.

## Fix

Map the provider's public API name to the SDK's name before building `providerOptions`. The alias table is keyed by *metadata key* rather than provider name, so OpenAI and Azure are both covered by one entry (Azure has no entry in `RULES`, so putting this in `openai.ts` would have missed it). An explicitly set `textVerbosity` / `text_verbosity` still wins over the alias.

## Verification

`pnpm test src/services/ai` in `packages/core` — 159 passed, including 4 new cases (OpenAI, Azure, explicit-wins, and a non-OpenAI provider left untouched).

I also ran a throwaway end-to-end test through `ai()` with a real Azure adapter and a stubbed `fetch`, to confirm the value actually lands in the HTTP body rather than just in `providerOptions`:

```
providerOptions -> {"openai":{"model":"gpt-5.1","reasoningEffort":"medium","textVerbosity":"low",...}}
request body    -> {"model":"gpt-5.1","verbosity":"low","reasoning_effort":"medium",...}
```

Before the fix the same probe produced a body with no `verbosity` key at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)