### PR TITLE
feat(backoffice): sort Organizations table by credit spend

### DIFF
--- a/apps/web/src/domains/admin/organizations.functions.test.ts
+++ b/apps/web/src/domains/admin/organizations.functions.test.ts
@@ -26,7 +26,7 @@ describe("adminGetOrganizationInputSchema", () => {
 })
 
 describe("adminListOrganizationsByUsageInputSchema", () => {
-  const encodeCursor = (cursor: { consumedCredits: number; organizationId: string }): string =>
+  const encodeCursor = (cursor: { consumedCredits: number; organizationId: string; asOf: string }): string =>
     Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url")
 
   it("accepts an empty payload (first page, default limit)", () => {
@@ -34,11 +34,16 @@ describe("adminListOrganizationsByUsageInputSchema", () => {
   })
 
   it("accepts and decodes a valid base64url-encoded cursor", () => {
-    const cursor = encodeCursor({ consumedCredits: 42, organizationId: "org-1" })
+    const asOf = "2026-04-30T12:00:00.000Z"
+    const cursor = encodeCursor({ consumedCredits: 42, organizationId: "org-1", asOf })
     const result = adminListOrganizationsByUsageInputSchema.safeParse({ cursor, limit: 25 })
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.cursor).toEqual({ consumedCredits: 42, organizationId: "org-1" })
+      expect(result.data.cursor).toEqual({
+        consumedCredits: 42,
+        organizationId: "org-1",
+        asOf: new Date(asOf),
+      })
     }
   })
 
@@ -49,6 +54,13 @@ describe("adminListOrganizationsByUsageInputSchema", () => {
 
   it("rejects a cursor whose decoded shape doesn't match the schema", () => {
     const cursor = Buffer.from(JSON.stringify({ consumedCredits: -1, organizationId: "" }), "utf8").toString(
+      "base64url",
+    )
+    expect(adminListOrganizationsByUsageInputSchema.safeParse({ cursor }).success).toBe(false)
+  })
+
+  it("rejects a cursor missing asOf", () => {
+    const cursor = Buffer.from(JSON.stringify({ consumedCredits: 42, organizationId: "org-1" }), "utf8").toString(
       "base64url",
     )
     expect(adminListOrganizationsByUsageInputSchema.safeParse({ cursor }).success).toBe(false)

--- a/apps/web/src/domains/admin/organizations.functions.test.ts
+++ b/apps/web/src/domains/admin/organizations.functions.test.ts
@@ -26,7 +26,7 @@ describe("adminGetOrganizationInputSchema", () => {
 })
 
 describe("adminListOrganizationsByUsageInputSchema", () => {
-  const encodeCursor = (cursor: { traceCount: number; organizationId: string }): string =>
+  const encodeCursor = (cursor: { consumedCredits: number; organizationId: string }): string =>
     Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url")
 
   it("accepts an empty payload (first page, default limit)", () => {
@@ -34,11 +34,11 @@ describe("adminListOrganizationsByUsageInputSchema", () => {
   })
 
   it("accepts and decodes a valid base64url-encoded cursor", () => {
-    const cursor = encodeCursor({ traceCount: 42, organizationId: "org-1" })
+    const cursor = encodeCursor({ consumedCredits: 42, organizationId: "org-1" })
     const result = adminListOrganizationsByUsageInputSchema.safeParse({ cursor, limit: 25 })
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.cursor).toEqual({ traceCount: 42, organizationId: "org-1" })
+      expect(result.data.cursor).toEqual({ consumedCredits: 42, organizationId: "org-1" })
     }
   })
 
@@ -48,7 +48,16 @@ describe("adminListOrganizationsByUsageInputSchema", () => {
   })
 
   it("rejects a cursor whose decoded shape doesn't match the schema", () => {
-    const cursor = Buffer.from(JSON.stringify({ traceCount: -1, organizationId: "" }), "utf8").toString("base64url")
+    const cursor = Buffer.from(JSON.stringify({ consumedCredits: -1, organizationId: "" }), "utf8").toString(
+      "base64url",
+    )
+    expect(adminListOrganizationsByUsageInputSchema.safeParse({ cursor }).success).toBe(false)
+  })
+
+  it("rejects a legacy traceCount cursor shape", () => {
+    const cursor = Buffer.from(JSON.stringify({ traceCount: 42, organizationId: "org-1" }), "utf8").toString(
+      "base64url",
+    )
     expect(adminListOrganizationsByUsageInputSchema.safeParse({ cursor }).success).toBe(false)
   })
 

--- a/apps/web/src/domains/admin/organizations.functions.ts
+++ b/apps/web/src/domains/admin/organizations.functions.ts
@@ -292,6 +292,7 @@ export interface AdminOrganizationUsageItemDto {
   slug: string
   plan: string | null
   memberCount: number
+  consumedCredits: number
   traceCount: number
   /** ISO-8601, or null when the org has no traces in the rolling window. */
   lastTraceAt: string | null
@@ -310,6 +311,7 @@ const toUsageItemDto = (item: AdminOrganizationUsageSummary): AdminOrganizationU
   slug: item.slug,
   plan: item.plan,
   memberCount: item.memberCount,
+  consumedCredits: item.consumedCredits,
   traceCount: item.traceCount,
   lastTraceAt: item.lastTraceAt ? item.lastTraceAt.toISOString() : null,
   createdAt: item.createdAt.toISOString(),
@@ -347,9 +349,10 @@ export const adminListOrganizationsByUsageInputSchema = z.object({
 })
 
 /**
- * Backoffice "organisations by usage" listing. Sorted by trace count over
- * the rolling 30-day window (descending), with org id as the tiebreaker so
- * pagination is deterministic.
+ * Backoffice "organisations by usage" listing. Sorted by current billing
+ * period credit spend (descending), with org id as the tiebreaker so
+ * pagination is deterministic. Trace counts over the rolling 30-day window
+ * are enriched from ClickHouse for the activity columns.
  *
  * Guard: {@link adminMiddleware}. Postgres queries run on the admin client
  * at the `"system"` org scope (RLS bypass); ClickHouse aggregates `traces`

--- a/apps/web/src/routes/backoffice/organizations/index.tsx
+++ b/apps/web/src/routes/backoffice/organizations/index.tsx
@@ -81,6 +81,19 @@ function BackofficeOrganizationsByUsagePage() {
           row.plan ? <Badge variant="outlineMuted">{row.plan}</Badge> : <Text.H6 color="foregroundMuted">—</Text.H6>,
       },
       {
+        key: "creditSpend",
+        header: "Credit Spend",
+        sortKey: "creditSpend",
+        align: "end",
+        minWidth: 110,
+        width: 140,
+        render: (row) => (
+          <Text.H5 weight="medium" noWrap>
+            <span className="tabular-nums">{formatCount(row.consumedCredits)}</span>
+          </Text.H5>
+        ),
+      },
+      {
         key: "members",
         header: "Members",
         align: "end",
@@ -99,9 +112,9 @@ function BackofficeOrganizationsByUsagePage() {
         minWidth: 100,
         width: 130,
         render: (row) => (
-          <Text.H5 weight="medium" noWrap>
+          <Text.H6 noWrap>
             <span className="tabular-nums">{formatCount(row.traceCount)}</span>
-          </Text.H5>
+          </Text.H6>
         ),
       },
       {
@@ -141,7 +154,7 @@ function BackofficeOrganizationsByUsagePage() {
         <div className="flex flex-1 flex-col gap-1">
           <Text.H4 weight="semibold">Organizations by usage</Text.H4>
           <Text.H6 color="foregroundMuted">
-            Sorted by trace count over the last 30 days. Click a row to open the org detail page.
+            Sorted by credit spend in the current billing period. Click a row to open the org detail page.
           </Text.H6>
         </div>
       </div>
@@ -153,7 +166,8 @@ function BackofficeOrganizationsByUsagePage() {
           getRowKey={(row) => row.id}
           renderRowLink={renderRowLink}
           infiniteScroll={infiniteScroll}
-          blankSlate="No organizations have produced traces in the last 30 days."
+          defaultSorting={{ column: "creditSpend", direction: "desc" }}
+          blankSlate="No organizations have consumed credits in their current billing period."
         />
       </div>
     </div>

--- a/packages/domain/admin/src/organizations/get-organization-details.test.ts
+++ b/packages/domain/admin/src/organizations/get-organization-details.test.ts
@@ -11,6 +11,7 @@ const successfulRepo = (result: AdminOrganizationDetails) =>
   Layer.succeed(AdminOrganizationRepository, {
     findById: () => Effect.succeed(result),
     findManySummariesByIds: () => Effect.succeed(new Map()),
+    listByConsumedCredits: () => Effect.die("listByConsumedCredits not used"),
     findFirstApiKeyId: () => Effect.succeed(null),
     setWantsShowcase: () => Effect.void,
   })
@@ -19,6 +20,7 @@ const missingRepo = () =>
   Layer.succeed(AdminOrganizationRepository, {
     findById: (id) => Effect.fail(new NotFoundError({ entity: "Organization", id })),
     findManySummariesByIds: () => Effect.succeed(new Map()),
+    listByConsumedCredits: () => Effect.die("listByConsumedCredits not used"),
     findFirstApiKeyId: () => Effect.succeed(null),
     setWantsShowcase: () => Effect.void,
   })

--- a/packages/domain/admin/src/organizations/index.ts
+++ b/packages/domain/admin/src/organizations/index.ts
@@ -17,12 +17,17 @@ export {
   adminOrganizationProjectSchema,
   adminOrganizationSandboxSchema,
 } from "./organization-details.ts"
-export { AdminOrganizationRepository, type AdminOrganizationSummary } from "./organization-repository.ts"
+export {
+  type AdminOrganizationCreditSpendRow,
+  AdminOrganizationRepository,
+  type AdminOrganizationSummary,
+  type ListOrganizationsByConsumedCreditsInput,
+  type OrganizationsByConsumedCreditsPage,
+} from "./organization-repository.ts"
 export {
   AdminOrganizationUsageRepository,
   type AdminOrganizationUsageRow,
-  type ListOrganizationsByTraceCountInput,
-  type OrganizationsByTraceCountPage,
+  type FindOrganizationUsageByIdsInput,
 } from "./organization-usage-repository.ts"
 export {
   type AdminOrganizationUsageCursor,

--- a/packages/domain/admin/src/organizations/list-organizations-by-usage.test.ts
+++ b/packages/domain/admin/src/organizations/list-organizations-by-usage.test.ts
@@ -151,7 +151,7 @@ describe("listOrganizationsByUsageUseCase", () => {
     )
 
     expect(result.items.map((i) => i.id)).toEqual(["a"])
-    expect(result.nextCursor).toEqual({ consumedCredits: 90, organizationId: "ghost" })
+    expect(result.nextCursor).toEqual({ consumedCredits: 90, organizationId: "ghost", asOf: NOW })
   })
 
   it("forwards now and limit to the credit ranking without enriching traces on an empty page", async () => {
@@ -199,16 +199,18 @@ describe("listOrganizationsByUsageUseCase", () => {
   })
 
   it("forwards the cursor to the repository when set", async () => {
-    const capture: { lastCursor?: unknown } = {}
+    const capture: { lastNow?: Date; lastCursor?: unknown } = {}
+    const asOf = new Date("2026-04-01T00:00:00Z")
     await Effect.runPromise(
       listOrganizationsByUsageUseCase({
         now: NOW,
-        cursor: { consumedCredits: 7, organizationId: "x" },
+        cursor: { consumedCredits: 7, organizationId: "x", asOf },
       }).pipe(
         Effect.provide(orgRepo({ rows: [], hasMore: false }, new Map(), capture)),
         Effect.provide(usageRepo(new Map())),
       ),
     )
-    expect(capture.lastCursor).toEqual({ consumedCredits: 7, organizationId: "x" })
+    expect(capture.lastCursor).toEqual({ consumedCredits: 7, organizationId: "x", asOf })
+    expect(capture.lastNow).toEqual(asOf)
   })
 })

--- a/packages/domain/admin/src/organizations/list-organizations-by-usage.test.ts
+++ b/packages/domain/admin/src/organizations/list-organizations-by-usage.test.ts
@@ -6,38 +6,55 @@ import {
   ORGANIZATION_USAGE_MAX_LIMIT,
   ORGANIZATION_USAGE_WINDOW_DAYS,
 } from "./list-organizations-by-usage.ts"
-import { AdminOrganizationRepository, type AdminOrganizationSummary } from "./organization-repository.ts"
+import {
+  type AdminOrganizationCreditSpendRow,
+  AdminOrganizationRepository,
+  type AdminOrganizationSummary,
+} from "./organization-repository.ts"
 import { AdminOrganizationUsageRepository, type AdminOrganizationUsageRow } from "./organization-usage-repository.ts"
 
 const NOW = new Date("2026-04-30T12:00:00Z")
 const orgId = (raw: string) => raw as OrganizationId
 
-const usageRepo = (
-  pages: readonly { rows: readonly AdminOrganizationUsageRow[]; hasMore: boolean }[],
-  capture?: { lastSince?: Date; lastCursor?: unknown; lastLimit?: number },
-) => {
-  let call = 0
-  return Layer.succeed(AdminOrganizationUsageRepository, {
-    listByTraceCount: (input) =>
-      Effect.sync(() => {
-        if (capture) {
-          capture.lastSince = input.since
-          capture.lastCursor = input.cursor
-          capture.lastLimit = input.limit
-        }
-        const page = pages[call] ?? { rows: [], hasMore: false }
-        call += 1
-        return page
-      }),
-  })
-}
-
-const orgRepo = (summaries: ReadonlyMap<OrganizationId, AdminOrganizationSummary>) =>
+const orgRepo = (
+  creditPage: { rows: readonly AdminOrganizationCreditSpendRow[]; hasMore: boolean },
+  summaries: ReadonlyMap<OrganizationId, AdminOrganizationSummary>,
+  capture?: { lastNow?: Date; lastCursor?: unknown; lastLimit?: number },
+) =>
   Layer.succeed(AdminOrganizationRepository, {
     findById: () => Effect.die("findById not used in usage tests"),
     findManySummariesByIds: () => Effect.succeed(summaries),
+    listByConsumedCredits: (input) =>
+      Effect.sync(() => {
+        if (capture) {
+          capture.lastNow = input.now
+          capture.lastCursor = input.cursor
+          capture.lastLimit = input.limit
+        }
+        return creditPage
+      }),
     findFirstApiKeyId: () => Effect.die("findFirstApiKeyId not used in usage tests"),
     setWantsShowcase: () => Effect.die("setWantsShowcase not used in usage tests"),
+  })
+
+const usageRepo = (
+  usage: ReadonlyMap<OrganizationId, AdminOrganizationUsageRow>,
+  capture?: { lastSince?: Date; lastIds?: readonly OrganizationId[] },
+) =>
+  Layer.succeed(AdminOrganizationUsageRepository, {
+    findManyByOrganizationIds: (input) =>
+      Effect.sync(() => {
+        if (capture) {
+          capture.lastSince = input.since
+          capture.lastIds = input.organizationIds
+        }
+        const result = new Map<OrganizationId, AdminOrganizationUsageRow>()
+        for (const id of input.organizationIds) {
+          const row = usage.get(id)
+          if (row) result.set(id, row)
+        }
+        return result
+      }),
   })
 
 const mkSummary = (id: string, overrides: Partial<AdminOrganizationSummary> = {}): AdminOrganizationSummary => ({
@@ -51,30 +68,34 @@ const mkSummary = (id: string, overrides: Partial<AdminOrganizationSummary> = {}
 })
 
 describe("listOrganizationsByUsageUseCase", () => {
-  it("returns empty page when CH reports no activity", async () => {
+  it("returns empty page when no orgs have current-period credit spend", async () => {
     const result = await Effect.runPromise(
       listOrganizationsByUsageUseCase({ now: NOW }).pipe(
-        Effect.provide(usageRepo([{ rows: [], hasMore: false }])),
-        Effect.provide(orgRepo(new Map())),
+        Effect.provide(orgRepo({ rows: [], hasMore: false }, new Map())),
+        Effect.provide(usageRepo(new Map())),
       ),
     )
     expect(result).toEqual({ items: [], nextCursor: null })
   })
 
-  it("hydrates rows from PG and preserves CH ordering", async () => {
-    const rows: AdminOrganizationUsageRow[] = [
-      { organizationId: orgId("a"), traceCount: 100, lastTraceAt: new Date("2026-04-29") },
-      { organizationId: orgId("b"), traceCount: 50, lastTraceAt: null },
+  it("hydrates rows from PG + CH and preserves credit-spend ordering", async () => {
+    const rows: AdminOrganizationCreditSpendRow[] = [
+      { organizationId: orgId("a"), consumedCredits: 10_000 },
+      { organizationId: orgId("b"), consumedCredits: 5_000 },
     ]
     const summaries = new Map<OrganizationId, AdminOrganizationSummary>([
       [orgId("a"), mkSummary("a", { plan: "team", memberCount: 5 })],
       [orgId("b"), mkSummary("b", { plan: null, memberCount: 1 })],
     ])
+    const usage = new Map<OrganizationId, AdminOrganizationUsageRow>([
+      [orgId("a"), { organizationId: orgId("a"), traceCount: 100, lastTraceAt: new Date("2026-04-29") }],
+      [orgId("b"), { organizationId: orgId("b"), traceCount: 50, lastTraceAt: null }],
+    ])
 
     const result = await Effect.runPromise(
       listOrganizationsByUsageUseCase({ now: NOW }).pipe(
-        Effect.provide(usageRepo([{ rows, hasMore: false }])),
-        Effect.provide(orgRepo(summaries)),
+        Effect.provide(orgRepo({ rows, hasMore: false }, summaries)),
+        Effect.provide(usageRepo(usage)),
       ),
     )
 
@@ -83,51 +104,95 @@ describe("listOrganizationsByUsageUseCase", () => {
       id: "a",
       plan: "team",
       memberCount: 5,
+      consumedCredits: 10_000,
       traceCount: 100,
       lastTraceAt: new Date("2026-04-29"),
+    })
+    expect(result.items[1]).toMatchObject({
+      id: "b",
+      consumedCredits: 5_000,
+      traceCount: 50,
+      lastTraceAt: null,
     })
     expect(result.nextCursor).toBeNull()
   })
 
-  it("anchors nextCursor on the last CH row (not the last hydrated item) so dropped orgs are not re-fetched", async () => {
-    const rows: AdminOrganizationUsageRow[] = [
-      { organizationId: orgId("a"), traceCount: 100, lastTraceAt: null },
-      { organizationId: orgId("ghost"), traceCount: 90, lastTraceAt: null },
+  it("defaults missing CH usage to zero traces", async () => {
+    const rows: AdminOrganizationCreditSpendRow[] = [{ organizationId: orgId("a"), consumedCredits: 42 }]
+    const summaries = new Map<OrganizationId, AdminOrganizationSummary>([[orgId("a"), mkSummary("a")]])
+
+    const result = await Effect.runPromise(
+      listOrganizationsByUsageUseCase({ now: NOW }).pipe(
+        Effect.provide(orgRepo({ rows, hasMore: false }, summaries)),
+        Effect.provide(usageRepo(new Map())),
+      ),
+    )
+
+    expect(result.items[0]).toMatchObject({
+      id: "a",
+      consumedCredits: 42,
+      traceCount: 0,
+      lastTraceAt: null,
+    })
+  })
+
+  it("anchors nextCursor on the last ranking row (not the last hydrated item) so dropped orgs are not re-fetched", async () => {
+    const rows: AdminOrganizationCreditSpendRow[] = [
+      { organizationId: orgId("a"), consumedCredits: 100 },
+      { organizationId: orgId("ghost"), consumedCredits: 90 },
     ]
     const summaries = new Map<OrganizationId, AdminOrganizationSummary>([[orgId("a"), mkSummary("a")]])
 
     const result = await Effect.runPromise(
       listOrganizationsByUsageUseCase({ now: NOW }).pipe(
-        Effect.provide(usageRepo([{ rows, hasMore: true }])),
-        Effect.provide(orgRepo(summaries)),
+        Effect.provide(orgRepo({ rows, hasMore: true }, summaries)),
+        Effect.provide(usageRepo(new Map())),
       ),
     )
 
     expect(result.items.map((i) => i.id)).toEqual(["a"])
-    expect(result.nextCursor).toEqual({ traceCount: 90, organizationId: "ghost" })
+    expect(result.nextCursor).toEqual({ consumedCredits: 90, organizationId: "ghost" })
   })
 
-  it("computes the rolling window relative to `now`", async () => {
-    const capture: { lastSince?: Date; lastCursor?: unknown; lastLimit?: number } = {}
+  it("forwards now and limit to the credit ranking without enriching traces on an empty page", async () => {
+    const creditCapture: { lastNow?: Date; lastCursor?: unknown; lastLimit?: number } = {}
+    const usageCapture: { lastSince?: Date; lastIds?: readonly OrganizationId[] } = {}
 
     await Effect.runPromise(
       listOrganizationsByUsageUseCase({ now: NOW, limit: 25 }).pipe(
-        Effect.provide(usageRepo([{ rows: [], hasMore: false }], capture)),
-        Effect.provide(orgRepo(new Map())),
+        Effect.provide(orgRepo({ rows: [], hasMore: false }, new Map(), creditCapture)),
+        Effect.provide(usageRepo(new Map(), usageCapture)),
+      ),
+    )
+
+    expect(creditCapture.lastNow).toEqual(NOW)
+    expect(creditCapture.lastLimit).toBe(25)
+    expect(usageCapture.lastSince).toBeUndefined()
+  })
+
+  it("forwards organization ids to the traces enrichment when ranking returns rows", async () => {
+    const usageCapture: { lastSince?: Date; lastIds?: readonly OrganizationId[] } = {}
+    const rows: AdminOrganizationCreditSpendRow[] = [{ organizationId: orgId("a"), consumedCredits: 1 }]
+    const summaries = new Map<OrganizationId, AdminOrganizationSummary>([[orgId("a"), mkSummary("a")]])
+
+    await Effect.runPromise(
+      listOrganizationsByUsageUseCase({ now: NOW }).pipe(
+        Effect.provide(orgRepo({ rows, hasMore: false }, summaries)),
+        Effect.provide(usageRepo(new Map(), usageCapture)),
       ),
     )
 
     const expectedSince = new Date(NOW.getTime() - ORGANIZATION_USAGE_WINDOW_DAYS * 24 * 60 * 60 * 1000)
-    expect(capture.lastSince).toEqual(expectedSince)
-    expect(capture.lastLimit).toBe(25)
+    expect(usageCapture.lastSince).toEqual(expectedSince)
+    expect(usageCapture.lastIds).toEqual([orgId("a")])
   })
 
   it("clamps oversized limits to the configured maximum", async () => {
     const capture: { lastLimit?: number } = {}
     await Effect.runPromise(
       listOrganizationsByUsageUseCase({ now: NOW, limit: 9999 }).pipe(
-        Effect.provide(usageRepo([{ rows: [], hasMore: false }], capture)),
-        Effect.provide(orgRepo(new Map())),
+        Effect.provide(orgRepo({ rows: [], hasMore: false }, new Map(), capture)),
+        Effect.provide(usageRepo(new Map())),
       ),
     )
     expect(capture.lastLimit).toBe(ORGANIZATION_USAGE_MAX_LIMIT)
@@ -138,9 +203,12 @@ describe("listOrganizationsByUsageUseCase", () => {
     await Effect.runPromise(
       listOrganizationsByUsageUseCase({
         now: NOW,
-        cursor: { traceCount: 7, organizationId: "x" },
-      }).pipe(Effect.provide(usageRepo([{ rows: [], hasMore: false }], capture)), Effect.provide(orgRepo(new Map()))),
+        cursor: { consumedCredits: 7, organizationId: "x" },
+      }).pipe(
+        Effect.provide(orgRepo({ rows: [], hasMore: false }, new Map(), capture)),
+        Effect.provide(usageRepo(new Map())),
+      ),
     )
-    expect(capture.lastCursor).toEqual({ traceCount: 7, organizationId: "x" })
+    expect(capture.lastCursor).toEqual({ consumedCredits: 7, organizationId: "x" })
   })
 })

--- a/packages/domain/admin/src/organizations/list-organizations-by-usage.ts
+++ b/packages/domain/admin/src/organizations/list-organizations-by-usage.ts
@@ -45,8 +45,7 @@ export const listOrganizationsByUsageUseCase = (
 > =>
   Effect.gen(function* () {
     const limit = clampLimit(input.limit)
-    // Prefer the cursor's asOf so later pages stay on the same ranking
-    // instant as the first page (period boundaries mid-scroll).
+    // Prefer cursor asOf so later pages keep the first page's ranking instant across period boundaries.
     const now = input.cursor?.asOf ?? input.now ?? new Date()
     const since = new Date(now.getTime() - ORGANIZATION_USAGE_WINDOW_DAYS * 24 * 60 * 60 * 1000)
 

--- a/packages/domain/admin/src/organizations/list-organizations-by-usage.ts
+++ b/packages/domain/admin/src/organizations/list-organizations-by-usage.ts
@@ -45,7 +45,9 @@ export const listOrganizationsByUsageUseCase = (
 > =>
   Effect.gen(function* () {
     const limit = clampLimit(input.limit)
-    const now = input.now ?? new Date()
+    // Prefer the cursor's asOf so later pages stay on the same ranking
+    // instant as the first page (period boundaries mid-scroll).
+    const now = input.cursor?.asOf ?? input.now ?? new Date()
     const since = new Date(now.getTime() - ORGANIZATION_USAGE_WINDOW_DAYS * 24 * 60 * 60 * 1000)
 
     yield* Effect.annotateCurrentSpan("admin.usage.windowDays", ORGANIZATION_USAGE_WINDOW_DAYS)
@@ -94,7 +96,11 @@ export const listOrganizationsByUsageUseCase = (
 
     const lastRow = page.hasMore ? page.rows[page.rows.length - 1] : undefined
     const nextCursor = lastRow
-      ? { consumedCredits: lastRow.consumedCredits, organizationId: lastRow.organizationId as string }
+      ? {
+          consumedCredits: lastRow.consumedCredits,
+          organizationId: lastRow.organizationId as string,
+          asOf: now,
+        }
       : null
 
     return { items, nextCursor }

--- a/packages/domain/admin/src/organizations/list-organizations-by-usage.ts
+++ b/packages/domain/admin/src/organizations/list-organizations-by-usage.ts
@@ -5,10 +5,10 @@ import { AdminOrganizationUsageRepository } from "./organization-usage-repositor
 import type { AdminOrganizationUsageCursor, AdminOrganizationUsageSummary } from "./organization-usage-summary.ts"
 
 /**
- * Rolling window for the usage ranking. 30d is short enough to track
- * "current" customers (a churned org drops out after a month) and long
- * enough to absorb weekend/holiday lulls without reshuffling the top
- * of the list.
+ * Rolling window for the traces column. Credit spend uses each org's
+ * current billing period instead. 30d is short enough to track "current"
+ * customers (a churned org drops out after a month) and long enough to
+ * absorb weekend/holiday lulls without reshuffling the activity signal.
  */
 export const ORGANIZATION_USAGE_WINDOW_DAYS = 30
 export const ORGANIZATION_USAGE_DEFAULT_LIMIT = 50
@@ -18,8 +18,8 @@ export interface ListOrganizationsByUsageInput {
   readonly cursor?: AdminOrganizationUsageCursor
   readonly limit?: number
   /**
-   * Anchor for the rolling window — defaults to "now". Tests pin this for
-   * determinism; production callers should leave it unset.
+   * Anchor for "now" (current billing period + rolling traces window).
+   * Tests pin this for determinism; production callers should leave it unset.
    */
   readonly now?: Date
 }
@@ -51,11 +51,11 @@ export const listOrganizationsByUsageUseCase = (
     yield* Effect.annotateCurrentSpan("admin.usage.windowDays", ORGANIZATION_USAGE_WINDOW_DAYS)
     yield* Effect.annotateCurrentSpan("admin.usage.limit", limit)
 
-    const usageRepo = yield* AdminOrganizationUsageRepository
     const orgRepo = yield* AdminOrganizationRepository
+    const usageRepo = yield* AdminOrganizationUsageRepository
 
-    const page = yield* usageRepo.listByTraceCount({
-      since,
+    const page = yield* orgRepo.listByConsumedCredits({
+      now,
       limit,
       ...(input.cursor ? { cursor: input.cursor } : {}),
     })
@@ -64,34 +64,37 @@ export const listOrganizationsByUsageUseCase = (
       return { items: [], nextCursor: null }
     }
 
-    const summaries = yield* orgRepo.findManySummariesByIds(page.rows.map((r) => r.organizationId))
+    const organizationIds = page.rows.map((r) => r.organizationId)
+    const [summaries, usageByOrg] = yield* Effect.all([
+      orgRepo.findManySummariesByIds(organizationIds),
+      usageRepo.findManyByOrganizationIds({ organizationIds, since }),
+    ])
 
     const items: AdminOrganizationUsageSummary[] = []
     for (const row of page.rows) {
-      // CH knows the org id; PG is authoritative for the rest. If a row
-      // appears in CH but is missing from PG (hard-deleted org with
-      // residual traces) we drop it silently — surfacing "(unknown)"
-      // would be confusing in a customer-ranking page.
+      // Ranking knows the org id; summaries are authoritative for the rest.
+      // If a row appears in billing but is missing from the summary map
+      // (hard-deleted org, or sandbox filtered out) we drop it silently —
+      // the cursor still anchors on the ranking row so pagination skips it.
       const summary = summaries.get(row.organizationId)
       if (!summary) continue
+      const usage = usageByOrg.get(row.organizationId)
       items.push({
         id: summary.id,
         name: summary.name,
         slug: summary.slug,
         plan: summary.plan,
         memberCount: summary.memberCount,
-        traceCount: row.traceCount,
-        lastTraceAt: row.lastTraceAt,
+        consumedCredits: row.consumedCredits,
+        traceCount: usage?.traceCount ?? 0,
+        lastTraceAt: usage?.lastTraceAt ?? null,
         createdAt: summary.createdAt,
       })
     }
 
-    // Cursor anchors on the last CH row (not the last *kept* item) so
-    // the next page query strictly skips past dropped/missing orgs and
-    // never re-fetches them.
     const lastRow = page.hasMore ? page.rows[page.rows.length - 1] : undefined
     const nextCursor = lastRow
-      ? { traceCount: lastRow.traceCount, organizationId: lastRow.organizationId as string }
+      ? { consumedCredits: lastRow.consumedCredits, organizationId: lastRow.organizationId as string }
       : null
 
     return { items, nextCursor }

--- a/packages/domain/admin/src/organizations/organization-repository.ts
+++ b/packages/domain/admin/src/organizations/organization-repository.ts
@@ -1,6 +1,7 @@
 import type { ApiKeyId, NotFoundError, OrganizationId, RepositoryError } from "@domain/shared"
 import { Context, type Effect } from "effect"
 import type { AdminOrganizationDetails } from "./organization-details.ts"
+import type { AdminOrganizationUsageCursor } from "./organization-usage-summary.ts"
 
 /**
  * Compact org summary keyed by id for the "organisations by usage" page.
@@ -14,6 +15,26 @@ export interface AdminOrganizationSummary {
   readonly plan: string | null
   readonly memberCount: number
   readonly createdAt: Date
+}
+
+/** One org's current-period credit spend for the backoffice spend ranking. */
+export interface AdminOrganizationCreditSpendRow {
+  readonly organizationId: OrganizationId
+  readonly consumedCredits: number
+}
+
+export interface ListOrganizationsByConsumedCreditsInput {
+  /** Instant used to resolve "current" billing periods. */
+  readonly now: Date
+  /** Page size; the adapter probes `limit + 1` internally to set `hasMore`. */
+  readonly limit: number
+  /** Resume marker from a previous page; absent on the first page. */
+  readonly cursor?: AdminOrganizationUsageCursor
+}
+
+export interface OrganizationsByConsumedCreditsPage {
+  readonly rows: readonly AdminOrganizationCreditSpendRow[]
+  readonly hasMore: boolean
 }
 
 /**
@@ -48,6 +69,16 @@ export class AdminOrganizationRepository extends Context.Service<
     findManySummariesByIds(
       ids: readonly OrganizationId[],
     ): Effect.Effect<ReadonlyMap<OrganizationId, AdminOrganizationSummary>, RepositoryError>
+
+    /**
+     * Rank non-sandbox organisations by current billing-period
+     * `consumedCredits` desc (+ organisation id asc), returning up to
+     * `limit` rows starting strictly after `cursor` when present. Orgs
+     * with zero current-period spend are excluded.
+     */
+    listByConsumedCredits(
+      input: ListOrganizationsByConsumedCreditsInput,
+    ): Effect.Effect<OrganizationsByConsumedCreditsPage, RepositoryError>
 
     /**
      * Return the first non-deleted api-key id for the org, or `null` when

--- a/packages/domain/admin/src/organizations/organization-usage-repository.ts
+++ b/packages/domain/admin/src/organizations/organization-usage-repository.ts
@@ -1,6 +1,5 @@
 import type { OrganizationId, RepositoryError } from "@domain/shared"
 import { Context, type Effect } from "effect"
-import type { AdminOrganizationUsageCursor } from "./organization-usage-summary.ts"
 
 /** Per-organisation slice of trace activity inside the rolling usage window. */
 export interface AdminOrganizationUsageRow {
@@ -9,18 +8,10 @@ export interface AdminOrganizationUsageRow {
   readonly lastTraceAt: Date | null
 }
 
-export interface ListOrganizationsByTraceCountInput {
+export interface FindOrganizationUsageByIdsInput {
+  readonly organizationIds: readonly OrganizationId[]
   /** Inclusive lower bound on trace start time. */
   readonly since: Date
-  /** Page size; the adapter probes `limit + 1` internally to set `hasMore`. */
-  readonly limit: number
-  /** Resume marker from a previous page; absent on the first page. */
-  readonly cursor?: AdminOrganizationUsageCursor
-}
-
-export interface OrganizationsByTraceCountPage {
-  readonly rows: readonly AdminOrganizationUsageRow[]
-  readonly hasMore: boolean
 }
 
 /**
@@ -37,14 +28,12 @@ export class AdminOrganizationUsageRepository extends Context.Service<
   AdminOrganizationUsageRepository,
   {
     /**
-     * Aggregate traces ingested at or after `since` by organisation, sort
-     * by trace count desc + organisation id asc, and return up to `limit`
-     * rows starting strictly after `cursor` when present. Excludes orgs
-     * with zero traces in the window — the table is a usage ranking, not
-     * a directory.
+     * Aggregate traces ingested at or after `since` for the given
+     * organisations. Orgs with no traces in the window are absent from
+     * the returned map (callers treat missing as zero).
      */
-    listByTraceCount(
-      input: ListOrganizationsByTraceCountInput,
-    ): Effect.Effect<OrganizationsByTraceCountPage, RepositoryError>
+    findManyByOrganizationIds(
+      input: FindOrganizationUsageByIdsInput,
+    ): Effect.Effect<ReadonlyMap<OrganizationId, AdminOrganizationUsageRow>, RepositoryError>
   }
 >()("@domain/admin/AdminOrganizationUsageRepository") {}

--- a/packages/domain/admin/src/organizations/organization-usage-summary.ts
+++ b/packages/domain/admin/src/organizations/organization-usage-summary.ts
@@ -43,9 +43,15 @@ export type AdminOrganizationUsageSummary = z.infer<typeof adminOrganizationUsag
  * sorted by `consumedCredits DESC, organizationId ASC`, so a stable cursor
  * needs both halves: the credit count alone repeats across orgs, the id
  * alone doesn't reflect the sort dimension.
+ *
+ * `asOf` pins the billing-period + traces window for the whole listing
+ * session so a page fetched after a period boundary still ranks against
+ * the same instant as the first page (otherwise counters reset mid-scroll
+ * and rows can duplicate or vanish).
  */
 export const adminOrganizationUsageCursorSchema = z.object({
   consumedCredits: z.number().int().nonnegative(),
   organizationId: z.string().min(1),
+  asOf: z.coerce.date(),
 })
 export type AdminOrganizationUsageCursor = z.infer<typeof adminOrganizationUsageCursorSchema>

--- a/packages/domain/admin/src/organizations/organization-usage-summary.ts
+++ b/packages/domain/admin/src/organizations/organization-usage-summary.ts
@@ -3,14 +3,13 @@ import { z } from "zod"
 /**
  * One row of the backoffice "organisations by usage" table — surfaces the
  * compact identity / billing / membership signals next to the activity
- * metric the page is sorted by.
+ * metrics the page is sorted by.
  *
- * The trace count is scoped to a rolling window (see
- * `ORGANIZATION_USAGE_WINDOW_DAYS` in `list-organizations-by-usage.ts`)
- * so the table answers "who's using the product right now?" rather than
- * "who has historically produced traces?". Orgs with zero traces in
- * that window do not appear at all — the listing is a usage ranking,
- * not an org directory.
+ * Credit spend is the current billing period's `consumedCredits`. Trace
+ * count is scoped to a rolling window (see `ORGANIZATION_USAGE_WINDOW_DAYS`
+ * in `list-organizations-by-usage.ts`). Orgs with zero credit spend in the
+ * current period do not appear — the listing is a spend ranking, not an
+ * org directory.
  */
 export const adminOrganizationUsageSummarySchema = z.object({
   id: z.string(),
@@ -23,11 +22,16 @@ export const adminOrganizationUsageSummarySchema = z.object({
   plan: z.string().nullable(),
   memberCount: z.number().int().nonnegative(),
   /**
-   * Trace count over the rolling usage window. Always > 0 for rows that
-   * reach this DTO — orgs with no traces in the window don't appear in
-   * the listing at all.
+   * Credits consumed in the organisation's current billing period.
+   * Always > 0 for rows that reach this DTO — orgs with no current-period
+   * spend don't appear in the listing at all.
    */
-  traceCount: z.number().int().positive(),
+  consumedCredits: z.number().int().positive(),
+  /**
+   * Trace count over the rolling usage window. May be 0 when the org has
+   * billed credits without producing traces in that window.
+   */
+  traceCount: z.number().int().nonnegative(),
   /** End time of the most recent trace in the window. */
   lastTraceAt: z.date().nullable(),
   createdAt: z.date(),
@@ -36,12 +40,12 @@ export type AdminOrganizationUsageSummary = z.infer<typeof adminOrganizationUsag
 
 /**
  * Composite cursor for `listOrganizationsByUsageUseCase`. The page is
- * sorted by `traceCount DESC, organizationId ASC`, so a stable cursor
- * needs both halves: the count alone repeats across orgs, the id alone
- * doesn't reflect the sort dimension.
+ * sorted by `consumedCredits DESC, organizationId ASC`, so a stable cursor
+ * needs both halves: the credit count alone repeats across orgs, the id
+ * alone doesn't reflect the sort dimension.
  */
 export const adminOrganizationUsageCursorSchema = z.object({
-  traceCount: z.number().int().nonnegative(),
+  consumedCredits: z.number().int().nonnegative(),
   organizationId: z.string().min(1),
 })
 export type AdminOrganizationUsageCursor = z.infer<typeof adminOrganizationUsageCursorSchema>

--- a/packages/domain/admin/src/organizations/reset-system-monitors.test.ts
+++ b/packages/domain/admin/src/organizations/reset-system-monitors.test.ts
@@ -30,6 +30,7 @@ const fakeAdminRepo = (org: AdminOrganizationDetails) =>
   AdminOrganizationRepository.of({
     findById: () => Effect.succeed(org),
     findManySummariesByIds: () => Effect.die("findManySummariesByIds not used"),
+    listByConsumedCredits: () => Effect.die("listByConsumedCredits not used"),
     findFirstApiKeyId: () => Effect.die("findFirstApiKeyId not used"),
     setWantsShowcase: () => Effect.die("setWantsShowcase not used"),
   })

--- a/packages/domain/admin/src/organizations/set-organization-showcase.test.ts
+++ b/packages/domain/admin/src/organizations/set-organization-showcase.test.ts
@@ -11,6 +11,7 @@ const fakeRepo = (calls: Array<{ organizationId: string; enabled: boolean }>, ex
   Layer.succeed(AdminOrganizationRepository, {
     findById: () => Effect.die("findById not used"),
     findManySummariesByIds: () => Effect.die("findManySummariesByIds not used"),
+    listByConsumedCredits: () => Effect.die("listByConsumedCredits not used"),
     findFirstApiKeyId: () => Effect.die("findFirstApiKeyId not used"),
     setWantsShowcase: (organizationId, enabled) =>
       exists

--- a/packages/platform/db-clickhouse/src/repositories/admin-organization-usage-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/admin-organization-usage-repository.ts
@@ -13,18 +13,14 @@ import { Effect, Layer } from "effect"
  * provide alongside per-tenant CH repositories on customer-facing
  * paths.
  *
- * Sort key is `trace_count DESC, organization_id ASC`. The mixed
- * directions mean the cursor predicate cannot use plain tuple
- * comparison — it expands to "trace_count smaller OR (same count AND
- * id larger)" so the page is strictly monotone with the ORDER BY.
- *
- * `min_start_time` is the partition key (PARTITION BY toYYYYMM(...))
- * and carries a minmax skip index, so the WHERE on it prunes
- * partitions and granules cheaply for the rolling window. Inner
- * GROUP BY collapses partial rows that AggregatingMergeTree may not
- * have merged yet (same discipline as `LIST_SELECT` in
- * `trace-repository`); the outer aggregation then counts traces and
- * picks the most recent end time per organisation.
+ * Used to enrich the Postgres credit-spend ranking with rolling-window
+ * trace counts. `min_start_time` is the partition key (PARTITION BY
+ * toYYYYMM(...)) and carries a minmax skip index, so the WHERE on it
+ * prunes partitions and granules cheaply. Inner GROUP BY collapses
+ * partial rows that AggregatingMergeTree may not have merged yet (same
+ * discipline as `LIST_SELECT` in `trace-repository`); the outer
+ * aggregation then counts traces and picks the most recent end time
+ * per organisation.
  *
  * Bound DateTime64 params reject `toISOString()`'s trailing `Z`, so
  * this query normalises to `YYYY-MM-DD HH:MM:SS.sss`.
@@ -35,15 +31,13 @@ export const AdminOrganizationUsageRepositoryLive = Layer.effect(
     const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
 
     return {
-      listByTraceCount: ({ since, cursor, limit }) =>
-        chSqlClient
-          .query(async (client) => {
-            const cursorClause = cursor
-              ? `HAVING (trace_count < {cursorTraceCount:UInt64})
-                       OR (trace_count = {cursorTraceCount:UInt64}
-                           AND organization_id > {cursorOrganizationId:String})`
-              : ""
+      findManyByOrganizationIds: ({ organizationIds, since }) => {
+        if (organizationIds.length === 0) {
+          return Effect.succeed(new Map<OrganizationId, AdminOrganizationUsageRow>())
+        }
 
+        return chSqlClient
+          .query(async (client) => {
             const result = await client.query({
               query: `SELECT
                         organization_id,
@@ -57,21 +51,13 @@ export const AdminOrganizationUsageRepositoryLive = Layer.effect(
                           max(max_end_time) AS end_time
                         FROM traces
                         WHERE min_start_time >= {since:DateTime64(9, 'UTC')}
+                          AND organization_id IN {organizationIds:Array(String)}
                         GROUP BY organization_id, project_id, trace_id
                       )
-                      GROUP BY organization_id
-                      ${cursorClause}
-                      ORDER BY trace_count DESC, organization_id ASC
-                      LIMIT {limit:UInt32}`,
+                      GROUP BY organization_id`,
               query_params: {
                 since: since.toISOString().replace("T", " ").replace("Z", ""),
-                limit: limit + 1,
-                ...(cursor
-                  ? {
-                      cursorTraceCount: cursor.traceCount,
-                      cursorOrganizationId: cursor.organizationId,
-                    }
-                  : {}),
+                organizationIds: organizationIds as readonly string[],
               },
               format: "JSONEachRow",
             })
@@ -83,17 +69,20 @@ export const AdminOrganizationUsageRepositoryLive = Layer.effect(
           })
           .pipe(
             Effect.map((rows) => {
-              const hasMore = rows.length > limit
-              const pageRows = hasMore ? rows.slice(0, limit) : rows
-              const items: AdminOrganizationUsageRow[] = pageRows.map((row) => ({
-                organizationId: OrganizationId(row.organization_id),
-                traceCount: Number(row.trace_count),
-                lastTraceAt: row.last_trace_at ? parseCHDate(row.last_trace_at) : null,
-              }))
-              return { rows: items, hasMore }
+              const result = new Map<OrganizationId, AdminOrganizationUsageRow>()
+              for (const row of rows) {
+                const organizationId = OrganizationId(row.organization_id)
+                result.set(organizationId, {
+                  organizationId,
+                  traceCount: Number(row.trace_count),
+                  lastTraceAt: row.last_trace_at ? parseCHDate(row.last_trace_at) : null,
+                })
+              }
+              return result
             }),
-            Effect.mapError((error) => toRepositoryError(error, "listByTraceCount")),
-          ),
+            Effect.mapError((error) => toRepositoryError(error, "findManyByOrganizationIds")),
+          )
+      },
     }
   }),
 )

--- a/packages/platform/db-postgres/src/repositories/admin-organization-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-organization-repository.test.ts
@@ -3,6 +3,7 @@ import { OrganizationId } from "@domain/shared"
 import { Effect } from "effect"
 import { beforeAll, describe, expect, it } from "vitest"
 import { members, organizations, users } from "../schema/better-auth.ts"
+import { billingUsagePeriods } from "../schema/billing.ts"
 import { projects } from "../schema/projects.ts"
 import { sandboxes } from "../schema/sandboxes.ts"
 import { setupTestPostgres } from "../test/in-memory-postgres.ts"
@@ -249,5 +250,175 @@ describe("AdminOrganizationRepositoryLive.setWantsShowcase", () => {
         }),
       ),
     ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Organization" })
+  })
+})
+
+describe("AdminOrganizationRepositoryLive.listByConsumedCredits", () => {
+  const NOW = new Date("2026-04-15T12:00:00.000Z")
+  const PERIOD_START = new Date("2026-04-01T00:00:00.000Z")
+  const PERIOD_END = new Date("2026-05-01T00:00:00.000Z")
+  const PAST_START = new Date("2026-03-01T00:00:00.000Z")
+  const PAST_END = new Date("2026-04-01T00:00:00.000Z")
+
+  const ORG_HIGH = makeId("org-credit-high")
+  const ORG_MID = makeId("org-credit-mid")
+  const ORG_LOW = makeId("org-credit-low")
+  const ORG_ZERO = makeId("org-credit-zero")
+  const ORG_SANDBOX = makeId("org-credit-sbx")
+  const ORG_PARENT = makeId("org-credit-parent")
+
+  beforeAll(async () => {
+    const baseTime = new Date("2025-06-01T12:00:00.000Z")
+
+    await pg.db.insert(organizations).values([
+      { id: ORG_HIGH, name: "High Spend", slug: "high-spend", createdAt: baseTime, updatedAt: baseTime },
+      { id: ORG_MID, name: "Mid Spend", slug: "mid-spend", createdAt: baseTime, updatedAt: baseTime },
+      { id: ORG_LOW, name: "Low Spend", slug: "low-spend", createdAt: baseTime, updatedAt: baseTime },
+      { id: ORG_ZERO, name: "Zero Spend", slug: "zero-spend", createdAt: baseTime, updatedAt: baseTime },
+      { id: ORG_PARENT, name: "Sandbox Parent", slug: "sandbox-parent", createdAt: baseTime, updatedAt: baseTime },
+      {
+        id: ORG_SANDBOX,
+        name: "Sandbox Child",
+        slug: "sandbox-child",
+        parentOrgId: ORG_PARENT,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+    ])
+
+    await pg.db.insert(billingUsagePeriods).values([
+      {
+        id: makeId("bup-high"),
+        organizationId: ORG_HIGH,
+        planSlug: "pro",
+        periodStart: PERIOD_START,
+        periodEnd: PERIOD_END,
+        includedCredits: 100_000,
+        consumedCredits: 50_000,
+        overageCredits: 0,
+        reportedOverageCredits: 0,
+        overageAmountMills: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: makeId("bup-mid"),
+        organizationId: ORG_MID,
+        planSlug: "pro",
+        periodStart: PERIOD_START,
+        periodEnd: PERIOD_END,
+        includedCredits: 100_000,
+        consumedCredits: 20_000,
+        overageCredits: 0,
+        reportedOverageCredits: 0,
+        overageAmountMills: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: makeId("bup-low"),
+        organizationId: ORG_LOW,
+        planSlug: "free",
+        periodStart: PERIOD_START,
+        periodEnd: PERIOD_END,
+        includedCredits: 20_000,
+        consumedCredits: 5_000,
+        overageCredits: 0,
+        reportedOverageCredits: 0,
+        overageAmountMills: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: makeId("bup-zero"),
+        organizationId: ORG_ZERO,
+        planSlug: "free",
+        periodStart: PERIOD_START,
+        periodEnd: PERIOD_END,
+        includedCredits: 20_000,
+        consumedCredits: 0,
+        overageCredits: 0,
+        reportedOverageCredits: 0,
+        overageAmountMills: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: makeId("bup-sbx"),
+        organizationId: ORG_SANDBOX,
+        planSlug: "free",
+        periodStart: PERIOD_START,
+        periodEnd: PERIOD_END,
+        includedCredits: 20_000,
+        consumedCredits: 99_000,
+        overageCredits: 0,
+        reportedOverageCredits: 0,
+        overageAmountMills: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: makeId("bup-past"),
+        organizationId: ORG_LOW,
+        planSlug: "free",
+        periodStart: PAST_START,
+        periodEnd: PAST_END,
+        includedCredits: 20_000,
+        consumedCredits: 80_000,
+        overageCredits: 0,
+        reportedOverageCredits: 0,
+        overageAmountMills: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+    ])
+  })
+
+  it("ranks non-sandbox orgs by current-period consumed credits descending", async () => {
+    const page = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminOrganizationRepository
+        return yield* repo.listByConsumedCredits({ now: NOW, limit: 10 })
+      }),
+    )
+
+    expect(page.hasMore).toBe(false)
+    expect(page.rows.map((r) => ({ id: r.organizationId as string, credits: r.consumedCredits }))).toEqual([
+      { id: ORG_HIGH, credits: 50_000 },
+      { id: ORG_MID, credits: 20_000 },
+      { id: ORG_LOW, credits: 5_000 },
+    ])
+  })
+
+  it("paginates with a composite consumedCredits + organizationId cursor", async () => {
+    const first = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminOrganizationRepository
+        return yield* repo.listByConsumedCredits({ now: NOW, limit: 1 })
+      }),
+    )
+    expect(first.rows).toHaveLength(1)
+    expect(first.hasMore).toBe(true)
+    const firstRow = first.rows[0]
+    expect(firstRow).toBeDefined()
+    if (!firstRow) throw new Error("expected first page row")
+    expect(firstRow.organizationId).toBe(ORG_HIGH)
+
+    const second = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminOrganizationRepository
+        return yield* repo.listByConsumedCredits({
+          now: NOW,
+          limit: 10,
+          cursor: {
+            consumedCredits: firstRow.consumedCredits,
+            organizationId: firstRow.organizationId as string,
+          },
+        })
+      }),
+    )
+
+    expect(second.rows.map((r) => r.organizationId as string)).toEqual([ORG_MID, ORG_LOW])
+    expect(second.hasMore).toBe(false)
   })
 })

--- a/packages/platform/db-postgres/src/repositories/admin-organization-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-organization-repository.test.ts
@@ -413,6 +413,7 @@ describe("AdminOrganizationRepositoryLive.listByConsumedCredits", () => {
           cursor: {
             consumedCredits: firstRow.consumedCredits,
             organizationId: firstRow.organizationId as string,
+            asOf: NOW,
           },
         })
       }),
@@ -420,5 +421,63 @@ describe("AdminOrganizationRepositoryLive.listByConsumedCredits", () => {
 
     expect(second.rows.map((r) => r.organizationId as string)).toEqual([ORG_MID, ORG_LOW])
     expect(second.hasMore).toBe(false)
+  })
+
+  it("picks the earliest overlapping current period before applying the zero-spend filter", async () => {
+    // Earliest overlapping row has 0 credits; a later overlapping row has spend.
+    // findOptionalCurrent would pick the earliest (zero) — ranking must match
+    // and therefore exclude the org rather than promote the later spend row.
+    const ORG_OVERLAP = makeId("org-credit-overlap")
+    const baseTime = new Date("2025-06-01T12:00:00.000Z")
+    const earlyStart = new Date("2026-03-15T00:00:00.000Z")
+    const lateStart = new Date("2026-04-01T00:00:00.000Z")
+    const lateEnd = new Date("2026-05-15T00:00:00.000Z")
+
+    await pg.db.insert(organizations).values({
+      id: ORG_OVERLAP,
+      name: "Overlap",
+      slug: "overlap",
+      createdAt: baseTime,
+      updatedAt: baseTime,
+    })
+    await pg.db.insert(billingUsagePeriods).values([
+      {
+        id: makeId("bup-ov-early"),
+        organizationId: ORG_OVERLAP,
+        planSlug: "free",
+        periodStart: earlyStart,
+        periodEnd: lateEnd,
+        includedCredits: 20_000,
+        consumedCredits: 0,
+        overageCredits: 0,
+        reportedOverageCredits: 0,
+        overageAmountMills: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: makeId("bup-ov-late"),
+        organizationId: ORG_OVERLAP,
+        planSlug: "pro",
+        periodStart: lateStart,
+        periodEnd: lateEnd,
+        includedCredits: 100_000,
+        consumedCredits: 75_000,
+        overageCredits: 0,
+        reportedOverageCredits: 0,
+        overageAmountMills: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+    ])
+
+    const page = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminOrganizationRepository
+        return yield* repo.listByConsumedCredits({ now: NOW, limit: 50 })
+      }),
+    )
+
+    expect(page.rows.map((r) => r.organizationId as string)).not.toContain(ORG_OVERLAP)
   })
 })

--- a/packages/platform/db-postgres/src/repositories/admin-organization-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-organization-repository.ts
@@ -264,8 +264,9 @@ export const AdminOrganizationRepositoryLive = Layer.effect(
         Effect.gen(function* () {
           // One current-period row per org (earliest period_start wins if
           // overlapping rows exist — same tie-break as findOptionalCurrent),
-          // then rank by consumed credits. Sandbox orgs are excluded here so
-          // they never consume a page slot.
+          // then drop zero-spend rows in the outer query so the DISTINCT ON
+          // pick is not skewed by the spend filter. Sandbox orgs are excluded
+          // here so they never consume a page slot.
           const ranked = yield* sqlClient.query((db) => {
             const currentPeriods = db
               .selectDistinctOn([billingUsagePeriods.organizationId], {
@@ -278,33 +279,30 @@ export const AdminOrganizationRepositoryLive = Layer.effect(
                 and(
                   lte(billingUsagePeriods.periodStart, now),
                   gt(billingUsagePeriods.periodEnd, now),
-                  gt(billingUsagePeriods.consumedCredits, 0),
                   isNull(organizations.parentOrgId),
                 ),
               )
               .orderBy(billingUsagePeriods.organizationId, asc(billingUsagePeriods.periodStart))
               .as("current_periods")
 
-            const base = db
-              .select({
-                organizationId: currentPeriods.organizationId,
-                consumedCredits: currentPeriods.consumedCredits,
-              })
-              .from(currentPeriods)
-
-            const filtered = cursor
-              ? base.where(
-                  sql`(
+            const spendFilter = gt(currentPeriods.consumedCredits, 0)
+            const cursorFilter = cursor
+              ? sql`(
                     ${currentPeriods.consumedCredits} < ${cursor.consumedCredits}
                     OR (
                       ${currentPeriods.consumedCredits} = ${cursor.consumedCredits}
                       AND ${currentPeriods.organizationId} > ${cursor.organizationId}
                     )
-                  )`,
-                )
-              : base
+                  )`
+              : undefined
 
-            return filtered
+            return db
+              .select({
+                organizationId: currentPeriods.organizationId,
+                consumedCredits: currentPeriods.consumedCredits,
+              })
+              .from(currentPeriods)
+              .where(cursorFilter ? and(spendFilter, cursorFilter) : spendFilter)
               .orderBy(desc(currentPeriods.consumedCredits), asc(currentPeriods.organizationId))
               .limit(limit + 1)
           })

--- a/packages/platform/db-postgres/src/repositories/admin-organization-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-organization-repository.ts
@@ -1,4 +1,5 @@
 import {
+  type AdminOrganizationCreditSpendRow,
   type AdminOrganizationDetails,
   type AdminOrganizationMember,
   type AdminOrganizationProject,
@@ -14,11 +15,12 @@ import {
   SqlClient,
   type SqlClientShape,
 } from "@domain/shared"
-import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm"
+import { and, asc, desc, eq, gt, inArray, isNull, lte, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { apiKeys } from "../schema/api-keys.ts"
 import { members, organizations, subscriptions, users } from "../schema/better-auth.ts"
+import { billingUsagePeriods } from "../schema/billing.ts"
 import { projects } from "../schema/projects.ts"
 import { sandboxes } from "../schema/sandboxes.ts"
 
@@ -256,6 +258,64 @@ export const AdminOrganizationRepositoryLive = Layer.effect(
             })
           }
           return result
+        }),
+
+      listByConsumedCredits: ({ now, cursor, limit }) =>
+        Effect.gen(function* () {
+          // One current-period row per org (earliest period_start wins if
+          // overlapping rows exist — same tie-break as findOptionalCurrent),
+          // then rank by consumed credits. Sandbox orgs are excluded here so
+          // they never consume a page slot.
+          const ranked = yield* sqlClient.query((db) => {
+            const currentPeriods = db
+              .selectDistinctOn([billingUsagePeriods.organizationId], {
+                organizationId: billingUsagePeriods.organizationId,
+                consumedCredits: billingUsagePeriods.consumedCredits,
+              })
+              .from(billingUsagePeriods)
+              .innerJoin(organizations, eq(organizations.id, billingUsagePeriods.organizationId))
+              .where(
+                and(
+                  lte(billingUsagePeriods.periodStart, now),
+                  gt(billingUsagePeriods.periodEnd, now),
+                  gt(billingUsagePeriods.consumedCredits, 0),
+                  isNull(organizations.parentOrgId),
+                ),
+              )
+              .orderBy(billingUsagePeriods.organizationId, asc(billingUsagePeriods.periodStart))
+              .as("current_periods")
+
+            const base = db
+              .select({
+                organizationId: currentPeriods.organizationId,
+                consumedCredits: currentPeriods.consumedCredits,
+              })
+              .from(currentPeriods)
+
+            const filtered = cursor
+              ? base.where(
+                  sql`(
+                    ${currentPeriods.consumedCredits} < ${cursor.consumedCredits}
+                    OR (
+                      ${currentPeriods.consumedCredits} = ${cursor.consumedCredits}
+                      AND ${currentPeriods.organizationId} > ${cursor.organizationId}
+                    )
+                  )`,
+                )
+              : base
+
+            return filtered
+              .orderBy(desc(currentPeriods.consumedCredits), asc(currentPeriods.organizationId))
+              .limit(limit + 1)
+          })
+
+          const hasMore = ranked.length > limit
+          const pageRows = hasMore ? ranked.slice(0, limit) : ranked
+          const rows: AdminOrganizationCreditSpendRow[] = pageRows.map((row) => ({
+            organizationId: OrganizationId(row.organizationId),
+            consumedCredits: Number(row.consumedCredits),
+          }))
+          return { rows, hasMore }
         }),
 
       findFirstApiKeyId: (organizationId: OrganizationId) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The backoffice Organizations listing now shows a **Credit Spend** column and ranks rows by current billing-period credit consumption (most spent → least spent) instead of 30-day trace count.

## What changed

- Ranking comes from Postgres `billing_usage_periods` for the period that contains the listing's pinned `asOf` instant, ordered by `consumedCredits DESC` (org id tiebreaker for stable pagination).
- Pagination cursors carry `asOf` so a scroll session stays on the same ranking instant across billing-period boundaries.
- Current-period selection uses the same earliest-`periodStart` tie-break as `findOptionalCurrent`; zero-spend filtering happens after that pick.
- Sandbox orgs and zero-spend orgs stay out of the listing.
- Each page still pulls 30d trace counts / last-trace timestamps from ClickHouse to keep the Traces columns useful.
- UI adds the Credit Spend column with a default sort indicator on that column.

## Test plan

- [x] `@domain/admin` use-case tests for credit-spend ranking, hydration, cursor anchoring, and `asOf` reuse
- [x] `@platform/db-postgres` adapter tests for `listByConsumedCredits` (ordering, pagination, sandbox/zero exclusion, overlapping-period tie-break)
- [x] Web input-schema tests for the cursor shape (including required `asOf`)
- [ ] Manually open `/backoffice/organizations` as a platform admin and confirm Credit Spend is shown and the table opens sorted highest → lowest

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb24f-96bb-7480-8aed-6bc4b68d7ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb24f-96bb-7480-8aed-6bc4b68d7ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The backoffice organisations-by-usage listing is now ranked by current billing-period credit spend.
  * Added a **Credit Spend** column with sorting and pagination (defaults to highest spend first).
  * Traces remain shown for context, including organizations without traces in the window.
* **Bug Fixes**
  * Pagination is now anchored to a stable billing-period instant for consistent results across pages.
  * Legacy trace-based pagination cursors are rejected, and missing/invalid cursor data is handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->