### PR TITLE
fix(ui): keep source offsets on soft breaks and raw HTML so user messages can be annotated

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,7 +56,6 @@
     "react-markdown": "10.1.0",
     "react-textarea-autosize": "8.5.9",
     "rehype-highlight": "7.0.2",
-    "remark-breaks": "4.0.0",
     "remark-emoji": "5.0.2",
     "remark-gfm": "4.0.1",
     "tailwind-merge": "2.6.1",

--- a/packages/ui/src/components/genai-conversation/parts/markdown-content.test.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/markdown-content.test.tsx
@@ -86,6 +86,38 @@ describe("MarkdownContent", () => {
     expect(markup).toMatch(/Show [\d,]+ more characters/)
   })
 
+  // Text runs that carry no `data-source-*` cannot be annotated: the selection
+  // popover opens, then the thumb click silently resolves to no anchor.
+  describe("source coverage", () => {
+    function sourceSpans(markup: string, content: string) {
+      return [...markup.matchAll(/data-source-start="(\d+)" data-source-end="(\d+)"/g)].map(([, start, end]) =>
+        content.slice(Number(start), Number(end)),
+      )
+    }
+
+    it("keeps offsets on both sides of a soft line break", () => {
+      const content = "line one\nline two"
+      const markup = renderToStaticMarkup(<MarkdownContent content={content} />)
+
+      expect(markup).toContain("<br/>")
+      expect(sourceSpans(markup, content)).toEqual(["line one", "line two"])
+    })
+
+    it("maps every line of a multi-line paragraph", () => {
+      const content = "Heyyy this is a test.\nName: Ada\nRole: engineer"
+      const markup = renderToStaticMarkup(<MarkdownContent content={content} />)
+
+      expect(sourceSpans(markup, content)).toEqual(["Heyyy this is a test.", "Name: Ada", "Role: engineer"])
+    })
+
+    it("maps raw HTML blocks, which render as escaped text", () => {
+      const content = "<system-reminder>\nbe brief\n</system-reminder>\n\nAfter"
+      const markup = renderToStaticMarkup(<MarkdownContent content={content} />)
+
+      expect(sourceSpans(markup, content)).toEqual(["<system-reminder>\nbe brief\n</system-reminder>", "After"])
+    })
+  })
+
   it("routes JSON object content to the JSON code-block renderer", () => {
     const json = '{"hello":"world","n":42}'
     const markup = renderToStaticMarkup(<MarkdownContent content={json} />)

--- a/packages/ui/src/components/genai-conversation/parts/markdown-content.test.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/markdown-content.test.tsx
@@ -86,8 +86,7 @@ describe("MarkdownContent", () => {
     expect(markup).toMatch(/Show [\d,]+ more characters/)
   })
 
-  // Text runs that carry no `data-source-*` cannot be annotated: the selection
-  // popover opens, then the thumb click silently resolves to no anchor.
+  // Text with no `data-source-*` cannot be annotated: the popover opens, then the thumb click resolves to no anchor.
   describe("source coverage", () => {
     function sourceSpans(markup: string, content: string) {
       return [...markup.matchAll(/data-source-start="(\d+)" data-source-end="(\d+)"/g)].map(([, start, end]) =>

--- a/packages/ui/src/components/genai-conversation/parts/markdown-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/markdown-content.tsx
@@ -2,7 +2,6 @@ import { isJsonBlock, LARGE_MARKDOWN_CONTENT_THRESHOLD, prettifyCompactJson } fr
 import { isValidElement, type ReactNode, use, useEffect, useMemo, useState } from "react"
 import ReactMarkdown, { type Components } from "react-markdown"
 import rehypeHighlight from "rehype-highlight"
-import remarkBreaks from "remark-breaks"
 import remarkEmoji from "remark-emoji"
 import remarkGfm from "remark-gfm"
 import { cn } from "../../../utils/cn.ts"
@@ -13,9 +12,10 @@ import { JsonContent } from "./json-content.tsx"
 import { RedactionChip } from "./redaction-chip.tsx"
 import { REDACTION_CHIP_LABEL_ATTR, rehypeRedactionChips } from "./rehype-redaction-chips.ts"
 import { remarkCodeContentPositions } from "./remark-code-content-positions.ts"
+import { remarkSourceMappedBreaks } from "./remark-source-mapped-breaks.ts"
 import { sourceMappedTextPlugin } from "./source-mapped-text-plugin.ts"
 
-const remarkPlugins = [remarkGfm, remarkEmoji, remarkBreaks, remarkCodeContentPositions] as const
+const remarkPlugins = [remarkGfm, remarkEmoji, remarkSourceMappedBreaks, remarkCodeContentPositions] as const
 
 // `rehype-highlight` only tokenizes `<code>` elements that carry a
 // `language-*` class (i.e. fences with an explicit language); it leaves

--- a/packages/ui/src/components/genai-conversation/parts/remark-source-mapped-breaks.test.ts
+++ b/packages/ui/src/components/genai-conversation/parts/remark-source-mapped-breaks.test.ts
@@ -1,0 +1,79 @@
+import type { Paragraph, Root, RootContent, Text } from "mdast"
+import { describe, expect, it } from "vitest"
+import { remarkSourceMappedBreaks } from "./remark-source-mapped-breaks.ts"
+
+/** Mirrors what remark-parse emits for a single-paragraph document. */
+function paragraphTree(source: string): Root {
+  const lines = source.split(/\r\n|\r|\n/)
+  const text: Text = {
+    type: "text",
+    value: source,
+    position: {
+      start: { line: 1, column: 1, offset: 0 },
+      end: { line: lines.length, column: (lines.at(-1)?.length ?? 0) + 1, offset: source.length },
+    },
+  }
+  const paragraph: Paragraph = { type: "paragraph", children: [text] }
+  return { type: "root", children: [paragraph] }
+}
+
+function run(source: string, tree: Root = paragraphTree(source)): RootContent[] {
+  remarkSourceMappedBreaks()(tree, source)
+  const paragraph = tree.children[0]
+  if (paragraph?.type !== "paragraph") throw new Error("expected a paragraph")
+  return paragraph.children
+}
+
+function offsetsOf(children: readonly RootContent[]): [number, number][] {
+  return children
+    .filter((child): child is Text => child.type === "text")
+    .map((child) => [child.position?.start.offset ?? -1, child.position?.end.offset ?? -1])
+}
+
+describe("remarkSourceMappedBreaks", () => {
+  it("turns a soft line break into a break node", () => {
+    expect(run("line one\nline two").map((child) => child.type)).toEqual(["text", "break", "text"])
+  })
+
+  it("keeps source offsets on both sides of the break", () => {
+    const source = "line one\nline two"
+    expect(offsetsOf(run(source))).toEqual([
+      [0, 8],
+      [9, 17],
+    ])
+  })
+
+  it("keeps offsets aligned across several breaks", () => {
+    expect(offsetsOf(run("alpha\nbeta\ngamma"))).toEqual([
+      [0, 5],
+      [6, 10],
+      [11, 16],
+    ])
+  })
+
+  it("handles CRLF endings", () => {
+    expect(offsetsOf(run("alpha\r\nbeta"))).toEqual([
+      [0, 5],
+      [7, 11],
+    ])
+  })
+
+  it("leaves single-line text untouched", () => {
+    const children = run("just one line")
+    expect(children.map((child) => child.type)).toEqual(["text"])
+    expect(offsetsOf(children)).toEqual([[0, 13]])
+  })
+
+  it("still splits when the node carries no position", () => {
+    const tree: Root = {
+      type: "root",
+      children: [{ type: "paragraph", children: [{ type: "text", value: "alpha\nbeta" }] }],
+    }
+    const children = run("alpha\nbeta", tree)
+    expect(children.map((child) => child.type)).toEqual(["text", "break", "text"])
+    expect(offsetsOf(children)).toEqual([
+      [-1, -1],
+      [-1, -1],
+    ])
+  })
+})

--- a/packages/ui/src/components/genai-conversation/parts/remark-source-mapped-breaks.test.ts
+++ b/packages/ui/src/components/genai-conversation/parts/remark-source-mapped-breaks.test.ts
@@ -1,4 +1,4 @@
-import type { Paragraph, Root, RootContent, Text } from "mdast"
+import type { Paragraph, PhrasingContent, Root, Text } from "mdast"
 import { describe, expect, it } from "vitest"
 import { remarkSourceMappedBreaks } from "./remark-source-mapped-breaks.ts"
 
@@ -17,14 +17,14 @@ function paragraphTree(source: string): Root {
   return { type: "root", children: [paragraph] }
 }
 
-function run(source: string, tree: Root = paragraphTree(source)): RootContent[] {
+function run(source: string, tree: Root = paragraphTree(source)): PhrasingContent[] {
   remarkSourceMappedBreaks()(tree, source)
   const paragraph = tree.children[0]
   if (paragraph?.type !== "paragraph") throw new Error("expected a paragraph")
   return paragraph.children
 }
 
-function offsetsOf(children: readonly RootContent[]): [number, number][] {
+function offsetsOf(children: readonly PhrasingContent[]): [number, number][] {
   return children
     .filter((child): child is Text => child.type === "text")
     .map((child) => [child.position?.start.offset ?? -1, child.position?.end.offset ?? -1])
@@ -62,6 +62,35 @@ describe("remarkSourceMappedBreaks", () => {
     const children = run("just one line")
     expect(children.map((child) => child.type)).toEqual(["text"])
     expect(offsetsOf(children)).toEqual([[0, 13]])
+  })
+
+  it("leaves a line unmapped when its decoded value diverges from the source", () => {
+    const source = "a &amp; b\nnext"
+    const tree: Root = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "text",
+              value: "a & b\nnext",
+              position: {
+                start: { line: 1, column: 1, offset: 0 },
+                end: { line: 2, column: 5, offset: source.length },
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    const children = run(source, tree)
+    expect(children.map((child) => child.type)).toEqual(["text", "break", "text"])
+    expect(offsetsOf(children)).toEqual([
+      [-1, -1],
+      [10, 14],
+    ])
   })
 
   it("still splits when the node carries no position", () => {

--- a/packages/ui/src/components/genai-conversation/parts/remark-source-mapped-breaks.ts
+++ b/packages/ui/src/components/genai-conversation/parts/remark-source-mapped-breaks.ts
@@ -30,9 +30,6 @@ function splitTextNode(node: Text, source: string): (Text | Break)[] | null {
   const endOffset = node.position?.end?.offset
   const sourceParts =
     startOffset != null && endOffset != null ? splitOnLineEndings(source.slice(startOffset, endOffset)) : null
-  // Markdown escapes and character references make `value` shorter than its
-  // source span, so offsets are only trustworthy when both sides split the
-  // same number of times.
   const aligned = sourceParts?.length === parts.length ? sourceParts : null
 
   const replacements: (Text | Break)[] = []
@@ -42,7 +39,8 @@ function splitTextNode(node: Text, source: string): (Text | Break)[] | null {
 
     const text: Text = { type: "text", value: part.value }
     const sourcePart = aligned?.[index]
-    if (sourcePart && start && startOffset != null) {
+    // Escapes and character references decode shorter than their source span, and consumers interpolate across it.
+    if (sourcePart?.value === part.value && start && startOffset != null) {
       const line = start.line + index
       const column = index === 0 ? start.column : 1
       text.position = {
@@ -56,13 +54,7 @@ function splitTextNode(node: Text, source: string): (Text | Break)[] | null {
   return replacements
 }
 
-/**
- * Drop-in for `remark-breaks` that keeps `position` on the split text nodes.
- * Upstream rebuilds them through `mdast-util-find-and-replace`, which emits
- * position-less nodes, and the rehype source mapper can only stamp
- * `data-source-*` on positioned text — so every paragraph written with soft
- * line breaks would silently lose annotation and search-highlight anchoring.
- */
+/** Drop-in for `remark-breaks` that keeps `position` on the split text nodes. */
 export function remarkSourceMappedBreaks() {
   return (tree: Root, file: unknown) => {
     const source = String(file)

--- a/packages/ui/src/components/genai-conversation/parts/remark-source-mapped-breaks.ts
+++ b/packages/ui/src/components/genai-conversation/parts/remark-source-mapped-breaks.ts
@@ -1,0 +1,79 @@
+import type { Break, Root, Text } from "mdast"
+import { SKIP, visit } from "unist-util-visit"
+
+interface Segment {
+  value: string
+  start: number
+  end: number
+}
+
+function splitOnLineEndings(text: string): Segment[] {
+  const segments: Segment[] = []
+  const pattern = /\r\n|\r|\n/g
+  let last = 0
+  let match = pattern.exec(text)
+  while (match) {
+    segments.push({ value: text.slice(last, match.index), start: last, end: match.index })
+    last = match.index + match[0].length
+    match = pattern.exec(text)
+  }
+  segments.push({ value: text.slice(last), start: last, end: text.length })
+  return segments
+}
+
+function splitTextNode(node: Text, source: string): (Text | Break)[] | null {
+  const parts = splitOnLineEndings(node.value)
+  if (parts.length === 1) return null
+
+  const start = node.position?.start
+  const startOffset = start?.offset
+  const endOffset = node.position?.end?.offset
+  const sourceParts =
+    startOffset != null && endOffset != null ? splitOnLineEndings(source.slice(startOffset, endOffset)) : null
+  // Markdown escapes and character references make `value` shorter than its
+  // source span, so offsets are only trustworthy when both sides split the
+  // same number of times.
+  const aligned = sourceParts?.length === parts.length ? sourceParts : null
+
+  const replacements: (Text | Break)[] = []
+  parts.forEach((part, index) => {
+    if (index > 0) replacements.push({ type: "break" })
+    if (!part.value) return
+
+    const text: Text = { type: "text", value: part.value }
+    const sourcePart = aligned?.[index]
+    if (sourcePart && start && startOffset != null) {
+      const line = start.line + index
+      const column = index === 0 ? start.column : 1
+      text.position = {
+        start: { line, column, offset: startOffset + sourcePart.start },
+        end: { line, column: column + sourcePart.value.length, offset: startOffset + sourcePart.end },
+      }
+    }
+    replacements.push(text)
+  })
+
+  return replacements
+}
+
+/**
+ * Drop-in for `remark-breaks` that keeps `position` on the split text nodes.
+ * Upstream rebuilds them through `mdast-util-find-and-replace`, which emits
+ * position-less nodes, and the rehype source mapper can only stamp
+ * `data-source-*` on positioned text — so every paragraph written with soft
+ * line breaks would silently lose annotation and search-highlight anchoring.
+ */
+export function remarkSourceMappedBreaks() {
+  return (tree: Root, file: unknown) => {
+    const source = String(file)
+
+    visit(tree, "text", (node: Text, index, parent) => {
+      if (!parent || index == null) return
+      const replacements = splitTextNode(node, source)
+      if (!replacements) return
+
+      parent.children.splice(index, 1, ...replacements)
+      return [SKIP, index + replacements.length]
+    })
+  }
+}

--- a/packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.ts
+++ b/packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.ts
@@ -60,7 +60,9 @@ export function sourceMappedTextPlugin(highlights: readonly HighlightRange[], sl
 
         for (const child of children) {
           if (!child) continue
-          if (child.type !== "text") {
+          // `raw` carries HTML that react-markdown renders as escaped text, so
+          // its value maps 1:1 onto the source the same way a text node does.
+          if (child.type !== "text" && child.type !== "raw") {
             visit(child, childCodeCtx)
             nextChildren.push(child)
             continue

--- a/packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.ts
+++ b/packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.ts
@@ -60,8 +60,7 @@ export function sourceMappedTextPlugin(highlights: readonly HighlightRange[], sl
 
         for (const child of children) {
           if (!child) continue
-          // `raw` carries HTML that react-markdown renders as escaped text, so
-          // its value maps 1:1 onto the source the same way a text node does.
+          // `raw` renders as escaped text, so its value maps 1:1 onto the source like a text node.
           if (child.type !== "text" && child.type !== "raw") {
             visit(child, childCodeCtx)
             nextChildren.push(child)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3387,9 +3387,6 @@ importers:
       rehype-highlight:
         specifier: 7.0.2
         version: 7.0.2
-      remark-breaks:
-        specifier: 4.0.0
-        version: 4.0.0
       remark-emoji:
         specifier: 5.0.2
         version: 5.0.2
@@ -11756,9 +11753,6 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
-  mdast-util-newline-to-break@2.0.0:
-    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
-
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -12767,9 +12761,6 @@ packages:
 
   rehype-highlight@7.0.2:
     resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
-
-  remark-breaks@4.0.0:
-    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-emoji@5.0.2:
     resolution: {integrity: sha512-IyIqGELcyK5AVdLFafoiNww+Eaw/F+rGrNSXoKucjo95uL267zrddgxGM83GN1wFIb68pyDuAsY3m5t2Cav1pQ==}
@@ -24074,11 +24065,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-newline-to-break@2.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-find-and-replace: 3.0.2
-
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -25405,12 +25391,6 @@ snapshots:
       lowlight: 3.3.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
-
-  remark-breaks@4.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-newline-to-break: 2.0.0
-      unified: 11.0.5
 
   remark-emoji@5.0.2:
     dependencies:


### PR DESCRIPTION
Selecting text inside a user message and clicking either thumb closed the popover without opening the feedback input. The same selection on an assistant message in the same conversation worked. It also depended on the session: some sessions annotated fine, others never did.

## why it happened

Annotating a selection is two phases. Phase one only needs a DOM selection, so the thumbs-up/down popover always appears. Phase two runs `resolveSourceOffsets` on click to turn the DOM range into markdown source offsets, and it does that by reading `data-source-start` / `data-source-end` off the rendered text — attributes stamped by `sourceMappedTextPlugin`. With no mapped span covering the selection it returns `null`, and `resolveAndAnnotate` still clears the selection and detection but never calls `onSelect`. Popover gone, no annotation, no error.

Two markdown paths were rendering text with no `data-source-*` at all:

**Soft line breaks.** `remark-breaks` splits a paragraph's text node on `\n` through `mdast-util-find-and-replace`, which emits replacement nodes without `position`. The rehype mapper skips positionless text, so every line of any paragraph written with single newlines was unannotatable. `"line one\nline two"` rendered as `<p>line one<br/>line two</p>` with zero source spans; `"line one\n\nline two"` mapped both lines correctly.

**Raw HTML blocks.** `<system-reminder>…</system-reminder>` parses as an mdast `html` node, becomes a hast `raw` node, and react-markdown renders it as escaped text the mapper never visited.

Nothing here is role-conditional — user and assistant messages go through the same renderer. Assistant output is well-formed markdown with blank lines between paragraphs, so it keeps positions. A Claude Code user turn is a pasted `<system_instruction>` / `<system-reminder>` block plus a prompt written with single newlines, which hits both failure modes at once. Sessions whose user turns are short single-line prompts were unaffected, which is why the bug looked intermittent.

## the fix

`remarkSourceMappedBreaks` replaces `remark-breaks`. It splits the source slice alongside the node value and assigns offsets only when both split the same number of times, so markdown escapes and character references — which make `value` shorter than its source span — can't desynchronise the arithmetic. When they do desynchronise, or the node has no position, it falls back to a positionless split and renders exactly like the old plugin.

`sourceMappedTextPlugin` now segments hast `raw` nodes the same way as text nodes. A raw node's value maps 1:1 onto the source, so the offsets are exact, and the block gains annotation and search highlighting rather than just resolution.

`remark-breaks` is no longer imported and is dropped from `@repo/ui`.

## validation

Replayed the real message parts from a failing session (a 27k `<system-reminder>` part plus a 1.5k multi-line part) through the render pipeline in jsdom and drove `resolveSourceOffsets` over every rendered text node. Before: the `<system-reminder>` run and every line of the `<system_instruction>` paragraph resolved to `null`. After: all resolve, and `content.slice(startOffset, endOffset)` round-trips to exactly the selected DOM text.

Regression tests cover the offset arithmetic across `\n`, `\r\n`, multiple breaks, and the positionless fallback, plus end-to-end source coverage through `MarkdownContent` for soft breaks, multi-line paragraphs, and raw HTML blocks.

## follow-up

The silent-failure path is untouched: if resolution fails for some other reason, the popover still closes with no signal. Keeping the selection and surfacing a toast there would turn a future instance of this class of bug into something reportable instead of invisible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown line-break rendering while preserving accurate source span mapping.
  * Fixed source highlighting/mapping for raw HTML content (rendered as escaped text).
  * Refined offset mapping behavior when decoded text diverges from the original source.
* **Tests**
  * Added additional test coverage for source coverage/span offset mapping across multi-line and line-break scenarios.
* **Chores**
  * Removed an unused Markdown formatting dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->