### PR TITLE
fix(annotations): resolve anchors on reasoning parts

### DIFF
--- a/packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.test.ts
+++ b/packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.test.ts
@@ -46,6 +46,58 @@ describe("resolveAnnotationAnchorText", () => {
     ).toBe(text.slice(4, 10))
   })
 
+  it("selects a reasoning part, which the conversation UI also lets users highlight", () => {
+    const thinking = "Let me check the refund policy before answering."
+    const reasoningMessages: GenAIMessage[] = [{ role: "assistant", parts: [{ type: "reasoning", content: thinking }] }]
+
+    expect(resolveAnnotationAnchorText(reasoningMessages, { messageIndex: 0, partIndex: 0 })).toBe(thinking)
+  })
+
+  it("applies offsets within a reasoning part", () => {
+    const thinking = "Let me check the refund policy before answering."
+    const reasoningMessages: GenAIMessage[] = [{ role: "assistant", parts: [{ type: "reasoning", content: thinking }] }]
+
+    expect(
+      resolveAnnotationAnchorText(reasoningMessages, {
+        messageIndex: 0,
+        partIndex: 0,
+        startOffset: 12,
+        endOffset: 30,
+      }),
+    ).toBe(thinking.slice(12, 30))
+  })
+
+  it("joins reasoning alongside text when partIndex is absent", () => {
+    const mixed: GenAIMessage[] = [
+      {
+        role: "assistant",
+        parts: [
+          { type: "reasoning", content: "Thinking. " },
+          { type: "text", content: "Answering." },
+        ],
+      },
+    ]
+
+    expect(resolveAnnotationAnchorText(mixed, { messageIndex: 0 })).toBe("Thinking. Answering.")
+  })
+
+  it("falls back to a synthesized text part when the message carries only `content`", () => {
+    // `normalizeMessage` / `getPartText` in the conversation UI synthesize
+    // `parts: [{ type: "text", content }]` for these and emit `partIndex: 0`.
+    const contentOnly = [{ role: "assistant", content: "hello there" }] as unknown as GenAIMessage[]
+
+    expect(
+      resolveAnnotationAnchorText(contentOnly, { messageIndex: 0, partIndex: 0, startOffset: 0, endOffset: 5 }),
+    ).toBe("hello")
+    expect(resolveAnnotationAnchorText(contentOnly, { messageIndex: 0 })).toBe("hello there")
+  })
+
+  it("returns undefined for parts the UI cannot select", () => {
+    const toolCall: GenAIMessage[] = [{ role: "assistant", parts: [{ type: "tool_call", name: "Read" }] }]
+
+    expect(resolveAnnotationAnchorText(toolCall, { messageIndex: 0, partIndex: 0 })).toBeUndefined()
+  })
+
   it("returns undefined when indices are out of range", () => {
     expect(
       resolveAnnotationAnchorText(messages, {

--- a/packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.test.ts
+++ b/packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.test.ts
@@ -82,8 +82,7 @@ describe("resolveAnnotationAnchorText", () => {
   })
 
   it("falls back to a synthesized text part when the message carries only `content`", () => {
-    // `normalizeMessage` / `getPartText` in the conversation UI synthesize
-    // `parts: [{ type: "text", content }]` for these and emit `partIndex: 0`.
+    // The conversation UI synthesizes a text part for these and emits `partIndex: 0`.
     const contentOnly = [{ role: "assistant", content: "hello there" }] as unknown as GenAIMessage[]
 
     expect(

--- a/packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.ts
+++ b/packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.ts
@@ -1,16 +1,6 @@
 import type { AnnotationAnchor } from "@domain/scores"
-import { formatPartText } from "@repo/utils"
+import { formatPartText, getAnchorPartText, joinAnchorPartText } from "@repo/utils"
 import type { GenAIMessage } from "rosetta-ai"
-
-function joinTextParts(parts: GenAIMessage["parts"] | undefined): string {
-  let out = ""
-  for (const part of parts ?? []) {
-    if (part.type === "text" && typeof part.content === "string") {
-      out += part.content
-    }
-  }
-  return out
-}
 
 /**
  * Resolves the exact substring the anchor refers to from the canonical GenAI messages
@@ -18,9 +8,9 @@ function joinTextParts(parts: GenAIMessage["parts"] | undefined): string {
  *
  * When `anchor.textFormat` is set, the part text is first transformed with
  * {@link formatPartText} so offsets line up with the representation the user
- * saw when the selection was captured. This is the single anchor-resolution
- * helper used by both the backend (annotation enrichment) and the frontend
- * (debug views); keep them in sync via this function.
+ * saw when the selection was captured. Which parts are anchorable comes from
+ * {@link getAnchorPartText}, shared with the conversation UI that captures the
+ * selection — a part selectable there but rejected here is a guaranteed 400.
  *
  * @returns `undefined` when the anchor does not select a message range, or indices are invalid.
  */
@@ -39,17 +29,13 @@ export function resolveAnnotationAnchorText(
 
   let text: string
   if (anchor.partIndex !== undefined) {
-    const part = message.parts?.[anchor.partIndex]
-    if (!part) {
+    const partText = getAnchorPartText(message, anchor.partIndex)
+    if (partText === null) {
       return undefined
     }
-    if (part.type === "text" && typeof part.content === "string") {
-      text = part.content
-    } else {
-      return undefined
-    }
+    text = partText
   } else {
-    text = joinTextParts(message.parts)
+    text = joinAnchorPartText(message)
   }
 
   text = formatPartText(text, anchor.textFormat)

--- a/packages/domain/annotations/src/use-cases/write-draft-annotation.test.ts
+++ b/packages/domain/annotations/src/use-cases/write-draft-annotation.test.ts
@@ -130,9 +130,7 @@ describe("persistDraftAnnotation", () => {
     expect(score.metadata.rawFeedback).toBe("Signal with refund policy")
   })
 
-  // Every assistant turn before the final answer in a coding-agent trace is
-  // `reasoning` + `tool_call`, so a thinking block is the only text a reviewer
-  // can highlight there — the final plain-text answer is the exception.
+  // Shaped like a coding-agent trace: reasoning is the only selectable text before the final answer.
   it("creates draft anchored to an assistant reasoning part", async () => {
     const thinking = "The user asked about refunds; the policy allows 30 days."
     const allMessages: GenAIMessage[] = [

--- a/packages/domain/annotations/src/use-cases/write-draft-annotation.test.ts
+++ b/packages/domain/annotations/src/use-cases/write-draft-annotation.test.ts
@@ -130,6 +130,48 @@ describe("persistDraftAnnotation", () => {
     expect(score.metadata.rawFeedback).toBe("Signal with refund policy")
   })
 
+  // Every assistant turn before the final answer in a coding-agent trace is
+  // `reasoning` + `tool_call`, so a thinking block is the only text a reviewer
+  // can highlight there — the final plain-text answer is the exception.
+  it("creates draft anchored to an assistant reasoning part", async () => {
+    const thinking = "The user asked about refunds; the policy allows 30 days."
+    const allMessages: GenAIMessage[] = [
+      { role: "system", parts: [{ type: "text", content: "You are a support agent." }] },
+      {
+        role: "assistant",
+        parts: [
+          { type: "reasoning", content: thinking },
+          { type: "tool_call", name: "Read" },
+        ],
+      },
+      { role: "assistant", parts: [{ type: "text", content: "Refunds are accepted for 30 days." }] },
+    ]
+    const { layer } = createTestLayers({ traceDetail: makeTraceDetail(allMessages) })
+
+    const score = await Effect.runPromise(
+      writeDraftAnnotationUseCase({
+        projectId: projectCuid,
+        sourceId: queueId,
+        traceId: traceIdRaw,
+        value: 0,
+        passed: false,
+        feedback: "Reasoning contradicts the answer",
+        anchor: {
+          messageIndex: 1,
+          partIndex: 0,
+          startOffset: 4,
+          endOffset: 8,
+        },
+        organizationId: cuid,
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(score.metadata.messageIndex).toBe(1)
+    expect(score.metadata.partIndex).toBe(0)
+    expect(score.metadata.startOffset).toBe(4)
+    expect(score.metadata.endOffset).toBe(8)
+  })
+
   it("writes ScoreCreated for draft persistence", async () => {
     const { events, layer } = createTestLayers()
 

--- a/packages/ui/src/components/genai-conversation/source-offset-resolver.ts
+++ b/packages/ui/src/components/genai-conversation/source-offset-resolver.ts
@@ -1,4 +1,4 @@
-import { detectPartTextFormat, formatPartText } from "@repo/utils"
+import { detectPartTextFormat, formatPartText, getAnchorPartText } from "@repo/utils"
 import type { GenAIMessage } from "rosetta-ai"
 
 export interface TextSelectionAnchor {
@@ -15,26 +15,7 @@ export function getPartText(
   messageIndex: number,
   partIndex: number,
 ): string | null {
-  const msg = messages[messageIndex]
-  if (!msg) return null
-
-  let parts = msg.parts
-  if (!parts || parts.length === 0) {
-    const content = (msg as { content?: string }).content
-    if (typeof content === "string") {
-      parts = [{ type: "text" as const, content }]
-    } else {
-      return null
-    }
-  }
-
-  const part = parts[partIndex]
-  if (!part) return null
-
-  if (part.type === "text" || part.type === "reasoning") {
-    return (part as { content: string }).content ?? null
-  }
-  return null
+  return getAnchorPartText(messages[messageIndex], partIndex)
 }
 
 export function findIndices(node: Node) {

--- a/packages/utils/src/genai-anchor-text.ts
+++ b/packages/utils/src/genai-anchor-text.ts
@@ -1,14 +1,6 @@
-/**
- * Which text a GenAI message part exposes to annotation anchors.
- *
- * Shared by the conversation UI (which decides what a user may highlight and
- * measures the offsets) and the backend anchor resolver (which replays those
- * offsets). The two must agree part-for-part: a part the UI lets a user select
- * but the resolver rejects turns every annotation on it into a 400.
- *
- * Typed structurally so this stays free of a `rosetta-ai` dependency.
- */
+// A part the conversation UI lets a user select but this rejects 400s every annotation on it.
 
+// Structural rather than `rosetta-ai`'s GenAIMessage: @repo/utils takes no domain dependencies.
 interface AnchorPart {
   readonly type?: string | undefined
   readonly content?: unknown

--- a/packages/utils/src/genai-anchor-text.ts
+++ b/packages/utils/src/genai-anchor-text.ts
@@ -1,0 +1,51 @@
+/**
+ * Which text a GenAI message part exposes to annotation anchors.
+ *
+ * Shared by the conversation UI (which decides what a user may highlight and
+ * measures the offsets) and the backend anchor resolver (which replays those
+ * offsets). The two must agree part-for-part: a part the UI lets a user select
+ * but the resolver rejects turns every annotation on it into a 400.
+ *
+ * Typed structurally so this stays free of a `rosetta-ai` dependency.
+ */
+
+interface AnchorPart {
+  readonly type?: string | undefined
+  readonly content?: unknown
+}
+
+interface AnchorMessage {
+  readonly parts?: readonly (AnchorPart | null | undefined)[] | undefined
+  readonly content?: unknown
+}
+
+/** The part types the conversation renders as selectable prose. */
+const ANCHOR_PART_TYPES: ReadonlySet<string> = new Set(["text", "reasoning"])
+
+const textOf = (part: AnchorPart | null | undefined): string | null =>
+  part && part.type !== undefined && ANCHOR_PART_TYPES.has(part.type) && typeof part.content === "string"
+    ? part.content
+    : null
+
+/** Producers that emit a bare `content` string get the same single text part the UI synthesizes for them. */
+const partsOf = (message: AnchorMessage): readonly (AnchorPart | null | undefined)[] => {
+  if (message.parts && message.parts.length > 0) return message.parts
+  return typeof message.content === "string" ? [{ type: "text", content: message.content }] : []
+}
+
+/** `null` when the part is absent or holds something other than selectable prose. */
+export function getAnchorPartText(message: AnchorMessage | null | undefined, partIndex: number): string | null {
+  if (!message) return null
+  return textOf(partsOf(message)[partIndex])
+}
+
+/** Concatenation of every anchorable part, for message-level anchors that carry no `partIndex`. */
+export function joinAnchorPartText(message: AnchorMessage | null | undefined): string {
+  if (!message) return ""
+  let out = ""
+  for (const part of partsOf(message)) {
+    const text = textOf(part)
+    if (text !== null) out += text
+  }
+  return out
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -35,6 +35,7 @@ export {
   safeStringifyJson,
   stableStringify,
 } from "./format.ts"
+export { getAnchorPartText, joinAnchorPartText } from "./genai-anchor-text.ts"
 export * from "./http-errors.ts"
 export {
   detectPartTextFormat,


### PR DESCRIPTION
Annotating any message other than the final assistant answer in a coding-agent trace failed with `BadRequestError: Could not resolve annotation anchor text from trace messages`. On 2026-07-29 production saw 38 failed `annotations.writeDraftAnnotation` calls against 1 success, with no errors on that resource in the preceding 30 days.

## cause

The conversation UI marks `reasoning` parts as selectable and builds a valid anchor for them:

- `message.tsx` — `const isSelectableTextPart = part.type === "text" || part.type === "reasoning"`
- `source-offset-resolver.ts` — `getPartText` returns content for `text` *or* `reasoning`

`resolveAnnotationAnchorText` accepted only `text` and returned `undefined` for everything else, which `resolveWriteAnnotationTraceContext` turns into a 400.

This looked positional ("the first messages fail, the last one works") because of how agent traces are shaped. A real Claude Code trace from the Claude Code project, 43 messages:

```
0  | system    | text,text,text,text,text
1  | assistant | reasoning,tool_call
3  | assistant | reasoning,tool_call
…  14 assistant turns are reasoning,tool_call
30 | user      | text
42 | assistant | text          ← the final answer
```

`tool_call` and `tool_call_response` are not text-selectable, so in every assistant turn before the final answer a thinking block is the only thing a reviewer can highlight. Message 42 is the single plain-text assistant part in the trace.

The UI half dates to #2550 (April). It only starts firing once traces carry thinking blocks — `otlp/content/flue.ts` maps Anthropic `thinking` to `{ type: "reasoning" }`.

## change

`getAnchorPartText` / `joinAnchorPartText` move into `@repo/utils` as the one place that decides which parts an anchor may address. Both sides call it: the resolver, and the UI's `getPartText` (which collapses to a one-line delegation, behaviour unchanged — it already accepted reasoning). The helper is typed structurally so `@repo/utils` does not take on a `rosetta-ai` dependency.

It also handles messages carrying a bare `content` string with no `parts`. The UI already synthesizes a text part for those and emits `partIndex: 0`; the resolver had no matching fallback, so those anchors 400'd too.

The two implementations had drifted for months behind a doc-block claiming they were already shared. That doc-block now describes what the code does and why the parity matters.

## tests

Written against the old code first, all five failing, including the use-case test reproducing the production error verbatim.

- `resolve-annotation-anchor-text.test.ts` — reasoning parts with and without offsets, mixed reasoning+text joins for message-level anchors, `content`-only messages, and a negative case asserting `tool_call` parts stay unanchorable.
- `write-draft-annotation.test.ts` — `writeDraftAnnotationUseCase` against a trace shaped like the one above, anchored to the reasoning part of a mid-conversation assistant turn.

## scope

An unresolvable anchor still fails the whole write. Degrading to a message-level anchor so the reviewer's feedback survives is a visible product change and is left out of this PR.

Ruled out during the investigation, recorded so nobody re-runs it: index drift between `findConversationChunk` and `findByTraceId` (the two SQL statements are equivalent, and a stored anchor was confirmed to resolve to exactly the flagged text), UI offset overshoot (`calculateTextOffsets` clamps against its own copy of the part text), and the PII redaction chips (emitted without `position` and ordered before the source mapper).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting and highlighting text within assistant reasoning content.
  - Improved anchor text resolution, including combining text and reasoning when no specific part is selected.
  - Messages containing only plain content now support offset-based text selection and annotations.
- **Bug Fixes**
  - Non-selectable parts (such as tool calls) are no longer treated as anchorable text.
  - Refinements to source offset resolution ensure correct slicing within reasoning/text content.
- **Tests**
  - Expanded unit coverage for reasoning-specific anchor selection and offset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->