### PR TITLE
fix(sessions): make the statistics panel follow the sessions/traces toggle

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
@@ -7,15 +7,16 @@ import { useShowIncidentsOverlay } from "../../../../../../domains/alerts/use-sh
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { GeneralAggregations } from "./general-aggregations.tsx"
 import { Histogram } from "./histogram.tsx"
+import { type AggregationsMode, resolveMetricForMode } from "./histogram-metrics.ts"
 
-const DEFAULT_HISTOGRAM_METRIC: TraceHistogramMetric = "sessions"
+const UNSET_HISTOGRAM_METRIC = ""
 
 interface TraceAggregationsPanelProps {
   readonly projectId: string
   readonly projectSlug: string
   readonly filters: FilterSet
   /** Must match the table below the panel — drives which rollup the cards + histogram use. */
-  readonly mode: "traces" | "sessions"
+  readonly mode: AggregationsMode
   /** Called when user selects a time range via brush on the histogram. */
   readonly onTimeRangeSelect?: (range: { from: string; to: string } | null) => void
   /** Overrides the histogram window (independent of `filters`) — used to anchor an "All time" list to recent activity. */
@@ -31,9 +32,11 @@ export function TraceAggregationsPanel({
   histogramRangeOverride,
 }: TraceAggregationsPanelProps) {
   const [collapsed, setCollapsed] = useState(false)
-  const [selectedMetric, setSelectedMetric] = useParamState("histogramMetric", DEFAULT_HISTOGRAM_METRIC, {
-    validate: isTraceHistogramMetric,
+  const [metricParam, setSelectedMetric] = useParamState("histogramMetric", UNSET_HISTOGRAM_METRIC, {
+    validate: (value): value is TraceHistogramMetric | typeof UNSET_HISTOGRAM_METRIC =>
+      value === UNSET_HISTOGRAM_METRIC || isTraceHistogramMetric(value),
   })
+  const selectedMetric = resolveMetricForMode(metricParam === UNSET_HISTOGRAM_METRIC ? undefined : metricParam, mode)
 
   const { flagEnabled: incidentsFlagEnabled, showIncidents, setShowIncidents } = useShowIncidentsOverlay()
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
@@ -5,11 +5,18 @@ import { ChevronUp } from "lucide-react"
 import { useState } from "react"
 import { useSessionMetrics, useSessionsCount } from "../../../../../../domains/sessions/sessions.collection.ts"
 import { useTraceMetrics, useTracesCount } from "../../../../../../domains/traces/traces.collection.ts"
-import { HISTOGRAM_METRIC_DEFINITIONS, type HistogramMetricDefinition } from "./histogram-metrics.ts"
+import {
+  type AggregationsMode,
+  HISTOGRAM_METRIC_DEFINITIONS,
+  type HistogramMetricDefinition,
+  metricOrderForMode,
+  unitNounForMode,
+} from "./histogram-metrics.ts"
 
 function AggregationItem({
   label,
   value,
+  subValue,
   isLoading,
   isSelected,
   skeletonWidthClassName = "w-16",
@@ -17,6 +24,7 @@ function AggregationItem({
 }: {
   readonly label: string
   readonly value: string
+  readonly subValue?: string | undefined
   readonly isLoading?: boolean
   readonly isSelected: boolean
   readonly skeletonWidthClassName?: string
@@ -28,7 +36,7 @@ function AggregationItem({
       onClick={onClick}
       aria-pressed={isSelected}
       className={cn(
-        "flex basis-[176px] min-w-[176px] shrink-0 cursor-pointer flex-col gap-2 rounded-md p-2 text-left",
+        "flex basis-[176px] min-w-[176px] shrink-0 cursor-pointer flex-col gap-1 rounded-md p-2 text-left",
         "transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         isSelected && "bg-muted",
       )}
@@ -41,21 +49,15 @@ function AggregationItem({
           {value}
         </Text.H5>
       )}
+      {/* Reserved even when empty so cards with and without a sub-value stay the same height. */}
+      <Text.H6 color="foregroundMuted" ellipsis>
+        {isLoading || !subValue ? "\u00a0" : subValue}
+      </Text.H6>
     </button>
   )
 }
 
 const DASH = "—"
-
-const METRIC_ORDER: readonly TraceHistogramMetric[] = [
-  "sessions",
-  "cost",
-  "duration",
-  "tokens",
-  "cacheHitRate",
-  "traces",
-  "spans",
-]
 
 export function GeneralAggregations({
   projectId,
@@ -67,7 +69,7 @@ export function GeneralAggregations({
 }: {
   readonly projectId: string
   readonly filters: FilterSet
-  readonly mode: "traces" | "sessions"
+  readonly mode: AggregationsMode
   readonly selectedMetric: TraceHistogramMetric
   readonly onMetricSelect: (metric: TraceHistogramMetric) => void
   readonly onCollapse: () => void
@@ -87,7 +89,7 @@ export function GeneralAggregations({
     ...filterOpts,
   })
   const { totalCount: sessionTotalCount, isLoading: sessionCountLoading } = useSessionsCount({
-    projectId,
+    projectId: sessionModeProjectId,
     ...filterOpts,
   })
   const { data: sessionMetrics, isLoading: sessionMetricsLoading } = useSessionMetrics({
@@ -106,7 +108,8 @@ export function GeneralAggregations({
   // Each metric declares its own visibility via `isAvailable` (e.g. cache hit
   // rate hides itself when there are no input-side tokens). The Boolean filter
   // defends the panel against a metric id with no definition.
-  const visibleMetrics = METRIC_ORDER.map((id) => HISTOGRAM_METRIC_DEFINITIONS[id])
+  const visibleMetrics = metricOrderForMode(mode)
+    .map((id) => HISTOGRAM_METRIC_DEFINITIONS[id])
     .filter((def): def is HistogramMetricDefinition => Boolean(def))
     .filter((def) => def.isAvailable?.(activeMetrics) ?? true)
 
@@ -117,6 +120,13 @@ export function GeneralAggregations({
     if (def.id === "traces") return def.formatBucket(traceCount)
     if (!activeMetrics) return DASH
     return def.formatBucket(def.selectMetricsValue(activeMetrics, traceCount))
+  }
+
+  const unitNoun = unitNounForMode(mode)
+
+  const renderSubValue = (def: HistogramMetricDefinition): string | undefined => {
+    if (!activeMetrics || !def.selectUnitAverage) return undefined
+    return `avg ${def.formatBucket(def.selectUnitAverage(activeMetrics))}/${unitNoun}`
   }
 
   const loadingForCard = (id: TraceHistogramMetric): boolean => {
@@ -137,6 +147,7 @@ export function GeneralAggregations({
               key={def.id}
               label={def.label}
               value={renderValue(def)}
+              subValue={renderSubValue(def)}
               isLoading={loadingForCard(def.id)}
               isSelected={selectedMetric === def.id}
               skeletonWidthClassName={def.cardSkeletonWidthClassName}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram-metrics.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram-metrics.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { metricOrderForMode, resolveMetricForMode, unitNounForMode } from "./histogram-metrics.ts"
+
+describe("metricOrderForMode", () => {
+  it("leads with the mode's own unit", () => {
+    expect(metricOrderForMode("sessions")[0]).toBe("sessions")
+    expect(metricOrderForMode("traces")[0]).toBe("traces")
+  })
+
+  it("omits the session count in traces mode", () => {
+    expect(metricOrderForMode("traces")).not.toContain("sessions")
+    expect(metricOrderForMode("sessions")).toContain("traces")
+  })
+})
+
+describe("resolveMetricForMode", () => {
+  it("falls back to the mode's leading metric when unset", () => {
+    expect(resolveMetricForMode(undefined, "sessions")).toBe("sessions")
+    expect(resolveMetricForMode(undefined, "traces")).toBe("traces")
+  })
+
+  it("keeps an explicit pick the mode offers", () => {
+    expect(resolveMetricForMode("cost", "traces")).toBe("cost")
+    expect(resolveMetricForMode("traces", "sessions")).toBe("traces")
+  })
+
+  it("drops a pick the mode does not offer", () => {
+    expect(resolveMetricForMode("sessions", "traces")).toBe("traces")
+  })
+})
+
+describe("unitNounForMode", () => {
+  it("names the row the aggregate is computed over", () => {
+    expect(unitNounForMode("sessions")).toBe("session")
+    expect(unitNounForMode("traces")).toBe("trace")
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram-metrics.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram-metrics.ts
@@ -23,11 +23,53 @@ export interface HistogramMetricDefinition {
    */
   readonly selectMetricsValue: (metrics: TraceMetrics | SessionMetrics, totalCount: number) => number
   /**
+   * Per-row average shown under the card value. The rollup is computed over session rows in sessions
+   * mode and trace rows in traces mode, so `avg` is already per-unit — and it is the only thing that
+   * moves between modes on a card whose headline is a sum, since a sum over sessions equals the same
+   * sum over their traces.
+   */
+  readonly selectUnitAverage?: (metrics: TraceMetrics | SessionMetrics) => number
+  /**
    * Whether to show this metric's card/series for the current aggregate. Omit
    * for always-visible metrics; a ratio metric hides itself when its
    * denominator is empty so it doesn't render a meaningless permanent 0.
    */
   readonly isAvailable?: (metrics: TraceMetrics | SessionMetrics | undefined) => boolean
+}
+
+export type AggregationsMode = "traces" | "sessions"
+
+/**
+ * Card + histogram metric order per mode, leading with the mode's own unit. `sessions` is absent in
+ * traces mode: the session count is a project-wide count of sessions matching the filters read as
+ * *session* filters, so it cannot answer "how many sessions do these traces belong to" — showing it
+ * beside a filtered trace list reads as a broken number rather than a different question.
+ */
+const METRIC_ORDER_BY_MODE: Readonly<
+  Record<AggregationsMode, readonly [TraceHistogramMetric, ...TraceHistogramMetric[]]>
+> = {
+  sessions: ["sessions", "cost", "duration", "tokens", "cacheHitRate", "traces", "spans"],
+  traces: ["traces", "cost", "duration", "tokens", "cacheHitRate", "spans"],
+}
+
+export const metricOrderForMode = (mode: AggregationsMode): readonly TraceHistogramMetric[] =>
+  METRIC_ORDER_BY_MODE[mode]
+
+/** Row noun of the aggregate backing each mode — the denominator of every `selectUnitAverage`. */
+export const unitNounForMode = (mode: AggregationsMode): string => (mode === "sessions" ? "session" : "trace")
+
+/**
+ * Resolves the selected metric against the active mode: an explicit pick wins as long as the mode
+ * offers that metric, otherwise the mode's leading metric does — so the chart plots the unit the
+ * table below it is listing.
+ */
+export const resolveMetricForMode = (
+  metric: TraceHistogramMetric | undefined,
+  mode: AggregationsMode,
+): TraceHistogramMetric => {
+  const [leading, ...rest] = METRIC_ORDER_BY_MODE[mode]
+  if (metric && (metric === leading || rest.includes(metric))) return metric
+  return leading
 }
 
 const microcentsToUSD = (microcents: number): string => formatPrice(microcents / 100_000_000)
@@ -61,6 +103,7 @@ export const HISTOGRAM_METRIC_DEFINITIONS: Readonly<Record<TraceHistogramMetric,
     formatBucket: microcentsToUSD,
     selectBucket: (b) => b.costTotalMicrocentsSum,
     selectMetricsValue: (m) => m.costTotalMicrocents.sum,
+    selectUnitAverage: (m) => m.costTotalMicrocents.avg,
   },
   duration: {
     id: "duration",
@@ -70,6 +113,7 @@ export const HISTOGRAM_METRIC_DEFINITIONS: Readonly<Record<TraceHistogramMetric,
     formatBucket: formatDuration,
     selectBucket: (b) => b.durationNsMedian,
     selectMetricsValue: (m) => m.durationNs.median,
+    selectUnitAverage: (m) => m.durationNs.avg,
   },
   tokens: {
     id: "tokens",
@@ -79,6 +123,7 @@ export const HISTOGRAM_METRIC_DEFINITIONS: Readonly<Record<TraceHistogramMetric,
     formatBucket: formatCount,
     selectBucket: (b) => b.tokensTotalSum,
     selectMetricsValue: (m) => m.tokensTotal.sum,
+    selectUnitAverage: (m) => m.tokensTotal.avg,
   },
   cacheHitRate: {
     id: "cacheHitRate",
@@ -105,5 +150,6 @@ export const HISTOGRAM_METRIC_DEFINITIONS: Readonly<Record<TraceHistogramMetric,
     formatBucket: formatCount,
     selectBucket: (b) => b.spanCountSum,
     selectMetricsValue: (m) => m.spanCount.sum,
+    selectUnitAverage: (m) => m.spanCount.avg,
   },
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
@@ -10,7 +10,7 @@ import { useIncidentBucketHoverPopover } from "../../../../../../domains/alerts/
 import { useSessionTimeHistogram } from "../../../../../../domains/sessions/sessions.collection.ts"
 import { useTraceTimeHistogram } from "../../../../../../domains/traces/traces.collection.ts"
 import { ChartHeader } from "../chart-header.tsx"
-import { HISTOGRAM_METRIC_DEFINITIONS } from "./histogram-metrics.ts"
+import { type AggregationsMode, HISTOGRAM_METRIC_DEFINITIONS } from "./histogram-metrics.ts"
 
 function formatBucketAxisLabel(iso: string): string {
   const d = new Date(iso)
@@ -26,7 +26,7 @@ interface HistogramProps {
   readonly projectId: string
   readonly projectSlug: string
   readonly filters: FilterSet
-  readonly mode: "traces" | "sessions"
+  readonly mode: AggregationsMode
   readonly metric: TraceHistogramMetric
   readonly showIncidents: boolean
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined


### PR DESCRIPTION
## What does this PR do?

Makes the Statistics panel above the Sessions/Traces table respond to the view toggle.

The panel was already mode-aware — `mode` reaches `GeneralAggregations` and `Histogram`, and each disables the other mode's query — but the switch was nearly invisible in the UI, which read as a bug. Three separate reasons:

1. The histogram metric was pinned to `sessions` (`DEFAULT_HISTOGRAM_METRIC`), so the Traces tab kept the Sessions card selected and kept plotting sessions per bucket.
2. Four of the seven cards are sums — Cost, Tokens, Spans, and the token-weighted Cache hit rate. A sum over sessions equals the same sum over those sessions' traces, so those values are *correctly* byte-identical in both tabs and can never move. Only Median duration (session duration vs trace duration) visibly changed, which is exactly what was reported.
3. The Sessions card ignored `mode` entirely: it called `useSessionsCount({ projectId })` with the raw project id in both tabs, unlike every other card.

## Changes

**Metric selection follows the mode.** `histogramMetric` is now unset by default and resolved against the active mode by `resolveMetricForMode`: the Traces tab leads on `traces`, the Sessions tab on `sessions`. An explicit click still wins and still persists in the URL, but only if the active mode offers that metric — so a bookmarked `?histogramMetric=sessions` opened on the Traces tab falls back to `traces` instead of selecting a card that isn't rendered.

**Sum cards state their denominator.** New optional `selectUnitAverage` on `HistogramMetricDefinition`, rendered as a sub-line under Cost, Median duration, Tokens and Spans: `avg $0.035/session` on one tab, `avg $0.024/trace` on the other. It reads `rollup.avg`, which is already per-row in each mode, so this adds no query. This is the honest fix for "the numbers don't change" — the headline sum *should* be identical, and the per-unit average is the figure that actually differs between the two rollups. The sub-line slot is always rendered (nbsp when a metric has no average) so card heights stay uniform.

**Traces leads in traces mode, and the Sessions card is not shown there.** `METRIC_ORDER` became `METRIC_ORDER_BY_MODE`, with `sessions` omitted from the traces order, and `useSessionsCount` is now gated on `sessionModeProjectId` like every other card — so the Traces tab stops issuing that request.

That last one is a scope decision worth flagging. The Sessions card in traces mode wasn't just static, it was answering a different question: the same `FilterSet` compiles through `buildSessionFilterClauses`/`SESSION_FIELD_REGISTRY` against the `sessions` aggregate, plus the implicit `hasLlmActivity: true` default that trace queries don't apply. Both registries define the same field names, so nothing is silently dropped — but the columns mean different things. With `duration > 30s` applied, the table lists traces over 30s while the card counts sessions whose *whole-session* duration exceeds 30s. Same for `cost`, `spanCount`, `errorCount`, `tokensInput`. Hiding it beats showing a number that disagrees with the list beside it.

## Follow-up

A correct trace-mode session count is small and needs no migration: `trace-repository.ts` already computes `uniqExact(coalesce(nullIf(session_id, ''), toString(trace_id)))` per bucket for the histogram (`HISTOGRAM_BUCKET_SELECT`). Dropping that expression into `aggregateMetricsByProjectId` and adding `sessionCount` to `TraceMetrics` would let the card come back in traces mode with filter-responsive semantics. Left out of this PR to keep it web-only.

Also unchanged: the `hasLlmActivity` asymmetry between session and trace queries means that in a project containing non-LLM traces, the traces tab reports higher sums than the sessions tab with no explanation in the UI. Worth its own issue.

## How was this tested?

`pnpm --filter @app/web typecheck` and Biome pass. Added `histogram-metrics.test.ts` covering per-mode order, the fallback when the metric is unset, an explicit pick surviving a mode that offers it, and a pick being dropped by a mode that doesn't (6 tests, passing).

Not verified in a browser — this worktree had no `node_modules`, so deps were installed and `@latitude-data/telemetry` built (it was unbuilt and failed typecheck), but no dev server was run against a real project. Reviewer sanity check worth doing: on the Traces tab confirm the Traces card is selected and leading, the histogram plots traces per bucket, and the `/trace` averages differ from the `/session` ones on the Sessions tab.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Aggregation panels now automatically select relevant metrics for trace and session views.
  * Metric cards display per-trace or per-session averages when available.
  * Metric ordering and unit labels now adapt to the selected view.

* **Bug Fixes**
  * Improved histogram metric selection when no explicit metric is chosen.
  * Prevented session-only metrics from appearing in trace views.
  * Improved consistency of aggregation card layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->