### PR TITLE
fix(clickhouse): collapse 00055 spans ALTERs into one statement

### DIFF
--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00055_add_cost_source_and_unpriced_rollups.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00055_add_cost_source_and_unpriced_rollups.sql
@@ -22,15 +22,15 @@
 -- are preserved. The count carries the same operation gate as the cost sums, so a non-zero count
 -- always means the cost total beside it understates real spend.
 
+-- Must stay one ALTER. Every ALTER on a replicated table bumps the shared metadata version, and the
+-- next one fails with code 517 until each server has caught up; split into three, the retry re-runs
+-- the first and re-bumps the version, so it never converges. The commands still apply in order, so
+-- each AFTER can name the column added before it.
 ALTER TABLE spans ON CLUSTER default
     ADD COLUMN IF NOT EXISTS cost_source LowCardinality(String)
-        DEFAULT '' CODEC(ZSTD(1)) AFTER cost_is_estimated;
-
-ALTER TABLE spans ON CLUSTER default
+        DEFAULT '' CODEC(ZSTD(1)) AFTER cost_is_estimated,
     ADD COLUMN IF NOT EXISTS cost_priced_provider LowCardinality(String)
-        DEFAULT '' CODEC(ZSTD(1)) AFTER cost_source;
-
-ALTER TABLE spans ON CLUSTER default
+        DEFAULT '' CODEC(ZSTD(1)) AFTER cost_source,
     ADD COLUMN IF NOT EXISTS cost_priced_model LowCardinality(String)
         DEFAULT '' CODEC(ZSTD(1)) AFTER cost_priced_provider;
 
@@ -152,12 +152,8 @@ DROP VIEW IF EXISTS traces_mv ON CLUSTER default;
 DROP VIEW IF EXISTS sessions_mv ON CLUSTER default;
 
 ALTER TABLE spans ON CLUSTER default
-    DROP COLUMN IF EXISTS cost_source;
-
-ALTER TABLE spans ON CLUSTER default
-    DROP COLUMN IF EXISTS cost_priced_provider;
-
-ALTER TABLE spans ON CLUSTER default
+    DROP COLUMN IF EXISTS cost_source,
+    DROP COLUMN IF EXISTS cost_priced_provider,
     DROP COLUMN IF EXISTS cost_priced_model;
 
 ALTER TABLE traces ON CLUSTER default

--- a/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00055_add_cost_source_and_unpriced_rollups.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00055_add_cost_source_and_unpriced_rollups.sql
@@ -22,15 +22,15 @@
 -- are preserved. The count carries the same operation gate as the cost sums, so a non-zero count
 -- always means the cost total beside it understates real spend.
 
+-- Must stay one ALTER. Every ALTER on a replicated table bumps the shared metadata version, and the
+-- next one fails with code 517 until each server has caught up; split into three, the retry re-runs
+-- the first and re-bumps the version, so it never converges. The commands still apply in order, so
+-- each AFTER can name the column added before it.
 ALTER TABLE spans
     ADD COLUMN IF NOT EXISTS cost_source LowCardinality(String)
-        DEFAULT '' CODEC(ZSTD(1)) AFTER cost_is_estimated;
-
-ALTER TABLE spans
+        DEFAULT '' CODEC(ZSTD(1)) AFTER cost_is_estimated,
     ADD COLUMN IF NOT EXISTS cost_priced_provider LowCardinality(String)
-        DEFAULT '' CODEC(ZSTD(1)) AFTER cost_source;
-
-ALTER TABLE spans
+        DEFAULT '' CODEC(ZSTD(1)) AFTER cost_source,
     ADD COLUMN IF NOT EXISTS cost_priced_model LowCardinality(String)
         DEFAULT '' CODEC(ZSTD(1)) AFTER cost_priced_provider;
 
@@ -152,12 +152,8 @@ DROP VIEW IF EXISTS traces_mv;
 DROP VIEW IF EXISTS sessions_mv;
 
 ALTER TABLE spans
-    DROP COLUMN IF EXISTS cost_source;
-
-ALTER TABLE spans
-    DROP COLUMN IF EXISTS cost_priced_provider;
-
-ALTER TABLE spans
+    DROP COLUMN IF EXISTS cost_source,
+    DROP COLUMN IF EXISTS cost_priced_provider,
     DROP COLUMN IF EXISTS cost_priced_model;
 
 ALTER TABLE traces

--- a/packages/platform/db-clickhouse/clickhouse/scripts/up.sh
+++ b/packages/platform/db-clickhouse/clickhouse/scripts/up.sh
@@ -106,7 +106,10 @@ while true; do
   if [ "$attempt" -ge "$MAX_RETRIES" ] || [ "$is_retryable_replica_lag" != "true" ]; then
     echo "ClickHouse migrations failed after ${attempt} attempt(s)." >&2
     if [ "$is_retryable_replica_lag" = "true" ]; then
-      echo "Hint: increase LAT_CLICKHOUSE_MIGRATION_MAX_RETRIES or LAT_CLICKHOUSE_MIGRATION_RETRY_DELAY_SECONDS for heavily loaded clusters." >&2
+      echo "Hint: if the reported metadata version rose on every attempt, the migration issues" >&2
+      echo "consecutive ALTERs on one replicated table and each retry re-runs the first and re-bumps" >&2
+      echo "the version. Combine them into a single ALTER. Raising LAT_CLICKHOUSE_MIGRATION_MAX_RETRIES" >&2
+      echo "only helps when the version stops advancing, which is genuine cluster load." >&2
     fi
     exit "$goose_status"
   fi


### PR DESCRIPTION
## Why

The `00055` cost_source migration **failed 20/20 attempts on staging** ([run 30522981272](https://github.com/latitude-dev/latitude-llm/actions/runs/30522981272)) and would have failed the same way on the next production deploy. goose only records a migration on success, so both staging and production are still at version `54`.

```
ALTER TABLE spans ADD COLUMN IF NOT EXISTS cost_priced_provider …
code: 517, metadata version on replica is 40, while common metadata is 41
```

Each `ALTER` on a replicated table bumps the shared metadata version, and the next `ALTER` on that table is rejected until the server's cached version catches up. Splitting the three `spans` columns across three statements made this unrecoverable: a retry re-runs the migration from the top, and its **first** `ALTER` re-bumps the version the **second** is waiting on.

The evidence: staging's reported version climbed exactly one step per attempt (40 → 60) while the error stayed pinned to `cost_priced_provider` for all 20 attempts, and that column was never created.

## Fix

The three `ADD COLUMN`s collapse into one `ALTER`, and the matching `DROP COLUMN`s in the `Down`. Multi-command ALTERs apply in order, so each `AFTER` still names the column added before it.

The retry-exhaustion hint is also corrected: it suggested raising `MAX_RETRIES` for a failure mode where more attempts cannot help.

## Editing 00055 in place

Normally ClickHouse migrations are append-only once merged. In-place is right here: **no environment has 00055 applied**, and it re-runs from the top on the next deploy. A new `00056` would leave the broken 00055 running first and still failing, blocking every deploy. The final schema is identical either way.

## Verification

Against a throwaway **ClickHouse 26.2** (staging's version):

- All 55 migrations apply from scratch.
- `spans` / `traces` / `sessions` column order matches the committed `schema.sql` dump exactly (67 / 39 / 41 columns, order identical), so the `AFTER` chain survived the collapse and the dump needs no regeneration.
- `goose down` then `up` works, exercising the combined `DROP COLUMN`.
- **Re-running from staging's exact partial state** (`cost_source` present, the other two absent) applies cleanly with no manual repair.
- Functional rollup check: `cost_total_microcents=500`, `tokens_total=45`, `models=['m1']`, `tools=['mytool']`, `trace_count=1` all preserved, and `unpriced_span_count=1` correctly honours the operation gate (the `execute_tool` span marked `unpriced` is excluded).

Staging remains partially applied (`spans.cost_source` exists; the other three columns do not; MVs are still the `00048`/`00049` bodies). No cleanup needed. The next deploy re-runs 00055 and finishes it.

The MV bodies are untouched by this PR.

## Considered and rejected

An earlier revision also hoisted `alter_sync` / `replication_wait_for_inactive_replica_timeout` out of the `IS_CLUSTERED` gate in `up.sh`, on the theory that ClickHouse Cloud is replicated yet takes the unclustered path. Dropped, because there is no evidence it helps and some that it hurts:

- Staging is a single replica and the default `alter_sync=1` already waits for the local replica, yet it still failed, so the wait was not the broken part. `ADD COLUMN IF NOT EXISTS` on an existing column appears to commit a metadata bump while skipping the local-apply wait, a path `alter_sync` does not govern.
- Production runs `numReplicas: 2` with `idleScaling` and a 15-minute idle timeout, so `alter_sync=2` plus a 300s inactive-replica wait could block each ALTER for minutes on a scaled-down replica. That is a new hang mode on the migration path, in exchange for an unproven benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)