### PR TITLE
feat(cost): cache economics — per-model break-even and the six-state classifier

### DIFF
--- a/apps/web/src/domains/cost/cost.collection.ts
+++ b/apps/web/src/domains/cost/cost.collection.ts
@@ -1,7 +1,13 @@
 import type { CostBreakdownDimension, CostSeriesMetric } from "@domain/spans"
 import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import { projectScopeData, projectScopeKey, useProjectScope } from "../projects/project-scope.tsx"
-import { getCostBreakdown, getCostOverview, getCostSeries, getModelUsageSeries } from "./cost.functions.ts"
+import {
+  getCacheEconomics,
+  getCostBreakdown,
+  getCostOverview,
+  getCostSeries,
+  getModelUsageSeries,
+} from "./cost.functions.ts"
 
 /** Time window shared by every cost query — lower bound inclusive, upper bound exclusive. */
 interface CostTimeRange {
@@ -51,6 +57,25 @@ export function useCostBreakdown({
     queryKey: [...projectScopeKey(scope), "cost-breakdown", projectId, range, dimension],
     queryFn: () => getCostBreakdown({ data: { ...projectScopeData(scope), projectId, ...range, dimension } }),
     staleTime: COST_STALE_TIME_MS,
+    enabled: enabled && projectId.length > 0,
+  })
+}
+
+export function useCacheEconomics({
+  projectId,
+  range,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly range: CostTimeRange
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "cache-economics", projectId, range],
+    queryFn: () => getCacheEconomics({ data: { ...projectScopeData(scope), projectId, ...range } }),
+    staleTime: COST_STALE_TIME_MS,
+    placeholderData: keepPreviousData,
     enabled: enabled && projectId.length > 0,
   })
 }

--- a/apps/web/src/domains/cost/cost.functions.ts
+++ b/apps/web/src/domains/cost/cost.functions.ts
@@ -1,5 +1,7 @@
 import { type OrganizationId, ProjectId } from "@domain/shared"
 import type {
+  CacheClassification,
+  CacheUsageMeasures,
   ClassifiedUnpricedPair,
   CostAnalyticsScope,
   CostBreakdown,
@@ -10,11 +12,14 @@ import {
   COST_BREAKDOWN_DIMENSIONS,
   COST_SERIES_METRICS,
   CostAnalyticsRepository,
+  classifyCacheState,
   isUnpricedGap,
+  modelCacheBreakEvenRate,
   summarizeUnpricedUsage,
 } from "@domain/spans"
 import { CostAnalyticsRepositoryLive } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
+import { cacheHitRate } from "@repo/utils"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
@@ -68,6 +73,24 @@ export interface ModelUsageSeriesRecord {
   readonly buckets: readonly ModelUsageBucketRecord[]
   readonly models: readonly string[]
   readonly otherModels: number
+}
+
+/**
+ * One model's cache position. Rates are exactly measured from token counts;
+ * `breakEvenRate` comes from the pricing registry, which the browser entry
+ * cannot reach, so it is resolved here rather than in the panel.
+ */
+export interface CacheModelRecord extends CacheUsageMeasures, CacheClassification {
+  readonly model: string
+  readonly provider: string
+  readonly cachingOn: boolean
+  readonly actualRate: number | null
+  readonly breakEvenRate: number | null
+}
+
+export interface CacheEconomicsRecord {
+  readonly rows: readonly CacheModelRecord[]
+  readonly totals: CacheUsageMeasures & { readonly distinctModels: number }
 }
 
 // Well above what any window the picker offers can ask for at its bucket width.
@@ -176,6 +199,47 @@ export const getCostBreakdown = createServerFn({ method: "GET" })
       Effect.gen(function* () {
         const repo = yield* CostAnalyticsRepository
         return yield* repo.getCostBreakdown({ ...toScope(orgId, data), dimension: data.dimension })
+      }).pipe(withScopedClickHouse(CostAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+  })
+
+export const getCacheEconomics = createServerFn({ method: "GET" })
+  .inputValidator(costScopeSchema)
+  .handler(async ({ data, context }): Promise<CacheEconomicsRecord> => {
+    const orgId = await resolveOrgScope(context)
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* CostAnalyticsRepository
+        const economics = yield* repo.getCacheEconomics(toScope(orgId, data))
+        return {
+          rows: economics.rows.map((row): CacheModelRecord => {
+            const cachingOn = row.cacheReadTokens + row.cacheCreateTokens > 0
+            const actualRate = cacheHitRate({
+              input: row.inputTokens,
+              cacheRead: row.cacheReadTokens,
+              cacheCreate: row.cacheCreateTokens,
+            })
+            const breakEvenRate = modelCacheBreakEvenRate({ provider: row.provider, model: row.model })
+            return {
+              ...row,
+              cachingOn,
+              actualRate,
+              breakEvenRate,
+              // The achievable ceiling lands with the recommendation cards; until
+              // then the classifier only returns verdicts that hold for any ceiling.
+              ...classifyCacheState({
+                cachingOn,
+                actualRate,
+                ceilingRate: null,
+                breakEvenRate,
+                calls: row.calls,
+                avgInputTokensPerCall:
+                  row.calls > 0 ? (row.inputTokens + row.cacheReadTokens + row.cacheCreateTokens) / row.calls : 0,
+              }),
+            }
+          }),
+          totals: economics.totals,
+        }
       }).pipe(withScopedClickHouse(CostAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cache-economics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cache-economics-panel.tsx
@@ -1,0 +1,308 @@
+import { CACHE_ECONOMICS_MIN_CALLS, CACHE_MIN_CACHEABLE_INPUT_TOKENS, type CacheState } from "@domain/spans"
+import type { BadgeProps } from "@repo/ui"
+import {
+  Badge,
+  DotIndicator,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableSkeleton,
+  Text,
+  Tooltip,
+} from "@repo/ui"
+import { formatCount, formatPercentage } from "@repo/utils"
+import type { CacheEconomicsRecord, CacheModelRecord } from "../../../../../../domains/cost/cost.functions.ts"
+import { rollupCostDisplay } from "../../../../../../domains/spans/cost-display.ts"
+import { CALLS_SERIES_COLOR, TREND_COLOR } from "./cost-series-colors.ts"
+
+const DASH = "—"
+
+// Beyond this the table stops being a comparison. Rows are ranked by spend, so
+// what falls off is what matters least.
+const CACHE_ROWS_SHOWN = 10
+
+const STATE_META: Record<CacheState, { readonly label: string; readonly variant: BadgeProps["variant"] }> = {
+  optimal: { label: "Optimal", variant: "successMuted" },
+  cacheIt: { label: "Cache it", variant: "warningMuted" },
+  stopCaching: { label: "Stop caching", variant: "destructiveMuted" },
+  investigate: { label: "Investigate", variant: "warningMuted" },
+  correctlyOff: { label: "Correctly off", variant: "muted" },
+  notEnoughData: { label: "Not enough data", variant: "muted" },
+}
+
+const avgInputTokensPerCall = (row: CacheModelRecord): number =>
+  row.calls > 0 ? (row.inputTokens + row.cacheReadTokens + row.cacheCreateTokens) / row.calls : 0
+
+function stateExplanation(row: CacheModelRecord): string {
+  const breakEven = row.breakEvenRate === null ? null : formatPercentage(row.breakEvenRate)
+  switch (row.state) {
+    case "optimal":
+      return `Reads cover ${formatPercentage(row.actualRate ?? 0)} of the input, past the ${breakEven} this model needs to pay for its cache writes.`
+    case "cacheIt":
+      return "This model charges no cache-write premium, so any prefix reuse is pure upside and turning caching on cannot cost more."
+    case "stopCaching":
+      return `This traffic cannot reach ${breakEven}, so every write is a cost with no matching discount ever arriving.`
+    case "investigate":
+      return row.urgency === "overpaying"
+        ? `Reads cover only ${formatPercentage(row.actualRate ?? 0)} of the input, below the ${breakEven} break-even — caching is currently costing more than not caching. Every lever lives in your own code, so this flags the gap rather than prescribing a fix.`
+        : "The rate clears break-even but leaves savings behind."
+    case "correctlyOff":
+      return avgInputTokensPerCall(row) < CACHE_MIN_CACHEABLE_INPUT_TOKENS
+        ? `Prompts average ${formatCount(Math.round(avgInputTokensPerCall(row)))} tokens, under the ${formatCount(CACHE_MIN_CACHEABLE_INPUT_TOKENS)} the major providers will cache at all, so caching is unavailable here rather than unprofitable.`
+        : `This traffic cannot reach ${breakEven}, so leaving caching off is the cheaper setup.`
+    case "notEnoughData":
+      if (row.breakEvenRate === null)
+        return "No cache pricing is published for this model, so it has no break-even to compare against."
+      if (row.calls < CACHE_ECONOMICS_MIN_CALLS)
+        return `${formatCount(row.calls)} calls is below the ${CACHE_ECONOMICS_MIN_CALLS} a hit rate needs before it is a finding rather than a one-sample artefact.`
+      return `Caching is off and this model charges a write premium, so whether caching would pay depends on how much of this traffic could hit the cache — the achievable ceiling that answers it is not computed yet.`
+  }
+}
+
+/**
+ * Actual against break-even on one shared 0-100% track: two numbers as position on
+ * the same axis rather than two more numeric columns, which is what makes the
+ * comparison readable down the table. Raw values move to the hover.
+ */
+function PositionBar({ row }: { readonly row: CacheModelRecord }) {
+  const actual = row.actualRate
+  const breakEven = row.breakEvenRate
+  const clear = actual !== null && breakEven !== null && actual >= breakEven
+
+  return (
+    <Tooltip
+      asChild
+      trigger={
+        <div className="flex w-full cursor-default flex-row items-center gap-2">
+          <div className="relative h-2.5 w-full overflow-hidden rounded-sm bg-muted">
+            <div
+              className="h-full rounded-sm"
+              style={{
+                width: `${Math.max(0, Math.min(100, (actual ?? 0) * 100))}%`,
+                backgroundColor: clear ? CALLS_SERIES_COLOR : TREND_COLOR,
+              }}
+            />
+            {breakEven === null ? null : (
+              <div
+                className="absolute inset-y-0 w-0.5 bg-foreground"
+                style={{ left: `${Math.max(0, Math.min(100, breakEven * 100))}%` }}
+                aria-hidden="true"
+              />
+            )}
+          </div>
+          <Text.H6 color="foregroundMuted" noWrap className="w-10 shrink-0 text-right tabular-nums">
+            {actual === null ? DASH : formatPercentage(actual)}
+          </Text.H6>
+        </div>
+      }
+    >
+      {[
+        `Cached input ${actual === null ? DASH : formatPercentage(actual)} · break-even ${breakEven === null ? "unknown" : formatPercentage(breakEven)}`,
+        `${formatCount(row.cacheReadTokens)} read, ${formatCount(row.cacheCreateTokens)} written, ${formatCount(row.inputTokens)} uncached input tokens`,
+      ].join("\n")}
+    </Tooltip>
+  )
+}
+
+function CacheTable({ economics }: { readonly economics: CacheEconomicsRecord }) {
+  const rows = economics.rows.slice(0, CACHE_ROWS_SHOWN)
+  const hidden = economics.totals.distinctModels - rows.length
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Table wrapperClassName="border-0 rounded-none">
+        <TableHeader className="[&_tr]:border-b-0">
+          <TableRow hoverable={false}>
+            <TableHead align="left" className="bg-transparent">
+              <Text.H5M color="foregroundMuted" noWrap>
+                Model
+              </Text.H5M>
+            </TableHead>
+            <TableHead align="left" className="bg-transparent border-l border-border">
+              <Text.H5M color="foregroundMuted" noWrap>
+                Provider
+              </Text.H5M>
+            </TableHead>
+            <TableHead align="left" className="bg-transparent border-l border-border">
+              <Tooltip
+                asChild
+                trigger={
+                  <span className="inline-flex cursor-default">
+                    <Text.H5M color="foregroundMuted" noWrap>
+                      Position
+                    </Text.H5M>
+                  </span>
+                }
+              >
+                The share of input tokens served from cache, against the rate this model needs to break even. The
+                break-even mark comes from the model's own registry prices, so it differs row to row.
+              </Tooltip>
+            </TableHead>
+            <TableHead align="left" className="bg-transparent border-l border-border">
+              <Text.H5M color="foregroundMuted" noWrap>
+                State
+              </Text.H5M>
+            </TableHead>
+            <TableHead align="right" className="bg-transparent border-l border-border">
+              <Text.H5M color="foregroundMuted" noWrap>
+                Calls
+              </Text.H5M>
+            </TableHead>
+            <TableHead align="right" className="bg-transparent border-l border-border">
+              <Text.H5M color="foregroundMuted" noWrap>
+                Spend
+              </Text.H5M>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => {
+            const spend = rollupCostDisplay({
+              costTotalMicrocents: row.costMicrocents,
+              unpricedSpanCount: row.unpricedCalls,
+              tokensTotal: row.inputTokens + row.cacheReadTokens + row.cacheCreateTokens,
+            })
+            const meta = STATE_META[row.state]
+            return (
+              <TableRow key={`${row.provider}/${row.model}`} className="border-background bg-secondary/40">
+                <TableCell>
+                  <div className="flex flex-row items-center gap-2">
+                    <Tooltip
+                      asChild
+                      trigger={
+                        <DotIndicator
+                          variant={row.cachingOn ? "success" : "default"}
+                          className={row.cachingOn ? undefined : "opacity-50"}
+                          aria-hidden={false}
+                          aria-label={row.cachingOn ? "Caching on" : "Caching off"}
+                        />
+                      }
+                    >
+                      {row.cachingOn ? "Caching on in this window" : "No cache reads or writes in this window"}
+                    </Tooltip>
+                    <Text.H5 color="foreground" ellipsis noWrap>
+                      {row.model || "unknown model"}
+                    </Text.H5>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Text.H5 color="foregroundMuted" ellipsis noWrap>
+                    {row.provider || "unknown"}
+                  </Text.H5>
+                </TableCell>
+                <TableCell>
+                  <PositionBar row={row} />
+                </TableCell>
+                <TableCell>
+                  <Tooltip
+                    asChild
+                    trigger={
+                      <Badge variant={meta.variant} size="small">
+                        {meta.label}
+                      </Badge>
+                    }
+                  >
+                    {stateExplanation(row)}
+                  </Tooltip>
+                </TableCell>
+                <TableCell align="right">
+                  <Text.H5 color="foreground" noWrap className="tabular-nums">
+                    {formatCount(row.calls)}
+                  </Text.H5>
+                </TableCell>
+                <TableCell align="right">
+                  {spend.note ? (
+                    <Tooltip
+                      asChild
+                      trigger={
+                        <span className="inline-flex cursor-default">
+                          <Text.H5 color="foreground" noWrap className="tabular-nums">
+                            {spend.label}
+                          </Text.H5>
+                        </span>
+                      }
+                    >
+                      {spend.note}
+                    </Tooltip>
+                  ) : (
+                    <Text.H5 color="foreground" noWrap className="tabular-nums">
+                      {spend.label}
+                    </Text.H5>
+                  )}
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+      <div className="flex flex-row items-center justify-between gap-2">
+        <Text.H6 color="foregroundMuted">
+          Rates are measured exactly from token counts; spend is the recorded total. Break-even is derived per model
+          from its registry prices, so a model with no cache-write premium breaks even at 0%.
+        </Text.H6>
+        {hidden > 0 ? (
+          <Text.H6 color="foregroundMuted" noWrap>
+            {`${formatCount(hidden)} lower-spending models not shown`}
+          </Text.H6>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Whether each model's caching is paying for itself. A comparison table rather
+ * than one model at a time: break-even differs per model, which is exactly the
+ * thing paging through them one by one hides.
+ */
+export function CacheEconomicsPanel({
+  economics,
+  isLoading,
+}: {
+  readonly economics: CacheEconomicsRecord | undefined
+  readonly isLoading: boolean
+}) {
+  return (
+    // The row separators are painted in `--background`, so the card must carry it.
+    <div className="flex flex-col gap-3 rounded-lg border border-border bg-background p-3">
+      <div className="flex flex-row flex-wrap items-center justify-between gap-2">
+        <Text.H6 color="foreground">Cache economics</Text.H6>
+        <div className="flex flex-row items-center gap-3">
+          {[
+            { label: "Clears break-even", color: CALLS_SERIES_COLOR },
+            { label: "Below break-even", color: TREND_COLOR },
+          ].map((entry) => (
+            <div key={entry.label} className="flex flex-row items-center gap-1.5">
+              <span
+                className="h-2 w-3 shrink-0 rounded-sm"
+                style={{ backgroundColor: entry.color }}
+                aria-hidden="true"
+              />
+              <Text.H6 color="foregroundMuted" noWrap>
+                {entry.label}
+              </Text.H6>
+            </div>
+          ))}
+          <div className="flex flex-row items-center gap-1.5">
+            <span className="h-2.5 w-0.5 shrink-0 bg-foreground" aria-hidden="true" />
+            <Text.H6 color="foregroundMuted" noWrap>
+              Break-even
+            </Text.H6>
+          </div>
+        </div>
+      </div>
+      {isLoading || !economics ? (
+        <TableSkeleton rows={5} cols={6} />
+      ) : economics.rows.length === 0 ? (
+        <div className="flex w-full min-h-[120px] items-center justify-center">
+          <Text.H6 color="foregroundMuted">No billable model usage in this time window</Text.H6>
+        </div>
+      ) : (
+        <CacheTable economics={economics} />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cache-economics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cache-economics-panel.tsx
@@ -2,6 +2,7 @@ import { CACHE_ECONOMICS_MIN_CALLS, CACHE_MIN_CACHEABLE_INPUT_TOKENS, type Cache
 import type { BadgeProps } from "@repo/ui"
 import {
   Badge,
+  cn,
   DotIndicator,
   Table,
   TableBody,
@@ -71,6 +72,10 @@ function PositionBar({ row }: { readonly row: CacheModelRecord }) {
   const actual = row.actualRate
   const breakEven = row.breakEvenRate
   const clear = actual !== null && breakEven !== null && actual >= breakEven
+  // A rate we declined to judge must not be the loudest mark on its own row: a
+  // real quotient over three calls still reads as a finding when it is coloured
+  // like one.
+  const unjudged = row.state === "notEnoughData"
 
   return (
     <Tooltip
@@ -79,13 +84,13 @@ function PositionBar({ row }: { readonly row: CacheModelRecord }) {
         <div className="flex w-full cursor-default flex-row items-center gap-2">
           <div className="relative h-2.5 w-full overflow-hidden rounded-sm bg-muted">
             <div
-              className="h-full rounded-sm"
+              className={cn("h-full rounded-sm", { "bg-muted-foreground/40": unjudged })}
               style={{
                 width: `${Math.max(0, Math.min(100, (actual ?? 0) * 100))}%`,
-                backgroundColor: clear ? CALLS_SERIES_COLOR : TREND_COLOR,
+                ...(unjudged ? {} : { backgroundColor: clear ? CALLS_SERIES_COLOR : TREND_COLOR }),
               }}
             />
-            {breakEven === null ? null : (
+            {breakEven === null || unjudged ? null : (
               <div
                 className="absolute inset-y-0 w-0.5 bg-foreground"
                 style={{ left: `${Math.max(0, Math.min(100, breakEven * 100))}%` }}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
@@ -2,6 +2,7 @@ import { Text } from "@repo/ui"
 import { createFileRoute } from "@tanstack/react-router"
 import { useMemo } from "react"
 import {
+  useCacheEconomics,
   useCostBreakdown,
   useCostOverview,
   useCostSeries,
@@ -15,6 +16,7 @@ import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { BreadcrumbText } from "../../../-components/breadcrumb-ui.tsx"
 import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
 import { useRouteProject } from "../-route-data.ts"
+import { CacheEconomicsPanel } from "./-components/cache-economics-panel.tsx"
 import { CostBreakdownPanel } from "./-components/cost-breakdown-panel.tsx"
 import { CostConfidenceStrip } from "./-components/cost-confidence-strip.tsx"
 import {
@@ -103,6 +105,11 @@ function CostPageContent() {
     projectId: project.id,
     range,
     bucketSeconds,
+    enabled,
+  })
+  const { data: cacheEconomics, isLoading: cacheEconomicsLoading } = useCacheEconomics({
+    projectId: project.id,
+    range,
     enabled,
   })
   const { data: breakdown, isLoading: breakdownLoading } = useCostBreakdown({
@@ -219,6 +226,8 @@ function CostPageContent() {
             />
           </div>
         </div>
+        <SectionHeading>Cache</SectionHeading>
+        <CacheEconomicsPanel economics={cacheEconomics} isLoading={cacheEconomicsLoading} />
         <CostBreakdownPanel
           breakdown={breakdown}
           dimension={dimension}

--- a/packages/domain/shared/src/seed-content/models.ts
+++ b/packages/domain/shared/src/seed-content/models.ts
@@ -5,6 +5,13 @@ export type ModelConfig = {
   readonly scopeName: string
   readonly costInPerMToken: number
   readonly costOutPerMToken: number
+  /**
+   * Per-1M-token cache rates. Absent means the provider charges no separate cache
+   * price, so the input rate applies — which is also what collapses a model's
+   * cache break-even to 0%.
+   */
+  readonly cacheReadPerMToken?: number
+  readonly cacheWritePerMToken?: number
   readonly latencyRange: readonly [min: number, max: number]
   readonly isReasoning?: boolean
   readonly finishReasonStop: string

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -40,6 +40,21 @@ export {
 export type { Trace, TraceConversationChunk, TraceDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
+export type {
+  CacheClassification,
+  CacheClassificationInput,
+  CacheEconomicsPricing,
+  CacheState,
+  CacheUrgency,
+} from "./helpers/cache-economics.ts"
+export {
+  CACHE_ECONOMICS_MIN_CALLS,
+  CACHE_MIN_CACHEABLE_INPUT_TOKENS,
+  CACHE_STATES,
+  CACHE_URGENCIES,
+  cacheBreakEvenRate,
+  classifyCacheState,
+} from "./helpers/cache-economics.ts"
 export {
   canonicalizeMessageForEmbedding,
   hashMessageContent,
@@ -62,6 +77,9 @@ export {
   resolveTraceHistogramRangeIso,
 } from "./helpers.ts"
 export type {
+  CacheEconomics,
+  CacheModelUsage,
+  CacheUsageMeasures,
   CostBreakdown,
   CostBreakdownDimension,
   CostBreakdownRow,
@@ -74,6 +92,7 @@ export type {
   ModelUsageSlice,
 } from "./ports/cost-analytics-repository.ts"
 export {
+  CACHE_ECONOMICS_ROW_LIMIT,
   COST_BREAKDOWN_DIMENSIONS,
   COST_PER_CALL_MIN_SAMPLE_CALLS,
   COST_SERIES_METRICS,

--- a/packages/domain/spans/src/helpers/cache-economics.test.ts
+++ b/packages/domain/spans/src/helpers/cache-economics.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest"
+import {
+  CACHE_ECONOMICS_MIN_CALLS,
+  CACHE_MIN_CACHEABLE_INPUT_TOKENS,
+  type CacheClassificationInput,
+  cacheBreakEvenRate,
+  classifyCacheState,
+} from "./cache-economics.ts"
+
+const ANTHROPIC = { input: 3, cacheRead: 0.3, cacheWrite: 3.75 }
+const OPENAI = { input: 2.5, cacheRead: 1.25 }
+
+describe("cacheBreakEvenRate", () => {
+  it("derives Anthropic's write premium from its own prices", () => {
+    expect(cacheBreakEvenRate(ANTHROPIC)).toBeCloseTo(0.2174, 4)
+  })
+
+  it("collapses to 0% when the provider charges no write premium", () => {
+    expect(cacheBreakEvenRate(OPENAI)).toBe(0)
+  })
+
+  it("holds across an Anthropic tier regardless of absolute price", () => {
+    expect(cacheBreakEvenRate({ input: 1, cacheRead: 0.1, cacheWrite: 1.25 })).toBeCloseTo(0.2174, 4)
+    expect(cacheBreakEvenRate({ input: 15, cacheRead: 1.5, cacheWrite: 18.75 })).toBeCloseTo(0.2174, 4)
+  })
+
+  it("is null without a cache-read price, which is an absence rather than a 0% floor", () => {
+    expect(cacheBreakEvenRate({ input: 3 })).toBeNull()
+    expect(cacheBreakEvenRate({ input: 3, cacheWrite: 3.75 })).toBeNull()
+  })
+
+  it("is null for a model with no input price, which has no economics to compare", () => {
+    expect(cacheBreakEvenRate({ input: 0, cacheRead: 0 })).toBeNull()
+  })
+
+  it("treats free reads as free upside", () => {
+    expect(cacheBreakEvenRate({ input: 2, cacheRead: 0 })).toBe(0)
+  })
+
+  it("returns 0 rather than a negative rate when writing is cheaper than fresh input", () => {
+    expect(cacheBreakEvenRate({ input: 3, cacheRead: 0.3, cacheWrite: 1 })).toBe(0)
+  })
+
+  it("handles reads and writes priced alike, where the hit rate stops mattering", () => {
+    expect(cacheBreakEvenRate({ input: 3, cacheRead: 2, cacheWrite: 2 })).toBe(0)
+    expect(cacheBreakEvenRate({ input: 3, cacheRead: 4, cacheWrite: 4 })).toBeNull()
+  })
+})
+
+const classify = (overrides: Partial<CacheClassificationInput>) =>
+  classifyCacheState({
+    cachingOn: true,
+    actualRate: 0.5,
+    ceilingRate: null,
+    breakEvenRate: 0.2174,
+    calls: 100,
+    avgInputTokensPerCall: 8_000,
+    ...overrides,
+  })
+
+describe("classifyCacheState", () => {
+  it("holds back every verdict below the sample floor", () => {
+    expect(classify({ calls: CACHE_ECONOMICS_MIN_CALLS - 1 }).state).toBe("notEnoughData")
+    expect(classify({ calls: CACHE_ECONOMICS_MIN_CALLS }).state).toBe("optimal")
+  })
+
+  it("holds back a verdict when the model has no cache pricing", () => {
+    expect(classify({ breakEvenRate: null }).state).toBe("notEnoughData")
+  })
+
+  it("holds back a verdict when no input-side token was recorded", () => {
+    expect(classify({ actualRate: null }).state).toBe("notEnoughData")
+  })
+
+  describe("caching on", () => {
+    it("is optimal once the rate clears break-even", () => {
+      expect(classify({ actualRate: 0.2174 })).toEqual({ state: "optimal", urgency: null })
+    })
+
+    it("flags a rate below break-even without prescribing a fix", () => {
+      expect(classify({ actualRate: 0.05 })).toEqual({ state: "investigate", urgency: "overpaying" })
+    })
+
+    it("says stop caching only once the ceiling proves break-even is unreachable", () => {
+      expect(classify({ actualRate: 0.05, ceilingRate: 0.1 })).toEqual({
+        state: "stopCaching",
+        urgency: "overpaying",
+      })
+    })
+
+    it("stays investigate when the ceiling clears break-even but the rate does not", () => {
+      expect(classify({ actualRate: 0.05, ceilingRate: 0.8 })).toEqual({
+        state: "investigate",
+        urgency: "overpaying",
+      })
+    })
+
+    it("separates savings left on the table from actively overpaying", () => {
+      expect(classify({ actualRate: 0.4, ceilingRate: 0.9 })).toEqual({
+        state: "investigate",
+        urgency: "underusing",
+      })
+    })
+
+    it("is optimal at the ceiling", () => {
+      expect(classify({ actualRate: 0.9, ceilingRate: 0.9 })).toEqual({ state: "optimal", urgency: null })
+    })
+
+    it("is optimal on a zero break-even model at any rate above zero", () => {
+      expect(classify({ actualRate: 0.03, breakEvenRate: 0 })).toEqual({ state: "optimal", urgency: null })
+    })
+  })
+
+  describe("caching off", () => {
+    const off = { cachingOn: false, actualRate: 0 } as const
+
+    it("recommends caching when the ceiling clears break-even", () => {
+      expect(classify({ ...off, ceilingRate: 0.6 })).toEqual({ state: "cacheIt", urgency: null })
+    })
+
+    it("stays quiet when the ceiling cannot clear break-even", () => {
+      expect(classify({ ...off, ceilingRate: 0.1 })).toEqual({ state: "correctlyOff", urgency: null })
+    })
+
+    it("recommends caching without a ceiling when there is no write premium to lose", () => {
+      expect(classify({ ...off, breakEvenRate: 0 })).toEqual({ state: "cacheIt", urgency: null })
+    })
+
+    it("makes no claim without a ceiling when the model charges a write premium", () => {
+      expect(classify({ ...off }).state).toBe("notEnoughData")
+    })
+
+    it("never recommends caching a prompt shorter than any provider will cache", () => {
+      const tiny = { ...off, avgInputTokensPerCall: CACHE_MIN_CACHEABLE_INPUT_TOKENS - 1 } as const
+      expect(classify({ ...tiny, breakEvenRate: 0 })).toEqual({ state: "correctlyOff", urgency: null })
+      expect(classify({ ...tiny, ceilingRate: 0.9 })).toEqual({ state: "correctlyOff", urgency: null })
+      expect(
+        classify({ ...off, avgInputTokensPerCall: CACHE_MIN_CACHEABLE_INPUT_TOKENS, breakEvenRate: 0 }).state,
+      ).toBe("cacheIt")
+    })
+  })
+})

--- a/packages/domain/spans/src/helpers/cache-economics.ts
+++ b/packages/domain/spans/src/helpers/cache-economics.ts
@@ -1,0 +1,125 @@
+/**
+ * Whether a model's prompt caching is paying for itself, decided per model from
+ * its own registry prices rather than against a threshold we invent.
+ *
+ * Nothing here reads the registry: every input is a number, so the whole state
+ * table is exhaustively testable and the module stays safe for the browser entry.
+ */
+
+/**
+ * Minimum reads a hit rate must be measured over before it may drive a finding.
+ * Below this the rate is a one-sample artefact — the same trap the breakdown
+ * table's `278x avg` chip fell into, which is what `notEnoughData` absorbs.
+ */
+export const CACHE_ECONOMICS_MIN_CALLS = 20
+
+/**
+ * Shortest prompt the major providers will cache at all — Anthropic and OpenAI
+ * both refuse below 1024 tokens. Below it caching is unavailable rather than
+ * unprofitable, so recommending it would be wrong however the prices work out.
+ */
+export const CACHE_MIN_CACHEABLE_INPUT_TOKENS = 1024
+
+/**
+ * Three of these render a finding — `cacheIt`, `stopCaching`, `investigate` —
+ * and three deliberately render nothing, which is what stops the panel nagging
+ * people who are already fine.
+ */
+export const CACHE_STATES = [
+  "optimal",
+  "cacheIt",
+  "stopCaching",
+  "investigate",
+  "correctlyOff",
+  "notEnoughData",
+] as const
+export type CacheState = (typeof CACHE_STATES)[number]
+
+/**
+ * Severity inside `investigate` / `stopCaching`, same recommendation type either
+ * way: `overpaying` means every write is currently costing more than not caching
+ * at all, `underusing` means the rate clears break-even but leaves savings behind.
+ */
+export const CACHE_URGENCIES = ["overpaying", "underusing"] as const
+export type CacheUrgency = (typeof CACHE_URGENCIES)[number]
+
+/** Per-1M-token rates, as `getCostSpec` returns them. */
+export interface CacheEconomicsPricing {
+  readonly input: number
+  readonly cacheRead?: number | undefined
+  readonly cacheWrite?: number | undefined
+}
+
+/**
+ * The hit rate at which caching costs exactly what not caching would, from
+ * `(input - cacheWrite) / (cacheRead - cacheWrite)`: every miss is priced as a
+ * write, which is the steady state a repeated prefix settles into.
+ *
+ * A missing `cacheWrite` is no write premium (OpenAI-style), so it reads as
+ * `input` and the rate collapses to 0% — any read at all is pure upside. Null
+ * when the model has no cache-read price, which is not a 0% break-even but an
+ * absence of cache economics to reason about.
+ */
+export function cacheBreakEvenRate({ input, cacheRead, cacheWrite }: CacheEconomicsPricing): number | null {
+  if (!(input > 0) || cacheRead === undefined) return null
+  const write = cacheWrite ?? input
+  const denominator = cacheRead - write
+  // Reads and writes priced alike: cost no longer depends on the hit rate at all.
+  if (denominator === 0) return write < input ? 0 : null
+  const rate = (input - write) / denominator
+  if (!Number.isFinite(rate)) return null
+  return Math.min(1, Math.max(0, rate))
+}
+
+export interface CacheClassificationInput {
+  /** Whether the window recorded any cache read or write for this model. */
+  readonly cachingOn: boolean
+  /** Measured `cacheRead / (input + cacheRead + cacheCreate)`; null when there is no input-side token. */
+  readonly actualRate: number | null
+  /** Highest rate this traffic's call cadence could reach. Null until it is computed. */
+  readonly ceilingRate: number | null
+  readonly breakEvenRate: number | null
+  readonly calls: number
+  /** Whole prompt per call — uncached input plus cache reads and writes. */
+  readonly avgInputTokensPerCall: number
+}
+
+export interface CacheClassification {
+  readonly state: CacheState
+  readonly urgency: CacheUrgency | null
+}
+
+const nothing = (state: CacheState): CacheClassification => ({ state, urgency: null })
+
+/**
+ * The state table. An unknown `ceilingRate` is treated as "somewhere in 0..1",
+ * so a verdict is only returned when every ceiling in that interval agrees:
+ * caching-off with a 0% break-even is `cacheIt` whatever the ceiling turns out
+ * to be, while a model with a write premium cannot be judged without one.
+ */
+export function classifyCacheState({
+  cachingOn,
+  actualRate,
+  ceilingRate,
+  breakEvenRate,
+  calls,
+  avgInputTokensPerCall,
+}: CacheClassificationInput): CacheClassification {
+  if (calls < CACHE_ECONOMICS_MIN_CALLS || breakEvenRate === null || actualRate === null) {
+    return nothing("notEnoughData")
+  }
+
+  if (!cachingOn) {
+    if (avgInputTokensPerCall < CACHE_MIN_CACHEABLE_INPUT_TOKENS) return nothing("correctlyOff")
+    if (ceilingRate === null) return breakEvenRate <= 0 ? nothing("cacheIt") : nothing("notEnoughData")
+    return ceilingRate >= breakEvenRate ? nothing("cacheIt") : nothing("correctlyOff")
+  }
+
+  if (actualRate < breakEvenRate) {
+    const hopeless = ceilingRate !== null && ceilingRate < breakEvenRate
+    return { state: hopeless ? "stopCaching" : "investigate", urgency: "overpaying" }
+  }
+
+  if (ceilingRate !== null && actualRate < ceilingRate) return { state: "investigate", urgency: "underusing" }
+  return nothing("optimal")
+}

--- a/packages/domain/spans/src/helpers/model-cache-break-even.ts
+++ b/packages/domain/spans/src/helpers/model-cache-break-even.ts
@@ -1,0 +1,24 @@
+import { getCostSpec } from "@domain/models"
+import { cacheBreakEvenRate } from "./cache-economics.ts"
+
+/**
+ * The break-even hit rate for a provider/model pair, read from the pricing
+ * registry. Null when the pair is unpriced or has no cache-read rate.
+ *
+ * Tiered pricing collapses to the base tier: long-context tiers scale every rate
+ * together, so they move the break-even hardly at all, and the dashboard already
+ * prices everything else at the base tier.
+ */
+export function modelCacheBreakEvenRate({
+  provider,
+  model,
+}: {
+  readonly provider: string
+  readonly model: string
+}): number | null {
+  const { cost, costImplemented } = getCostSpec(provider, model)
+  if (!costImplemented) return null
+  const tier = Array.isArray(cost) ? cost[0] : cost
+  if (!tier) return null
+  return cacheBreakEvenRate({ input: tier.input, cacheRead: tier.cacheRead, cacheWrite: tier.cacheWrite })
+}

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -67,6 +67,21 @@ export {
 export type { Trace, TraceConversationChunk, TraceDetail, TraceMetadataDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
+export type {
+  CacheClassification,
+  CacheClassificationInput,
+  CacheEconomicsPricing,
+  CacheState,
+  CacheUrgency,
+} from "./helpers/cache-economics.ts"
+export {
+  CACHE_ECONOMICS_MIN_CALLS,
+  CACHE_MIN_CACHEABLE_INPUT_TOKENS,
+  CACHE_STATES,
+  CACHE_URGENCIES,
+  cacheBreakEvenRate,
+  classifyCacheState,
+} from "./helpers/cache-economics.ts"
 export type { ClassifiedUnpricedPair, UnpricedCause, UnpricedUsageSummary } from "./helpers/classify-unpriced-cost.ts"
 export {
   classifyUnpricedPair,
@@ -80,6 +95,7 @@ export {
   type MessageEmbeddingInput,
   type MessageEmbeddingRole,
 } from "./helpers/message-embedding.ts"
+export { modelCacheBreakEvenRate } from "./helpers/model-cache-break-even.ts"
 export { normalizeLiteralPhrase, stripLoneSurrogates } from "./helpers/normalize-literal-phrase.ts"
 export {
   isLlmCompletionOperation,
@@ -107,6 +123,9 @@ export type { UnpricedSpanGroup } from "./otlp/transform.ts"
 export type { AnalyticsQueryInput, AnalyticsQueryReaderShape } from "./ports/analytics-query-reader.ts"
 export { AnalyticsQueryReader } from "./ports/analytics-query-reader.ts"
 export type {
+  CacheEconomics,
+  CacheModelUsage,
+  CacheUsageMeasures,
   CostAnalyticsRepositoryShape,
   CostAnalyticsScope,
   CostBreakdown,
@@ -127,6 +146,7 @@ export type {
   ModelUsageSlice,
 } from "./ports/cost-analytics-repository.ts"
 export {
+  CACHE_ECONOMICS_ROW_LIMIT,
   COST_BREAKDOWN_DIMENSIONS,
   COST_BREAKDOWN_ROW_LIMIT,
   COST_PER_CALL_MIN_SAMPLE_CALLS,

--- a/packages/domain/spans/src/ports/cost-analytics-repository.ts
+++ b/packages/domain/spans/src/ports/cost-analytics-repository.ts
@@ -45,6 +45,13 @@ export interface CostAnalyticsRepositoryShape {
   getModelUsageSeries(
     input: CostAnalyticsScope & { readonly bucketSeconds: number },
   ): Effect.Effect<ModelUsageSeries, RepositoryError, ChSqlClient>
+
+  /**
+   * Cache token flow per model, the measured half of cache economics. Rates are
+   * exact — every figure is a token count — while the break-even they are judged
+   * against comes from the pricing registry, not from here.
+   */
+  getCacheEconomics(input: CostAnalyticsScope): Effect.Effect<CacheEconomics, RepositoryError, ChSqlClient>
 }
 
 export interface CostAnalyticsScope {
@@ -185,6 +192,46 @@ export interface ModelUsageSeries {
   readonly models: readonly string[]
   /** Distinct models folded into every bucket's `other`, so the legend can name how many. */
   readonly otherModels: number
+}
+
+/**
+ * Models listed in the cache table. Beyond this the comparison stops being one,
+ * and `distinctModels` says how many were left off.
+ */
+export const CACHE_ECONOMICS_ROW_LIMIT = 25
+
+/**
+ * Token counts, never dollars: provider-reported cache spend is folded into
+ * `cost_input_microcents` and cannot be recovered by subtraction, so a cache
+ * dollar figure would have to be modeled. `costMicrocents` is the row's
+ * authoritative total spend, which is what makes a row worth reading at all.
+ */
+export interface CacheUsageMeasures {
+  readonly calls: number
+  /** Uncached input tokens only; the three input-side counts are additive. */
+  readonly inputTokens: number
+  readonly cacheReadTokens: number
+  readonly cacheCreateTokens: number
+  readonly costMicrocents: number
+  /** Usage ingestion could not price, so this row's spend is understated. */
+  readonly unpricedCalls: number
+  readonly unpricedTokens: number
+}
+
+export interface CacheModelUsage extends CacheUsageMeasures {
+  readonly model: string
+  readonly provider: string
+}
+
+export interface CacheEconomics {
+  /**
+   * One row per provider/model pair, highest spend first, capped at
+   * `CACHE_ECONOMICS_ROW_LIMIT`. Split by provider because break-even is a
+   * property of the price list, and the same model slug served by two providers
+   * is two different price lists.
+   */
+  readonly rows: readonly CacheModelUsage[]
+  readonly totals: CacheUsageMeasures & { readonly distinctModels: number }
 }
 
 export interface CostModelSpend {

--- a/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.test.ts
@@ -15,6 +15,7 @@ const PROJECT_ID = ProjectId("costanalytics00000000000")
 // breakdown and model-usage fixtures grow their own shapes.
 const BREAKDOWN_PROJECT_ID = ProjectId("costbreakdown00000000000")
 const MODEL_USAGE_PROJECT_ID = ProjectId("costmodelusage0000000000")
+const CACHE_PROJECT_ID = ProjectId("costcache00000000000000a")
 
 const DAY1 = new Date("2026-06-01T10:00:00.000Z")
 const DAY2 = new Date("2026-06-02T10:00:00.000Z")
@@ -42,6 +43,8 @@ type SpanOpts = {
   costOutput?: number
   isEstimated?: boolean
   tokensInput?: number
+  tokensCacheRead?: number
+  tokensCacheCreate?: number
   costSource?: string
 }
 
@@ -73,8 +76,8 @@ const span = (n: number, startTime: Date, opts: SpanOpts = {}): CostSpanRow =>
     response_model: "",
     tokens_input: opts.tokensInput ?? 0,
     tokens_output: 0,
-    tokens_cache_read: 0,
-    tokens_cache_create: 0,
+    tokens_cache_read: opts.tokensCacheRead ?? 0,
+    tokens_cache_create: opts.tokensCacheCreate ?? 0,
     tokens_reasoning: 0,
     cost_input_microcents: opts.costInput ?? 0,
     cost_output_microcents: opts.costOutput ?? 0,
@@ -110,6 +113,10 @@ const runCh = <A, E>(effect: Effect.Effect<A, E, ChSqlClient>) =>
 const scope = { organizationId: ORG_ID, projectId: PROJECT_ID, from: FROM, to: TO }
 const breakdownScope = { ...scope, projectId: BREAKDOWN_PROJECT_ID }
 const modelUsageScope = { ...scope, projectId: MODEL_USAGE_PROJECT_ID }
+const cacheScope = { ...scope, projectId: CACHE_PROJECT_ID }
+
+const cacheSpan = (n: number, startTime: Date, opts: Omit<SpanOpts, "project">): CostSpanRow =>
+  span(n, startTime, { ...opts, project: CACHE_PROJECT_ID })
 
 const breakdownSpan = (n: number, startTime: Date, opts: Omit<SpanOpts, "project">): CostSpanRow =>
   span(n, startTime, { ...opts, project: BREAKDOWN_PROJECT_ID })
@@ -218,6 +225,49 @@ describe("CostAnalyticsRepositoryLive", () => {
           costTotal: 50,
           costSource: "estimated",
           tokensInput: 5,
+        }),
+
+        // Cache fixture: one model caching, one not, plus an unpriced model and a
+        // tool span that must stay out of every cache figure.
+        cacheSpan(31, DAY1, {
+          trace: 31,
+          model: "cached-1",
+          costTotal: 400,
+          costSource: "estimated",
+          tokensInput: 100,
+          tokensCacheRead: 300,
+          tokensCacheCreate: 100,
+        }),
+        cacheSpan(32, DAY2, {
+          trace: 31,
+          model: "cached-1",
+          costTotal: 200,
+          costSource: "estimated",
+          tokensInput: 100,
+          tokensCacheRead: 100,
+          tokensCacheCreate: 0,
+        }),
+        cacheSpan(33, DAY1, {
+          trace: 32,
+          model: "uncached-1",
+          costTotal: 900,
+          costSource: "estimated",
+          tokensInput: 500,
+        }),
+        cacheSpan(34, DAY2, {
+          trace: 32,
+          model: "mystery-1",
+          provider: "acme",
+          costSource: "unpriced",
+          tokensInput: 700,
+        }),
+        cacheSpan(35, DAY2, {
+          trace: 32,
+          operation: "execute_tool",
+          model: "cached-1",
+          costTotal: 9_999,
+          tokensInput: 9_999,
+          tokensCacheRead: 9_999,
         }),
       ]),
     )
@@ -421,6 +471,55 @@ describe("CostAnalyticsRepositoryLive", () => {
       ])
       expect(series.buckets[0]?.byModel).toContainEqual({ model: "mu1", costMicrocents: 700, tokens: 10 })
       expect(series.buckets[1]?.byModel).toEqual([{ model: "mu1", costMicrocents: 50, tokens: 5 }])
+    })
+  })
+
+  describe("getCacheEconomics", () => {
+    it("splits cache token flow per provider/model pair, ranked by spend", async () => {
+      const economics = await runCh(repo.getCacheEconomics(cacheScope))
+
+      expect(economics.rows.map((row) => `${row.provider}/${row.model}`)).toEqual([
+        "openai/uncached-1",
+        "openai/cached-1",
+        "acme/mystery-1",
+      ])
+      expect(economics.rows[1]).toMatchObject({
+        model: "cached-1",
+        calls: 2,
+        inputTokens: 200,
+        cacheReadTokens: 400,
+        cacheCreateTokens: 100,
+        costMicrocents: 600,
+      })
+    })
+
+    it("keeps tool spans out of every cache figure", async () => {
+      const economics = await runCh(repo.getCacheEconomics(cacheScope))
+
+      // The excluded tool span carries 9,999 cache reads on `cached-1`.
+      expect(economics.rows.find((row) => row.model === "cached-1")?.cacheReadTokens).toBe(400)
+      expect(economics.totals.calls).toBe(4)
+    })
+
+    it("reports a caching-off model as zero cache tokens rather than omitting it", async () => {
+      const economics = await runCh(repo.getCacheEconomics(cacheScope))
+
+      expect(economics.rows.find((row) => row.model === "uncached-1")).toMatchObject({
+        cacheReadTokens: 0,
+        cacheCreateTokens: 0,
+        inputTokens: 500,
+      })
+    })
+
+    it("carries the unpriced caveat so a row's spend is never read as complete", async () => {
+      const economics = await runCh(repo.getCacheEconomics(cacheScope))
+
+      expect(economics.rows.find((row) => row.model === "mystery-1")).toMatchObject({
+        unpricedCalls: 1,
+        unpricedTokens: 700,
+        costMicrocents: 0,
+      })
+      expect(economics.totals).toMatchObject({ distinctModels: 3, unpricedCalls: 1, costMicrocents: 1_500 })
     })
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.ts
@@ -1,6 +1,9 @@
 import type { ClickHouseClient } from "@clickhouse/client"
 import { ChSqlClient, type ChSqlClientShape } from "@domain/shared"
 import type {
+  CacheEconomics,
+  CacheModelUsage,
+  CacheUsageMeasures,
   CostAnalyticsScope,
   CostBreakdown,
   CostBreakdownDimension,
@@ -16,6 +19,7 @@ import type {
   ModelUsageSlice,
 } from "@domain/spans"
 import {
+  CACHE_ECONOMICS_ROW_LIMIT,
   COST_BREAKDOWN_ROW_LIMIT,
   CostAnalyticsRepository,
   costSourceSchema,
@@ -92,6 +96,29 @@ const BREAKDOWN_MEASURES = `sum(cost_total_microcents) AS total_microcents,
         sumIf(tokens_total, cost_source = 'unknown') AS unknown_tokens,
         countIf(cost_source = 'unknown') AS unknown_calls`
 
+// Both zero-cost buckets fold into one `unpriced` pair here: the table shows a
+// single "this spend is understated" caveat, the same reading the breakdown
+// table composes at display time.
+const CACHE_MEASURES = `count() AS calls,
+        sum(tokens_input) AS input_tokens,
+        sum(tokens_cache_read) AS cache_read_tokens,
+        sum(tokens_cache_create) AS cache_create_tokens,
+        sum(cost_total_microcents) AS cost_microcents,
+        countIf(cost_source IN ('unpriced', 'unknown')) AS unpriced_calls,
+        sumIf(tokens_total, cost_source IN ('unpriced', 'unknown')) AS unpriced_tokens`
+
+const CACHE_SOURCE = `SELECT
+        model,
+        provider,
+        tokens_input,
+        tokens_cache_read,
+        tokens_cache_create,
+        tokens_total,
+        cost_total_microcents,
+        ${COST_SOURCE} AS cost_source
+      FROM spans
+      WHERE ${BILLABLE_FILTER}`
+
 const BUCKET_START = `toDateTime(
   intDiv(toUnixTimestamp(start_time), {bucketSeconds:UInt32}) * {bucketSeconds:UInt32},
   'UTC'
@@ -167,6 +194,20 @@ type BreakdownRow = BreakdownMeasureRow & { key: string; traces_with_value: stri
 
 type BreakdownTotalsRow = BreakdownMeasureRow & { traces_with_usage: string; distinct_values: string }
 
+type CacheMeasureRow = {
+  calls: string
+  input_tokens: string
+  cache_read_tokens: string
+  cache_create_tokens: string
+  cost_microcents: string
+  unpriced_calls: string
+  unpriced_tokens: string
+}
+
+type CacheRow = CacheMeasureRow & { model: string; provider: string }
+
+type CacheTotalsRow = CacheMeasureRow & { distinct_models: string }
+
 type ModelUsageMeasuresDraft = { cost: number; tokens: number }
 
 type ModelUsageRow = {
@@ -227,6 +268,22 @@ const toBreakdownTotals = (row: BreakdownTotalsRow | undefined): CostBreakdownTo
     distinctValues: num(row?.distinct_values),
   }
 }
+
+const toCacheMeasures = (row: CacheMeasureRow | undefined): CacheUsageMeasures => ({
+  calls: num(row?.calls),
+  inputTokens: num(row?.input_tokens),
+  cacheReadTokens: num(row?.cache_read_tokens),
+  cacheCreateTokens: num(row?.cache_create_tokens),
+  costMicrocents: num(row?.cost_microcents),
+  unpricedCalls: num(row?.unpriced_calls),
+  unpricedTokens: num(row?.unpriced_tokens),
+})
+
+const toCacheRow = (row: CacheRow): CacheModelUsage => ({
+  ...toCacheMeasures(row),
+  model: normalizeCHString(row.model),
+  provider: normalizeCHString(row.provider),
+})
 
 const toZeroCostPair = (row: ZeroCostPairRow): CostZeroCostPair => ({
   provider: normalizeCHString(row.provider),
@@ -565,6 +622,47 @@ export const CostAnalyticsRepositoryLive = Layer.effect(
                   otherModels: Math.max(0, num(distinctRows[0]?.distinct_models) - models.length),
                 }
               }),
+            )
+        }),
+
+      getCacheEconomics: (input) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const params = scopeParams(input)
+              const [rowsResult, totalsResult] = await Promise.all([
+                client.query({
+                  query: `SELECT model, provider, ${CACHE_MEASURES}
+                      FROM (${CACHE_SOURCE})
+                      GROUP BY model, provider
+                      ORDER BY cost_microcents DESC, model ASC, provider ASC
+                      LIMIT {rowLimit:UInt16}`,
+                  query_params: { ...params, rowLimit: CACHE_ECONOMICS_ROW_LIMIT },
+                  format: "JSONEachRow",
+                }),
+                client.query({
+                  // Window-wide, so a truncated row list still says how much was left off.
+                  query: `SELECT ${CACHE_MEASURES}, uniqExact((model, provider)) AS distinct_models
+                      FROM (${CACHE_SOURCE})`,
+                  query_params: params,
+                  format: "JSONEachRow",
+                }),
+              ])
+              const rows = await rowsResult.json<CacheRow>()
+              const totalsRows = await totalsResult.json<CacheTotalsRow>()
+              return { rows, totalsRows }
+            })
+            .pipe(
+              Effect.map(
+                ({ rows, totalsRows }): CacheEconomics => ({
+                  rows: rows.map(toCacheRow),
+                  totals: {
+                    ...toCacheMeasures(totalsRows[0]),
+                    distinctModels: num(totalsRows[0]?.distinct_models),
+                  },
+                }),
+              ),
             )
         }),
     }

--- a/packages/platform/db-clickhouse/src/seeds/run.ts
+++ b/packages/platform/db-clickhouse/src/seeds/run.ts
@@ -7,6 +7,7 @@ import { Effect } from "effect"
 import { closeClickhouse, createClickhouseClient } from "../client.ts"
 import { allSeeders } from "./all.ts"
 import { runSeeders } from "./runner.ts"
+import { cacheEconomicsQaSeeder } from "./spans/cache-economics-qa.ts"
 import { customBehaviorQaSeeder } from "./spans/custom-behavior-qa.ts"
 import { oldTracesQaSeeder } from "./spans/index.ts"
 import { truncateDataTables } from "./truncate-data-tables.ts"
@@ -46,9 +47,9 @@ const main = async () => {
           console.log("- truncating all data tables")
           yield* truncateDataTables(client)
         }
-        // `oldTracesQaSeeder` and `customBehaviorQaSeeder` are bootstrap-only (kept out of `allSeeders`
-        // so they never run during runtime demo-project creation, which reuses `allSeeders`).
-        yield* runSeeders([...allSeeders, oldTracesQaSeeder, customBehaviorQaSeeder], {
+        // The QA seeders are bootstrap-only (kept out of `allSeeders` so they never
+        // run during runtime demo-project creation, which reuses `allSeeders`).
+        yield* runSeeders([...allSeeders, oldTracesQaSeeder, customBehaviorQaSeeder, cacheEconomicsQaSeeder], {
           client,
           scope: bootstrapSeedScope,
         })

--- a/packages/platform/db-clickhouse/src/seeds/spans/cache-economics-qa.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cache-economics-qa.test.ts
@@ -1,0 +1,114 @@
+import { createSeedScope, SEED_API_KEY_ID, SEED_ORG_ID, SEED_PROJECT_ID } from "@domain/shared/seeding"
+import { type CacheState, classifyCacheState, modelCacheBreakEvenRate } from "@domain/spans"
+import { cacheHitRate } from "@repo/utils"
+import { describe, expect, it } from "vitest"
+import { buildCacheEconomicsQaFixture, CACHE_QA_COHORTS } from "./cache-economics-qa.ts"
+
+const scope = createSeedScope({
+  organizationId: SEED_ORG_ID,
+  projectId: SEED_PROJECT_ID,
+  timelineAnchor: new Date("2026-06-16T12:00:00.000Z"),
+  apiKeyId: SEED_API_KEY_ID,
+})
+
+const NOW_MS = Date.parse("2026-06-16T12:00:00.000Z")
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const spans = buildCacheEconomicsQaFixture(scope, NOW_MS)
+
+/** The panel's own reading of the fixture: aggregate per model, then classify. */
+const stateFor = (model: string): { state: CacheState; breakEven: number | null; actual: number | null } => {
+  const rows = spans.filter((span) => span.model === model)
+  const totals = rows.reduce(
+    (sum, span) => ({
+      input: sum.input + span.tokens_input,
+      cacheRead: sum.cacheRead + span.tokens_cache_read,
+      cacheCreate: sum.cacheCreate + span.tokens_cache_create,
+    }),
+    { input: 0, cacheRead: 0, cacheCreate: 0 },
+  )
+  const provider = rows[0]?.provider ?? ""
+  const breakEven = modelCacheBreakEvenRate({ provider, model })
+  const actual = cacheHitRate(totals)
+  return {
+    breakEven,
+    actual,
+    state: classifyCacheState({
+      cachingOn: totals.cacheRead + totals.cacheCreate > 0,
+      actualRate: actual,
+      ceilingRate: null,
+      breakEvenRate: breakEven,
+      calls: rows.length,
+      avgInputTokensPerCall: rows.length > 0 ? (totals.input + totals.cacheRead + totals.cacheCreate) / rows.length : 0,
+    }).state,
+  }
+}
+
+describe("cache economics QA fixture", () => {
+  it("assigns deterministic trace and span ids, which is what the idempotency sentinel keys on", () => {
+    const rebuilt = buildCacheEconomicsQaFixture(scope, NOW_MS)
+    expect(rebuilt.map((span) => span.span_id)).toEqual(spans.map((span) => span.span_id))
+    expect(rebuilt.map((span) => span.trace_id)).toEqual(spans.map((span) => span.trace_id))
+    expect(new Set(spans.map((span) => span.span_id)).size).toBe(spans.length)
+  })
+
+  it("carves cache reads and writes out of the prompt so the token columns stay additive", () => {
+    for (const cohort of CACHE_QA_COHORTS) {
+      const call = spans.find((span) => span.model === cohort.modelConfig.model)
+      expect(call).toBeDefined()
+      const total = (call?.tokens_input ?? 0) + (call?.tokens_cache_read ?? 0) + (call?.tokens_cache_create ?? 0)
+      expect(total).toBe(cohort.promptTokens)
+    }
+  })
+
+  it("lands every call inside the trailing week the cost page defaults to", () => {
+    const oldest = Math.min(...spans.map((span) => Date.parse(`${span.start_time.replace(" ", "T")}Z`)))
+    expect(NOW_MS - oldest).toBeLessThan(7 * DAY_MS)
+  })
+
+  it("uses models the ambient generator never emits, so no row blends two cache stories", () => {
+    const ambient = new Set(["gpt-4o", "gpt-4o-mini", "o3-mini", "claude-sonnet-4-6", "claude-3-5-haiku", "gpt-4.1"])
+    for (const cohort of CACHE_QA_COHORTS) expect(ambient.has(cohort.modelConfig.model)).toBe(false)
+  })
+
+  it("prices every cohort against a model the registry knows", () => {
+    for (const cohort of CACHE_QA_COHORTS) {
+      expect(
+        modelCacheBreakEvenRate({ provider: cohort.modelConfig.provider, model: cohort.modelConfig.model }),
+      ).not.toBeNull()
+    }
+  })
+
+  it("puts an Anthropic-style break-even beside a no-premium one, so the difference is visible", () => {
+    expect(stateFor("claude-opus-4-5").breakEven).toBeCloseTo(0.2174, 4)
+    expect(stateFor("gpt-5-mini").breakEven).toBe(0)
+    // Same provider, different price list: break-even is a per-model property.
+    expect(stateFor("gpt-5.6").breakEven).toBeCloseTo(0.2174, 4)
+  })
+
+  it("reaches every state the classifier can decide without an achievable ceiling", () => {
+    expect(stateFor("claude-opus-4-5").state).toBe("optimal")
+    expect(stateFor("claude-haiku-4-5").state).toBe("investigate")
+    expect(stateFor("gpt-5-mini").state).toBe("cacheIt")
+    expect(stateFor("gpt-5.6").state).toBe("investigate")
+    expect(stateFor("gemini-2.5-flash-lite").state).toBe("notEnoughData")
+  })
+
+  it("shows the same rate reading as fine on one model and broken on another", () => {
+    const noPremium = stateFor("gpt-5.4-mini")
+    const withPremium = stateFor("claude-haiku-4-5")
+    expect(noPremium.actual).toBeLessThan(0.2174)
+    expect(withPremium.actual).toBeLessThan(0.2174)
+    expect(noPremium.state).toBe("optimal")
+    expect(withPremium.state).toBe("investigate")
+  })
+
+  it("records no cache tokens at all for the caching-off cohort", () => {
+    const off = spans.filter((span) => span.model === "gpt-5-mini")
+    expect(off.every((span) => span.tokens_cache_read === 0 && span.tokens_cache_create === 0)).toBe(true)
+  })
+
+  it("gives each cohort its own call cadence", () => {
+    expect(new Set(CACHE_QA_COHORTS.map((cohort) => cohort.gapMinutes)).size).toBe(CACHE_QA_COHORTS.length)
+  })
+})

--- a/packages/platform/db-clickhouse/src/seeds/spans/cache-economics-qa.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cache-economics-qa.ts
@@ -1,0 +1,235 @@
+import type { ModelConfig, SeedScope } from "@domain/shared/seeding"
+import { Effect } from "effect"
+import { insertJsonEachRow } from "../../sql.ts"
+import { isSentinelPresent } from "../idempotency.ts"
+import type { Seeder } from "../types.ts"
+import {
+  assistantTextMessage,
+  CACHE_OFF,
+  type CacheProfile,
+  makeLlmSpan,
+  type SpanRow,
+  type TraceContext,
+  toBase,
+  userMessage,
+} from "./span-builders.ts"
+
+const MINUTE_MS = 60 * 1000
+const DAY_MS = 24 * 60 * MINUTE_MS
+
+/**
+ * Every cohort lands inside this trailing window, so the cost page's default
+ * range shows all of them without reaching for All time.
+ */
+const CACHE_QA_WINDOW_DAYS = 7
+
+/** Calls per session, so the fixture carries sessions rather than one-call pseudo-sessions. */
+const CALLS_PER_SESSION = 4
+
+/**
+ * One cohort per cache state the panel can reach without an achievable ceiling,
+ * plus the pair that makes break-even visibly a per-model property: an
+ * Anthropic-style write premium (21.7%) beside models with no cache-write price
+ * at all (0%).
+ *
+ * The models are deliberately ones the ambient generator never emits — they share
+ * the seed project with its generated traces, and a collision would blend two
+ * different cache stories into one row.
+ */
+interface CacheQaCohort {
+  readonly key: string
+  readonly serviceName: string
+  readonly modelConfig: ModelConfig
+  readonly calls: number
+  readonly cacheProfile: CacheProfile
+  readonly promptTokens: number
+  /** Inter-call gap, varied per cohort so the achievable-ceiling work has cadence to read. */
+  readonly gapMinutes: number
+}
+
+const model = (config: Omit<ModelConfig, "latencyRange" | "finishReasonStop" | "responseModel" | "scopeName">) => ({
+  ...config,
+  responseModel: config.model,
+  scopeName: `${config.provider}-instrumentation`,
+  latencyRange: [600, 2500] as const,
+  finishReasonStop: config.provider === "anthropic" ? "end_turn" : "stop",
+})
+
+export const CACHE_QA_COHORTS: readonly CacheQaCohort[] = [
+  {
+    key: "cache-qa-optimal",
+    serviceName: "cache-qa-research-agent",
+    modelConfig: model({
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      costInPerMToken: 5,
+      costOutPerMToken: 25,
+      cacheReadPerMToken: 0.5,
+      cacheWritePerMToken: 6.25,
+    }),
+    calls: 96,
+    cacheProfile: { hitRate: 0.62, writeShare: 0.06 },
+    promptTokens: 12_000,
+    gapMinutes: 90,
+  },
+  {
+    key: "cache-qa-investigate",
+    serviceName: "cache-qa-classifier",
+    modelConfig: model({
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      costInPerMToken: 1,
+      costOutPerMToken: 5,
+      cacheReadPerMToken: 0.1,
+      cacheWritePerMToken: 1.25,
+    }),
+    calls: 140,
+    cacheProfile: { hitRate: 0.06, writeShare: 0.3 },
+    promptTokens: 9_000,
+    gapMinutes: 60,
+  },
+  {
+    key: "cache-qa-cache-it",
+    serviceName: "cache-qa-doc-extractor",
+    modelConfig: model({
+      provider: "openai",
+      model: "gpt-5-mini",
+      costInPerMToken: 0.25,
+      costOutPerMToken: 2,
+      cacheReadPerMToken: 0.025,
+    }),
+    calls: 48,
+    cacheProfile: CACHE_OFF,
+    promptTokens: 26_000,
+    gapMinutes: 180,
+  },
+  {
+    key: "cache-qa-premium-openai",
+    serviceName: "cache-qa-planner",
+    modelConfig: model({
+      provider: "openai",
+      model: "gpt-5.6",
+      costInPerMToken: 5,
+      costOutPerMToken: 30,
+      cacheReadPerMToken: 0.5,
+      cacheWritePerMToken: 6.25,
+    }),
+    calls: 64,
+    cacheProfile: { hitRate: 0.14, writeShare: 0.22 },
+    promptTokens: 15_000,
+    gapMinutes: 135,
+  },
+  {
+    key: "cache-qa-no-premium-on",
+    serviceName: "cache-qa-router",
+    modelConfig: model({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      costInPerMToken: 0.75,
+      costOutPerMToken: 4.5,
+      cacheReadPerMToken: 0.075,
+    }),
+    calls: 110,
+    cacheProfile: { hitRate: 0.05, writeShare: 0 },
+    promptTokens: 7_000,
+    gapMinutes: 75,
+  },
+  {
+    key: "cache-qa-thin",
+    serviceName: "cache-qa-tagger",
+    modelConfig: model({
+      provider: "google",
+      model: "gemini-2.5-flash-lite",
+      costInPerMToken: 0.1,
+      costOutPerMToken: 0.4,
+      cacheReadPerMToken: 0.01,
+    }),
+    calls: 8,
+    cacheProfile: { hitRate: 0.4, writeShare: 0.1 },
+    promptTokens: 5_000,
+    gapMinutes: 720,
+  },
+]
+
+const formatClickHouseTimestamp = (date: Date): string => date.toISOString().replace("T", " ").replace("Z", "000")
+
+/** The sentinel row: first call of the first cohort, which is also the oldest one written. */
+const cacheQaSentinelSpanId = (scope: SeedScope): string =>
+  scope.spanHex(CACHE_QA_COHORTS[0]?.key ?? "cache-qa-optimal", 0)
+
+const buildCohortSpans = (cohort: CacheQaCohort, scope: SeedScope, nowMs: number): SpanRow[] => {
+  const spans: SpanRow[] = []
+  for (let call = 0; call < cohort.calls; call++) {
+    // Newest call first, walking backwards at the cohort's own cadence.
+    const start = new Date(nowMs - (cohort.calls - 1 - call) * cohort.gapMinutes * MINUTE_MS)
+    const traceId = scope.traceHex(cohort.key, call)
+    const ctx: TraceContext = {
+      organizationId: scope.organizationId,
+      projectId: scope.projectId,
+      apiKeyId: scope.apiKeyId,
+      simulationId: "",
+      startTime: start,
+      sessionId: scope.traceHex(`${cohort.key}:session`, Math.floor(call / CALLS_PER_SESSION)),
+      userId: "",
+      userEmail: "",
+      serviceName: cohort.serviceName,
+      tags: ["cache-qa", cohort.key],
+      metadata: {},
+    }
+
+    const span = makeLlmSpan({
+      base: toBase(ctx, traceId, "", start, 2_400),
+      modelConfig: cohort.modelConfig,
+      inputMessages: [userMessage(`Cache QA request ${call} for ${cohort.key}`)],
+      outputMessages: [assistantTextMessage(`Cache QA response ${call}`)],
+      systemInstructions: "You are a cache-economics QA fixture agent.",
+      finishReason: cohort.modelConfig.finishReasonStop,
+      promptTokens: cohort.promptTokens,
+      cacheProfile: cohort.cacheProfile,
+    })
+    // The builder assigns a random span id; the sentinel needs a stable one.
+    span.span_id = scope.spanHex(cohort.key, call)
+    spans.push(span)
+  }
+  return spans
+}
+
+/**
+ * The full fixture. Pure — the seeder inserts it and the tests read the same rows
+ * back through the classifier, so what ships is what was asserted.
+ */
+export const buildCacheEconomicsQaFixture = (scope: SeedScope, nowMs: number): SpanRow[] =>
+  CACHE_QA_COHORTS.flatMap((cohort) => buildCohortSpans(cohort, scope, nowMs))
+
+/**
+ * Bootstrap-only QA fixture for the cost section's cache panel. Kept out of
+ * `allSeeders` so it never runs during runtime demo-project creation.
+ */
+export const cacheEconomicsQaSeeder: Seeder = {
+  name: "spans/cache-economics-qa",
+  run: (ctx) =>
+    Effect.gen(function* () {
+      const nowMs = Date.now()
+      // Recency-aware: a fixture seeded longer ago than its own window has drifted
+      // out of the page's default range, so reseed rather than skip.
+      const freshFixturePresent = yield* isSentinelPresent(
+        ctx.client,
+        "spans",
+        "span_id = {spanId:String} AND start_time >= {since:DateTime64(9, 'UTC')}",
+        {
+          spanId: cacheQaSentinelSpanId(ctx.scope),
+          since: formatClickHouseTimestamp(new Date(nowMs - CACHE_QA_WINDOW_DAYS * DAY_MS)),
+        },
+      )
+      if (freshFixturePresent) {
+        if (!ctx.quiet) console.log("  -> spans/cache-economics-qa: already seeded (fresh), skipping")
+        return
+      }
+
+      const spans = buildCacheEconomicsQaFixture(ctx.scope, nowMs)
+      yield* insertJsonEachRow(ctx.client, "spans", spans)
+      if (!ctx.quiet) {
+        console.log(`  -> spans/cache-economics-qa: ${spans.length} calls across ${CACHE_QA_COHORTS.length} cohorts`)
+      }
+    }),
+}

--- a/packages/platform/db-clickhouse/src/seeds/spans/span-builders.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/span-builders.test.ts
@@ -1,0 +1,61 @@
+import type { ModelConfig } from "@domain/shared/seeding"
+import { describe, expect, it } from "vitest"
+import { CACHE_OFF, inputSideCostMicrocents, splitCacheTokens } from "./span-builders.ts"
+
+const anthropicStyle: ModelConfig = {
+  provider: "anthropic",
+  model: "claude-opus-4-5",
+  responseModel: "claude-opus-4-5",
+  scopeName: "anthropic-instrumentation",
+  costInPerMToken: 5,
+  costOutPerMToken: 25,
+  cacheReadPerMToken: 0.5,
+  cacheWritePerMToken: 6.25,
+  latencyRange: [600, 2500],
+  finishReasonStop: "end_turn",
+}
+
+const noCachePricing: ModelConfig = {
+  provider: "openai",
+  model: "gpt-5-mini",
+  responseModel: "gpt-5-mini",
+  scopeName: "openai-instrumentation",
+  costInPerMToken: 5,
+  costOutPerMToken: 25,
+  latencyRange: [600, 2500],
+  finishReasonStop: "stop",
+}
+
+describe("splitCacheTokens", () => {
+  it("carves reads and writes out of the prompt so the token columns stay additive", () => {
+    const split = splitCacheTokens(10_000, { hitRate: 0.6, writeShare: 0.1 })
+
+    expect(split).toEqual({ input: 3_000, cacheRead: 6_000, cacheCreate: 1_000 })
+    expect(split.input + split.cacheRead + split.cacheCreate).toBe(10_000)
+  })
+
+  it("leaves the whole prompt uncached when caching is off", () => {
+    expect(splitCacheTokens(10_000, CACHE_OFF)).toEqual({ input: 10_000, cacheRead: 0, cacheCreate: 0 })
+  })
+
+  it("never returns a negative input remainder", () => {
+    expect(splitCacheTokens(1_000, { hitRate: 0.8, writeShare: 0.5 }).input).toBe(0)
+  })
+})
+
+describe("inputSideCostMicrocents", () => {
+  it("prices reads and writes at their own rates, folded into the input side", () => {
+    const split = splitCacheTokens(1_000_000, { hitRate: 0.6, writeShare: 0.1 })
+
+    // 300k at $5 + 600k at $0.50 + 100k at $6.25 = $1.50 + $0.30 + $0.625
+    expect(inputSideCostMicrocents(split, anthropicStyle)).toBe(242_500_000)
+  })
+
+  it("charges cache tokens at the input rate when the model publishes no cache price", () => {
+    const split = splitCacheTokens(1_000_000, { hitRate: 0.6, writeShare: 0.1 })
+
+    expect(inputSideCostMicrocents(split, noCachePricing)).toBe(
+      inputSideCostMicrocents(splitCacheTokens(1_000_000, CACHE_OFF), noCachePricing),
+    )
+  })
+})

--- a/packages/platform/db-clickhouse/src/seeds/spans/span-builders.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/span-builders.ts
@@ -199,6 +199,54 @@ function computeCost(tokens: number, costPerMToken: number): number {
 }
 
 // ---------------------------------------------------------------------------
+// Prompt cache
+// ---------------------------------------------------------------------------
+
+/** What share of a call's prompt the provider served from cache, and wrote to it. */
+export type CacheProfile = {
+  readonly hitRate: number
+  readonly writeShare: number
+}
+
+type CacheTokenSplit = {
+  readonly input: number
+  readonly cacheRead: number
+  readonly cacheCreate: number
+}
+
+export const CACHE_OFF: CacheProfile = { hitRate: 0, writeShare: 0 }
+
+/**
+ * Carves reads and writes *out* of the prompt rather than adding them alongside
+ * it: `spans.tokens_total` is materialized as the sum of all five token columns,
+ * so a prompt counted in both `tokens_input` and `tokens_cache_read` is billed
+ * twice and reads back as half the cache hit rate it actually had.
+ */
+export function splitCacheTokens(promptTokens: number, profile: CacheProfile): CacheTokenSplit {
+  const cacheRead = Math.floor(promptTokens * profile.hitRate)
+  const cacheCreate = Math.floor(promptTokens * profile.writeShare)
+  return { input: Math.max(0, promptTokens - cacheRead - cacheCreate), cacheRead, cacheCreate }
+}
+
+/**
+ * Input-side dollars with cache reads and writes folded in — the shape
+ * provider-reported cost arrives in, where the cache portion cannot be recovered
+ * by subtraction. A model with no cache rate is charged at its input rate.
+ */
+export function inputSideCostMicrocents(split: CacheTokenSplit, modelConfig: ModelConfig): number {
+  return (
+    computeCost(split.input, modelConfig.costInPerMToken) +
+    computeCost(split.cacheRead, modelConfig.cacheReadPerMToken ?? modelConfig.costInPerMToken) +
+    computeCost(split.cacheCreate, modelConfig.cacheWritePerMToken ?? modelConfig.costInPerMToken)
+  )
+}
+
+const randomCacheProfile = (): CacheProfile => ({
+  hitRate: Math.random() > 0.6 ? randFloat(0.2, 0.6) : 0,
+  writeShare: 0,
+})
+
+// ---------------------------------------------------------------------------
 // Message builders (OTEL GenAI format)
 // ---------------------------------------------------------------------------
 
@@ -314,6 +362,8 @@ export function makeLlmSpan({
   toolDefinitions,
   finishReason,
   temperature,
+  promptTokens,
+  cacheProfile,
 }: {
   base: SpanBase
   modelConfig: ModelConfig
@@ -323,13 +373,16 @@ export function makeLlmSpan({
   toolDefinitions?: ToolConfig[]
   finishReason: string
   temperature?: number
+  /** Overrides the estimate from the message text, for fixtures that need a specific prompt size. */
+  promptTokens?: number
+  cacheProfile?: CacheProfile
 }): SpanRow {
   const span = makeBaseSpan(base)
-  const inputTokens = estimateTokens(JSON.stringify(inputMessages))
+  const inputTokens = promptTokens ?? estimateTokens(JSON.stringify(inputMessages))
   const outputTokens = estimateTokens(JSON.stringify(outputMessages))
-  const cacheRead = Math.random() > 0.6 ? Math.floor(inputTokens * randFloat(0.2, 0.6)) : 0
+  const cache = splitCacheTokens(inputTokens, cacheProfile ?? randomCacheProfile())
   const reasoningTokens = modelConfig.isReasoning ? Math.floor(outputTokens * randFloat(1.5, 4)) : 0
-  const costIn = computeCost(inputTokens, modelConfig.costInPerMToken)
+  const costIn = inputSideCostMicrocents(cache, modelConfig)
   const costOut = computeCost(outputTokens + reasoningTokens, modelConfig.costOutPerMToken)
 
   span.name = `chat ${modelConfig.model}`
@@ -337,9 +390,10 @@ export function makeLlmSpan({
   span.provider = modelConfig.provider
   span.model = modelConfig.model
   span.response_model = modelConfig.responseModel
-  span.tokens_input = inputTokens
+  span.tokens_input = cache.input
   span.tokens_output = outputTokens
-  span.tokens_cache_read = cacheRead
+  span.tokens_cache_read = cache.cacheRead
+  span.tokens_cache_create = cache.cacheCreate
   span.tokens_reasoning = reasoningTokens
   span.cost_input_microcents = costIn
   span.cost_output_microcents = costOut


### PR DESCRIPTION
Closes LAT-796. PR 2a of the cost dashboard, on top of LAT-794 (#4290) and LAT-795 (#4313).

The measured half of the cache section: exact hit rates per model, a break-even derived from each model's own registry prices, and a pure classifier that turns the two into one of six states.

## Break-even is derived, never chosen

```
break_even = (input − cacheWrite) / (cacheRead − cacheWrite)
```

A missing `cacheWrite` means no write premium, so it reads as `input` and the rate collapses to **0%** — any read at all is upside. Anthropic's 1.25x write / 0.1x read gives **21.7%**.

The difference is **per model, not per provider**: `gpt-5.6` carries a write premium (21.7%) while `gpt-5-mini` does not (0%). A 5% hit rate is fine on one and actively costing money on the other, which is the whole reason there is no project-wide blend here.

## What you can review quickly

Real numbers from the seeded project, read through the actual repository + classifier:

| model | provider | calls | actual | break-even | state |
| -- | -- | -- | -- | -- | -- |
| gpt-5.6 | openai | 64 | 14.0% | 21.7% | Investigate (overpaying) |
| claude-opus-4-5 | anthropic | 96 | 62.0% | 21.7% | Optimal |
| claude-haiku-4-5 | anthropic | 140 | 6.0% | 21.7% | Investigate (overpaying) |
| gpt-5.4-mini | openai | 110 | 5.0% | 0.0% | Optimal |
| gpt-5-mini | openai | 48 | 0.0% | 0.0% | Cache it |

## Design calls

- **Comparison table, not the carousel.** Break-even differing per model is the entire point, and paging through one model at a time buries the comparison it exists to enable.
- **No hypothetical-rate slider.** It explains the concept but nobody's real decision is "what if my rate were 53%".
- **Position column, not three percentage columns.** Actual and break-even are position on one shared 0–100% track; raw token counts move to the hover, matching the trace tables.

## Where review should focus

1. **`stopCaching` and the `underusing` branch of `investigate` are unreachable in this PR** — both need the achievable ceiling from LAT-798. `classifyCacheState` takes `ceilingRate` and returns a verdict only when *every* ceiling in 0..1 agrees, so 2b lights them up with no rework. Both are unit-tested with an explicit ceiling. Worth confirming that staging is what you expected.
2. **No modeled dollars.** Spend is the authoritative recorded total, so it ties to the breakdown table exactly; cache rates are measured exactly from token counts. I deliberately did not invent a modeled dollar figure just to label it as modeled — estimated savings belong to LAT-798. Flagging in case you wanted something in that column now.
3. **`CACHE_MIN_CACHEABLE_INPUT_TOKENS = 1024`.** End-to-end testing surfaced a 40-token-per-call model landing in **Cache it**. Below the provider minimum, caching is *unavailable* rather than unprofitable, so recommending it is wrong however the prices work out. It now reads Correctly off. This is a real external constraint rather than a threshold I picked, but it is the one judgement call in the classifier.
4. **A pre-existing seed double count is fixed here.** `makeLlmSpan` set `tokens_input` to the whole prompt *and* carved out `tokens_cache_read`, but `spans.tokens_total` is materialized as the sum of all five token columns. Every ambient seeded model therefore read back at roughly half its true cache hit rate. `splitCacheTokens` now carves reads and writes *out* of the prompt. Ambient costs are unchanged (models with no cache rate fall back to the input rate).

## Seeds — deliberately minimal, LAT-809 owns the rest

Scoped down to just enough to unit-test the classifier and eyeball the table once. **No new projects, no long histories, no archetypes** — those are LAT-809's six project archetypes, which a separate agent picks up next.

Cache-token support lives in the **shared span builders** (`CacheProfile`, `splitCacheTokens`, `inputSideCostMicrocents`, plus `promptTokens` / `cacheProfile` on `makeLlmSpan`) precisely so LAT-809 extends that surface rather than a parallel one. Six cohorts on the **existing** seed project, ~6 days of data, bootstrap-only.

## Verification

- 23 classifier unit tests (state table exhaustive, both break-even shapes, the sample floor, the cacheable-prefix floor)
- 5 shared span-builder tests pinning the additivity invariant
- 10 fixture tests asserting each cohort reaches its intended state
- 4 new ClickHouse repository tests; full `@platform/db-clickhouse` suite green (40 files, 529 tests — needs `--maxWorkers=2` locally, it OOMs at full concurrency on a shared machine)
- `typecheck` clean on `@domain/shared`, `@domain/spans`, `@platform/db-clickhouse`, `@app/web`; biome and knip clean
- Ran end-to-end against local ClickHouse after seeding, driving the real repository and classifier (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
