### PR TITLE
feat(cost): cost per session — log-space contribution decomposition

### DIFF
--- a/apps/web/src/domains/cost/cost.collection.ts
+++ b/apps/web/src/domains/cost/cost.collection.ts
@@ -66,16 +66,19 @@ export function useCostBreakdown({
 export function useCostPerSessionDecomposition({
   projectId,
   range,
+  bucketSeconds,
   enabled = true,
 }: {
   readonly projectId: string
   readonly range: CostTimeRange
+  readonly bucketSeconds: number
   readonly enabled?: boolean
 }) {
   const scope = useProjectScope()
   return useQuery({
-    queryKey: [...projectScopeKey(scope), "cost-per-session", projectId, range],
-    queryFn: () => getCostPerSessionDecomposition({ data: { ...projectScopeData(scope), projectId, ...range } }),
+    queryKey: [...projectScopeKey(scope), "cost-per-session", projectId, range, bucketSeconds],
+    queryFn: () =>
+      getCostPerSessionDecomposition({ data: { ...projectScopeData(scope), projectId, ...range, bucketSeconds } }),
     staleTime: COST_STALE_TIME_MS,
     placeholderData: keepPreviousData,
     enabled: enabled && projectId.length > 0,

--- a/apps/web/src/domains/cost/cost.collection.ts
+++ b/apps/web/src/domains/cost/cost.collection.ts
@@ -5,6 +5,7 @@ import {
   getCacheEconomics,
   getCostBreakdown,
   getCostOverview,
+  getCostPerSessionDecomposition,
   getCostSeries,
   getModelUsageSeries,
 } from "./cost.functions.ts"
@@ -57,6 +58,26 @@ export function useCostBreakdown({
     queryKey: [...projectScopeKey(scope), "cost-breakdown", projectId, range, dimension],
     queryFn: () => getCostBreakdown({ data: { ...projectScopeData(scope), projectId, ...range, dimension } }),
     staleTime: COST_STALE_TIME_MS,
+    enabled: enabled && projectId.length > 0,
+  })
+}
+
+/** The comparison window is derived server-side from this one, so it is not a key. */
+export function useCostPerSessionDecomposition({
+  projectId,
+  range,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly range: CostTimeRange
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "cost-per-session", projectId, range],
+    queryFn: () => getCostPerSessionDecomposition({ data: { ...projectScopeData(scope), projectId, ...range } }),
+    staleTime: COST_STALE_TIME_MS,
+    placeholderData: keepPreviousData,
     enabled: enabled && projectId.length > 0,
   })
 }

--- a/apps/web/src/domains/cost/cost.functions.ts
+++ b/apps/web/src/domains/cost/cost.functions.ts
@@ -16,6 +16,7 @@ import {
   decomposeCostPerSession,
   isUnpricedGap,
   judgeCacheEconomics,
+  sessionCostTokens,
   summarizeUnpricedUsage,
 } from "@domain/spans"
 import { CostAnalyticsRepositoryLive } from "@platform/db-clickhouse"
@@ -105,6 +106,16 @@ export interface CostPerSessionRecord extends CostPerSessionDecomposition {
   /** Both feed the shared rollup cost display, so a zero headline never reads as free. */
   readonly unpricedCalls: number
   readonly tokens: number
+  /** Sparkline points for the two headline blocks, spanning both windows, oldest first. */
+  readonly buckets: readonly SessionCostSparkPoint[]
+}
+
+/** Cost per session is derived here rather than in the panel: an empty bucket has none. */
+export interface SessionCostSparkPoint {
+  readonly bucketStartIso: string
+  readonly sessions: number
+  readonly costMicrocents: number
+  readonly costPerSessionMicrocents: number | null
 }
 
 // Well above what any window the picker offers can ask for at its bucket width.
@@ -242,24 +253,31 @@ export const getCacheEconomics = createServerFn({ method: "GET" })
  * period-over-period figure cannot drift apart.
  */
 export const getCostPerSessionDecomposition = createServerFn({ method: "GET" })
-  .inputValidator(costScopeSchema)
+  .inputValidator(
+    costScopeSchema.extend({ bucketSeconds: bucketSecondsSchema }).refine(withinBucketBudget, bucketBudgetIssue),
+  )
   .handler(async ({ data, context }): Promise<CostPerSessionRecord> => {
     const orgId = await resolveOrgScope(context)
     return Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* CostAnalyticsRepository
         const scope = toScope(orgId, data)
-        const { previous, current } = yield* repo.getSessionCostFactors({
+        const { previous, current, buckets } = yield* repo.getSessionCostFactors({
           ...scope,
           previousFrom: new Date(scope.from.getTime() - (scope.to.getTime() - scope.from.getTime())),
+          bucketSeconds: data.bucketSeconds,
         })
-        // TODO(LAT-798): pass `cacheEfficiencyEffect` once the achievable ceiling
-        // lands, so cache efficiency splits out of the within-model rate row.
         return {
           ...decomposeCostPerSession({ previous, current }),
           traceKeyedSessionShare: current.sessions > 0 ? current.traceKeyedSessions / current.sessions : null,
           unpricedCalls: current.unpricedCalls,
-          tokens: current.tokens,
+          tokens: sessionCostTokens(current),
+          buckets: buckets.map((bucket) => ({
+            bucketStartIso: bucket.bucketStart.toISOString(),
+            sessions: bucket.sessions,
+            costMicrocents: bucket.costMicrocents,
+            costPerSessionMicrocents: bucket.sessions > 0 ? bucket.costMicrocents / bucket.sessions : null,
+          })),
         }
       }).pipe(withScopedClickHouse(CostAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )

--- a/apps/web/src/domains/cost/cost.functions.ts
+++ b/apps/web/src/domains/cost/cost.functions.ts
@@ -106,6 +106,14 @@ export interface CostPerSessionRecord extends CostPerSessionDecomposition {
   /** Both feed the shared rollup cost display, so a zero headline never reads as free. */
   readonly unpricedCalls: number
   readonly tokens: number
+  /**
+   * The window this one is compared against. Named on the card because the picker's
+   * label does not describe it: under All time the shown window is a bounded recent
+   * slice, so the comparison is that slice against the slice before it, and "All time"
+   * reads as if there were nothing to compare against.
+   */
+  readonly comparedFromIso: string
+  readonly comparedToIso: string
   /** Sparkline points for the two headline blocks, spanning both windows, oldest first. */
   readonly buckets: readonly SessionCostSparkPoint[]
 }
@@ -272,13 +280,16 @@ export const getCostPerSessionDecomposition = createServerFn({ method: "GET" })
       Effect.gen(function* () {
         const repo = yield* CostAnalyticsRepository
         const scope = toScope(orgId, data)
+        const previousFrom = new Date(scope.from.getTime() - (scope.to.getTime() - scope.from.getTime()))
         const { previous, current, buckets } = yield* repo.getSessionCostFactors({
           ...scope,
-          previousFrom: new Date(scope.from.getTime() - (scope.to.getTime() - scope.from.getTime())),
+          previousFrom,
           bucketSeconds: data.bucketSeconds,
         })
         return {
           ...decomposeCostPerSession({ previous, current }),
+          comparedFromIso: previousFrom.toISOString(),
+          comparedToIso: scope.from.toISOString(),
           traceKeyedSessionShare: current.sessions > 0 ? current.traceKeyedSessions / current.sessions : null,
           unpricedCalls: current.unpricedCalls,
           tokens: sessionCostTokens(current),

--- a/apps/web/src/domains/cost/cost.functions.ts
+++ b/apps/web/src/domains/cost/cost.functions.ts
@@ -179,11 +179,21 @@ const bucketSecondsSchema = z
   .max(90 * 24 * 60 * 60)
 
 // Counts the aligned positions the client will densify to, not the raw duration: the start floors to a boundary.
-const withinBucketBudget = (input: { fromIso: string; toIso: string; bucketSeconds: number }) => {
-  const stepMs = input.bucketSeconds * 1000
-  return (
-    Math.ceil(Date.parse(input.toIso) / stepMs) - Math.floor(Date.parse(input.fromIso) / stepMs) <= MAX_SERIES_BUCKETS
-  )
+const bucketsBetween = ({ fromMs, toIso, bucketSeconds }: { fromMs: number; toIso: string; bucketSeconds: number }) => {
+  const stepMs = bucketSeconds * 1000
+  return Math.ceil(Date.parse(toIso) / stepMs) - Math.floor(fromMs / stepMs)
+}
+
+const withinBucketBudget = (input: { fromIso: string; toIso: string; bucketSeconds: number }) =>
+  bucketsBetween({ fromMs: Date.parse(input.fromIso), ...input }) <= MAX_SERIES_BUCKETS
+
+/**
+ * The decomposition scans the comparison window as well, so its budget covers both.
+ * Checking only the shown window would let a request through at twice the cap.
+ */
+const withinPairedBucketBudget = (input: { fromIso: string; toIso: string; bucketSeconds: number }) => {
+  const fromMs = Date.parse(input.fromIso)
+  return bucketsBetween({ fromMs: fromMs - (Date.parse(input.toIso) - fromMs), ...input }) <= MAX_SERIES_BUCKETS
 }
 
 const bucketBudgetIssue = {
@@ -254,7 +264,7 @@ export const getCacheEconomics = createServerFn({ method: "GET" })
  */
 export const getCostPerSessionDecomposition = createServerFn({ method: "GET" })
   .inputValidator(
-    costScopeSchema.extend({ bucketSeconds: bucketSecondsSchema }).refine(withinBucketBudget, bucketBudgetIssue),
+    costScopeSchema.extend({ bucketSeconds: bucketSecondsSchema }).refine(withinPairedBucketBudget, bucketBudgetIssue),
   )
   .handler(async ({ data, context }): Promise<CostPerSessionRecord> => {
     const orgId = await resolveOrgScope(context)

--- a/apps/web/src/domains/cost/cost.functions.ts
+++ b/apps/web/src/domains/cost/cost.functions.ts
@@ -4,6 +4,7 @@ import type {
   ClassifiedUnpricedPair,
   CostAnalyticsScope,
   CostBreakdown,
+  CostPerSessionDecomposition,
   JudgedCacheModel,
   ModelUsageMeasures,
   ModelUsageSlice,
@@ -12,6 +13,7 @@ import {
   COST_BREAKDOWN_DIMENSIONS,
   COST_SERIES_METRICS,
   CostAnalyticsRepository,
+  decomposeCostPerSession,
   isUnpricedGap,
   judgeCacheEconomics,
   summarizeUnpricedUsage,
@@ -87,6 +89,22 @@ export interface CacheModelRecord extends JudgedCacheModel {}
 export interface CacheEconomicsRecord {
   readonly rows: readonly CacheModelRecord[]
   readonly totals: CacheUsageMeasures & { readonly distinctModels: number }
+}
+
+/**
+ * The decomposition as the card renders it: the arithmetic is done here, so the
+ * panel receives a headline, a total, and rows it only has to lay out.
+ */
+export interface CostPerSessionRecord extends CostPerSessionDecomposition {
+  /**
+   * Share of this window's sessions keyed on a trace id because the traffic
+   * reported no session id. Above a small share, "cost per session" is largely
+   * cost per trace wearing another name, which the card has to say out loud.
+   */
+  readonly traceKeyedSessionShare: number | null
+  /** Both feed the shared rollup cost display, so a zero headline never reads as free. */
+  readonly unpricedCalls: number
+  readonly tokens: number
 }
 
 // Well above what any window the picker offers can ask for at its bucket width.
@@ -211,6 +229,37 @@ export const getCacheEconomics = createServerFn({ method: "GET" })
         return {
           rows: judgeCacheEconomics({ economics, windowMs: scope.to.getTime() - scope.from.getTime() }),
           totals: economics.totals,
+        }
+      }).pipe(withScopedClickHouse(CostAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+  })
+
+/**
+ * Why average cost per session moved against the window immediately before it.
+ *
+ * The comparison window is derived here rather than accepted from the client: it
+ * is the same length ending where the shown window starts, so the two halves of a
+ * period-over-period figure cannot drift apart.
+ */
+export const getCostPerSessionDecomposition = createServerFn({ method: "GET" })
+  .inputValidator(costScopeSchema)
+  .handler(async ({ data, context }): Promise<CostPerSessionRecord> => {
+    const orgId = await resolveOrgScope(context)
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* CostAnalyticsRepository
+        const scope = toScope(orgId, data)
+        const { previous, current } = yield* repo.getSessionCostFactors({
+          ...scope,
+          previousFrom: new Date(scope.from.getTime() - (scope.to.getTime() - scope.from.getTime())),
+        })
+        // TODO(LAT-798): pass `cacheEfficiencyEffect` once the achievable ceiling
+        // lands, so cache efficiency splits out of the within-model rate row.
+        return {
+          ...decomposeCostPerSession({ previous, current }),
+          traceKeyedSessionShare: current.sessions > 0 ? current.traceKeyedSessions / current.sessions : null,
+          unpricedCalls: current.unpricedCalls,
+          tokens: current.tokens,
         }
       }).pipe(withScopedClickHouse(CostAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -160,6 +160,7 @@ function HeadlineBlock({
   changePct,
   detail,
   points,
+  boundaryIndex,
   hint,
 }: {
   readonly label: string
@@ -167,6 +168,7 @@ function HeadlineBlock({
   readonly changePct: number | null
   readonly detail?: string
   readonly points: readonly (number | null)[]
+  readonly boundaryIndex: number | undefined
   readonly hint: string
 }) {
   const neutral = changePct === null || Math.abs(Math.round(changePct)) < NEUTRAL_PERCENT
@@ -209,7 +211,7 @@ function HeadlineBlock({
           </Text.H6>
         ) : null}
       </div>
-      <SessionSparkline points={points} label={`${label} over both periods`} />
+      <SessionSparkline points={points} boundaryIndex={boundaryIndex} label={`${label} over both periods`} />
     </div>
   )
 }
@@ -273,6 +275,12 @@ export function CostPerSessionPanel({
       ? (record.volume.currentSessions / record.volume.previousSessions - 1) * 100
       : null
   const traceKeyed = record?.traceKeyedSessionShare ?? null
+  // Where the comparison window ends and the shown one begins, so the sparklines can
+  // mark it. Both blocks plot the same buckets, so one index serves both.
+  const currentWindowStart = record?.buckets.findIndex(
+    (bucket) => Date.parse(bucket.bucketStartIso) >= Date.parse(rangeFromIso),
+  )
+  const boundaryIndex = currentWindowStart !== undefined && currentWindowStart > 0 ? currentWindowStart : undefined
 
   return (
     <div className="flex flex-col rounded-lg bg-secondary">
@@ -296,6 +304,7 @@ export function CostPerSessionPanel({
                   ? { detail: `from ${formatCount(record.volume.previousSessions)}` }
                   : {})}
                 points={record.buckets.map((bucket) => bucket.sessions)}
+                boundaryIndex={boundaryIndex}
                 hint="Sessions with billable spend. Traffic that reported no session id keys on its trace id instead, so it counts as a single-trace session rather than dropping out of the denominator. More sessions does not move what each one costs — that is the figure below."
               />
               <HeadlineBlock
@@ -306,6 +315,7 @@ export function CostPerSessionPanel({
                 points={record.buckets.map((bucket) =>
                   bucket.costPerSessionMicrocents === null ? null : microcentsToUsd(bucket.costPerSessionMicrocents),
                 )}
+                boundaryIndex={boundaryIndex}
                 hint="Spend divided by sessions, for this window against the equal-length window before it. The factors beside it are its multiplicative parts, so their multipliers multiply to this change."
               />
             </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -1,18 +1,20 @@
 import { SESSION_COST_MIN_SESSIONS, type SessionCostContribution, type SessionCostFactor } from "@domain/spans"
-import { cn, Icon, Skeleton, Text, Tooltip } from "@repo/ui"
-import { formatCount } from "@repo/utils"
-import { ArrowDownIcon, ArrowUpIcon, InfoIcon, MinusIcon } from "lucide-react"
+import { Icon, Skeleton, Text, Tooltip } from "@repo/ui"
+import { formatCount, formatPercentage } from "@repo/utils"
+import { InfoIcon } from "lucide-react"
 import type { CostPerSessionRecord } from "../../../../../../domains/cost/cost.functions.ts"
 import { rollupCostDisplay } from "../../../../../../domains/spans/cost-display.ts"
 import { ChartHeader } from "../../-components/chart-header.tsx"
+import { microcentsToUsd } from "./cost-formatters.ts"
+import { SessionSparkline } from "./session-sparkline.tsx"
 
 // Above this share of the denominator, "per session" stops meaning what it says and
 // the card has to name the substitution rather than leaving it in a tooltip.
 const TRACE_KEYED_DISCLOSURE_SHARE = 0.1
 
-// Below a point the bar is a sliver either way, and the row's own figure already
-// says it is nothing. Colouring it would make a rounding artefact look like a cause.
-const NEUTRAL_POINTS = 1
+// Below a whole point the headline change is noise, and colouring it would make a
+// rounding artefact look like a movement.
+const NEUTRAL_PERCENT = 1
 
 interface FactorMeta {
   readonly label: string
@@ -21,104 +23,168 @@ interface FactorMeta {
 }
 
 const ratio = (value: number): string => value.toFixed(2)
-const rounded = (value: number): string => formatCount(Math.round(value))
+const whole = (value: number): string => formatCount(Math.round(value))
 
 const FACTOR_META: Record<SessionCostFactor, FactorMeta> = {
-  turnsPerSession: {
-    label: "Turns per session",
-    hint: "Traces with a billable call, per session. Longer conversations cost more even when nothing else changes.",
+  tracesPerSession: {
+    label: "Traces per session",
+    hint: "Traces with a billable call, per session. One trace is one request to an agent, not one conversational turn.",
     formatValue: ratio,
   },
-  stepsPerTurn: {
-    label: "Steps per turn",
-    hint: "Billable LLM calls per trace. Retry loops and extra tool round trips land here.",
+  callsPerTrace: {
+    label: "LLM calls per trace",
+    hint: "Billable model calls a single trace spent to answer. Retry loops and extra tool round trips land here.",
     formatValue: ratio,
   },
-  tokensPerStep: {
-    label: "Tokens per step",
-    hint: "Tokens per billable call — prompt growth, larger retrieved context, longer outputs.",
-    formatValue: rounded,
+  tokensPerCall: {
+    label: "Tokens per call",
+    hint: "Prompt plus output tokens per call — prompt growth, larger retrieved context, longer answers.",
+    formatValue: whole,
   },
   modelMix: {
     label: "Model mix",
-    hint: "Tokens moving between price lists at unchanged prices. A migration to a cheaper model shows up here.",
+    hint: "Tokens moving between price lists while each list's own prices hold. A migration to a cheaper model shows up here rather than as a rate cut.",
   },
-  cacheEfficiency: {
-    label: "Cache efficiency",
-    hint: "The share of the prompt charged at the cache-read rate rather than the full input rate.",
+  tokenMix: {
+    label: "Prompt / output mix",
+    hint: "How the tokens divided between the cheap prompt side and the dearer output side. Growing the prompt while the answer stays the same length lowers the blended rate with no price changing, which is why it is not in the rate rows.",
   },
-  pricePerToken: {
-    label: "Price per token",
-    hint: "Whatever within-model rate change is left once model mix and cache efficiency are taken out.",
+  promptRate: {
+    label: "Prompt rate",
+    hint: "What a prompt token actually costs, holding model and prompt/output mix fixed.",
+  },
+  outputRate: {
+    label: "Output rate",
+    hint: "What an output token actually costs, holding model and prompt/output mix fixed.",
   },
 }
 
-const signedPoints = (points: number): string => `${points > 0 ? "+" : points < 0 ? "−" : ""}${Math.abs(points)} pts`
+const formatMultiplier = (multiplier: number): string => `×${multiplier.toFixed(2)}`
 
 const signedPercent = (pct: number): string => `${pct > 0 ? "▲" : pct < 0 ? "▼" : ""} ${Math.abs(Math.round(pct))}%`
 
-function ContributionRow({
-  row,
-  widestPoints,
-}: {
-  readonly row: SessionCostContribution
-  readonly widestPoints: number
-}) {
-  const meta = FACTOR_META[row.factor]
-  const neutral = Math.abs(row.points) < NEUTRAL_POINTS
-  const width = widestPoints > 0 ? (Math.abs(row.points) / widestPoints) * 100 : 0
-  const icon = neutral ? MinusIcon : row.points > 0 ? ArrowUpIcon : ArrowDownIcon
-  const color = neutral ? "foregroundMuted" : row.points > 0 ? "destructive" : "success"
-  const values = row.values
-  const format = meta.formatValue ?? ratio
+const directionColor = (multiplier: number): "destructive" | "success" | "foregroundMuted" => {
+  if (multiplier > 1) return "destructive"
+  if (multiplier < 1) return "success"
+  return "foregroundMuted"
+}
+
+const rowLabel = (row: SessionCostContribution): string =>
+  row.factor === null
+    ? `${row.foldedFactors} ${row.foldedFactors === 1 ? "factor" : "factors"} unchanged`
+    : FACTOR_META[row.factor].label
+
+/** The concrete move behind a row: its own before/after, or the share shift driving a mix row. */
+function rowDetail(row: SessionCostContribution): string | null {
+  if (row.factor === null) return null
+  if (row.values) {
+    const format = FACTOR_META[row.factor].formatValue ?? ratio
+    return `${format(row.values.previous)} → ${format(row.values.current)}`
+  }
+  if (!row.shareShift) return null
+  const { label, previousShare, currentShare } = row.shareShift
+  return `${label} ${formatPercentage(previousShare)} → ${formatPercentage(currentShare)}`
+}
+
+function ContributionRow({ row }: { readonly row: SessionCostContribution }) {
+  const detail = rowDetail(row)
+  const muted = row.factor === null
 
   return (
     <Tooltip
       asChild
       trigger={
-        <div className="flex w-full cursor-default flex-row items-center gap-3">
-          <div className="flex w-36 shrink-0 flex-col">
-            <Text.H6 color="foreground" ellipsis noWrap>
-              {meta.label}
-            </Text.H6>
-          </div>
-          <div className="relative h-2.5 w-full overflow-hidden rounded-sm bg-muted">
-            <div
-              className={cn("h-full rounded-sm", {
-                "bg-muted-foreground/40": neutral,
-                "bg-destructive": !neutral && row.points > 0,
-                "bg-success": !neutral && row.points < 0,
-              })}
-              style={{ width: `${Math.max(0, Math.min(100, width))}%` }}
-            />
-          </div>
-          <div className="flex w-20 shrink-0 flex-row items-center justify-end gap-1">
-            <Icon icon={icon} size="sm" color={color} />
-            <Text.H6 color={color} noWrap className="tabular-nums">
-              {signedPoints(row.points)}
-            </Text.H6>
-          </div>
+        <div className="flex w-full cursor-default flex-row items-baseline gap-3">
+          <Text.H6 color={muted ? "foregroundMuted" : "foreground"} noWrap className="w-40 shrink-0">
+            {rowLabel(row)}
+          </Text.H6>
+          <Text.H6 color="foregroundMuted" ellipsis noWrap className="flex-1 tabular-nums">
+            {detail ?? ""}
+          </Text.H6>
+          <Text.H6
+            color={muted ? "foregroundMuted" : directionColor(row.multiplier)}
+            noWrap
+            className="w-14 shrink-0 text-right tabular-nums"
+          >
+            {formatMultiplier(row.multiplier)}
+          </Text.H6>
         </div>
       }
     >
-      {[
-        meta.hint,
-        values ? `${format(values.previous)} → ${format(values.current)}` : null,
-        `Contributed ${signedPoints(row.points)} of the change above.`,
-      ]
-        .filter((line) => line !== null)
-        .join("\n")}
+      {row.factor === null
+        ? "Factors that did not move. Folded into one row so the visible ones still multiply to the total."
+        : FACTOR_META[row.factor].hint}
     </Tooltip>
+  )
+}
+
+/** A headline measure: the number, its change, and the shape it took getting there. */
+function HeadlineBlock({
+  label,
+  value,
+  changePct,
+  detail,
+  points,
+  hint,
+}: {
+  readonly label: string
+  readonly value: string
+  readonly changePct: number | null
+  readonly detail?: string
+  readonly points: readonly (number | null)[]
+  readonly hint: string
+}) {
+  const neutral = changePct === null || Math.abs(Math.round(changePct)) < NEUTRAL_PERCENT
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <div className="flex flex-row items-center gap-1">
+        <Text.H6 color="foregroundMuted">{label}</Text.H6>
+        <Tooltip
+          asChild
+          trigger={
+            <span className="inline-flex cursor-default">
+              <Icon icon={InfoIcon} size="sm" color="foregroundMuted" />
+            </span>
+          }
+        >
+          {hint}
+        </Tooltip>
+      </div>
+      <Text.H3 color="foreground" className="tabular-nums">
+        {value}
+      </Text.H3>
+      <div className="flex flex-row items-baseline gap-2">
+        {changePct === null ? (
+          <Text.H6 color="foregroundMuted" noWrap>
+            no comparison
+          </Text.H6>
+        ) : (
+          <Text.H6
+            color={neutral ? "foregroundMuted" : changePct > 0 ? "destructive" : "success"}
+            noWrap
+            className="tabular-nums"
+          >
+            {neutral ? "flat" : signedPercent(changePct)}
+          </Text.H6>
+        )}
+        {detail ? (
+          <Text.H6 color="foregroundMuted" ellipsis noWrap>
+            {detail}
+          </Text.H6>
+        ) : null}
+      </div>
+      <SessionSparkline points={points} label={`${label} over both periods`} />
+    </div>
   )
 }
 
 /**
  * Names the side that is short and by how much, rather than restating the rule.
  *
- * An empty comparison window is a different answer from a thin one and gets its
- * own sentence: no traffic precedes the window at all, so widening the range
- * cannot help and only more history will. Reporting that as "0 against the 20 a
- * comparison needs" points at a threshold when the problem is the project's age.
+ * An empty comparison window is a different answer from a thin one and gets its own
+ * sentence: no traffic precedes the window at all, so widening the range cannot
+ * help and only more history will.
  */
 function notEnoughDataReason(record: CostPerSessionRecord): string {
   const { previousSessions, currentSessions } = record.volume
@@ -137,101 +203,15 @@ function notEnoughDataReason(record: CostPerSessionRecord): string {
   return `Not enough data to compare periods: ${short.join(" and ")}, against the ${SESSION_COST_MIN_SESSIONS} sessions a comparison needs on both sides.`
 }
 
-function Headline({ record }: { readonly record: CostPerSessionRecord }) {
-  // The same rollup vocabulary the KPI row uses, so an average of zero reads as
-  // "not known" rather than as free.
-  const current = rollupCostDisplay({
-    costTotalMicrocents: record.currentCostPerSessionMicrocents,
-    unpricedSpanCount: record.unpricedCalls,
-    tokensTotal: record.tokens,
-  })
-  const previous = rollupCostDisplay({
-    costTotalMicrocents: record.previousCostPerSessionMicrocents,
-    unpricedSpanCount: 0,
-    tokensTotal: record.tokens,
-  })
-  const changePct = record.changePct
-  const neutral = Math.abs(Math.round(changePct ?? 0)) < NEUTRAL_POINTS
-
-  return (
-    <div className="flex flex-row flex-wrap items-baseline gap-3">
-      <Text.H3 color="foreground" className="tabular-nums">
-        {current.label}
-      </Text.H3>
-      {/* Both halves are withheld together: printing the previous period's figure while
-          declining to quantify the move states a comparison the card just refused. */}
-      {changePct === null ? null : (
-        <>
-          <Text.H5 color={neutral ? "foregroundMuted" : changePct > 0 ? "destructive" : "success"} noWrap>
-            {signedPercent(changePct)}
-          </Text.H5>
-          <Text.H6 color="foregroundMuted" noWrap>
-            {`from ${previous.label} in the previous period of equal length`}
-          </Text.H6>
-        </>
-      )}
-    </div>
-  )
-}
-
-function VolumeContext({ record }: { readonly record: CostPerSessionRecord }) {
-  const { previousSessions, currentSessions } = record.volume
-  const changePct = previousSessions > 0 ? (currentSessions / previousSessions - 1) * 100 : null
-
-  return (
-    <Tooltip
-      asChild
-      trigger={
-        <div className="flex w-full cursor-default flex-row items-center gap-3 border-border border-t pt-2">
-          <div className="flex w-36 shrink-0 flex-col">
-            <Text.H6 color="foregroundMuted" ellipsis noWrap>
-              Sessions
-            </Text.H6>
-          </div>
-          <Text.H6 color="foregroundMuted" noWrap className="tabular-nums">
-            {`${formatCount(previousSessions)} → ${formatCount(currentSessions)}${
-              changePct === null ? "" : ` · ${signedPercent(changePct)}`
-            }`}
-          </Text.H6>
-        </div>
-      }
-    >
-      Not part of the change above: sessions are its denominator, so more of them does not move the average. Shown
-      because growth in usage is the one kind of rising spend that is good news.
-    </Tooltip>
-  )
-}
-
-function Disclosures({ record }: { readonly record: CostPerSessionRecord }) {
-  const traceKeyed = record.traceKeyedSessionShare
-  const lines = [
-    traceKeyed !== null && traceKeyed >= TRACE_KEYED_DISCLOSURE_SHARE
-      ? `${Math.round(traceKeyed * 100)}% of these sessions are single traces that reported no session id, so this figure is close to average cost per trace.`
-      : null,
-    // Describes how to read the rows, so it has nothing to qualify without them.
-    record.rows.length > 0
-      ? "Traffic shifting toward an inherently longer use case raises this with nothing wrong — the rise lands on turns per session. Compare per agent before acting on it."
-      : null,
-  ].filter((line) => line !== null)
-
-  return (
-    <div className="flex flex-col gap-1">
-      {lines.map((line) => (
-        <Text.H6 key={line} color="foregroundMuted">
-          {line}
-        </Text.H6>
-      ))}
-    </div>
-  )
-}
-
 /**
- * Which factor moved average cost per session, in points that sum to the headline.
+ * What moved average cost per session, as a multiplier per factor.
  *
- * Cost per session is `turns/session x steps/turn x tokens/step x price/token`, and
- * a product decomposes exactly in log space — so each row is a share of the same
- * change rather than an independently-measured correlation. Every figure here is
- * computed server-side; this file only lays the rows out.
+ * Cost per session is `traces/session x calls/trace x tokens/call x cost/token`, so
+ * each row's multiplier is that factor's own before/after ratio and the rows
+ * multiply to the headline. Sessions sits beside it rather than among the rows
+ * because it is the denominator: more of them does not move the cost of each one.
+ *
+ * Every figure is computed server-side; this file lays the rows out.
  */
 export function CostPerSessionPanel({
   record,
@@ -246,40 +226,57 @@ export function CostPerSessionPanel({
   readonly isAllTime: boolean
   readonly isLoading: boolean
 }) {
-  const widestPoints = record ? Math.max(...record.rows.map((row) => Math.abs(row.points)), 1) : 1
+  const cost = record
+    ? rollupCostDisplay({
+        costTotalMicrocents: record.currentCostPerSessionMicrocents,
+        unpricedSpanCount: record.unpricedCalls,
+        tokensTotal: record.tokens,
+      })
+    : null
+  const sessionsChangePct =
+    record && record.volume.previousSessions > 0
+      ? (record.volume.currentSessions / record.volume.previousSessions - 1) * 100
+      : null
+  const traceKeyed = record?.traceKeyedSessionShare ?? null
 
   return (
     <div className="flex flex-col rounded-lg bg-secondary">
-      <ChartHeader
-        title="Cost per session"
-        fromIso={rangeFromIso}
-        toIso={rangeToIso}
-        isAllTime={isAllTime}
-        showWindow={isAllTime}
-        actions={
-          <Tooltip
-            asChild
-            trigger={
-              <span className="inline-flex cursor-default">
-                <Icon icon={InfoIcon} size="sm" color="foregroundMuted" />
-              </span>
-            }
-          >
-            Total spend divided by sessions, where traffic that reported no session id keys on its trace id instead — so
-            it becomes a single-trace session rather than dropping out of the denominator.
-          </Tooltip>
-        }
-      />
-      {isLoading || !record ? (
-        <div className="flex flex-col gap-3 px-4 py-3">
-          <Skeleton className="h-8 w-40" />
-          {[0, 1, 2, 3].map((row) => (
+      <ChartHeader title="Cost per session" fromIso={rangeFromIso} toIso={rangeToIso} isAllTime={isAllTime} />
+      {isLoading || !record || !cost ? (
+        <div className="flex flex-col gap-4 px-4 py-3">
+          <div className="flex flex-row gap-6">
+            <Skeleton className="h-24 flex-1" />
+            <Skeleton className="h-24 flex-1" />
+          </div>
+          {[0, 1, 2].map((row) => (
             <Skeleton key={row} className="h-4 w-full" />
           ))}
         </div>
       ) : (
-        <div className="flex flex-col gap-3 px-4 py-3">
-          <Headline record={record} />
+        <div className="flex flex-col gap-4 px-4 py-3">
+          <div className="flex flex-col gap-6 sm:flex-row">
+            <HeadlineBlock
+              label="Sessions"
+              value={formatCount(record.volume.currentSessions)}
+              changePct={sessionsChangePct}
+              {...(record.volume.previousSessions > 0
+                ? { detail: `from ${formatCount(record.volume.previousSessions)}` }
+                : {})}
+              points={record.buckets.map((bucket) => bucket.sessions)}
+              hint="Sessions with billable spend. Traffic that reported no session id keys on its trace id instead, so it counts as a single-trace session rather than dropping out of the denominator. More sessions does not move what each one costs — that is the figure beside this."
+            />
+            <HeadlineBlock
+              label="Cost per session"
+              value={cost.label}
+              changePct={record.changePct}
+              {...(record.totalMultiplier === null ? {} : { detail: formatMultiplier(record.totalMultiplier) })}
+              points={record.buckets.map((bucket) =>
+                bucket.costPerSessionMicrocents === null ? null : microcentsToUsd(bucket.costPerSessionMicrocents),
+              )}
+              hint="Spend divided by sessions, for this window against the equal-length window before it. The factors below are its multiplicative parts, so their multipliers multiply to this change."
+            />
+          </div>
+
           {record.status === "notEnoughData" ? (
             <Text.H6 color="foregroundMuted">{notEnoughDataReason(record)}</Text.H6>
           ) : record.status === "flat" ? (
@@ -289,15 +286,33 @@ export function CostPerSessionPanel({
           ) : (
             <div className="flex flex-col gap-2">
               <Text.H6 color="foregroundMuted">What changed it</Text.H6>
-              <div className="flex flex-col gap-2">
+              <div className="flex flex-col gap-1.5">
                 {record.rows.map((row) => (
-                  <ContributionRow key={row.factor} row={row} widestPoints={widestPoints} />
+                  <ContributionRow key={row.factor ?? "unchanged"} row={row} />
                 ))}
+                <div className="flex w-full flex-row items-baseline gap-3 border-border border-t pt-1.5">
+                  <Text.H6 color="foreground" noWrap className="w-40 shrink-0">
+                    Cost per session
+                  </Text.H6>
+                  <div className="flex-1" />
+                  {/* `rowsMultiplyTo`, not the exact total: this is the figure the rows above multiply to. */}
+                  <Text.H6
+                    color={record.rowsMultiplyTo === null ? "foregroundMuted" : directionColor(record.rowsMultiplyTo)}
+                    noWrap
+                    className="w-14 shrink-0 text-right tabular-nums"
+                  >
+                    {record.rowsMultiplyTo === null ? "" : formatMultiplier(record.rowsMultiplyTo)}
+                  </Text.H6>
+                </div>
               </div>
-              <VolumeContext record={record} />
             </div>
           )}
-          <Disclosures record={record} />
+
+          {traceKeyed !== null && traceKeyed >= TRACE_KEYED_DISCLOSURE_SHARE ? (
+            <Text.H6 color="foregroundMuted">
+              {`${Math.round(traceKeyed * 100)}% of these sessions are single traces that reported no session id, so this figure is close to average cost per trace.`}
+            </Text.H6>
+          ) : null}
         </div>
       )}
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -42,20 +42,20 @@ const FACTOR_META: Record<SessionCostFactor, FactorMeta> = {
     formatValue: whole,
   },
   modelMix: {
-    label: "Model mix",
-    hint: "Tokens moving between price lists while each list's own prices hold. A migration to a cheaper model shows up here rather than as a rate cut.",
+    label: "Model choice",
+    hint: "Which models the tokens went to, with every price list's own prices held fixed. Moving traffic to a dearer model raises the blended cost of a token without anything being repriced. The model named is where the tokens went.",
   },
   tokenMix: {
-    label: "Prompt / output mix",
-    hint: "How the tokens divided between the cheap prompt side and the dearer output side. Growing the prompt while the answer stays the same length lowers the blended rate with no price changing, which is why it is not in the rate rows.",
+    label: "Prompt vs output split",
+    hint: "How the tokens divided between the cheap prompt side and the dearer output side — output runs 10-25x prompt. Growing the prompt while the answer stays the same length makes the average token cheaper with no price changing, which is why it is not one of the price rows.",
   },
   promptRate: {
-    label: "Prompt rate",
-    hint: "What a prompt token actually costs, holding model and prompt/output mix fixed.",
+    label: "Prompt price",
+    hint: "What a prompt token actually costs, holding the model and the prompt/output split fixed. Only a real price change lands here.",
   },
   outputRate: {
-    label: "Output rate",
-    hint: "What an output token actually costs, holding model and prompt/output mix fixed.",
+    label: "Output price",
+    hint: "What an output token actually costs, holding the model and the prompt/output split fixed. Only a real price change lands here.",
   },
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -66,7 +66,12 @@ const FACTOR_META: Record<SessionCostFactor, FactorMeta> = {
 
 const formatMultiplier = (multiplier: number): string => `×${multiplier.toFixed(2)}`
 
-const signedPercent = (pct: number): string => `${pct > 0 ? "▲" : pct < 0 ? "▼" : ""} ${Math.abs(Math.round(pct))}%`
+// The arrow reads off the rounded figure, not the raw one: at +0.4 the two disagree
+// and the caret points up beside a `0%`.
+const signedPercent = (pct: number): string => {
+  const rounded = Math.round(pct)
+  return `${rounded > 0 ? "▲" : rounded < 0 ? "▼" : ""} ${Math.abs(rounded)}%`
+}
 
 const isStill = (multiplier: number): boolean => Math.abs(multiplier - 1) < SESSION_COST_QUIET_BAND
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -112,6 +112,24 @@ function ContributionRow({
   )
 }
 
+/**
+ * Names the side that is short and by how much, rather than restating the rule.
+ * Which window is thin decides what to do about it — widen the range, or accept
+ * that the project is too new to compare — and the counts are already to hand.
+ */
+function notEnoughDataReason(record: CostPerSessionRecord): string {
+  const { previousSessions, currentSessions } = record.volume
+  const short = [
+    currentSessions < SESSION_COST_MIN_SESSIONS ? `${formatCount(currentSessions)} in this window` : null,
+    previousSessions < SESSION_COST_MIN_SESSIONS ? `${formatCount(previousSessions)} in the one before it` : null,
+  ].filter((part) => part !== null)
+
+  if (short.length === 0) {
+    return "Not enough data to compare periods: one of the two windows recorded no billable spend."
+  }
+  return `Not enough data to compare periods: ${short.join(" and ")}, against the ${SESSION_COST_MIN_SESSIONS} sessions a comparison needs on both sides.`
+}
+
 function Headline({ record }: { readonly record: CostPerSessionRecord }) {
   // The same rollup vocabulary the KPI row uses, so an average of zero reads as
   // "not known" rather than as free.
@@ -126,21 +144,25 @@ function Headline({ record }: { readonly record: CostPerSessionRecord }) {
     tokensTotal: record.tokens,
   })
   const changePct = record.changePct
-  const neutral = changePct === null || Math.abs(Math.round(changePct)) < NEUTRAL_POINTS
+  const neutral = Math.abs(Math.round(changePct ?? 0)) < NEUTRAL_POINTS
 
   return (
     <div className="flex flex-row flex-wrap items-baseline gap-3">
       <Text.H3 color="foreground" className="tabular-nums">
         {current.label}
       </Text.H3>
+      {/* Both halves are withheld together: printing the previous period's figure while
+          declining to quantify the move states a comparison the card just refused. */}
       {changePct === null ? null : (
-        <Text.H5 color={neutral ? "foregroundMuted" : changePct > 0 ? "destructive" : "success"} noWrap>
-          {signedPercent(changePct)}
-        </Text.H5>
+        <>
+          <Text.H5 color={neutral ? "foregroundMuted" : changePct > 0 ? "destructive" : "success"} noWrap>
+            {signedPercent(changePct)}
+          </Text.H5>
+          <Text.H6 color="foregroundMuted" noWrap>
+            {`from ${previous.label} in the previous period of equal length`}
+          </Text.H6>
+        </>
       )}
-      <Text.H6 color="foregroundMuted" noWrap>
-        {`from ${previous.label} in the previous period of equal length`}
-      </Text.H6>
     </div>
   )
 }
@@ -179,7 +201,10 @@ function Disclosures({ record }: { readonly record: CostPerSessionRecord }) {
     traceKeyed !== null && traceKeyed >= TRACE_KEYED_DISCLOSURE_SHARE
       ? `${Math.round(traceKeyed * 100)}% of these sessions are single traces that reported no session id, so this figure is close to average cost per trace.`
       : null,
-    "Traffic shifting toward an inherently longer use case raises this with nothing wrong — the rise lands on turns per session. Compare per agent before acting on it.",
+    // Describes how to read the rows, so it has nothing to qualify without them.
+    record.rows.length > 0
+      ? "Traffic shifting toward an inherently longer use case raises this with nothing wrong — the rise lands on turns per session. Compare per agent before acting on it."
+      : null,
   ].filter((line) => line !== null)
 
   return (
@@ -249,9 +274,7 @@ export function CostPerSessionPanel({
         <div className="flex flex-col gap-3 px-4 py-3">
           <Headline record={record} />
           {record.status === "notEnoughData" ? (
-            <Text.H6 color="foregroundMuted">
-              {`Not enough data to compare periods. Both this window and the one before it need at least ${SESSION_COST_MIN_SESSIONS} sessions with recorded spend.`}
-            </Text.H6>
+            <Text.H6 color="foregroundMuted">{notEnoughDataReason(record)}</Text.H6>
           ) : record.status === "flat" ? (
             <Text.H6 color="foregroundMuted">
               Cost per session held flat against the previous period, so no factor moved it.

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -5,7 +5,7 @@ import {
   type SessionCostFactor,
 } from "@domain/spans"
 import { Icon, Skeleton, Text, Tooltip } from "@repo/ui"
-import { formatCount, formatPercentage } from "@repo/utils"
+import { formatChartWindowCaption, formatCount, formatPercentage, formatPrice } from "@repo/utils"
 import { ArrowDownIcon, ArrowUpIcon, InfoIcon, MinusIcon } from "lucide-react"
 import type { CostPerSessionRecord } from "../../../../../../domains/cost/cost.functions.ts"
 import { rollupCostDisplay } from "../../../../../../domains/spans/cost-display.ts"
@@ -24,42 +24,53 @@ const NEUTRAL_PERCENT = 1
 interface FactorMeta {
   readonly label: string
   readonly hint: string
-  readonly formatValue?: (value: number) => string
+  /** Formats the factor's standing value, which is in that factor's own unit. */
+  readonly format: (value: number) => string
 }
 
 const ratio = (value: number): string => value.toFixed(2)
 const whole = (value: number): string => formatCount(Math.round(value))
+const share = (value: number): string => formatPercentage(value)
+
+// Microcents per token reads as nothing; per million tokens is how price lists are quoted.
+const MICROCENTS_PER_USD = 100_000_000
+const perMillionTokens = (microcentsPerToken: number): string =>
+  `${formatPrice((microcentsPerToken * 1_000_000) / MICROCENTS_PER_USD)} /1M`
 
 const FACTOR_META: Record<SessionCostFactor, FactorMeta> = {
   tracesPerSession: {
     label: "Traces per session",
     hint: "Traces with a billable call, per session. One trace is one request to an agent, not one conversational turn.",
-    formatValue: ratio,
+    format: ratio,
   },
   callsPerTrace: {
     label: "LLM calls per trace",
     hint: "Billable model calls a single trace spent to answer. Retry loops and extra tool round trips land here.",
-    formatValue: ratio,
+    format: ratio,
   },
   tokensPerCall: {
     label: "Tokens per call",
     hint: "Prompt plus output tokens per call — prompt growth, larger retrieved context, longer answers.",
-    formatValue: whole,
+    format: whole,
   },
   modelMix: {
     label: "Which models",
+    format: share,
     hint: "The share of tokens each model took, with every price list's own prices held fixed — moving traffic to a dearer model raises what an average token costs without anything being repriced. The model named is where most of the effect went; `+N more` means other models gained share too, so the shift is broader than one name. A share can move because someone changed a model or because a busier agent happens to use a dearer one, and this row cannot tell those apart.",
   },
   tokenMix: {
     label: "Prompt vs output split",
+    format: share,
     hint: "How the tokens divided between the cheap prompt side and the dearer output side — output runs 10-25x prompt. Growing the prompt while the answer stays the same length makes the average token cheaper with no price changing, which is why it is not one of the price rows.",
   },
   promptRate: {
     label: "Prompt price",
+    format: perMillionTokens,
     hint: "What a prompt token actually costs, holding the model and the prompt/output split fixed. Only a real price change lands here.",
   },
   outputRate: {
     label: "Output price",
+    format: perMillionTokens,
     hint: "What an output token actually costs, holding the model and the prompt/output split fixed. Only a real price change lands here.",
   },
 }
@@ -84,35 +95,28 @@ const directionArrow = (multiplier: number) =>
   isStill(multiplier) ? MinusIcon : multiplier > 1 ? ArrowUpIcon : ArrowDownIcon
 
 /**
- * The evidence under a tile's multiplier, in that factor's own units.
- *
- * Null for the two rate factors, and deliberately: the number a reader would expect
- * there is the blended price per side, and that moves with model mix, so a tile
- * could show a doubled prompt price beside a x1.00 saying nothing repriced. There
- * is no honest single figure for those two, only the multiplier.
+ * What the standing value is a share of, where the number alone would be ambiguous.
  */
-function rowDetail(row: SessionCostContribution): string | null {
-  if (row.values) {
-    const format = FACTOR_META[row.factor].formatValue ?? ratio
-    return `${format(row.values.previous)} → ${format(row.values.current)}`
-  }
-  if (!row.shareShift) return null
-  const { label, previousShare, currentShare, alsoMoved } = row.shareShift
-  const move = `${label} ${formatPercentage(previousShare)} → ${formatPercentage(currentShare)}`
-  return alsoMoved > 0 ? `${move} +${alsoMoved} more` : move
+function rowSubject(row: SessionCostContribution): string | null {
+  if (!row.subject) return null
+  return row.alsoMoved > 0 ? `${row.subject} +${row.alsoMoved} more` : row.subject
 }
 
 /**
- * One factor. The multiplier leads and always means the same thing — effect on cost
- * per session — with the factor's own before and after underneath as evidence.
+ * One factor: where it stands now, and which way it pushed the cost of a session.
+ *
+ * The standing value leads; the arrow and its figure say the direction and size of the
+ * push. Never a before-and-after pair — for the two rate factors the pair would be a
+ * blended per-side price, which moves with model mix, so it would contradict a marker
+ * that holds the mix fixed.
  *
  * A still factor keeps its tile rather than disappearing: which seven things the
  * decomposition accounts for is part of what the card says, and it cannot be read
  * off a list whose shape changes every period.
  */
 function FactorTile({ row }: { readonly row: SessionCostContribution }) {
-  const detail = rowDetail(row)
-  const still = isStill(row.multiplier)
+  const meta = FACTOR_META[row.factor]
+  const subject = rowSubject(row)
   const color = directionColor(row.multiplier)
 
   return (
@@ -121,21 +125,26 @@ function FactorTile({ row }: { readonly row: SessionCostContribution }) {
       trigger={
         <div className="flex min-w-0 cursor-default flex-col gap-0.5 rounded-md bg-background/40 p-2">
           <Text.H6 color="foregroundMuted" ellipsis noWrap>
-            {FACTOR_META[row.factor].label}
+            {meta.label}
           </Text.H6>
-          <div className="flex flex-row items-center gap-1">
-            <Icon icon={directionArrow(row.multiplier)} size="sm" color={color} />
-            <Text.H5M color={color} noWrap className="tabular-nums">
-              {formatMultiplier(row.multiplier)}
-            </Text.H5M>
+          <div className="flex flex-row flex-wrap items-baseline gap-x-2">
+            <Text.H4M color="foreground" noWrap className="tabular-nums">
+              {meta.format(row.current)}
+            </Text.H4M>
+            <div className="flex flex-row items-center gap-0.5">
+              <Icon icon={directionArrow(row.multiplier)} size="sm" color={color} />
+              <Text.H6 color={color} noWrap className="tabular-nums">
+                {formatMultiplier(row.multiplier)}
+              </Text.H6>
+            </div>
           </div>
-          <Text.H6 color="foregroundMuted" ellipsis noWrap className="tabular-nums">
-            {still && !detail ? "unchanged" : (detail ?? "")}
+          <Text.H6 color="foregroundMuted" ellipsis noWrap>
+            {subject ?? ""}
           </Text.H6>
         </div>
       }
     >
-      {FACTOR_META[row.factor].hint}
+      {meta.hint}
     </Tooltip>
   )
 }
@@ -151,9 +160,7 @@ function TotalTile() {
   return (
     <div className="col-span-2 flex min-w-0 flex-col justify-center gap-1 p-2">
       <Text.H4M color="foreground">What changed</Text.H4M>
-      <Text.H6 color="foregroundMuted">
-        Cost per session is these seven multiplied together, so each one is a multiplier on it.
-      </Text.H6>
+      <Text.H6 color="foregroundMuted">Each of these pushed the cost of a session up or down.</Text.H6>
     </div>
   )
 }
@@ -316,12 +323,11 @@ export function CostPerSessionPanel({
                 label="Cost per session"
                 value={cost.label}
                 changePct={record.changePct}
-                {...(record.totalMultiplier === null ? {} : { detail: formatMultiplier(record.totalMultiplier) })}
                 points={record.buckets.map((bucket) =>
                   bucket.costPerSessionMicrocents === null ? null : microcentsToUsd(bucket.costPerSessionMicrocents),
                 )}
                 boundaryIndex={boundaryIndex}
-                hint="Spend divided by sessions, for this window against the equal-length window before it. The factors beside it are its multiplicative parts, so their multipliers multiply to this change."
+                hint={`Spend divided by sessions, against the equal-length window before it (${formatChartWindowCaption(record.comparedFromIso, record.comparedToIso)}). Each factor beside it shows where it stands now and which way it pushed this figure.`}
               />
             </div>
             <div className="flex min-w-0 flex-1 flex-col gap-2 lg:border-border lg:border-l lg:pl-6">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -1,0 +1,275 @@
+import { SESSION_COST_MIN_SESSIONS, type SessionCostContribution, type SessionCostFactor } from "@domain/spans"
+import { cn, Icon, Skeleton, Text, Tooltip } from "@repo/ui"
+import { formatCount } from "@repo/utils"
+import { ArrowDownIcon, ArrowUpIcon, InfoIcon, MinusIcon } from "lucide-react"
+import type { CostPerSessionRecord } from "../../../../../../domains/cost/cost.functions.ts"
+import { rollupCostDisplay } from "../../../../../../domains/spans/cost-display.ts"
+import { ChartHeader } from "../../-components/chart-header.tsx"
+
+// Above this share of the denominator, "per session" stops meaning what it says and
+// the card has to name the substitution rather than leaving it in a tooltip.
+const TRACE_KEYED_DISCLOSURE_SHARE = 0.1
+
+// Below a point the bar is a sliver either way, and the row's own figure already
+// says it is nothing. Colouring it would make a rounding artefact look like a cause.
+const NEUTRAL_POINTS = 1
+
+interface FactorMeta {
+  readonly label: string
+  readonly hint: string
+  readonly formatValue?: (value: number) => string
+}
+
+const ratio = (value: number): string => value.toFixed(2)
+const rounded = (value: number): string => formatCount(Math.round(value))
+
+const FACTOR_META: Record<SessionCostFactor, FactorMeta> = {
+  turnsPerSession: {
+    label: "Turns per session",
+    hint: "Traces with a billable call, per session. Longer conversations cost more even when nothing else changes.",
+    formatValue: ratio,
+  },
+  stepsPerTurn: {
+    label: "Steps per turn",
+    hint: "Billable LLM calls per trace. Retry loops and extra tool round trips land here.",
+    formatValue: ratio,
+  },
+  tokensPerStep: {
+    label: "Tokens per step",
+    hint: "Tokens per billable call — prompt growth, larger retrieved context, longer outputs.",
+    formatValue: rounded,
+  },
+  modelMix: {
+    label: "Model mix",
+    hint: "Tokens moving between price lists at unchanged prices. A migration to a cheaper model shows up here.",
+  },
+  cacheEfficiency: {
+    label: "Cache efficiency",
+    hint: "The share of the prompt charged at the cache-read rate rather than the full input rate.",
+  },
+  pricePerToken: {
+    label: "Price per token",
+    hint: "Whatever within-model rate change is left once model mix and cache efficiency are taken out.",
+  },
+}
+
+const signedPoints = (points: number): string => `${points > 0 ? "+" : points < 0 ? "−" : ""}${Math.abs(points)} pts`
+
+const signedPercent = (pct: number): string => `${pct > 0 ? "▲" : pct < 0 ? "▼" : ""} ${Math.abs(Math.round(pct))}%`
+
+function ContributionRow({
+  row,
+  widestPoints,
+}: {
+  readonly row: SessionCostContribution
+  readonly widestPoints: number
+}) {
+  const meta = FACTOR_META[row.factor]
+  const neutral = Math.abs(row.points) < NEUTRAL_POINTS
+  const width = widestPoints > 0 ? (Math.abs(row.points) / widestPoints) * 100 : 0
+  const icon = neutral ? MinusIcon : row.points > 0 ? ArrowUpIcon : ArrowDownIcon
+  const color = neutral ? "foregroundMuted" : row.points > 0 ? "destructive" : "success"
+  const values = row.values
+  const format = meta.formatValue ?? ratio
+
+  return (
+    <Tooltip
+      asChild
+      trigger={
+        <div className="flex w-full cursor-default flex-row items-center gap-3">
+          <div className="flex w-36 shrink-0 flex-col">
+            <Text.H6 color="foreground" ellipsis noWrap>
+              {meta.label}
+            </Text.H6>
+          </div>
+          <div className="relative h-2.5 w-full overflow-hidden rounded-sm bg-muted">
+            <div
+              className={cn("h-full rounded-sm", {
+                "bg-muted-foreground/40": neutral,
+                "bg-destructive": !neutral && row.points > 0,
+                "bg-success": !neutral && row.points < 0,
+              })}
+              style={{ width: `${Math.max(0, Math.min(100, width))}%` }}
+            />
+          </div>
+          <div className="flex w-20 shrink-0 flex-row items-center justify-end gap-1">
+            <Icon icon={icon} size="sm" color={color} />
+            <Text.H6 color={color} noWrap className="tabular-nums">
+              {signedPoints(row.points)}
+            </Text.H6>
+          </div>
+        </div>
+      }
+    >
+      {[
+        meta.hint,
+        values ? `${format(values.previous)} → ${format(values.current)}` : null,
+        `Contributed ${signedPoints(row.points)} of the change above.`,
+      ]
+        .filter((line) => line !== null)
+        .join("\n")}
+    </Tooltip>
+  )
+}
+
+function Headline({ record }: { readonly record: CostPerSessionRecord }) {
+  // The same rollup vocabulary the KPI row uses, so an average of zero reads as
+  // "not known" rather than as free.
+  const current = rollupCostDisplay({
+    costTotalMicrocents: record.currentCostPerSessionMicrocents,
+    unpricedSpanCount: record.unpricedCalls,
+    tokensTotal: record.tokens,
+  })
+  const previous = rollupCostDisplay({
+    costTotalMicrocents: record.previousCostPerSessionMicrocents,
+    unpricedSpanCount: 0,
+    tokensTotal: record.tokens,
+  })
+  const changePct = record.changePct
+  const neutral = changePct === null || Math.abs(Math.round(changePct)) < NEUTRAL_POINTS
+
+  return (
+    <div className="flex flex-row flex-wrap items-baseline gap-3">
+      <Text.H3 color="foreground" className="tabular-nums">
+        {current.label}
+      </Text.H3>
+      {changePct === null ? null : (
+        <Text.H5 color={neutral ? "foregroundMuted" : changePct > 0 ? "destructive" : "success"} noWrap>
+          {signedPercent(changePct)}
+        </Text.H5>
+      )}
+      <Text.H6 color="foregroundMuted" noWrap>
+        {`from ${previous.label} in the previous period of equal length`}
+      </Text.H6>
+    </div>
+  )
+}
+
+function VolumeContext({ record }: { readonly record: CostPerSessionRecord }) {
+  const { previousSessions, currentSessions } = record.volume
+  const changePct = previousSessions > 0 ? (currentSessions / previousSessions - 1) * 100 : null
+
+  return (
+    <Tooltip
+      asChild
+      trigger={
+        <div className="flex w-full cursor-default flex-row items-center gap-3 border-border border-t pt-2">
+          <div className="flex w-36 shrink-0 flex-col">
+            <Text.H6 color="foregroundMuted" ellipsis noWrap>
+              Sessions
+            </Text.H6>
+          </div>
+          <Text.H6 color="foregroundMuted" noWrap className="tabular-nums">
+            {`${formatCount(previousSessions)} → ${formatCount(currentSessions)}${
+              changePct === null ? "" : ` · ${signedPercent(changePct)}`
+            }`}
+          </Text.H6>
+        </div>
+      }
+    >
+      Not part of the change above: sessions are its denominator, so more of them does not move the average. Shown
+      because growth in usage is the one kind of rising spend that is good news.
+    </Tooltip>
+  )
+}
+
+function Disclosures({ record }: { readonly record: CostPerSessionRecord }) {
+  const traceKeyed = record.traceKeyedSessionShare
+  const lines = [
+    traceKeyed !== null && traceKeyed >= TRACE_KEYED_DISCLOSURE_SHARE
+      ? `${Math.round(traceKeyed * 100)}% of these sessions are single traces that reported no session id, so this figure is close to average cost per trace.`
+      : null,
+    "Traffic shifting toward an inherently longer use case raises this with nothing wrong — the rise lands on turns per session. Compare per agent before acting on it.",
+  ].filter((line) => line !== null)
+
+  return (
+    <div className="flex flex-col gap-1">
+      {lines.map((line) => (
+        <Text.H6 key={line} color="foregroundMuted">
+          {line}
+        </Text.H6>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Which factor moved average cost per session, in points that sum to the headline.
+ *
+ * Cost per session is `turns/session x steps/turn x tokens/step x price/token`, and
+ * a product decomposes exactly in log space — so each row is a share of the same
+ * change rather than an independently-measured correlation. Every figure here is
+ * computed server-side; this file only lays the rows out.
+ */
+export function CostPerSessionPanel({
+  record,
+  rangeFromIso,
+  rangeToIso,
+  isAllTime,
+  isLoading,
+}: {
+  readonly record: CostPerSessionRecord | undefined
+  readonly rangeFromIso: string
+  readonly rangeToIso: string
+  readonly isAllTime: boolean
+  readonly isLoading: boolean
+}) {
+  const widestPoints = record ? Math.max(...record.rows.map((row) => Math.abs(row.points)), 1) : 1
+
+  return (
+    <div className="flex flex-col rounded-lg bg-secondary">
+      <ChartHeader
+        title="Cost per session"
+        fromIso={rangeFromIso}
+        toIso={rangeToIso}
+        isAllTime={isAllTime}
+        showWindow={isAllTime}
+        actions={
+          <Tooltip
+            asChild
+            trigger={
+              <span className="inline-flex cursor-default">
+                <Icon icon={InfoIcon} size="sm" color="foregroundMuted" />
+              </span>
+            }
+          >
+            Total spend divided by sessions, where traffic that reported no session id keys on its trace id instead — so
+            it becomes a single-trace session rather than dropping out of the denominator.
+          </Tooltip>
+        }
+      />
+      {isLoading || !record ? (
+        <div className="flex flex-col gap-3 px-4 py-3">
+          <Skeleton className="h-8 w-40" />
+          {[0, 1, 2, 3].map((row) => (
+            <Skeleton key={row} className="h-4 w-full" />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3 px-4 py-3">
+          <Headline record={record} />
+          {record.status === "notEnoughData" ? (
+            <Text.H6 color="foregroundMuted">
+              {`Not enough data to compare periods. Both this window and the one before it need at least ${SESSION_COST_MIN_SESSIONS} sessions with recorded spend.`}
+            </Text.H6>
+          ) : record.status === "flat" ? (
+            <Text.H6 color="foregroundMuted">
+              Cost per session held flat against the previous period, so no factor moved it.
+            </Text.H6>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <Text.H6 color="foregroundMuted">What changed it</Text.H6>
+              <div className="flex flex-col gap-2">
+                {record.rows.map((row) => (
+                  <ContributionRow key={row.factor} row={row} widestPoints={widestPoints} />
+                ))}
+              </div>
+              <VolumeContext record={record} />
+            </div>
+          )}
+          <Disclosures record={record} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -26,6 +26,13 @@ interface FactorMeta {
   readonly hint: string
   /** Formats the factor's standing value, which is in that factor's own unit. */
   readonly format: (value: number) => string
+  /**
+   * What the value covers, for a factor whose row carries no subject of its own. The
+   * two rate tiles need it: their figure is blended over every model while their
+   * marker holds the mix fixed, and a tile reading `Prompt price $0.72/1M` invites
+   * "whose price?" unless it answers on its face.
+   */
+  readonly covers?: string
 }
 
 const ratio = (value: number): string => value.toFixed(2)
@@ -66,12 +73,14 @@ const FACTOR_META: Record<SessionCostFactor, FactorMeta> = {
   promptRate: {
     label: "Prompt price",
     format: perMillionTokens,
-    hint: "What a prompt token actually costs, holding the model and the prompt/output split fixed. Only a real price change lands here.",
+    covers: "averaged over all models",
+    hint: "What you actually paid per prompt token, averaged over every model — so it matches no single price list. The marker beside it holds the model mix fixed, and moves only when a price list itself changes: routing tokens to a dearer model shows up under Which models, not here.",
   },
   outputRate: {
     label: "Output price",
     format: perMillionTokens,
-    hint: "What an output token actually costs, holding the model and the prompt/output split fixed. Only a real price change lands here.",
+    covers: "averaged over all models",
+    hint: "What you actually paid per output token, averaged over every model — so it matches no single price list. The marker beside it holds the model mix fixed, and moves only when a price list itself changes: routing tokens to a dearer model shows up under Which models, not here.",
   },
 }
 
@@ -98,7 +107,7 @@ const directionArrow = (multiplier: number) =>
  * What the standing value is a share of, where the number alone would be ambiguous.
  */
 function rowSubject(row: SessionCostContribution): string | null {
-  if (!row.subject) return null
+  if (!row.subject) return FACTOR_META[row.factor].covers ?? null
   return row.alsoMoved > 0 ? `${row.subject} +${row.alsoMoved} more` : row.subject
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -114,11 +114,18 @@ function ContributionRow({
 
 /**
  * Names the side that is short and by how much, rather than restating the rule.
- * Which window is thin decides what to do about it — widen the range, or accept
- * that the project is too new to compare — and the counts are already to hand.
+ *
+ * An empty comparison window is a different answer from a thin one and gets its
+ * own sentence: no traffic precedes the window at all, so widening the range
+ * cannot help and only more history will. Reporting that as "0 against the 20 a
+ * comparison needs" points at a threshold when the problem is the project's age.
  */
 function notEnoughDataReason(record: CostPerSessionRecord): string {
   const { previousSessions, currentSessions } = record.volume
+  if (previousSessions === 0 && currentSessions > 0) {
+    return "No sessions recorded before this window, so there is nothing to compare it against yet."
+  }
+
   const short = [
     currentSessions < SESSION_COST_MIN_SESSIONS ? `${formatCount(currentSessions)} in this window` : null,
     previousSessions < SESSION_COST_MIN_SESSIONS ? `${formatCount(previousSessions)} in the one before it` : null,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -42,8 +42,8 @@ const FACTOR_META: Record<SessionCostFactor, FactorMeta> = {
     formatValue: whole,
   },
   modelMix: {
-    label: "Model choice",
-    hint: "Which models the tokens went to, with every price list's own prices held fixed. Moving traffic to a dearer model raises the blended cost of a token without anything being repriced. The model named is where the tokens went.",
+    label: "Which models",
+    hint: "The share of tokens each model took, with every price list's own prices held fixed — moving traffic to a dearer model raises what an average token costs without anything being repriced. The model named is where the tokens went. A share can move because someone changed a model or because a busier agent happens to use a dearer one, and this row cannot tell those apart.",
   },
   tokenMix: {
     label: "Prompt vs output split",
@@ -94,20 +94,26 @@ function ContributionRow({ row }: { readonly row: SessionCostContribution }) {
     <Tooltip
       asChild
       trigger={
-        <div className="flex w-full cursor-default flex-row items-baseline gap-3">
-          <Text.H6 color={muted ? "foregroundMuted" : "foreground"} noWrap className="w-40 shrink-0">
-            {rowLabel(row)}
-          </Text.H6>
-          <Text.H6 color="foregroundMuted" ellipsis noWrap className="flex-1 tabular-nums">
-            {detail ?? ""}
-          </Text.H6>
-          <Text.H6
-            color={muted ? "foregroundMuted" : directionColor(row.multiplier)}
-            noWrap
-            className="w-14 shrink-0 text-right tabular-nums"
-          >
-            {formatMultiplier(row.multiplier)}
-          </Text.H6>
+        // The multiplier sits against its own label rather than across the card: at
+        // full width the eye had to travel the whole panel to pair the two up.
+        <div className="flex w-full cursor-default flex-col gap-0.5">
+          <div className="flex flex-row items-baseline justify-between gap-2">
+            <Text.H6 color={muted ? "foregroundMuted" : "foreground"} ellipsis noWrap>
+              {rowLabel(row)}
+            </Text.H6>
+            <Text.H6
+              color={muted ? "foregroundMuted" : directionColor(row.multiplier)}
+              noWrap
+              className="shrink-0 tabular-nums"
+            >
+              {formatMultiplier(row.multiplier)}
+            </Text.H6>
+          </div>
+          {detail ? (
+            <Text.H6 color="foregroundMuted" ellipsis noWrap className="tabular-nums">
+              {detail}
+            </Text.H6>
+          ) : null}
         </div>
       }
     >
@@ -243,18 +249,14 @@ export function CostPerSessionPanel({
     <div className="flex flex-col rounded-lg bg-secondary">
       <ChartHeader title="Cost per session" fromIso={rangeFromIso} toIso={rangeToIso} isAllTime={isAllTime} />
       {isLoading || !record || !cost ? (
-        <div className="flex flex-col gap-4 px-4 py-3">
-          <div className="flex flex-row gap-6">
-            <Skeleton className="h-24 flex-1" />
-            <Skeleton className="h-24 flex-1" />
-          </div>
-          {[0, 1, 2].map((row) => (
-            <Skeleton key={row} className="h-4 w-full" />
+        <div className="flex flex-col gap-6 px-4 py-3 lg:flex-row">
+          {[0, 1, 2].map((column) => (
+            <Skeleton key={column} className="h-24 flex-1" />
           ))}
         </div>
       ) : (
         <div className="flex flex-col gap-4 px-4 py-3">
-          <div className="flex flex-col gap-6 sm:flex-row">
+          <div className="flex flex-col gap-6 lg:flex-row">
             <HeadlineBlock
               label="Sessions"
               value={formatCount(record.volume.currentSessions)}
@@ -273,40 +275,43 @@ export function CostPerSessionPanel({
               points={record.buckets.map((bucket) =>
                 bucket.costPerSessionMicrocents === null ? null : microcentsToUsd(bucket.costPerSessionMicrocents),
               )}
-              hint="Spend divided by sessions, for this window against the equal-length window before it. The factors below are its multiplicative parts, so their multipliers multiply to this change."
+              hint="Spend divided by sessions, for this window against the equal-length window before it. The factors beside it are its multiplicative parts, so their multipliers multiply to this change."
             />
-          </div>
-
-          {record.status === "notEnoughData" ? (
-            <Text.H6 color="foregroundMuted">{notEnoughDataReason(record)}</Text.H6>
-          ) : record.status === "flat" ? (
-            <Text.H6 color="foregroundMuted">
-              Cost per session held flat against the previous period, so no factor moved it.
-            </Text.H6>
-          ) : (
-            <div className="flex flex-col gap-2">
-              <Text.H6 color="foregroundMuted">What changed it</Text.H6>
-              <div className="flex flex-col gap-1.5">
-                {record.rows.map((row) => (
-                  <ContributionRow key={row.factor ?? "unchanged"} row={row} />
-                ))}
-                <div className="flex w-full flex-row items-baseline gap-3 border-border border-t pt-1.5">
-                  <Text.H6 color="foreground" noWrap className="w-40 shrink-0">
-                    Cost per session
-                  </Text.H6>
-                  <div className="flex-1" />
-                  {/* `rowsMultiplyTo`, not the exact total: this is the figure the rows above multiply to. */}
-                  <Text.H6
-                    color={record.rowsMultiplyTo === null ? "foregroundMuted" : directionColor(record.rowsMultiplyTo)}
-                    noWrap
-                    className="w-14 shrink-0 text-right tabular-nums"
-                  >
-                    {record.rowsMultiplyTo === null ? "" : formatMultiplier(record.rowsMultiplyTo)}
-                  </Text.H6>
-                </div>
-              </div>
+            {/* Third column, so each row's multiplier reads next to its own label. */}
+            <div className="flex min-w-0 flex-1 flex-col gap-2 lg:border-border lg:border-l lg:pl-6">
+              {record.status === "notEnoughData" ? (
+                <Text.H6 color="foregroundMuted">{notEnoughDataReason(record)}</Text.H6>
+              ) : record.status === "flat" ? (
+                <Text.H6 color="foregroundMuted">
+                  Cost per session held flat against the previous period, so no factor moved it.
+                </Text.H6>
+              ) : (
+                <>
+                  <Text.H6 color="foregroundMuted">What changed it</Text.H6>
+                  <div className="flex flex-col gap-1.5">
+                    {record.rows.map((row) => (
+                      <ContributionRow key={row.factor ?? "unchanged"} row={row} />
+                    ))}
+                    <div className="flex flex-row items-baseline justify-between gap-2 border-border border-t pt-1.5">
+                      <Text.H6 color="foreground" ellipsis noWrap>
+                        Cost per session
+                      </Text.H6>
+                      {/* `rowsMultiplyTo`, not the exact total: this is what the rows above multiply to. */}
+                      <Text.H6
+                        color={
+                          record.rowsMultiplyTo === null ? "foregroundMuted" : directionColor(record.rowsMultiplyTo)
+                        }
+                        noWrap
+                        className="shrink-0 tabular-nums"
+                      >
+                        {record.rowsMultiplyTo === null ? "" : formatMultiplier(record.rowsMultiplyTo)}
+                      </Text.H6>
+                    </div>
+                  </div>
+                </>
+              )}
             </div>
-          )}
+          </div>
 
           {traceKeyed !== null && traceKeyed >= TRACE_KEYED_DISCLOSURE_SHARE ? (
             <Text.H6 color="foregroundMuted">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-per-session-panel.tsx
@@ -1,7 +1,12 @@
-import { SESSION_COST_MIN_SESSIONS, type SessionCostContribution, type SessionCostFactor } from "@domain/spans"
+import {
+  SESSION_COST_MIN_SESSIONS,
+  SESSION_COST_QUIET_BAND,
+  type SessionCostContribution,
+  type SessionCostFactor,
+} from "@domain/spans"
 import { Icon, Skeleton, Text, Tooltip } from "@repo/ui"
 import { formatCount, formatPercentage } from "@repo/utils"
-import { InfoIcon } from "lucide-react"
+import { ArrowDownIcon, ArrowUpIcon, InfoIcon, MinusIcon } from "lucide-react"
 import type { CostPerSessionRecord } from "../../../../../../domains/cost/cost.functions.ts"
 import { rollupCostDisplay } from "../../../../../../domains/spans/cost-display.ts"
 import { ChartHeader } from "../../-components/chart-header.tsx"
@@ -43,7 +48,7 @@ const FACTOR_META: Record<SessionCostFactor, FactorMeta> = {
   },
   modelMix: {
     label: "Which models",
-    hint: "The share of tokens each model took, with every price list's own prices held fixed — moving traffic to a dearer model raises what an average token costs without anything being repriced. The model named is where the tokens went. A share can move because someone changed a model or because a busier agent happens to use a dearer one, and this row cannot tell those apart.",
+    hint: "The share of tokens each model took, with every price list's own prices held fixed — moving traffic to a dearer model raises what an average token costs without anything being repriced. The model named is where most of the effect went; `+N more` means other models gained share too, so the shift is broader than one name. A share can move because someone changed a model or because a busier agent happens to use a dearer one, and this row cannot tell those apart.",
   },
   tokenMix: {
     label: "Prompt vs output split",
@@ -63,64 +68,88 @@ const formatMultiplier = (multiplier: number): string => `×${multiplier.toFixed
 
 const signedPercent = (pct: number): string => `${pct > 0 ? "▲" : pct < 0 ? "▼" : ""} ${Math.abs(Math.round(pct))}%`
 
+const isStill = (multiplier: number): boolean => Math.abs(multiplier - 1) < SESSION_COST_QUIET_BAND
+
 const directionColor = (multiplier: number): "destructive" | "success" | "foregroundMuted" => {
-  if (multiplier > 1) return "destructive"
-  if (multiplier < 1) return "success"
-  return "foregroundMuted"
+  if (isStill(multiplier)) return "foregroundMuted"
+  return multiplier > 1 ? "destructive" : "success"
 }
 
-const rowLabel = (row: SessionCostContribution): string =>
-  row.factor === null
-    ? `${row.foldedFactors} ${row.foldedFactors === 1 ? "factor" : "factors"} unchanged`
-    : FACTOR_META[row.factor].label
+const directionArrow = (multiplier: number) =>
+  isStill(multiplier) ? MinusIcon : multiplier > 1 ? ArrowUpIcon : ArrowDownIcon
 
-/** The concrete move behind a row: its own before/after, or the share shift driving a mix row. */
+/**
+ * The evidence under a tile's multiplier, in that factor's own units.
+ *
+ * Null for the two rate factors, and deliberately: the number a reader would expect
+ * there is the blended price per side, and that moves with model mix, so a tile
+ * could show a doubled prompt price beside a x1.00 saying nothing repriced. There
+ * is no honest single figure for those two, only the multiplier.
+ */
 function rowDetail(row: SessionCostContribution): string | null {
-  if (row.factor === null) return null
   if (row.values) {
     const format = FACTOR_META[row.factor].formatValue ?? ratio
     return `${format(row.values.previous)} → ${format(row.values.current)}`
   }
   if (!row.shareShift) return null
-  const { label, previousShare, currentShare } = row.shareShift
-  return `${label} ${formatPercentage(previousShare)} → ${formatPercentage(currentShare)}`
+  const { label, previousShare, currentShare, alsoMoved } = row.shareShift
+  const move = `${label} ${formatPercentage(previousShare)} → ${formatPercentage(currentShare)}`
+  return alsoMoved > 0 ? `${move} +${alsoMoved} more` : move
 }
 
-function ContributionRow({ row }: { readonly row: SessionCostContribution }) {
+/**
+ * One factor. The multiplier leads and always means the same thing — effect on cost
+ * per session — with the factor's own before and after underneath as evidence.
+ *
+ * A still factor keeps its tile rather than disappearing: which seven things the
+ * decomposition accounts for is part of what the card says, and it cannot be read
+ * off a list whose shape changes every period.
+ */
+function FactorTile({ row }: { readonly row: SessionCostContribution }) {
   const detail = rowDetail(row)
-  const muted = row.factor === null
+  const still = isStill(row.multiplier)
+  const color = directionColor(row.multiplier)
 
   return (
     <Tooltip
       asChild
       trigger={
-        // The multiplier sits against its own label rather than across the card: at
-        // full width the eye had to travel the whole panel to pair the two up.
-        <div className="flex w-full cursor-default flex-col gap-0.5">
-          <div className="flex flex-row items-baseline justify-between gap-2">
-            <Text.H6 color={muted ? "foregroundMuted" : "foreground"} ellipsis noWrap>
-              {rowLabel(row)}
-            </Text.H6>
-            <Text.H6
-              color={muted ? "foregroundMuted" : directionColor(row.multiplier)}
-              noWrap
-              className="shrink-0 tabular-nums"
-            >
+        <div className="flex min-w-0 cursor-default flex-col gap-0.5 rounded-md bg-background/40 p-2">
+          <Text.H6 color="foregroundMuted" ellipsis noWrap>
+            {FACTOR_META[row.factor].label}
+          </Text.H6>
+          <div className="flex flex-row items-center gap-1">
+            <Icon icon={directionArrow(row.multiplier)} size="sm" color={color} />
+            <Text.H5M color={color} noWrap className="tabular-nums">
               {formatMultiplier(row.multiplier)}
-            </Text.H6>
+            </Text.H5M>
           </div>
-          {detail ? (
-            <Text.H6 color="foregroundMuted" ellipsis noWrap className="tabular-nums">
-              {detail}
-            </Text.H6>
-          ) : null}
+          <Text.H6 color="foregroundMuted" ellipsis noWrap className="tabular-nums">
+            {still && !detail ? "unchanged" : (detail ?? "")}
+          </Text.H6>
         </div>
       }
     >
-      {row.factor === null
-        ? "Factors that did not move. Folded into one row so the visible ones still multiply to the total."
-        : FACTOR_META[row.factor].hint}
+      {FACTOR_META[row.factor].hint}
     </Tooltip>
+  )
+}
+
+/**
+ * Heading for the grid, spanning the cells the seven factors leave over.
+ *
+ * Carries no figure of its own. The total belongs to the Cost per session block, and
+ * printing it twice invited the two copies to disagree in their last digit — which is
+ * unavoidable once each tile is rounded for display.
+ */
+function TotalTile() {
+  return (
+    <div className="col-span-2 flex min-w-0 flex-col justify-center gap-1 p-2">
+      <Text.H4M color="foreground">What changed</Text.H4M>
+      <Text.H6 color="foregroundMuted">
+        Cost per session is these seven multiplied together, so each one is a multiplier on it.
+      </Text.H6>
+    </div>
   )
 }
 
@@ -257,27 +286,29 @@ export function CostPerSessionPanel({
       ) : (
         <div className="flex flex-col gap-4 px-4 py-3">
           <div className="flex flex-col gap-6 lg:flex-row">
-            <HeadlineBlock
-              label="Sessions"
-              value={formatCount(record.volume.currentSessions)}
-              changePct={sessionsChangePct}
-              {...(record.volume.previousSessions > 0
-                ? { detail: `from ${formatCount(record.volume.previousSessions)}` }
-                : {})}
-              points={record.buckets.map((bucket) => bucket.sessions)}
-              hint="Sessions with billable spend. Traffic that reported no session id keys on its trace id instead, so it counts as a single-trace session rather than dropping out of the denominator. More sessions does not move what each one costs — that is the figure beside this."
-            />
-            <HeadlineBlock
-              label="Cost per session"
-              value={cost.label}
-              changePct={record.changePct}
-              {...(record.totalMultiplier === null ? {} : { detail: formatMultiplier(record.totalMultiplier) })}
-              points={record.buckets.map((bucket) =>
-                bucket.costPerSessionMicrocents === null ? null : microcentsToUsd(bucket.costPerSessionMicrocents),
-              )}
-              hint="Spend divided by sessions, for this window against the equal-length window before it. The factors beside it are its multiplicative parts, so their multipliers multiply to this change."
-            />
-            {/* Third column, so each row's multiplier reads next to its own label. */}
+            {/* The two measures on the left, the factors of the second one on the right. */}
+            <div className="flex min-w-0 flex-col gap-4 lg:w-1/3 lg:shrink-0">
+              <HeadlineBlock
+                label="Sessions"
+                value={formatCount(record.volume.currentSessions)}
+                changePct={sessionsChangePct}
+                {...(record.volume.previousSessions > 0
+                  ? { detail: `from ${formatCount(record.volume.previousSessions)}` }
+                  : {})}
+                points={record.buckets.map((bucket) => bucket.sessions)}
+                hint="Sessions with billable spend. Traffic that reported no session id keys on its trace id instead, so it counts as a single-trace session rather than dropping out of the denominator. More sessions does not move what each one costs — that is the figure below."
+              />
+              <HeadlineBlock
+                label="Cost per session"
+                value={cost.label}
+                changePct={record.changePct}
+                {...(record.totalMultiplier === null ? {} : { detail: formatMultiplier(record.totalMultiplier) })}
+                points={record.buckets.map((bucket) =>
+                  bucket.costPerSessionMicrocents === null ? null : microcentsToUsd(bucket.costPerSessionMicrocents),
+                )}
+                hint="Spend divided by sessions, for this window against the equal-length window before it. The factors beside it are its multiplicative parts, so their multipliers multiply to this change."
+              />
+            </div>
             <div className="flex min-w-0 flex-1 flex-col gap-2 lg:border-border lg:border-l lg:pl-6">
               {record.status === "notEnoughData" ? (
                 <Text.H6 color="foregroundMuted">{notEnoughDataReason(record)}</Text.H6>
@@ -287,26 +318,11 @@ export function CostPerSessionPanel({
                 </Text.H6>
               ) : (
                 <>
-                  <Text.H6 color="foregroundMuted">What changed it</Text.H6>
-                  <div className="flex flex-col gap-1.5">
+                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                    <TotalTile />
                     {record.rows.map((row) => (
-                      <ContributionRow key={row.factor ?? "unchanged"} row={row} />
+                      <FactorTile key={row.factor} row={row} />
                     ))}
-                    <div className="flex flex-row items-baseline justify-between gap-2 border-border border-t pt-1.5">
-                      <Text.H6 color="foreground" ellipsis noWrap>
-                        Cost per session
-                      </Text.H6>
-                      {/* `rowsMultiplyTo`, not the exact total: this is what the rows above multiply to. */}
-                      <Text.H6
-                        color={
-                          record.rowsMultiplyTo === null ? "foregroundMuted" : directionColor(record.rowsMultiplyTo)
-                        }
-                        noWrap
-                        className="shrink-0 tabular-nums"
-                      >
-                        {record.rowsMultiplyTo === null ? "" : formatMultiplier(record.rowsMultiplyTo)}
-                      </Text.H6>
-                    </div>
                   </div>
                 </>
               )}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+import { type SparklinePoint, smoothPath } from "./session-sparkline.tsx"
+
+const at = (values: readonly number[]): SparklinePoint[] => values.map((y, x) => ({ x, y }))
+
+interface Cubic {
+  readonly from: number
+  readonly c1: number
+  readonly c2: number
+  readonly to: number
+}
+
+/**
+ * The control points of each cubic, which is all an overshoot check needs: a Bezier
+ * curve stays inside the convex hull of its control points, so a segment whose two
+ * controls sit within its endpoints cannot leave that range.
+ */
+function cubics(path: string): Cubic[] {
+  const [move, ...rest] = path.split(" C")
+  let from = Number(move?.replace("M", "").split(",")[1])
+  const segments: Cubic[] = []
+  for (const chunk of rest) {
+    const [c1, c2, end] = chunk.split(" ")
+    const to = Number(end?.split(",")[1])
+    segments.push({ from, c1: Number(c1?.split(",")[1]), c2: Number(c2?.split(",")[1]), to })
+    from = to
+  }
+  return segments
+}
+
+const overshoots = (path: string): boolean =>
+  cubics(path).some((cubic) => {
+    const low = Math.min(cubic.from, cubic.to)
+    const high = Math.max(cubic.from, cubic.to)
+    return cubic.c1 < low || cubic.c1 > high || cubic.c2 < low || cubic.c2 > high
+  })
+
+describe("smoothPath", () => {
+  it("rounds the corners rather than drawing straight segments", () => {
+    const path = smoothPath(at([0, 4, 6, 6, 2]))
+
+    expect(path.startsWith("M")).toBe(true)
+    expect(path).toContain("C")
+    expect(path).not.toContain("L")
+  })
+
+  /**
+   * The reason this is a monotone cubic and not a cardinal spline: a spike in an
+   * otherwise flat run makes those overshoot past the peak on the way in and dip
+   * under the plateau on the way out, drawing values the series never held.
+   */
+  it("never leaves the range of the two points it is drawn between", () => {
+    const shapes = [
+      [10, 10, 10, 16, 10, 10, 10],
+      [10, 10, 4, 10, 10],
+      [16, 4, 16, 4, 16, 4],
+      [0, 0, 0, 20, 0, 0],
+      [1, 2, 3, 4, 5, 4, 3, 2, 1],
+      [5, 5, 5, 5, 5],
+    ]
+
+    for (const shape of shapes) expect(overshoots(smoothPath(at(shape))), JSON.stringify(shape)).toBe(false)
+  })
+
+  it("keeps a flat run flat, so a steady metric draws as a straight line", () => {
+    for (const cubic of cubics(smoothPath(at([7, 7, 7, 7])))) {
+      expect(cubic.c1).toBeCloseTo(7, 6)
+      expect(cubic.c2).toBeCloseTo(7, 6)
+    }
+  })
+
+  it("flattens at a local peak instead of rounding past it", () => {
+    // The tangent at the summit is zero, so both controls either side sit at its height.
+    const summit = cubics(smoothPath(at([2, 9, 2])))
+
+    expect(summit[0]?.c2).toBeCloseTo(9, 6)
+    expect(summit[1]?.c1).toBeCloseTo(9, 6)
+  })
+
+  it("degrades safely on a single point or none", () => {
+    expect(smoothPath([])).toBe("")
+    expect(smoothPath(at([3]))).toBe("M0.00,3.00")
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.test.ts
@@ -77,6 +77,12 @@ describe("smoothPath", () => {
     expect(summit[1]?.c1).toBeCloseTo(9, 6)
   })
 
+  it("keeps an isolated point rather than dropping the run it is alone in", () => {
+    // `[1, null, 2]` has two known values but no two adjacent, so every run holds one
+    // point. Discarding short runs rendered a blank chart for a series that has data.
+    expect(smoothPath(at([5]))).toBe("M0.00,5.00")
+  })
+
   it("degrades safely on a single point or none", () => {
     expect(smoothPath([])).toBe("")
     expect(smoothPath(at([3]))).toBe("M0.00,3.00")

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.tsx
@@ -111,18 +111,20 @@ export function SessionSparkline({
   const y = (value: number) =>
     VIEWBOX_HEIGHT - STROKE_WIDTH - (Math.max(0, value) / max) * (VIEWBOX_HEIGHT - STROKE_WIDTH * 2)
 
-  // One path per run of known values, so a gap renders as a gap.
+  // One run per stretch of known values, so a gap renders as a gap. A run of one has
+  // no line to draw and becomes a dot: dropping it renders a blank chart for a series
+  // whose known values are all isolated, such as `[1, null, 2]`.
   const runs: SparklinePoint[][] = []
   let current: SparklinePoint[] = []
   points.forEach((point, index) => {
     if (point === null) {
-      if (current.length > 1) runs.push(current)
+      if (current.length > 0) runs.push(current)
       current = []
       return
     }
     current.push({ x: x(index), y: y(point) })
   })
-  if (current.length > 1) runs.push(current)
+  if (current.length > 0) runs.push(current)
 
   const boundary =
     boundaryIndex !== undefined && boundaryIndex > 0 && boundaryIndex < points.length ? x(boundaryIndex) : null
@@ -149,6 +151,10 @@ export function SessionSparkline({
         />
       )}
       {runs.map((run) => {
+        const only = run.length === 1 ? run[0] : undefined
+        if (only) {
+          return <circle key={`${only.x},${only.y}`} cx={only.x} cy={only.y} r={STROKE_WIDTH} fill="currentColor" />
+        }
         const path = smoothPath(run)
         return (
           <path

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.tsx
@@ -2,37 +2,44 @@ const VIEWBOX_WIDTH = 100
 const VIEWBOX_HEIGHT = 28
 const STROKE_WIDTH = 1.6
 
-// A flat series would sit on the floor of its own range; centre it instead so a
-// steady metric reads as steady rather than as zero.
-const FLAT_RANGE_EPSILON = 1e-9
+// An all-zero series has no shape to draw, and dividing by its range would put the
+// line at an arbitrary height.
+const EMPTY_RANGE_EPSILON = 1e-9
 
 /**
  * Shape of a headline measure over the two compared windows, drawn from the same
  * buckets the decomposition was computed on.
  *
+ * Zero-baselined, never scaled to the series' own minimum. Normalising to min..max
+ * makes any variation fill the full height however small it is in absolute terms:
+ * sessions sitting at 10 with the odd 4 and 16 drew as full-height cliffs off a
+ * mid-line, which reads as a crisis rather than as a steady 10. Anchoring at zero
+ * also makes the two sparklines on the card comparable to each other, which two
+ * independently self-scaling ones never are.
+ *
  * Gaps are breaks in the line, not zeroes: a bucket with no sessions has no cost
- * per session, and joining across it would invent a value. Deliberately axis-free
- * and label-free — it carries shape only, and the figure above it carries the
- * magnitude.
+ * per session, and joining across it would invent a value. Otherwise axis-free and
+ * label-free — it carries shape, and the figure above it carries the magnitude.
  */
 export function SessionSparkline({
   points,
   label,
+  boundaryIndex,
 }: {
   readonly points: readonly (number | null)[]
   readonly label: string
+  /** First index of the current window, marked so the comparison is visible. */
+  readonly boundaryIndex?: number | undefined
 }) {
   const known = points.filter((point): point is number => point !== null)
   if (known.length < 2) return <div className="h-7" aria-hidden />
 
-  const min = Math.min(...known)
-  const max = Math.max(...known)
-  const span = max - min
+  const max = Math.max(...known, 0)
+  if (max <= EMPTY_RANGE_EPSILON) return <div className="h-7" aria-hidden />
+
   const x = (index: number) => (points.length === 1 ? 0 : (index / (points.length - 1)) * VIEWBOX_WIDTH)
   const y = (value: number) =>
-    span <= FLAT_RANGE_EPSILON
-      ? VIEWBOX_HEIGHT / 2
-      : VIEWBOX_HEIGHT - STROKE_WIDTH - ((value - min) / span) * (VIEWBOX_HEIGHT - STROKE_WIDTH * 2)
+    VIEWBOX_HEIGHT - STROKE_WIDTH - (Math.max(0, value) / max) * (VIEWBOX_HEIGHT - STROKE_WIDTH * 2)
 
   // One `path` per run of known values, so a gap renders as a gap.
   const segments: string[] = []
@@ -47,6 +54,9 @@ export function SessionSparkline({
   })
   if (current.length > 1) segments.push(current.join(" "))
 
+  const boundary =
+    boundaryIndex !== undefined && boundaryIndex > 0 && boundaryIndex < points.length ? x(boundaryIndex) : null
+
   return (
     <svg
       viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
@@ -55,6 +65,19 @@ export function SessionSparkline({
       role="img"
       aria-label={label}
     >
+      {boundary === null ? null : (
+        <line
+          x1={boundary}
+          x2={boundary}
+          y1={0}
+          y2={VIEWBOX_HEIGHT}
+          stroke="currentColor"
+          strokeWidth={1}
+          strokeDasharray="2 2"
+          className="text-border"
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
       {segments.map((segment) => (
         <path
           key={segment}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.tsx
@@ -1,0 +1,72 @@
+const VIEWBOX_WIDTH = 100
+const VIEWBOX_HEIGHT = 28
+const STROKE_WIDTH = 1.6
+
+// A flat series would sit on the floor of its own range; centre it instead so a
+// steady metric reads as steady rather than as zero.
+const FLAT_RANGE_EPSILON = 1e-9
+
+/**
+ * Shape of a headline measure over the two compared windows, drawn from the same
+ * buckets the decomposition was computed on.
+ *
+ * Gaps are breaks in the line, not zeroes: a bucket with no sessions has no cost
+ * per session, and joining across it would invent a value. Deliberately axis-free
+ * and label-free — it carries shape only, and the figure above it carries the
+ * magnitude.
+ */
+export function SessionSparkline({
+  points,
+  label,
+}: {
+  readonly points: readonly (number | null)[]
+  readonly label: string
+}) {
+  const known = points.filter((point): point is number => point !== null)
+  if (known.length < 2) return <div className="h-7" aria-hidden />
+
+  const min = Math.min(...known)
+  const max = Math.max(...known)
+  const span = max - min
+  const x = (index: number) => (points.length === 1 ? 0 : (index / (points.length - 1)) * VIEWBOX_WIDTH)
+  const y = (value: number) =>
+    span <= FLAT_RANGE_EPSILON
+      ? VIEWBOX_HEIGHT / 2
+      : VIEWBOX_HEIGHT - STROKE_WIDTH - ((value - min) / span) * (VIEWBOX_HEIGHT - STROKE_WIDTH * 2)
+
+  // One `path` per run of known values, so a gap renders as a gap.
+  const segments: string[] = []
+  let current: string[] = []
+  points.forEach((point, index) => {
+    if (point === null) {
+      if (current.length > 1) segments.push(current.join(" "))
+      current = []
+      return
+    }
+    current.push(`${current.length === 0 ? "M" : "L"}${x(index).toFixed(2)},${y(point).toFixed(2)}`)
+  })
+  if (current.length > 1) segments.push(current.join(" "))
+
+  return (
+    <svg
+      viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+      preserveAspectRatio="none"
+      className="h-7 w-full text-muted-foreground"
+      role="img"
+      aria-label={label}
+    >
+      {segments.map((segment) => (
+        <path
+          key={segment}
+          d={segment}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={STROKE_WIDTH}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      ))}
+    </svg>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/session-sparkline.tsx
@@ -6,6 +6,76 @@ const STROKE_WIDTH = 1.6
 // line at an arbitrary height.
 const EMPTY_RANGE_EPSILON = 1e-9
 
+export interface SparklinePoint {
+  readonly x: number
+  readonly y: number
+}
+
+/**
+ * Tangents for a monotone cubic through the points (Fritsch–Carlson).
+ *
+ * Monotone rather than a cardinal spline or Catmull-Rom, because those overshoot:
+ * a run at 10 with a single 16 in it would bulge above 16 on the way in and dip
+ * below 10 on the way out, drawing values the data never held. On a zero-baselined
+ * chart the dips can also cross the floor. The constraint step here bounds every
+ * segment by its own two endpoints, so the curve can only smooth the corners.
+ */
+function monotoneTangents(points: readonly SparklinePoint[]): number[] {
+  const secants: number[] = []
+  for (let index = 0; index < points.length - 1; index++) {
+    const from = points[index]
+    const to = points[index + 1]
+    if (!from || !to) continue
+    secants.push((to.y - from.y) / (to.x - from.x))
+  }
+
+  const tangents = points.map((_, index) => {
+    if (index === 0) return secants[0] ?? 0
+    if (index === points.length - 1) return secants[secants.length - 1] ?? 0
+    const before = secants[index - 1] ?? 0
+    const after = secants[index] ?? 0
+    // A local extreme has to flatten, or the curve rounds straight past it.
+    return before * after <= 0 ? 0 : (before + after) / 2
+  })
+
+  for (let index = 0; index < secants.length; index++) {
+    const secant = secants[index] ?? 0
+    if (secant === 0) {
+      tangents[index] = 0
+      tangents[index + 1] = 0
+      continue
+    }
+    const alpha = (tangents[index] ?? 0) / secant
+    const beta = (tangents[index + 1] ?? 0) / secant
+    const magnitude = alpha * alpha + beta * beta
+    if (magnitude <= 9) continue
+    const scale = 3 / Math.sqrt(magnitude)
+    tangents[index] = scale * alpha * secant
+    tangents[index + 1] = scale * beta * secant
+  }
+
+  return tangents
+}
+
+export const smoothPath = (points: readonly SparklinePoint[]): string => {
+  const first = points[0]
+  if (!first) return ""
+  if (points.length === 1) return `M${first.x.toFixed(2)},${first.y.toFixed(2)}`
+
+  const tangents = monotoneTangents(points)
+  let path = `M${first.x.toFixed(2)},${first.y.toFixed(2)}`
+  for (let index = 0; index < points.length - 1; index++) {
+    const from = points[index]
+    const to = points[index + 1]
+    if (!from || !to) continue
+    const run = (to.x - from.x) / 3
+    const c1y = from.y + (tangents[index] ?? 0) * run
+    const c2y = to.y - (tangents[index + 1] ?? 0) * run
+    path += ` C${(from.x + run).toFixed(2)},${c1y.toFixed(2)} ${(to.x - run).toFixed(2)},${c2y.toFixed(2)} ${to.x.toFixed(2)},${to.y.toFixed(2)}`
+  }
+  return path
+}
+
 /**
  * Shape of a headline measure over the two compared windows, drawn from the same
  * buckets the decomposition was computed on.
@@ -41,18 +111,18 @@ export function SessionSparkline({
   const y = (value: number) =>
     VIEWBOX_HEIGHT - STROKE_WIDTH - (Math.max(0, value) / max) * (VIEWBOX_HEIGHT - STROKE_WIDTH * 2)
 
-  // One `path` per run of known values, so a gap renders as a gap.
-  const segments: string[] = []
-  let current: string[] = []
+  // One path per run of known values, so a gap renders as a gap.
+  const runs: SparklinePoint[][] = []
+  let current: SparklinePoint[] = []
   points.forEach((point, index) => {
     if (point === null) {
-      if (current.length > 1) segments.push(current.join(" "))
+      if (current.length > 1) runs.push(current)
       current = []
       return
     }
-    current.push(`${current.length === 0 ? "M" : "L"}${x(index).toFixed(2)},${y(point).toFixed(2)}`)
+    current.push({ x: x(index), y: y(point) })
   })
-  if (current.length > 1) segments.push(current.join(" "))
+  if (current.length > 1) runs.push(current)
 
   const boundary =
     boundaryIndex !== undefined && boundaryIndex > 0 && boundaryIndex < points.length ? x(boundaryIndex) : null
@@ -78,18 +148,21 @@ export function SessionSparkline({
           vectorEffect="non-scaling-stroke"
         />
       )}
-      {segments.map((segment) => (
-        <path
-          key={segment}
-          d={segment}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={STROKE_WIDTH}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          vectorEffect="non-scaling-stroke"
-        />
-      ))}
+      {runs.map((run) => {
+        const path = smoothPath(run)
+        return (
+          <path
+            key={path}
+            d={path}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={STROKE_WIDTH}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        )
+      })}
     </svg>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
@@ -189,6 +189,9 @@ function CostPageContent() {
             {...(tw.pickerStartFrom ? { startTimeFrom: tw.pickerStartFrom } : {})}
             {...(tw.pickerStartTo ? { startTimeTo: tw.pickerStartTo } : {})}
             onChange={tw.onTimeChange}
+            // Unlike the other sections, every figure here is clamped to the recent
+            // slice, so an unset range is not all time.
+            placeholder="Recent activity"
           />
         }
       />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
@@ -6,6 +6,7 @@ import {
   useCacheEconomics,
   useCostBreakdown,
   useCostOverview,
+  useCostPerSessionDecomposition,
   useCostSeries,
   useModelUsageSeries,
 } from "../../../../../domains/cost/cost.collection.ts"
@@ -31,6 +32,7 @@ import {
 } from "./-components/cost-formatters.ts"
 import { CostKpiRow } from "./-components/cost-kpi-row.tsx"
 import { CostOverTimePanel } from "./-components/cost-over-time-panel.tsx"
+import { CostPerSessionPanel } from "./-components/cost-per-session-panel.tsx"
 import { ModelImpactPanel } from "./-components/model-impact-panel.tsx"
 import { ModelUsagePanel } from "./-components/model-usage-panel.tsx"
 
@@ -107,6 +109,11 @@ function CostPageContent() {
     projectId: project.id,
     range,
     bucketSeconds,
+    enabled,
+  })
+  const { data: perSession, isLoading: perSessionLoading } = useCostPerSessionDecomposition({
+    projectId: project.id,
+    range,
     enabled,
   })
   const { data: cacheEconomics, isLoading: cacheEconomicsLoading } = useCacheEconomics({
@@ -201,6 +208,14 @@ function CostPageContent() {
           rangeToIso={range.toIso}
           isAllTime={tw.isAllTime}
           isLoading={seriesLoading}
+        />
+        <SectionHeading>Session</SectionHeading>
+        <CostPerSessionPanel
+          record={perSession}
+          rangeFromIso={range.fromIso}
+          rangeToIso={range.toIso}
+          isAllTime={tw.isAllTime}
+          isLoading={perSessionLoading}
         />
         <SectionHeading>Model</SectionHeading>
         {/* The two model questions side by side: how spend moves, and who it goes to. */}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
@@ -114,6 +114,7 @@ function CostPageContent() {
   const { data: perSession, isLoading: perSessionLoading } = useCostPerSessionDecomposition({
     projectId: project.id,
     range,
+    bucketSeconds,
     enabled,
   })
   const { data: cacheEconomics, isLoading: cacheEconomicsLoading } = useCacheEconomics({

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -78,13 +78,22 @@ export {
 export type {
   CostPerSessionDecomposition,
   DecomposeCostPerSessionInput,
+  SessionCostCell,
   SessionCostContribution,
   SessionCostDecompositionStatus,
   SessionCostFactor,
-  SessionCostModelSlice,
   SessionCostPeriod,
+  SessionCostShareShift,
+  TokenSide,
 } from "./helpers/decompose-cost-per-session.ts"
-export { decomposeCostPerSession, SESSION_COST_MIN_SESSIONS } from "./helpers/decompose-cost-per-session.ts"
+export {
+  decomposeCostPerSession,
+  SESSION_COST_MIN_SESSIONS,
+  SESSION_COST_QUIET_BAND,
+  sessionCostMicrocents,
+  sessionCostTokens,
+  TOKEN_SIDES,
+} from "./helpers/decompose-cost-per-session.ts"
 export {
   canonicalizeMessageForEmbedding,
   hashMessageContent,
@@ -121,6 +130,7 @@ export type {
   ModelUsageMeasures,
   ModelUsageSeries,
   ModelUsageSlice,
+  SessionCostBucket,
   SessionCostFactorsPair,
   SessionCostFactorsScope,
 } from "./ports/cost-analytics-repository.ts"

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -75,6 +75,16 @@ export {
   cacheBreakEvenRate,
   classifyCacheState,
 } from "./helpers/cache-economics.ts"
+export type {
+  CostPerSessionDecomposition,
+  DecomposeCostPerSessionInput,
+  SessionCostContribution,
+  SessionCostDecompositionStatus,
+  SessionCostFactor,
+  SessionCostModelSlice,
+  SessionCostPeriod,
+} from "./helpers/decompose-cost-per-session.ts"
+export { decomposeCostPerSession, SESSION_COST_MIN_SESSIONS } from "./helpers/decompose-cost-per-session.ts"
 export {
   canonicalizeMessageForEmbedding,
   hashMessageContent,
@@ -111,6 +121,8 @@ export type {
   ModelUsageMeasures,
   ModelUsageSeries,
   ModelUsageSlice,
+  SessionCostFactorsPair,
+  SessionCostFactorsScope,
 } from "./ports/cost-analytics-repository.ts"
 export {
   CACHE_ECONOMICS_ROW_LIMIT,

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
@@ -381,6 +381,24 @@ describe("decomposeCostPerSession", () => {
     expect(result.status).toBe("flat")
   })
 
+  it("charges a new model's price gap against the old blend to the rate factors", () => {
+    // Its share arriving is mix-neutral, because the baseline is the old blended price.
+    // Whatever it costs beyond that blend is a price difference, so it lands on a rate.
+    const result = decomposeCostPerSession({
+      previous: period({ ...BASELINE, models: [{ ...CHEAP, share: 1 }] }),
+      current: period({
+        ...BASELINE,
+        models: [
+          { ...CHEAP, share: 0.5 },
+          { ...DEAR, name: "brand-new", share: 0.5 },
+        ],
+      }),
+    })
+
+    expect(multiplierFor(result.rows, "promptRate")).toBeGreaterThan(1)
+    expect(multiplierFor(result.rows, "tokenMix")).toBeCloseTo(1, 6)
+  })
+
   it("baselines a model with no previous tokens at the previous blended price", () => {
     const result = decomposeCostPerSession({
       previous: period({ ...BASELINE, models: [{ ...CHEAP, share: 1 }] }),

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
@@ -211,12 +211,17 @@ describe("decomposeCostPerSession", () => {
     expect(factors(result.rows)).not.toContain("tokenMix")
   })
 
-  it("names the model whose share moved most on the mix row", () => {
+  it("names where the tokens went, not the model they drained out of", () => {
+    // Two traps at once: mini loses the most share, and sonnet gains more of it than
+    // opus does. Neither should be named — mini's share is falling while the row
+    // rises, and sonnet's cheaper gain moves the blend less than opus's dearer one.
+    const mid = { name: "sonnet", promptShare: 0.9, promptPrice: 50, outputPrice: 500 }
     const result = decomposeCostPerSession({
       previous: period({
         ...BASELINE,
         models: [
-          { ...CHEAP, share: 0.9 },
+          { ...CHEAP, share: 0.7 },
+          { ...mid, share: 0.2 },
           { ...DEAR, share: 0.1 },
         ],
       }),
@@ -224,7 +229,8 @@ describe("decomposeCostPerSession", () => {
         ...BASELINE,
         models: [
           { ...CHEAP, share: 0.1 },
-          { ...DEAR, share: 0.9 },
+          { ...mid, share: 0.45 },
+          { ...DEAR, share: 0.45 },
         ],
       }),
     })
@@ -232,7 +238,31 @@ describe("decomposeCostPerSession", () => {
     const shift = result.rows.find((row) => row.factor === "modelMix")?.shareShift
     expect(shift?.label).toBe("acme/opus")
     expect(shift?.previousShare).toBeCloseTo(0.1, 6)
-    expect(shift?.currentShare).toBeCloseTo(0.9, 6)
+    expect(shift?.currentShare).toBeCloseTo(0.45, 6)
+  })
+
+  it("names the cheaper destination when traffic migrates down", () => {
+    const cheap = { name: "haiku", promptShare: 0.9, promptPrice: 1, outputPrice: 10 }
+    const result = decomposeCostPerSession({
+      previous: period({
+        ...BASELINE,
+        models: [
+          { ...DEAR, share: 0.9 },
+          { ...cheap, share: 0.1 },
+        ],
+      }),
+      current: period({
+        ...BASELINE,
+        models: [
+          { ...DEAR, share: 0.1 },
+          { ...cheap, share: 0.9 },
+        ],
+      }),
+    })
+
+    const row = result.rows.find((candidate) => candidate.factor === "modelMix")
+    expect(row?.shareShift?.label).toBe("acme/haiku")
+    expect(row?.multiplier).toBeLessThan(1)
   })
 
   it("folds the factors that did not move into one row that keeps the product intact", () => {

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
@@ -2,161 +2,105 @@ import { describe, expect, it } from "vitest"
 import {
   decomposeCostPerSession,
   SESSION_COST_MIN_SESSIONS,
+  type SessionCostCell,
   type SessionCostFactor,
-  type SessionCostModelSlice,
   type SessionCostPeriod,
 } from "./decompose-cost-per-session.ts"
 
-const model = (
-  name: string,
-  { tokens, pricePerToken }: { tokens: number; pricePerToken: number },
-): SessionCostModelSlice => ({
-  provider: "openai",
-  model: name,
-  tokens,
-  costMicrocents: tokens * pricePerToken,
-})
+interface ModelSpec {
+  readonly name: string
+  /** Share of the period's tokens this model takes. */
+  readonly share: number
+  /** Share of *this model's* tokens that are prompt tokens. */
+  readonly promptShare: number
+  readonly promptPrice: number
+  readonly outputPrice: number
+}
 
 /** A period built from the factors themselves, so a test can move exactly one of them. */
 const period = ({
   sessions,
-  turnsPerSession,
-  stepsPerTurn,
-  tokensPerStep,
+  tracesPerSession,
+  callsPerTrace,
+  tokensPerCall,
   models,
   traceKeyedSessions = 0,
 }: {
   sessions: number
-  turnsPerSession: number
-  stepsPerTurn: number
-  tokensPerStep: number
-  models: readonly { name: string; share: number; pricePerToken: number }[]
+  tracesPerSession: number
+  callsPerTrace: number
+  tokensPerCall: number
+  models: readonly ModelSpec[]
   traceKeyedSessions?: number
 }): SessionCostPeriod => {
-  const turns = sessions * turnsPerSession
-  const steps = turns * stepsPerTurn
-  const tokens = steps * tokensPerStep
-  const slices = models.map((entry) =>
-    model(entry.name, { tokens: tokens * entry.share, pricePerToken: entry.pricePerToken }),
-  )
-  return {
-    sessions,
-    traceKeyedSessions,
-    turns,
-    steps,
-    tokens,
-    costMicrocents: slices.reduce((sum, slice) => sum + slice.costMicrocents, 0),
-    unpricedCalls: 0,
-    models: slices,
-  }
+  const traces = sessions * tracesPerSession
+  const calls = traces * callsPerTrace
+  const tokens = calls * tokensPerCall
+  const cells: SessionCostCell[] = models.flatMap((model) => {
+    const own = tokens * model.share
+    const prompt = own * model.promptShare
+    const output = own - prompt
+    return [
+      {
+        provider: "acme",
+        model: model.name,
+        side: "prompt",
+        tokens: prompt,
+        costMicrocents: prompt * model.promptPrice,
+      },
+      {
+        provider: "acme",
+        model: model.name,
+        side: "output",
+        tokens: output,
+        costMicrocents: output * model.outputPrice,
+      },
+    ].filter((cell): cell is SessionCostCell => cell.tokens > 0)
+  })
+  return { sessions, traceKeyedSessions, traces, calls, unpricedCalls: 0, cells }
 }
 
-const CHEAP = { name: "gpt-5-mini", share: 1, pricePerToken: 10 }
+const CHEAP: ModelSpec = { name: "mini", share: 1, promptShare: 0.9, promptPrice: 10, outputPrice: 100 }
+const DEAR = { name: "opus", promptShare: 0.9, promptPrice: 100, outputPrice: 1_000 }
 
 const BASELINE = {
   sessions: 400,
-  turnsPerSession: 3,
-  stepsPerTurn: 2,
-  tokensPerStep: 1_000,
+  tracesPerSession: 3,
+  callsPerTrace: 2,
+  tokensPerCall: 1_000,
   models: [CHEAP],
 } as const
 
-const pointsFor = (rows: readonly { factor: SessionCostFactor; points: number }[], factor: SessionCostFactor): number =>
-  rows.find((row) => row.factor === factor)?.points ?? 0
+const multiplierFor = (
+  rows: readonly { factor: SessionCostFactor | null; multiplier: number }[],
+  factor: SessionCostFactor,
+): number | undefined => rows.find((row) => row.factor === factor)?.multiplier
 
-const factors = (rows: readonly { factor: SessionCostFactor }[]): readonly SessionCostFactor[] =>
+const factors = (rows: readonly { factor: SessionCostFactor | null }[]): readonly (SessionCostFactor | null)[] =>
   rows.map((row) => row.factor)
 
+const product = (rows: readonly { multiplier: number }[]): number =>
+  rows.reduce((total, row) => total * row.multiplier, 1)
+
 describe("decomposeCostPerSession", () => {
-  it("attributes a pure turn-count rise entirely to turns per session", () => {
+  it("gives every factor its own before/after ratio as a multiplier", () => {
     const result = decomposeCostPerSession({
       previous: period(BASELINE),
-      current: period({ ...BASELINE, turnsPerSession: 6 }),
+      current: period({ ...BASELINE, tracesPerSession: 6 }),
     })
 
     expect(result.status).toBe("ok")
-    expect(result.totalPoints).toBe(100)
-    expect(pointsFor(result.rows, "turnsPerSession")).toBe(100)
-    expect(pointsFor(result.rows, "tokensPerStep")).toBe(0)
-    expect(pointsFor(result.rows, "stepsPerTurn")).toBe(0)
-    expect(pointsFor(result.rows, "modelMix")).toBe(0)
-    expect(pointsFor(result.rows, "pricePerToken")).toBe(0)
+    expect(result.totalMultiplier).toBeCloseTo(2, 10)
+    expect(multiplierFor(result.rows, "tracesPerSession")).toBeCloseTo(2, 2)
+    expect(result.changePct).toBeCloseTo(100, 10)
   })
 
-  it("attributes prompt growth to tokens per step, not to the price rows", () => {
-    const result = decomposeCostPerSession({
-      previous: period(BASELINE),
-      current: period({ ...BASELINE, tokensPerStep: 4_000 }),
-    })
-
-    expect(pointsFor(result.rows, "tokensPerStep")).toBe(result.totalPoints)
-    expect(pointsFor(result.rows, "modelMix")).toBe(0)
-    expect(pointsFor(result.rows, "pricePerToken")).toBe(0)
-  })
-
-  it("puts a migration to a cheaper model on the model mix row, not on price per token", () => {
-    const previous = period({
-      ...BASELINE,
-      models: [
-        { name: "claude-opus", share: 0.8, pricePerToken: 100 },
-        { name: "claude-haiku", share: 0.2, pricePerToken: 10 },
-      ],
-    })
-    const current = period({
-      ...BASELINE,
-      models: [
-        { name: "claude-opus", share: 0.2, pricePerToken: 100 },
-        { name: "claude-haiku", share: 0.8, pricePerToken: 10 },
-      ],
-    })
-    const result = decomposeCostPerSession({ previous, current })
-
-    expect(result.totalPoints).toBeLessThan(0)
-    expect(pointsFor(result.rows, "modelMix")).toBe(result.totalPoints)
-    // Nothing repriced, so the within-model rate row has nothing to carry.
-    expect(pointsFor(result.rows, "pricePerToken")).toBe(0)
-  })
-
-  it("puts a list-price rise on price per token, not on model mix", () => {
-    const result = decomposeCostPerSession({
-      previous: period(BASELINE),
-      current: period({ ...BASELINE, models: [{ ...CHEAP, pricePerToken: 20 }] }),
-    })
-
-    expect(pointsFor(result.rows, "pricePerToken")).toBe(result.totalPoints)
-    expect(pointsFor(result.rows, "modelMix")).toBe(0)
-  })
-
-  it("separates a mix shift from a simultaneous prompt-growth rise", () => {
-    const previous = period({
-      ...BASELINE,
-      models: [
-        { name: "cheap", share: 0.9, pricePerToken: 10 },
-        { name: "premium", share: 0.1, pricePerToken: 100 },
-      ],
-    })
-    const current = period({
-      ...BASELINE,
-      tokensPerStep: 2_000,
-      models: [
-        { name: "cheap", share: 0.5, pricePerToken: 10 },
-        { name: "premium", share: 0.5, pricePerToken: 100 },
-      ],
-    })
-    const result = decomposeCostPerSession({ previous, current })
-
-    expect(pointsFor(result.rows, "modelMix")).toBeGreaterThan(0)
-    expect(pointsFor(result.rows, "tokensPerStep")).toBeGreaterThan(0)
-    expect(pointsFor(result.rows, "turnsPerSession")).toBe(0)
-    expect(pointsFor(result.rows, "stepsPerTurn")).toBe(0)
-  })
-
-  it("sums every row to the headline total, for any combination of moves", () => {
+  it("multiplies the displayed rows to the displayed total", () => {
     const cases = [
-      { turnsPerSession: 3.7, stepsPerTurn: 2.3, tokensPerStep: 1_311, price: 13 },
-      { turnsPerSession: 2.9, stepsPerTurn: 1.1, tokensPerStep: 907, price: 7 },
-      { turnsPerSession: 3.01, stepsPerTurn: 2.02, tokensPerStep: 1_003, price: 10.1 },
-      { turnsPerSession: 11, stepsPerTurn: 5, tokensPerStep: 40_000, price: 91 },
+      { tracesPerSession: 3.7, callsPerTrace: 2.3, tokensPerCall: 1_311, promptPrice: 13 },
+      { tracesPerSession: 2.9, callsPerTrace: 1.1, tokensPerCall: 907, promptPrice: 7 },
+      { tracesPerSession: 3.01, callsPerTrace: 2.02, tokensPerCall: 1_003, promptPrice: 10.1 },
+      { tracesPerSession: 11, callsPerTrace: 5, tokensPerCall: 40_000, promptPrice: 91 },
     ]
 
     for (const shape of cases) {
@@ -164,68 +108,187 @@ describe("decomposeCostPerSession", () => {
         previous: period(BASELINE),
         current: period({
           sessions: 517,
-          turnsPerSession: shape.turnsPerSession,
-          stepsPerTurn: shape.stepsPerTurn,
-          tokensPerStep: shape.tokensPerStep,
-          models: [{ ...CHEAP, pricePerToken: shape.price }],
+          tracesPerSession: shape.tracesPerSession,
+          callsPerTrace: shape.callsPerTrace,
+          tokensPerCall: shape.tokensPerCall,
+          models: [{ ...CHEAP, promptPrice: shape.promptPrice }],
         }),
       })
 
-      const summed = result.rows.reduce((sum, row) => sum + row.points, 0)
-      expect(summed, JSON.stringify(shape)).toBe(result.totalPoints)
-      expect(result.totalPoints).toBe(Math.round(result.changePct ?? 0))
+      // The rows multiply to the figure printed under them, exactly.
+      expect(product(result.rows), JSON.stringify(shape)).toBeCloseTo(result.rowsMultiplyTo ?? 0, 2)
+      // And that figure sits within a rounding step of the true change. Relative,
+      // because a rounding step is worth far less on a x1000 multiplier than on x2.
+      const drift = Math.abs((result.rowsMultiplyTo ?? 0) / (result.totalMultiplier ?? 1) - 1)
+      expect(drift, JSON.stringify(shape)).toBeLessThan(0.01)
     }
   })
 
-  it("absorbs the rounding residual into the largest contribution", () => {
-    // Three factors each land on a .5-ish share of a total that does not divide evenly.
+  it("attributes prompt growth to tokens per call, with the price rows quiet", () => {
     const result = decomposeCostPerSession({
       previous: period(BASELINE),
-      current: period({ ...BASELINE, turnsPerSession: 3.31, stepsPerTurn: 2.07, tokensPerStep: 1_013 }),
+      current: period({ ...BASELINE, tokensPerCall: 4_000 }),
     })
 
-    expect(result.rows.reduce((sum, row) => sum + row.points, 0)).toBe(result.totalPoints)
-    const largest = result.rows[0]
-    expect(largest?.factor).toBe("turnsPerSession")
+    expect(multiplierFor(result.rows, "tokensPerCall")).toBeCloseTo(4, 2)
+    expect(factors(result.rows)).not.toContain("modelMix")
+    expect(factors(result.rows)).not.toContain("promptRate")
   })
 
-  it("orders rows by absolute contribution so the cause reads first", () => {
+  it("puts a migration to a cheaper model on model mix, not on either rate", () => {
+    const cheap = { name: "haiku", promptShare: 0.9, promptPrice: 10, outputPrice: 100 }
     const result = decomposeCostPerSession({
-      previous: period(BASELINE),
-      current: period({ ...BASELINE, turnsPerSession: 3.3, tokensPerStep: 3_000 }),
+      previous: period({
+        ...BASELINE,
+        models: [
+          { ...DEAR, share: 0.8 },
+          { ...cheap, share: 0.2 },
+        ],
+      }),
+      current: period({
+        ...BASELINE,
+        models: [
+          { ...DEAR, share: 0.2 },
+          { ...cheap, share: 0.8 },
+        ],
+      }),
     })
 
-    const magnitudes = result.rows.map((row) => Math.abs(row.points))
-    expect(magnitudes).toEqual([...magnitudes].sort((a, b) => b - a))
-    expect(result.rows[0]?.factor).toBe("tokensPerStep")
+    expect(result.totalMultiplier).toBeLessThan(1)
+    expect(multiplierFor(result.rows, "modelMix")).toBeLessThan(1)
+    // No price list changed, so neither rate row may claim credit.
+    expect(factors(result.rows)).not.toContain("promptRate")
+    expect(factors(result.rows)).not.toContain("outputRate")
+  })
+
+  it("puts a real price rise on the rate rows, not on either mix row", () => {
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, models: [{ ...CHEAP, promptPrice: 20, outputPrice: 200 }] }),
+    })
+
+    expect(multiplierFor(result.rows, "promptRate")).toBeGreaterThan(1)
+    expect(factors(result.rows)).not.toContain("modelMix")
+    expect(factors(result.rows)).not.toContain("tokenMix")
+  })
+
+  /**
+   * The defect the four-way price split exists to fix: prompt tokens are cheaper
+   * than output ones, so growing the prompt alone drags the blended per-token price
+   * down. That has to read as a mix shift, never as a rate cut.
+   */
+  it("charges a prompt/output shift to token mix and leaves both rates quiet", () => {
+    const result = decomposeCostPerSession({
+      previous: period({ ...BASELINE, models: [{ ...CHEAP, promptShare: 0.5 }] }),
+      current: period({ ...BASELINE, models: [{ ...CHEAP, promptShare: 0.95 }] }),
+    })
+
+    expect(multiplierFor(result.rows, "tokenMix")).toBeLessThan(1)
+    expect(factors(result.rows)).not.toContain("promptRate")
+    expect(factors(result.rows)).not.toContain("outputRate")
+    expect(factors(result.rows)).not.toContain("modelMix")
+  })
+
+  it("keeps a model-share shift out of the token mix row when each model's split holds", () => {
+    const result = decomposeCostPerSession({
+      previous: period({
+        ...BASELINE,
+        models: [
+          { ...CHEAP, share: 0.9 },
+          { ...DEAR, share: 0.1 },
+        ],
+      }),
+      current: period({
+        ...BASELINE,
+        models: [
+          { ...CHEAP, share: 0.1 },
+          { ...DEAR, share: 0.9 },
+        ],
+      }),
+    })
+
+    expect(multiplierFor(result.rows, "modelMix")).toBeGreaterThan(1)
+    expect(factors(result.rows)).not.toContain("tokenMix")
+  })
+
+  it("names the model whose share moved most on the mix row", () => {
+    const result = decomposeCostPerSession({
+      previous: period({
+        ...BASELINE,
+        models: [
+          { ...CHEAP, share: 0.9 },
+          { ...DEAR, share: 0.1 },
+        ],
+      }),
+      current: period({
+        ...BASELINE,
+        models: [
+          { ...CHEAP, share: 0.1 },
+          { ...DEAR, share: 0.9 },
+        ],
+      }),
+    })
+
+    const shift = result.rows.find((row) => row.factor === "modelMix")?.shareShift
+    expect(shift?.label).toBe("acme/opus")
+    expect(shift?.previousShare).toBeCloseTo(0.1, 6)
+    expect(shift?.currentShare).toBeCloseTo(0.9, 6)
+  })
+
+  it("folds the factors that did not move into one row that keeps the product intact", () => {
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, tokensPerCall: 4_000 }),
+    })
+
+    const folded = result.rows.find((row) => row.foldedFactors > 0)
+    expect(folded?.foldedFactors).toBeGreaterThan(0)
+    expect(folded?.values).toBeNull()
+    expect(product(result.rows)).toBeCloseTo(result.rowsMultiplyTo ?? 0, 2)
+  })
+
+  it("orders rows by how far each moved so the cause reads first", () => {
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, tracesPerSession: 3.3, tokensPerCall: 3_000 }),
+    })
+
+    expect(result.rows[0]?.factor).toBe("tokensPerCall")
+  })
+
+  it("carries before and after values for the volume factors only", () => {
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, tracesPerSession: 6, models: [{ ...CHEAP, promptPrice: 20 }] }),
+    })
+
+    expect(result.rows.find((row) => row.factor === "tracesPerSession")?.values).toEqual({ previous: 3, current: 6 })
+    expect(result.rows.find((row) => row.factor === "promptRate")?.values).toBeNull()
   })
 
   it("reports flat rather than dividing by a near-zero log", () => {
-    const previous = period(BASELINE)
-    const result = decomposeCostPerSession({ previous, current: { ...previous, sessions: previous.sessions } })
+    const result = decomposeCostPerSession({ previous: period(BASELINE), current: period(BASELINE) })
 
     expect(result.status).toBe("flat")
     expect(result.rows).toEqual([])
     expect(result.changePct).toBe(0)
-    expect(result.totalPoints).toBe(0)
   })
 
   it("refuses to compare when either period is under the session floor", () => {
     const small = period({ ...BASELINE, sessions: SESSION_COST_MIN_SESSIONS - 1 })
-    const big = period({ ...BASELINE, turnsPerSession: 6 })
+    const big = period({ ...BASELINE, tracesPerSession: 6 })
 
     expect(decomposeCostPerSession({ previous: small, current: big }).status).toBe("notEnoughData")
     expect(decomposeCostPerSession({ previous: big, current: small }).status).toBe("notEnoughData")
     expect(decomposeCostPerSession({ previous: small, current: big }).changePct).toBeNull()
+    expect(decomposeCostPerSession({ previous: small, current: big }).totalMultiplier).toBeNull()
   })
 
   it("refuses to compare when the previous period recorded no spend", () => {
-    const free = period({ ...BASELINE, models: [{ ...CHEAP, pricePerToken: 0 }] })
-    const paid = period(BASELINE)
+    const free = period({ ...BASELINE, models: [{ ...CHEAP, promptPrice: 0, outputPrice: 0 }] })
+    const result = decomposeCostPerSession({ previous: free, current: period(BASELINE) })
 
-    const result = decomposeCostPerSession({ previous: free, current: paid })
     expect(result.status).toBe("notEnoughData")
-    expect(result.rows).toEqual([])
     // The headline still renders — only the comparison is withheld.
     expect(result.currentCostPerSessionMicrocents).toBeGreaterThan(0)
   })
@@ -241,41 +304,18 @@ describe("decomposeCostPerSession", () => {
   })
 
   it("baselines a model with no previous tokens at the previous blended price", () => {
-    const previous = period({ ...BASELINE, models: [{ name: "cheap", share: 1, pricePerToken: 10 }] })
-    const current = period({
-      ...BASELINE,
-      models: [
-        { name: "cheap", share: 0.5, pricePerToken: 10 },
-        { name: "brand-new", share: 0.5, pricePerToken: 10 },
-      ],
-    })
-    const result = decomposeCostPerSession({ previous, current })
-
-    // Routing half the traffic somewhere priced identically is not a mix effect.
-    expect(result.status).toBe("flat")
-  })
-
-  it("only emits a cache efficiency row once an effect is supplied", () => {
-    const previous = period(BASELINE)
-    const current = period({ ...BASELINE, models: [{ ...CHEAP, pricePerToken: 20 }] })
-
-    expect(factors(decomposeCostPerSession({ previous, current }).rows)).not.toContain("cacheEfficiency")
-
-    const withCache = decomposeCostPerSession({ previous, current, cacheEfficiencyEffect: 5 })
-    expect(factors(withCache.rows)).toContain("cacheEfficiency")
-    expect(withCache.rows.reduce((sum, row) => sum + row.points, 0)).toBe(withCache.totalPoints)
-    // Half the 10-microcent price rise was handed to caching, so it takes half the points.
-    expect(pointsFor(withCache.rows, "cacheEfficiency")).toBe(pointsFor(withCache.rows, "pricePerToken"))
-  })
-
-  it("carries the before and after values for the volume factors only", () => {
     const result = decomposeCostPerSession({
-      previous: period(BASELINE),
-      current: period({ ...BASELINE, turnsPerSession: 6, models: [{ ...CHEAP, pricePerToken: 20 }] }),
+      previous: period({ ...BASELINE, models: [{ ...CHEAP, share: 1 }] }),
+      current: period({
+        ...BASELINE,
+        models: [
+          { ...CHEAP, share: 0.5 },
+          { ...CHEAP, name: "brand-new", share: 0.5 },
+        ],
+      }),
     })
 
-    expect(result.rows.find((row) => row.factor === "turnsPerSession")?.values).toEqual({ previous: 3, current: 6 })
-    expect(result.rows.find((row) => row.factor === "modelMix")?.values).toBeNull()
-    expect(result.rows.find((row) => row.factor === "pricePerToken")?.values).toBeNull()
+    // Routing half the traffic to an identically-priced model changes nothing.
+    expect(result.status).toBe("flat")
   })
 })

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
@@ -232,10 +232,9 @@ describe("decomposeCostPerSession", () => {
       }),
     })
 
-    const shift = result.rows.find((row) => row.factor === "modelMix")?.shareShift
-    expect(shift?.label).toBe("acme/opus")
-    expect(shift?.previousShare).toBeCloseTo(0.1, 6)
-    expect(shift?.currentShare).toBeCloseTo(0.45, 6)
+    const row = result.rows.find((candidate) => candidate.factor === "modelMix")
+    expect(row?.subject).toBe("acme/opus")
+    expect(row?.current).toBeCloseTo(0.45, 6)
   })
 
   it("counts the other models that also gained, so one name cannot pass for the whole shift", () => {
@@ -260,7 +259,7 @@ describe("decomposeCostPerSession", () => {
     })
 
     // Two models gained 30 points each: the tile names one and says so.
-    expect(result.rows.find((row) => row.factor === "modelMix")?.shareShift?.alsoMoved).toBe(1)
+    expect(result.rows.find((row) => row.factor === "modelMix")?.alsoMoved).toBe(1)
   })
 
   it("counts no other movers when a single model took all the traffic", () => {
@@ -281,7 +280,7 @@ describe("decomposeCostPerSession", () => {
       }),
     })
 
-    expect(result.rows.find((row) => row.factor === "modelMix")?.shareShift?.alsoMoved).toBe(0)
+    expect(result.rows.find((row) => row.factor === "modelMix")?.alsoMoved).toBe(0)
   })
 
   it("names the cheaper destination when traffic migrates down", () => {
@@ -304,7 +303,7 @@ describe("decomposeCostPerSession", () => {
     })
 
     const row = result.rows.find((candidate) => candidate.factor === "modelMix")
-    expect(row?.shareShift?.label).toBe("acme/haiku")
+    expect(row?.subject).toBe("acme/haiku")
     expect(row?.multiplier).toBeLessThan(1)
   })
 
@@ -328,14 +327,21 @@ describe("decomposeCostPerSession", () => {
     expect(result.rows[0]?.factor).toBe("tokensPerCall")
   })
 
-  it("carries before and after values for the volume factors only", () => {
+  it("reports where every factor stands now, in that factor's own unit", () => {
     const result = decomposeCostPerSession({
       previous: period(BASELINE),
       current: period({ ...BASELINE, tracesPerSession: 6, models: [{ ...CHEAP, promptPrice: 20 }] }),
     })
+    const currentOf = (factor: SessionCostFactor) => result.rows.find((row) => row.factor === factor)?.current
 
-    expect(result.rows.find((row) => row.factor === "tracesPerSession")?.values).toEqual({ previous: 3, current: 6 })
-    expect(result.rows.find((row) => row.factor === "promptRate")?.values).toBeNull()
+    expect(currentOf("tracesPerSession")).toBeCloseTo(6, 6)
+    expect(currentOf("callsPerTrace")).toBeCloseTo(2, 6)
+    expect(currentOf("tokensPerCall")).toBeCloseTo(1_000, 6)
+    // Microcents per token on each side, blended over models.
+    expect(currentOf("promptRate")).toBeCloseTo(20, 6)
+    expect(currentOf("outputRate")).toBeCloseTo(100, 6)
+    // Shares, so the mix tiles have a figure of their own to stand on.
+    expect(currentOf("tokenMix")).toBeCloseTo(0.9, 6)
   })
 
   it("reports flat rather than dividing by a near-zero log", () => {

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "vitest"
+import {
+  decomposeCostPerSession,
+  SESSION_COST_MIN_SESSIONS,
+  type SessionCostFactor,
+  type SessionCostModelSlice,
+  type SessionCostPeriod,
+} from "./decompose-cost-per-session.ts"
+
+const model = (
+  name: string,
+  { tokens, pricePerToken }: { tokens: number; pricePerToken: number },
+): SessionCostModelSlice => ({
+  provider: "openai",
+  model: name,
+  tokens,
+  costMicrocents: tokens * pricePerToken,
+})
+
+/** A period built from the factors themselves, so a test can move exactly one of them. */
+const period = ({
+  sessions,
+  turnsPerSession,
+  stepsPerTurn,
+  tokensPerStep,
+  models,
+  traceKeyedSessions = 0,
+}: {
+  sessions: number
+  turnsPerSession: number
+  stepsPerTurn: number
+  tokensPerStep: number
+  models: readonly { name: string; share: number; pricePerToken: number }[]
+  traceKeyedSessions?: number
+}): SessionCostPeriod => {
+  const turns = sessions * turnsPerSession
+  const steps = turns * stepsPerTurn
+  const tokens = steps * tokensPerStep
+  const slices = models.map((entry) =>
+    model(entry.name, { tokens: tokens * entry.share, pricePerToken: entry.pricePerToken }),
+  )
+  return {
+    sessions,
+    traceKeyedSessions,
+    turns,
+    steps,
+    tokens,
+    costMicrocents: slices.reduce((sum, slice) => sum + slice.costMicrocents, 0),
+    unpricedCalls: 0,
+    models: slices,
+  }
+}
+
+const CHEAP = { name: "gpt-5-mini", share: 1, pricePerToken: 10 }
+
+const BASELINE = {
+  sessions: 400,
+  turnsPerSession: 3,
+  stepsPerTurn: 2,
+  tokensPerStep: 1_000,
+  models: [CHEAP],
+} as const
+
+const pointsFor = (rows: readonly { factor: SessionCostFactor; points: number }[], factor: SessionCostFactor): number =>
+  rows.find((row) => row.factor === factor)?.points ?? 0
+
+const factors = (rows: readonly { factor: SessionCostFactor }[]): readonly SessionCostFactor[] =>
+  rows.map((row) => row.factor)
+
+describe("decomposeCostPerSession", () => {
+  it("attributes a pure turn-count rise entirely to turns per session", () => {
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, turnsPerSession: 6 }),
+    })
+
+    expect(result.status).toBe("ok")
+    expect(result.totalPoints).toBe(100)
+    expect(pointsFor(result.rows, "turnsPerSession")).toBe(100)
+    expect(pointsFor(result.rows, "tokensPerStep")).toBe(0)
+    expect(pointsFor(result.rows, "stepsPerTurn")).toBe(0)
+    expect(pointsFor(result.rows, "modelMix")).toBe(0)
+    expect(pointsFor(result.rows, "pricePerToken")).toBe(0)
+  })
+
+  it("attributes prompt growth to tokens per step, not to the price rows", () => {
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, tokensPerStep: 4_000 }),
+    })
+
+    expect(pointsFor(result.rows, "tokensPerStep")).toBe(result.totalPoints)
+    expect(pointsFor(result.rows, "modelMix")).toBe(0)
+    expect(pointsFor(result.rows, "pricePerToken")).toBe(0)
+  })
+
+  it("puts a migration to a cheaper model on the model mix row, not on price per token", () => {
+    const previous = period({
+      ...BASELINE,
+      models: [
+        { name: "claude-opus", share: 0.8, pricePerToken: 100 },
+        { name: "claude-haiku", share: 0.2, pricePerToken: 10 },
+      ],
+    })
+    const current = period({
+      ...BASELINE,
+      models: [
+        { name: "claude-opus", share: 0.2, pricePerToken: 100 },
+        { name: "claude-haiku", share: 0.8, pricePerToken: 10 },
+      ],
+    })
+    const result = decomposeCostPerSession({ previous, current })
+
+    expect(result.totalPoints).toBeLessThan(0)
+    expect(pointsFor(result.rows, "modelMix")).toBe(result.totalPoints)
+    // Nothing repriced, so the within-model rate row has nothing to carry.
+    expect(pointsFor(result.rows, "pricePerToken")).toBe(0)
+  })
+
+  it("puts a list-price rise on price per token, not on model mix", () => {
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, models: [{ ...CHEAP, pricePerToken: 20 }] }),
+    })
+
+    expect(pointsFor(result.rows, "pricePerToken")).toBe(result.totalPoints)
+    expect(pointsFor(result.rows, "modelMix")).toBe(0)
+  })
+
+  it("separates a mix shift from a simultaneous prompt-growth rise", () => {
+    const previous = period({
+      ...BASELINE,
+      models: [
+        { name: "cheap", share: 0.9, pricePerToken: 10 },
+        { name: "premium", share: 0.1, pricePerToken: 100 },
+      ],
+    })
+    const current = period({
+      ...BASELINE,
+      tokensPerStep: 2_000,
+      models: [
+        { name: "cheap", share: 0.5, pricePerToken: 10 },
+        { name: "premium", share: 0.5, pricePerToken: 100 },
+      ],
+    })
+    const result = decomposeCostPerSession({ previous, current })
+
+    expect(pointsFor(result.rows, "modelMix")).toBeGreaterThan(0)
+    expect(pointsFor(result.rows, "tokensPerStep")).toBeGreaterThan(0)
+    expect(pointsFor(result.rows, "turnsPerSession")).toBe(0)
+    expect(pointsFor(result.rows, "stepsPerTurn")).toBe(0)
+  })
+
+  it("sums every row to the headline total, for any combination of moves", () => {
+    const cases = [
+      { turnsPerSession: 3.7, stepsPerTurn: 2.3, tokensPerStep: 1_311, price: 13 },
+      { turnsPerSession: 2.9, stepsPerTurn: 1.1, tokensPerStep: 907, price: 7 },
+      { turnsPerSession: 3.01, stepsPerTurn: 2.02, tokensPerStep: 1_003, price: 10.1 },
+      { turnsPerSession: 11, stepsPerTurn: 5, tokensPerStep: 40_000, price: 91 },
+    ]
+
+    for (const shape of cases) {
+      const result = decomposeCostPerSession({
+        previous: period(BASELINE),
+        current: period({
+          sessions: 517,
+          turnsPerSession: shape.turnsPerSession,
+          stepsPerTurn: shape.stepsPerTurn,
+          tokensPerStep: shape.tokensPerStep,
+          models: [{ ...CHEAP, pricePerToken: shape.price }],
+        }),
+      })
+
+      const summed = result.rows.reduce((sum, row) => sum + row.points, 0)
+      expect(summed, JSON.stringify(shape)).toBe(result.totalPoints)
+      expect(result.totalPoints).toBe(Math.round(result.changePct ?? 0))
+    }
+  })
+
+  it("absorbs the rounding residual into the largest contribution", () => {
+    // Three factors each land on a .5-ish share of a total that does not divide evenly.
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, turnsPerSession: 3.31, stepsPerTurn: 2.07, tokensPerStep: 1_013 }),
+    })
+
+    expect(result.rows.reduce((sum, row) => sum + row.points, 0)).toBe(result.totalPoints)
+    const largest = result.rows[0]
+    expect(largest?.factor).toBe("turnsPerSession")
+  })
+
+  it("orders rows by absolute contribution so the cause reads first", () => {
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, turnsPerSession: 3.3, tokensPerStep: 3_000 }),
+    })
+
+    const magnitudes = result.rows.map((row) => Math.abs(row.points))
+    expect(magnitudes).toEqual([...magnitudes].sort((a, b) => b - a))
+    expect(result.rows[0]?.factor).toBe("tokensPerStep")
+  })
+
+  it("reports flat rather than dividing by a near-zero log", () => {
+    const previous = period(BASELINE)
+    const result = decomposeCostPerSession({ previous, current: { ...previous, sessions: previous.sessions } })
+
+    expect(result.status).toBe("flat")
+    expect(result.rows).toEqual([])
+    expect(result.changePct).toBe(0)
+    expect(result.totalPoints).toBe(0)
+  })
+
+  it("refuses to compare when either period is under the session floor", () => {
+    const small = period({ ...BASELINE, sessions: SESSION_COST_MIN_SESSIONS - 1 })
+    const big = period({ ...BASELINE, turnsPerSession: 6 })
+
+    expect(decomposeCostPerSession({ previous: small, current: big }).status).toBe("notEnoughData")
+    expect(decomposeCostPerSession({ previous: big, current: small }).status).toBe("notEnoughData")
+    expect(decomposeCostPerSession({ previous: small, current: big }).changePct).toBeNull()
+  })
+
+  it("refuses to compare when the previous period recorded no spend", () => {
+    const free = period({ ...BASELINE, models: [{ ...CHEAP, pricePerToken: 0 }] })
+    const paid = period(BASELINE)
+
+    const result = decomposeCostPerSession({ previous: free, current: paid })
+    expect(result.status).toBe("notEnoughData")
+    expect(result.rows).toEqual([])
+    // The headline still renders — only the comparison is withheld.
+    expect(result.currentCostPerSessionMicrocents).toBeGreaterThan(0)
+  })
+
+  it("reports the session-count change without letting it move a row", () => {
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, sessions: BASELINE.sessions * 2 }),
+    })
+
+    expect(result.volume).toEqual({ previousSessions: 400, currentSessions: 800 })
+    expect(result.status).toBe("flat")
+  })
+
+  it("baselines a model with no previous tokens at the previous blended price", () => {
+    const previous = period({ ...BASELINE, models: [{ name: "cheap", share: 1, pricePerToken: 10 }] })
+    const current = period({
+      ...BASELINE,
+      models: [
+        { name: "cheap", share: 0.5, pricePerToken: 10 },
+        { name: "brand-new", share: 0.5, pricePerToken: 10 },
+      ],
+    })
+    const result = decomposeCostPerSession({ previous, current })
+
+    // Routing half the traffic somewhere priced identically is not a mix effect.
+    expect(result.status).toBe("flat")
+  })
+
+  it("only emits a cache efficiency row once an effect is supplied", () => {
+    const previous = period(BASELINE)
+    const current = period({ ...BASELINE, models: [{ ...CHEAP, pricePerToken: 20 }] })
+
+    expect(factors(decomposeCostPerSession({ previous, current }).rows)).not.toContain("cacheEfficiency")
+
+    const withCache = decomposeCostPerSession({ previous, current, cacheEfficiencyEffect: 5 })
+    expect(factors(withCache.rows)).toContain("cacheEfficiency")
+    expect(withCache.rows.reduce((sum, row) => sum + row.points, 0)).toBe(withCache.totalPoints)
+    // Half the 10-microcent price rise was handed to caching, so it takes half the points.
+    expect(pointsFor(withCache.rows, "cacheEfficiency")).toBe(pointsFor(withCache.rows, "pricePerToken"))
+  })
+
+  it("carries the before and after values for the volume factors only", () => {
+    const result = decomposeCostPerSession({
+      previous: period(BASELINE),
+      current: period({ ...BASELINE, turnsPerSession: 6, models: [{ ...CHEAP, pricePerToken: 20 }] }),
+    })
+
+    expect(result.rows.find((row) => row.factor === "turnsPerSession")?.values).toEqual({ previous: 3, current: 6 })
+    expect(result.rows.find((row) => row.factor === "modelMix")?.values).toBeNull()
+    expect(result.rows.find((row) => row.factor === "pricePerToken")?.values).toBeNull()
+  })
+})

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.test.ts
@@ -72,12 +72,11 @@ const BASELINE = {
 } as const
 
 const multiplierFor = (
-  rows: readonly { factor: SessionCostFactor | null; multiplier: number }[],
+  rows: readonly { factor: SessionCostFactor; multiplier: number }[],
   factor: SessionCostFactor,
 ): number | undefined => rows.find((row) => row.factor === factor)?.multiplier
 
-const factors = (rows: readonly { factor: SessionCostFactor | null }[]): readonly (SessionCostFactor | null)[] =>
-  rows.map((row) => row.factor)
+const factors = (rows: readonly { factor: SessionCostFactor }[]): SessionCostFactor[] => rows.map((row) => row.factor)
 
 const product = (rows: readonly { multiplier: number }[]): number =>
   rows.reduce((total, row) => total * row.multiplier, 1)
@@ -115,12 +114,10 @@ describe("decomposeCostPerSession", () => {
         }),
       })
 
-      // The rows multiply to the figure printed under them, exactly.
-      expect(product(result.rows), JSON.stringify(shape)).toBeCloseTo(result.rowsMultiplyTo ?? 0, 2)
-      // And that figure sits within a rounding step of the true change. Relative,
-      // because a rounding step is worth far less on a x1000 multiplier than on x2.
-      const drift = Math.abs((result.rowsMultiplyTo ?? 0) / (result.totalMultiplier ?? 1) - 1)
-      expect(drift, JSON.stringify(shape)).toBeLessThan(0.01)
+      // Exactly, not to display precision: each multiplier is exp of a log share and
+      // the shares sum to the total's log, so the product is the total by construction.
+      const drift = Math.abs(product(result.rows) / (result.totalMultiplier ?? 1) - 1)
+      expect(drift, JSON.stringify(shape)).toBeLessThan(1e-9)
     }
   })
 
@@ -131,8 +128,8 @@ describe("decomposeCostPerSession", () => {
     })
 
     expect(multiplierFor(result.rows, "tokensPerCall")).toBeCloseTo(4, 2)
-    expect(factors(result.rows)).not.toContain("modelMix")
-    expect(factors(result.rows)).not.toContain("promptRate")
+    expect(multiplierFor(result.rows, "modelMix")).toBeCloseTo(1, 2)
+    expect(multiplierFor(result.rows, "promptRate")).toBeCloseTo(1, 2)
   })
 
   it("puts a migration to a cheaper model on model mix, not on either rate", () => {
@@ -157,8 +154,8 @@ describe("decomposeCostPerSession", () => {
     expect(result.totalMultiplier).toBeLessThan(1)
     expect(multiplierFor(result.rows, "modelMix")).toBeLessThan(1)
     // No price list changed, so neither rate row may claim credit.
-    expect(factors(result.rows)).not.toContain("promptRate")
-    expect(factors(result.rows)).not.toContain("outputRate")
+    expect(multiplierFor(result.rows, "promptRate")).toBeCloseTo(1, 2)
+    expect(multiplierFor(result.rows, "outputRate")).toBeCloseTo(1, 2)
   })
 
   it("puts a real price rise on the rate rows, not on either mix row", () => {
@@ -168,8 +165,8 @@ describe("decomposeCostPerSession", () => {
     })
 
     expect(multiplierFor(result.rows, "promptRate")).toBeGreaterThan(1)
-    expect(factors(result.rows)).not.toContain("modelMix")
-    expect(factors(result.rows)).not.toContain("tokenMix")
+    expect(multiplierFor(result.rows, "modelMix")).toBeCloseTo(1, 2)
+    expect(multiplierFor(result.rows, "tokenMix")).toBeCloseTo(1, 2)
   })
 
   /**
@@ -184,9 +181,9 @@ describe("decomposeCostPerSession", () => {
     })
 
     expect(multiplierFor(result.rows, "tokenMix")).toBeLessThan(1)
-    expect(factors(result.rows)).not.toContain("promptRate")
-    expect(factors(result.rows)).not.toContain("outputRate")
-    expect(factors(result.rows)).not.toContain("modelMix")
+    expect(multiplierFor(result.rows, "promptRate")).toBeCloseTo(1, 2)
+    expect(multiplierFor(result.rows, "outputRate")).toBeCloseTo(1, 2)
+    expect(multiplierFor(result.rows, "modelMix")).toBeCloseTo(1, 2)
   })
 
   it("keeps a model-share shift out of the token mix row when each model's split holds", () => {
@@ -208,7 +205,7 @@ describe("decomposeCostPerSession", () => {
     })
 
     expect(multiplierFor(result.rows, "modelMix")).toBeGreaterThan(1)
-    expect(factors(result.rows)).not.toContain("tokenMix")
+    expect(multiplierFor(result.rows, "tokenMix")).toBeCloseTo(1, 2)
   })
 
   it("names where the tokens went, not the model they drained out of", () => {
@@ -241,6 +238,52 @@ describe("decomposeCostPerSession", () => {
     expect(shift?.currentShare).toBeCloseTo(0.45, 6)
   })
 
+  it("counts the other models that also gained, so one name cannot pass for the whole shift", () => {
+    const mid = { name: "sonnet", promptShare: 0.9, promptPrice: 50, outputPrice: 500 }
+    const result = decomposeCostPerSession({
+      previous: period({
+        ...BASELINE,
+        models: [
+          { ...CHEAP, share: 0.8 },
+          { ...mid, share: 0.1 },
+          { ...DEAR, share: 0.1 },
+        ],
+      }),
+      current: period({
+        ...BASELINE,
+        models: [
+          { ...CHEAP, share: 0.2 },
+          { ...mid, share: 0.4 },
+          { ...DEAR, share: 0.4 },
+        ],
+      }),
+    })
+
+    // Two models gained 30 points each: the tile names one and says so.
+    expect(result.rows.find((row) => row.factor === "modelMix")?.shareShift?.alsoMoved).toBe(1)
+  })
+
+  it("counts no other movers when a single model took all the traffic", () => {
+    const result = decomposeCostPerSession({
+      previous: period({
+        ...BASELINE,
+        models: [
+          { ...CHEAP, share: 0.9 },
+          { ...DEAR, share: 0.1 },
+        ],
+      }),
+      current: period({
+        ...BASELINE,
+        models: [
+          { ...CHEAP, share: 0.1 },
+          { ...DEAR, share: 0.9 },
+        ],
+      }),
+    })
+
+    expect(result.rows.find((row) => row.factor === "modelMix")?.shareShift?.alsoMoved).toBe(0)
+  })
+
   it("names the cheaper destination when traffic migrates down", () => {
     const cheap = { name: "haiku", promptShare: 0.9, promptPrice: 1, outputPrice: 10 }
     const result = decomposeCostPerSession({
@@ -265,16 +308,15 @@ describe("decomposeCostPerSession", () => {
     expect(row?.multiplier).toBeLessThan(1)
   })
 
-  it("folds the factors that did not move into one row that keeps the product intact", () => {
+  it("always reports all seven factors, so the card's shape never moves", () => {
     const result = decomposeCostPerSession({
       previous: period(BASELINE),
       current: period({ ...BASELINE, tokensPerCall: 4_000 }),
     })
 
-    const folded = result.rows.find((row) => row.foldedFactors > 0)
-    expect(folded?.foldedFactors).toBeGreaterThan(0)
-    expect(folded?.values).toBeNull()
-    expect(product(result.rows)).toBeCloseTo(result.rowsMultiplyTo ?? 0, 2)
+    expect(factors(result.rows).sort()).toEqual(
+      ["callsPerTrace", "modelMix", "outputRate", "promptRate", "tokenMix", "tokensPerCall", "tracesPerSession"].sort(),
+    )
   })
 
   it("orders rows by how far each moved so the cause reads first", () => {

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
@@ -1,12 +1,15 @@
 /**
- * Why average cost per session moved, as contributions in percentage points that
- * add up to the move itself.
+ * Why average cost per session moved, as a multiplier per factor.
  *
- * Cost per session is a product — `turns/session x steps/turn x tokens/step x
- * price/token` — and a product decomposes exactly in log space: each factor's
- * share of `ln(C_c / C_p)` is its share of the change, with no regression and no
- * double counting. A correlation would attribute the same rise twice, since
- * tokens grow with turns.
+ * Cost per session is a product — `traces/session x calls/trace x tokens/call x
+ * cost/token` — so each factor's own before/after ratio is a multiplier, and the
+ * multipliers multiply to the headline ratio exactly. No shared synthetic unit:
+ * every figure stays in the unit the factor is measured in.
+ *
+ * The price factor is split four ways because a blended per-token price moves for
+ * reasons that are not price changes. Routing tokens to a dearer model, or simply
+ * sending more prompt and the same output, both move it — so `modelMix` and
+ * `tokenMix` absorb those and the two rate factors carry what actually repriced.
  *
  * Nothing here reads a repository or the pricing registry: every input is a
  * number, so the whole thing is exhaustively testable and safe for the browser
@@ -15,41 +18,59 @@
  */
 
 /**
- * `turnsPerSession`, `stepsPerTurn` and `tokensPerStep` are the volume factors —
- * how much work a session does. The last three are all price: `modelMix` is
- * which models the tokens went to, `cacheEfficiency` is how much of the prompt
- * was charged at the read rate, and `pricePerToken` is whatever within-model
- * rate change is left after those two.
+ * `tracesPerSession`, `callsPerTrace` and `tokensPerCall` are volume — how much
+ * work a session does. The last four are the price factor, split so each points
+ * at a different fix: which model got the tokens, how the tokens divided between
+ * the cheap prompt side and the dear output side, and the two per-side rates.
  */
 const SESSION_COST_FACTORS = [
-  "turnsPerSession",
-  "stepsPerTurn",
-  "tokensPerStep",
+  "tracesPerSession",
+  "callsPerTrace",
+  "tokensPerCall",
   "modelMix",
-  "cacheEfficiency",
-  "pricePerToken",
+  "tokenMix",
+  "promptRate",
+  "outputRate",
 ] as const
 export type SessionCostFactor = (typeof SESSION_COST_FACTORS)[number]
 
+/** Prompt covers cache reads and writes; they are charged on the input side. */
+export const TOKEN_SIDES = ["prompt", "output"] as const
+export type TokenSide = (typeof TOKEN_SIDES)[number]
+
 /**
  * Sessions a period needs before its cost per session may be compared to another
- * period's. Below this one expensive session moves the average by tens of points,
- * so the decomposition would be arithmetic over noise — the same trap the
- * breakdown table's `278x avg` chip fell into.
+ * period's. Below this one expensive session moves the average by a multiple, so
+ * the decomposition would be arithmetic over noise — the same trap the breakdown
+ * table's `278x avg` chip fell into.
  */
 export const SESSION_COST_MIN_SESSIONS = 20
 
-// Below this the cost is flat and the weights would divide by ~0, so every row reads 0.
-const SESSION_COST_FLAT_LOG_EPSILON = 1e-6
+/**
+ * A factor whose multiplier is this close to 1 did not move. Matches the display
+ * precision, so a row is folded away exactly when it would have read `x1.0`.
+ */
+export const SESSION_COST_QUIET_BAND = 0.05
+
+/** Below this the cost is flat and the weights would divide by ~0, so nothing moved. */
+const FLAT_LOG_EPSILON = 1e-6
 
 // Sub-effects this close to cancelling each other out leave the factor they split
 // with no change to divide by, whatever their individual sizes.
 const NEGLIGIBLE_EFFECT_SHARE = 1e-9
 
-/** Per price-list, so the same model slug served by two providers is two entries. */
-export interface SessionCostModelSlice {
+/** Displayed multipliers carry two decimals, and must still multiply to the total. */
+const DISPLAY_DECIMALS = 2
+
+/**
+ * One (price list x token side) bucket. Splitting by provider as well as model
+ * because the same model slug served by two providers is two price lists, and
+ * splitting by side because prompt and output are priced an order apart.
+ */
+export interface SessionCostCell {
   readonly provider: string
   readonly model: string
+  readonly side: TokenSide
   readonly tokens: number
   readonly costMicrocents: number
 }
@@ -60,33 +81,52 @@ export interface SessionCostModelSlice {
  * no session id is a single-trace pseudo-session rather than being dropped.
  * `traceKeyedSessions` is how many of them are that, which is what lets the
  * caller say so instead of quietly renaming cost per trace.
+ *
+ * Tokens and cost are derived from `cells` rather than carried alongside them, so
+ * the price factor's four sub-effects always close on the price change.
  */
 export interface SessionCostPeriod {
   readonly sessions: number
   readonly traceKeyedSessions: number
-  /** Traces with a billable call: one turn of a conversation. */
-  readonly turns: number
-  /** Billable LLM calls: the steps a single turn took. */
-  readonly steps: number
-  readonly tokens: number
-  readonly costMicrocents: number
+  /** Traces with a billable call. One request to an agent, not one conversational turn. */
+  readonly traces: number
+  /** Billable LLM calls: what a single trace spent to answer. */
+  readonly calls: number
   /** Calls whose model has no known pricing, so this period's cost is understated. */
   readonly unpricedCalls: number
-  readonly models: readonly SessionCostModelSlice[]
+  readonly cells: readonly SessionCostCell[]
+}
+
+export const sessionCostTokens = (period: SessionCostPeriod): number =>
+  period.cells.reduce((sum, cell) => sum + cell.tokens, 0)
+
+export const sessionCostMicrocents = (period: SessionCostPeriod): number =>
+  period.cells.reduce((sum, cell) => sum + cell.costMicrocents, 0)
+
+/** The share move behind a mix row, so an abstract factor still names something concrete. */
+export interface SessionCostShareShift {
+  readonly label: string
+  readonly previousShare: number
+  readonly currentShare: number
 }
 
 export interface SessionCostContribution {
-  readonly factor: SessionCostFactor
-  /** Percentage points of the headline change, rounded so the rows sum to it exactly. */
-  readonly points: number
-  /** The factor's own before/after values, absent for the price sub-factors, which are not ratios. */
+  /** Null on the folded row, which stands for several factors and so names none. */
+  readonly factor: SessionCostFactor | null
+  /** Multiplier on cost per session. Every row's multiplier multiplies to `totalMultiplier`. */
+  readonly multiplier: number
+  /** Before and after in the factor's own unit. Null for the price sub-factors, which are not ratios. */
   readonly values: { readonly previous: number; readonly current: number } | null
+  /** What moved, for a mix row that has no before/after value of its own. */
+  readonly shareShift: SessionCostShareShift | null
+  /** How many quiet factors this row stands in for; 0 on a real factor. */
+  readonly foldedFactors: number
 }
 
 /**
  * `notEnoughData` means no comparison is possible and only the headline should
  * render; `flat` means the comparison held still, which is a real answer and not
- * an error. Both leave `rows` empty rather than shipping zeros that look measured.
+ * an error. Both leave `rows` empty rather than shipping ones that look measured.
  */
 export type SessionCostDecompositionStatus = "ok" | "flat" | "notEnoughData"
 
@@ -94,16 +134,21 @@ export interface CostPerSessionDecomposition {
   readonly status: SessionCostDecompositionStatus
   readonly previousCostPerSessionMicrocents: number
   readonly currentCostPerSessionMicrocents: number
-  /** Null when the periods cannot be compared. Unrounded; `totalPoints` is what the rows sum to. */
+  /** Null when the periods cannot be compared. */
   readonly changePct: number | null
-  /** The headline change as shown, to the whole point. Every row's `points` sums to this. */
-  readonly totalPoints: number
-  /** Largest contribution first, so the row that explains the move reads first. */
+  /** `current / previous`, exact. The headline change is this figure. */
+  readonly totalMultiplier: number | null
+  /**
+   * What the rows' displayed multipliers multiply to, which is the total to print
+   * beneath them. A rounding step from `totalMultiplier` and never further.
+   */
+  readonly rowsMultiplyTo: number | null
+  /** Largest move first. Quiet factors are folded into one trailing row. */
   readonly rows: readonly SessionCostContribution[]
   /**
    * Session-count change, deliberately not a row: sessions are the denominator,
-   * so growth in them does not move cost per session at all. Shown as context
-   * because "we are simply busier" is the one cost story that is good news.
+   * so growth in them does not move cost per session at all. Its own block in the
+   * UI, because "we are simply busier" is the one cost story that is good news.
    */
   readonly volume: { readonly previousSessions: number; readonly currentSessions: number }
 }
@@ -111,87 +156,154 @@ export interface CostPerSessionDecomposition {
 export interface DecomposeCostPerSessionInput {
   readonly previous: SessionCostPeriod
   readonly current: SessionCostPeriod
-  /**
-   * Change in price per token attributable to cache efficiency, in microcents per
-   * token, signed the same way as the mix and rate effects. Its own row when
-   * supplied; folded into `pricePerToken` when not.
-   */
-  readonly cacheEfficiencyEffect?: number | undefined
 }
 
 const costPerSession = (period: SessionCostPeriod): number =>
-  period.sessions > 0 ? period.costMicrocents / period.sessions : 0
+  period.sessions > 0 ? sessionCostMicrocents(period) / period.sessions : 0
 
 interface Factors {
-  readonly turnsPerSession: number
-  readonly stepsPerTurn: number
-  readonly tokensPerStep: number
-  readonly pricePerToken: number
+  readonly tracesPerSession: number
+  readonly callsPerTrace: number
+  readonly tokensPerCall: number
+  readonly costPerToken: number
 }
+
+type VolumeFactor = Exclude<keyof Factors, "costPerToken">
+
+const VOLUME_FACTORS: readonly VolumeFactor[] = ["tracesPerSession", "callsPerTrace", "tokensPerCall"]
 
 /** Null when any denominator is empty, which is what makes the whole product unusable. */
 function factorsOf(period: SessionCostPeriod): Factors | null {
-  if (period.sessions <= 0 || period.turns <= 0 || period.steps <= 0 || period.tokens <= 0) return null
-  if (period.costMicrocents <= 0) return null
+  const tokens = sessionCostTokens(period)
+  const cost = sessionCostMicrocents(period)
+  if (period.sessions <= 0 || period.traces <= 0 || period.calls <= 0 || tokens <= 0 || cost <= 0) return null
   return {
-    turnsPerSession: period.turns / period.sessions,
-    stepsPerTurn: period.steps / period.turns,
-    tokensPerStep: period.tokens / period.steps,
-    pricePerToken: period.costMicrocents / period.tokens,
+    tracesPerSession: period.traces / period.sessions,
+    callsPerTrace: period.calls / period.traces,
+    tokensPerCall: tokens / period.calls,
+    costPerToken: cost / tokens,
   }
 }
 
-const priceListKey = (slice: SessionCostModelSlice): string => `${slice.provider}/${slice.model}`
+const modelKey = (cell: { provider: string; model: string }): string => `${cell.provider}/${cell.model}`
+const cellKey = (cell: SessionCostCell): string => `${modelKey(cell)}/${cell.side}`
 
-interface ModelPosition {
+interface CellPosition {
   readonly share: number
   readonly price: number
 }
 
-const positionsOf = (period: SessionCostPeriod): Map<string, ModelPosition> => {
-  const positions = new Map<string, ModelPosition>()
-  for (const slice of period.models) {
-    if (slice.tokens <= 0) continue
-    positions.set(priceListKey(slice), {
-      share: slice.tokens / period.tokens,
-      price: slice.costMicrocents / slice.tokens,
+interface ModelPosition {
+  readonly share: number
+  readonly averagePrice: number
+  /** Token share within this model, by side, summing to 1. */
+  readonly sideShares: Map<TokenSide, number>
+}
+
+interface Positions {
+  readonly cells: Map<string, CellPosition>
+  readonly models: Map<string, ModelPosition>
+}
+
+function positionsOf(period: SessionCostPeriod): Positions {
+  const tokens = sessionCostTokens(period)
+  const cells = new Map<string, CellPosition>()
+  const modelTokens = new Map<string, number>()
+  const modelCost = new Map<string, number>()
+  const modelSideTokens = new Map<string, Map<TokenSide, number>>()
+
+  for (const cell of period.cells) {
+    if (cell.tokens <= 0) continue
+    cells.set(cellKey(cell), { share: cell.tokens / tokens, price: cell.costMicrocents / cell.tokens })
+    const key = modelKey(cell)
+    modelTokens.set(key, (modelTokens.get(key) ?? 0) + cell.tokens)
+    modelCost.set(key, (modelCost.get(key) ?? 0) + cell.costMicrocents)
+    const sides = modelSideTokens.get(key) ?? new Map<TokenSide, number>()
+    sides.set(cell.side, (sides.get(cell.side) ?? 0) + cell.tokens)
+    modelSideTokens.set(key, sides)
+  }
+
+  const models = new Map<string, ModelPosition>()
+  for (const [key, ownTokens] of modelTokens) {
+    const sides = new Map<TokenSide, number>()
+    for (const [side, sideTokens] of modelSideTokens.get(key) ?? []) sides.set(side, sideTokens / ownTokens)
+    models.set(key, {
+      share: ownTokens / tokens,
+      averagePrice: (modelCost.get(key) ?? 0) / ownTokens,
+      sideShares: sides,
     })
   }
-  return positions
+
+  return { cells, models }
+}
+
+interface PriceEffects {
+  readonly modelMix: number
+  readonly tokenMix: number
+  readonly promptRate: number
+  readonly outputRate: number
 }
 
 /**
- * How much of the price move came from tokens shifting between price lists rather
- * than from any price changing: `sum((share_c - share_p) * price_p)`.
+ * Splits the change in blended price per token four ways, exactly.
  *
- * A price list with no previous tokens is baselined at the previous period's
- * blended price, so simply routing traffic somewhere new is mix-neutral and only
- * that destination's deviation from the old average shows up as a rate change.
+ * Two levels of mix, then the rates. A model's share moving is valued at that
+ * model's old average price, so rerouting to an identically-priced model is
+ * mix-neutral; the sides moving within a model are valued at that model's own old
+ * per-side prices, so growing the prompt while output holds shows up here rather
+ * than as a rate cut. What is left is the two sides' prices actually changing.
+ *
+ * A price list with no previous tokens is baselined at the previous blended price,
+ * and its side split at its current one, so a brand-new model contributes to mix
+ * and not to either rate.
  */
-function modelMixEffect({
+function priceEffects({
   previous,
   current,
   previousBlendedPrice,
 }: {
-  readonly previous: Map<string, ModelPosition>
-  readonly current: Map<string, ModelPosition>
+  readonly previous: Positions
+  readonly current: Positions
   readonly previousBlendedPrice: number
-}): number {
-  let effect = 0
-  for (const key of new Set([...previous.keys(), ...current.keys()])) {
-    const previousPosition = previous.get(key)
-    const shareDelta = (current.get(key)?.share ?? 0) - (previousPosition?.share ?? 0)
-    effect += shareDelta * (previousPosition?.price ?? previousBlendedPrice)
+}): PriceEffects {
+  let modelMix = 0
+  let tokenMix = 0
+  const rates = new Map<TokenSide, number>(TOKEN_SIDES.map((side) => [side, 0]))
+
+  for (const key of new Set([...previous.models.keys(), ...current.models.keys()])) {
+    const previousModel = previous.models.get(key)
+    const currentModel = current.models.get(key)
+    const previousAverage = previousModel?.averagePrice ?? previousBlendedPrice
+    modelMix += ((currentModel?.share ?? 0) - (previousModel?.share ?? 0)) * previousAverage
+
+    if (!currentModel) continue
+    for (const side of TOKEN_SIDES) {
+      const currentSideShare = currentModel.sideShares.get(side) ?? 0
+      const previousSideShare = previousModel ? (previousModel.sideShares.get(side) ?? 0) : currentSideShare
+      const previousPrice = previous.cells.get(`${key}/${side}`)?.price ?? previousAverage
+      tokenMix += currentModel.share * (currentSideShare - previousSideShare) * previousPrice
+
+      const currentPrice = current.cells.get(`${key}/${side}`)?.price
+      if (currentPrice === undefined) continue
+      const cellShare = currentModel.share * currentSideShare
+      rates.set(side, (rates.get(side) ?? 0) + cellShare * (currentPrice - previousPrice))
+    }
   }
-  return effect
+
+  return {
+    modelMix,
+    tokenMix,
+    promptRate: rates.get("prompt") ?? 0,
+    outputRate: rates.get("output") ?? 0,
+  }
 }
 
 /**
- * Splits one factor's contribution across sub-effects that sum to the factor's own
- * change, so the parts still add up to the whole. When the change is negligible
- * next to the sub-effects — a mix shift cancelled by a rate move — the factor
- * contributed nothing, and an even split keeps every part at that same nothing
- * instead of dividing by it.
+ * Splits one factor's log contribution across sub-effects that sum to the factor's
+ * own change, so the parts still multiply to the whole. When the change is
+ * negligible next to the sub-effects — a mix shift cancelled by a rate move — the
+ * factor contributed nothing, and an even split keeps every part at that same
+ * nothing instead of dividing by it.
  */
 function allocate({
   contribution,
@@ -208,29 +320,90 @@ function allocate({
   return effects.map((effect) => (contribution * effect) / total)
 }
 
+const round = (value: number): number => {
+  const factor = 10 ** DISPLAY_DECIMALS
+  return Math.round(value * factor) / factor
+}
+
 /**
- * Whole points that still sum to the headline. The residual lands on the largest
- * contribution, where a one-point adjustment is proportionally smallest — if the
- * rows do not add up to the number above them, the card reads as decoration.
+ * Rounds every multiplier to display precision and nudges the largest row toward
+ * the true total, so the rows a reader multiplies land on the figure printed under
+ * them. A decomposition whose rows do not reconcile reads as decoration.
+ *
+ * The product of the rounded rows is what that figure has to be: absorbing the
+ * whole residual into one row cannot close the gap, because that row's own
+ * rounding error is then multiplied by everything else on the card. So the
+ * displayed total follows the rows rather than the rows chasing the total — which
+ * leaves it a rounding step away from `totalMultiplier`, and the headline change
+ * beside it carries the exact figure.
  */
-function toWholePoints({
-  raw,
-  totalPoints,
+function reconcile({
+  rows,
+  totalMultiplier,
 }: {
-  readonly raw: readonly { readonly factor: SessionCostFactor; readonly value: number }[]
-  readonly totalPoints: number
-}): readonly { readonly factor: SessionCostFactor; readonly points: number; readonly value: number }[] {
-  const rounded = raw.map((entry) => ({ ...entry, points: Math.round(entry.value) }))
-  const residual = totalPoints - rounded.reduce((sum, entry) => sum + entry.points, 0)
-  if (residual === 0 || rounded.length === 0) return rounded
+  readonly rows: readonly SessionCostContribution[]
+  readonly totalMultiplier: number
+}): { readonly rows: readonly SessionCostContribution[]; readonly rowsMultiplyTo: number } {
+  if (rows.length === 0) return { rows, rowsMultiplyTo: round(totalMultiplier) }
+  const rounded = rows.map((row) => ({ ...row, multiplier: round(row.multiplier) }))
 
   let largest = 0
   for (let index = 1; index < rounded.length; index++) {
     const candidate = rounded[index]
     const incumbent = rounded[largest]
-    if (candidate && incumbent && Math.abs(candidate.value) > Math.abs(incumbent.value)) largest = index
+    if (candidate && incumbent && Math.abs(Math.log(candidate.multiplier)) > Math.abs(Math.log(incumbent.multiplier))) {
+      largest = index
+    }
   }
-  return rounded.map((entry, index) => (index === largest ? { ...entry, points: entry.points + residual } : entry))
+
+  const others = rounded.reduce((product, row, index) => (index === largest ? product : product * row.multiplier), 1)
+  const settled =
+    others === 0
+      ? rounded
+      : rounded.map((row, index) =>
+          index === largest ? { ...row, multiplier: round(round(totalMultiplier) / others) } : row,
+        )
+
+  return { rows: settled, rowsMultiplyTo: round(settled.reduce((product, row) => product * row.multiplier, 1)) }
+}
+
+/** The model whose token share moved most, so the mix row names a cause. */
+function dominantShareShift({
+  previous,
+  current,
+}: {
+  readonly previous: Positions
+  readonly current: Positions
+}): SessionCostShareShift | null {
+  let shift: SessionCostShareShift | null = null
+  let widest = 0
+  for (const key of new Set([...previous.models.keys(), ...current.models.keys()])) {
+    const previousShare = previous.models.get(key)?.share ?? 0
+    const currentShare = current.models.get(key)?.share ?? 0
+    const move = Math.abs(currentShare - previousShare)
+    // A swap moves both models equally; the one that gained share names the cause.
+    const incumbentLost = shift !== null && shift.currentShare < shift.previousShare
+    if (move < widest || (move === widest && !(currentShare > previousShare && incumbentLost))) continue
+    widest = move
+    shift = { label: key, previousShare, currentShare }
+  }
+  return shift
+}
+
+/** Prompt is the readable half of the split: the cheap side's share of the tokens. */
+function promptShareShift({
+  previous,
+  current,
+}: {
+  readonly previous: SessionCostPeriod
+  readonly current: SessionCostPeriod
+}): SessionCostShareShift {
+  const shareOf = (period: SessionCostPeriod): number => {
+    const tokens = sessionCostTokens(period)
+    if (tokens <= 0) return 0
+    return period.cells.reduce((sum, cell) => (cell.side === "prompt" ? sum + cell.tokens : sum), 0) / tokens
+  }
+  return { label: "prompt tokens", previousShare: shareOf(previous), currentShare: shareOf(current) }
 }
 
 const emptyResult = ({
@@ -246,13 +419,27 @@ const emptyResult = ({
   previousCostPerSessionMicrocents: costPerSession(input.previous),
   currentCostPerSessionMicrocents: costPerSession(input.current),
   changePct,
-  totalPoints: changePct === null ? 0 : Math.round(changePct),
+  totalMultiplier: changePct === null ? null : changePct / 100 + 1,
+  rowsMultiplyTo: null,
   rows: [],
   volume: { previousSessions: input.previous.sessions, currentSessions: input.current.sessions },
 })
 
+/**
+ * Folds the factors that did not move into one trailing row carrying their
+ * combined multiplier, so the visible rows still multiply to the headline while
+ * the card shows only what changed.
+ */
+function foldQuietFactors(rows: readonly SessionCostContribution[]): readonly SessionCostContribution[] {
+  const moved = rows.filter((row) => Math.abs(row.multiplier - 1) >= SESSION_COST_QUIET_BAND)
+  const quiet = rows.filter((row) => Math.abs(row.multiplier - 1) < SESSION_COST_QUIET_BAND)
+  if (quiet.length === 0) return moved
+  const combined = quiet.reduce((product, row) => product * row.multiplier, 1)
+  return [...moved, { factor: null, multiplier: combined, values: null, shareShift: null, foldedFactors: quiet.length }]
+}
+
 export function decomposeCostPerSession(input: DecomposeCostPerSessionInput): CostPerSessionDecomposition {
-  const { previous, current, cacheEfficiencyEffect } = input
+  const { previous, current } = input
   const previousFactors = factorsOf(previous)
   const currentFactors = factorsOf(current)
   const previousCost = costPerSession(previous)
@@ -267,66 +454,63 @@ export function decomposeCostPerSession(input: DecomposeCostPerSessionInput): Co
     return emptyResult({ status: "notEnoughData", input, changePct: null })
   }
 
-  const changePct = (currentCost / previousCost - 1) * 100
-  const totalLog = Math.log(currentCost / previousCost)
-  if (Math.abs(totalLog) < SESSION_COST_FLAT_LOG_EPSILON) return emptyResult({ status: "flat", input, changePct })
+  const totalMultiplier = currentCost / previousCost
+  const changePct = (totalMultiplier - 1) * 100
+  const totalLog = Math.log(totalMultiplier)
+  if (Math.abs(totalLog) < FLAT_LOG_EPSILON) return emptyResult({ status: "flat", input, changePct })
 
-  const totalPoints = Math.round(changePct)
-  const contributionOf = (factor: keyof Factors): number =>
-    (Math.log(currentFactors[factor] / previousFactors[factor]) / totalLog) * changePct
-
-  const priceContribution = contributionOf("pricePerToken")
-  const mixEffect = modelMixEffect({
-    previous: positionsOf(previous),
-    current: positionsOf(current),
-    previousBlendedPrice: previousFactors.pricePerToken,
+  const previousPositions = positionsOf(previous)
+  const currentPositions = positionsOf(current)
+  const effects = priceEffects({
+    previous: previousPositions,
+    current: currentPositions,
+    previousBlendedPrice: previousFactors.costPerToken,
   })
-  const cacheEffect = cacheEfficiencyEffect ?? 0
-  // The rate effect is the remainder rather than its own sum, so the three price
-  // sub-effects always close on the price change however the cache one is defined.
-  const rateEffect = currentFactors.pricePerToken - previousFactors.pricePerToken - mixEffect - cacheEffect
-  const priceEffects =
-    cacheEfficiencyEffect === undefined ? [mixEffect, rateEffect] : [mixEffect, cacheEffect, rateEffect]
-  const priceParts = allocate({ contribution: priceContribution, effects: priceEffects })
-
-  const values = (factor: keyof Factors): { previous: number; current: number } => ({
-    previous: previousFactors[factor],
-    current: currentFactors[factor],
+  const priceLog = Math.log(currentFactors.costPerToken / previousFactors.costPerToken)
+  const [modelMixLog = 0, tokenMixLog = 0, promptRateLog = 0, outputRateLog = 0] = allocate({
+    contribution: priceLog,
+    effects: [effects.modelMix, effects.tokenMix, effects.promptRate, effects.outputRate],
   })
-  const valuesByFactor = new Map<SessionCostFactor, { previous: number; current: number }>([
-    ["turnsPerSession", values("turnsPerSession")],
-    ["stepsPerTurn", values("stepsPerTurn")],
-    ["tokensPerStep", values("tokensPerStep")],
-  ])
 
-  const raw: { readonly factor: SessionCostFactor; readonly value: number }[] = [
-    { factor: "turnsPerSession", value: contributionOf("turnsPerSession") },
-    { factor: "stepsPerTurn", value: contributionOf("stepsPerTurn") },
-    { factor: "tokensPerStep", value: contributionOf("tokensPerStep") },
-    { factor: "modelMix", value: priceParts[0] ?? 0 },
-    ...(cacheEfficiencyEffect === undefined
-      ? []
-      : [{ factor: "cacheEfficiency" as SessionCostFactor, value: priceParts[1] ?? 0 }]),
-    { factor: "pricePerToken", value: priceParts[priceParts.length - 1] ?? 0 },
+  const volumeRows = VOLUME_FACTORS.map(
+    (factor): SessionCostContribution => ({
+      factor,
+      multiplier: currentFactors[factor] / previousFactors[factor],
+      values: { previous: previousFactors[factor], current: currentFactors[factor] },
+      shareShift: null,
+      foldedFactors: 0,
+    }),
+  )
+  const priceRows: readonly SessionCostContribution[] = [
+    {
+      factor: "modelMix",
+      multiplier: Math.exp(modelMixLog),
+      values: null,
+      shareShift: dominantShareShift({ previous: previousPositions, current: currentPositions }),
+      foldedFactors: 0,
+    },
+    {
+      factor: "tokenMix",
+      multiplier: Math.exp(tokenMixLog),
+      values: null,
+      shareShift: promptShareShift({ previous, current }),
+      foldedFactors: 0,
+    },
+    { factor: "promptRate", multiplier: Math.exp(promptRateLog), values: null, shareShift: null, foldedFactors: 0 },
+    { factor: "outputRate", multiplier: Math.exp(outputRateLog), values: null, shareShift: null, foldedFactors: 0 },
   ]
 
-  const rows = toWholePoints({ raw, totalPoints })
-    .map(
-      (entry): SessionCostContribution => ({
-        factor: entry.factor,
-        points: entry.points,
-        values: valuesByFactor.get(entry.factor) ?? null,
-      }),
-    )
-    .sort((a, b) => Math.abs(b.points) - Math.abs(a.points))
+  const ordered = [...volumeRows, ...priceRows].sort(
+    (a, b) => Math.abs(Math.log(b.multiplier)) - Math.abs(Math.log(a.multiplier)),
+  )
 
   return {
     status: "ok",
     previousCostPerSessionMicrocents: previousCost,
     currentCostPerSessionMicrocents: currentCost,
     changePct,
-    totalPoints,
-    rows,
+    totalMultiplier,
+    ...reconcile({ rows: foldQuietFactors(ordered), totalMultiplier }),
     volume: { previousSessions: previous.sessions, currentSessions: current.sessions },
   }
 }

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
@@ -106,15 +106,14 @@ export const sessionCostMicrocents = (period: SessionCostPeriod): number =>
   period.cells.reduce((sum, cell) => sum + cell.costMicrocents, 0)
 
 /**
- * A share move behind a mix row, so an abstract factor still names something concrete.
+ * Where a mix row's tokens went, and how many other places also gained.
  *
- * `alsoMoved` counts the other price lists that gained share too. One named model
- * reads as *the* cause, and on a broad shift — three models each taking ten points
- * off a fourth — that is the wrong story, so the count has to be sayable.
+ * One named model reads as *the* cause, and on a broad shift — three models each
+ * taking ten points off a fourth — that is the wrong story, so the count has to be
+ * sayable.
  */
 export interface SessionCostShareShift {
   readonly label: string
-  readonly previousShare: number
   readonly currentShare: number
   readonly alsoMoved: number
 }
@@ -126,10 +125,20 @@ export interface SessionCostContribution {
    * `totalMultiplier`; rounding for display is the caller's business.
    */
   readonly multiplier: number
-  /** Before and after in the factor's own unit. Null for the price sub-factors, which are not ratios. */
-  readonly values: { readonly previous: number; readonly current: number } | null
-  /** What moved, for a mix row that has no before/after value of its own. */
-  readonly shareShift: SessionCostShareShift | null
+  /**
+   * Where the factor stands now, in its own unit: a ratio for the volume factors, a
+   * token share for the two mix factors, microcents per token for the two rates.
+   *
+   * Only the current value, never the pair. A blended per-side price moves with model
+   * mix, so printing its before and after next to a multiplier that holds the mix
+   * fixed reads as a contradiction — the pair is what made those two factors
+   * unshowable, and one value is not.
+   */
+  readonly current: number
+  /** What `current` is a share of, where the number alone would be ambiguous. */
+  readonly subject: string | null
+  /** Other price lists that also gained share, for a mix row. Zero elsewhere. */
+  readonly alsoMoved: number
 }
 
 /**
@@ -367,7 +376,7 @@ function destinationShareShift({
     const effect = Math.abs(gain * (price - previousBlendedPrice))
     if (effect < widestEffect) continue
     widestEffect = effect
-    shift = { label: key, previousShare, currentShare }
+    shift = { label: key, currentShare }
   }
   return shift === null ? null : { ...shift, alsoMoved: Math.max(0, gainers - 1) }
 }
@@ -386,7 +395,25 @@ function promptShareShift({
     return period.cells.reduce((sum, cell) => (cell.side === "prompt" ? sum + cell.tokens : sum), 0) / tokens
   }
   // Only two sides exist, so there is never another mover to count.
-  return { label: "prompt tokens", previousShare: shareOf(previous), currentShare: shareOf(current), alsoMoved: 0 }
+  return { label: "prompt tokens", currentShare: shareOf(current), alsoMoved: 0 }
+}
+
+/**
+ * What a token on one side costs across the whole period, in microcents.
+ *
+ * Blended over models, so it moves with model mix as well as with prices — fine as a
+ * standing figure, which is why only the current one is reported. Its *change* is not
+ * this factor's multiplier, and the two must never be shown as a pair.
+ */
+function sidePrice(period: SessionCostPeriod, side: TokenSide): number {
+  let tokens = 0
+  let cost = 0
+  for (const cell of period.cells) {
+    if (cell.side !== side) continue
+    tokens += cell.tokens
+    cost += cell.costMicrocents
+  }
+  return tokens > 0 ? cost / tokens : 0
 }
 
 const emptyResult = ({
@@ -445,29 +472,46 @@ export function decomposeCostPerSession(input: DecomposeCostPerSessionInput): Co
     (factor): SessionCostContribution => ({
       factor,
       multiplier: currentFactors[factor] / previousFactors[factor],
-      values: { previous: previousFactors[factor], current: currentFactors[factor] },
-      shareShift: null,
+      current: currentFactors[factor],
+      subject: null,
+      alsoMoved: 0,
     }),
   )
+  const destination = destinationShareShift({
+    previous: previousPositions,
+    current: currentPositions,
+    previousBlendedPrice: previousFactors.costPerToken,
+  })
+  const promptSide = promptShareShift({ previous, current })
   const priceRows: readonly SessionCostContribution[] = [
     {
       factor: "modelMix",
       multiplier: Math.exp(modelMixLog),
-      values: null,
-      shareShift: destinationShareShift({
-        previous: previousPositions,
-        current: currentPositions,
-        previousBlendedPrice: previousFactors.costPerToken,
-      }),
+      current: destination?.currentShare ?? 0,
+      subject: destination?.label ?? null,
+      alsoMoved: destination?.alsoMoved ?? 0,
     },
     {
       factor: "tokenMix",
       multiplier: Math.exp(tokenMixLog),
-      values: null,
-      shareShift: promptShareShift({ previous, current }),
+      current: promptSide.currentShare,
+      subject: promptSide.label,
+      alsoMoved: 0,
     },
-    { factor: "promptRate", multiplier: Math.exp(promptRateLog), values: null, shareShift: null },
-    { factor: "outputRate", multiplier: Math.exp(outputRateLog), values: null, shareShift: null },
+    {
+      factor: "promptRate",
+      multiplier: Math.exp(promptRateLog),
+      current: sidePrice(current, "prompt"),
+      subject: null,
+      alsoMoved: 0,
+    },
+    {
+      factor: "outputRate",
+      multiplier: Math.exp(outputRateLog),
+      current: sidePrice(current, "output"),
+      subject: null,
+      alsoMoved: 0,
+    },
   ]
 
   const ordered = [...volumeRows, ...priceRows].sort(

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
@@ -47,20 +47,22 @@ export type TokenSide = (typeof TOKEN_SIDES)[number]
 export const SESSION_COST_MIN_SESSIONS = 20
 
 /**
- * A factor whose multiplier is this close to 1 did not move. Matches the display
- * precision, so a row is folded away exactly when it would have read `x1.0`.
+ * A factor whose multiplier is this close to 1 did not move, so it renders as
+ * unchanged rather than as a movement. Matches the display precision: a factor is
+ * called still exactly when its multiplier would have read `x1.00`.
  */
 export const SESSION_COST_QUIET_BAND = 0.05
 
 /** Below this the cost is flat and the weights would divide by ~0, so nothing moved. */
 const FLAT_LOG_EPSILON = 1e-6
 
+// Share gain worth counting as a second mover. Under a point it is drift, and
+// counting it would report a broad shift where there was one.
+const SHARE_MOVE_FLOOR = 0.01
+
 // Sub-effects this close to cancelling each other out leave the factor they split
 // with no change to divide by, whatever their individual sizes.
 const NEGLIGIBLE_EFFECT_SHARE = 1e-9
-
-/** Displayed multipliers carry two decimals, and must still multiply to the total. */
-const DISPLAY_DECIMALS = 2
 
 /**
  * One (price list x token side) bucket. Splitting by provider as well as model
@@ -103,24 +105,31 @@ export const sessionCostTokens = (period: SessionCostPeriod): number =>
 export const sessionCostMicrocents = (period: SessionCostPeriod): number =>
   period.cells.reduce((sum, cell) => sum + cell.costMicrocents, 0)
 
-/** The share move behind a mix row, so an abstract factor still names something concrete. */
+/**
+ * A share move behind a mix row, so an abstract factor still names something concrete.
+ *
+ * `alsoMoved` counts the other price lists that gained share too. One named model
+ * reads as *the* cause, and on a broad shift — three models each taking ten points
+ * off a fourth — that is the wrong story, so the count has to be sayable.
+ */
 export interface SessionCostShareShift {
   readonly label: string
   readonly previousShare: number
   readonly currentShare: number
+  readonly alsoMoved: number
 }
 
 export interface SessionCostContribution {
-  /** Null on the folded row, which stands for several factors and so names none. */
-  readonly factor: SessionCostFactor | null
-  /** Multiplier on cost per session. Every row's multiplier multiplies to `totalMultiplier`. */
+  readonly factor: SessionCostFactor
+  /**
+   * Multiplier on cost per session, exact. Every row's multiplier multiplies to
+   * `totalMultiplier`; rounding for display is the caller's business.
+   */
   readonly multiplier: number
   /** Before and after in the factor's own unit. Null for the price sub-factors, which are not ratios. */
   readonly values: { readonly previous: number; readonly current: number } | null
   /** What moved, for a mix row that has no before/after value of its own. */
   readonly shareShift: SessionCostShareShift | null
-  /** How many quiet factors this row stands in for; 0 on a real factor. */
-  readonly foldedFactors: number
 }
 
 /**
@@ -139,11 +148,10 @@ export interface CostPerSessionDecomposition {
   /** `current / previous`, exact. The headline change is this figure. */
   readonly totalMultiplier: number | null
   /**
-   * What the rows' displayed multipliers multiply to, which is the total to print
-   * beneath them. A rounding step from `totalMultiplier` and never further.
+   * Every factor, always, largest move first. A factor that did not move still gets
+   * a row: the set of things the decomposition accounts for is part of what the card
+   * says, and a list that changes shape between periods hides it.
    */
-  readonly rowsMultiplyTo: number | null
-  /** Largest move first. Quiet factors are folded into one trailing row. */
   readonly rows: readonly SessionCostContribution[]
   /**
    * Session-count change, deliberately not a row: sessions are the denominator,
@@ -320,53 +328,6 @@ function allocate({
   return effects.map((effect) => (contribution * effect) / total)
 }
 
-const round = (value: number): number => {
-  const factor = 10 ** DISPLAY_DECIMALS
-  return Math.round(value * factor) / factor
-}
-
-/**
- * Rounds every multiplier to display precision and nudges the largest row toward
- * the true total, so the rows a reader multiplies land on the figure printed under
- * them. A decomposition whose rows do not reconcile reads as decoration.
- *
- * The product of the rounded rows is what that figure has to be: absorbing the
- * whole residual into one row cannot close the gap, because that row's own
- * rounding error is then multiplied by everything else on the card. So the
- * displayed total follows the rows rather than the rows chasing the total — which
- * leaves it a rounding step away from `totalMultiplier`, and the headline change
- * beside it carries the exact figure.
- */
-function reconcile({
-  rows,
-  totalMultiplier,
-}: {
-  readonly rows: readonly SessionCostContribution[]
-  readonly totalMultiplier: number
-}): { readonly rows: readonly SessionCostContribution[]; readonly rowsMultiplyTo: number } {
-  if (rows.length === 0) return { rows, rowsMultiplyTo: round(totalMultiplier) }
-  const rounded = rows.map((row) => ({ ...row, multiplier: round(row.multiplier) }))
-
-  let largest = 0
-  for (let index = 1; index < rounded.length; index++) {
-    const candidate = rounded[index]
-    const incumbent = rounded[largest]
-    if (candidate && incumbent && Math.abs(Math.log(candidate.multiplier)) > Math.abs(Math.log(incumbent.multiplier))) {
-      largest = index
-    }
-  }
-
-  const others = rounded.reduce((product, row, index) => (index === largest ? product : product * row.multiplier), 1)
-  const settled =
-    others === 0
-      ? rounded
-      : rounded.map((row, index) =>
-          index === largest ? { ...row, multiplier: round(round(totalMultiplier) / others) } : row,
-        )
-
-  return { rows: settled, rowsMultiplyTo: round(settled.reduce((product, row) => product * row.multiplier, 1)) }
-}
-
 /**
  * Where the tokens went: among the price lists that gained share, the one whose
  * gain moved the blended price most.
@@ -393,20 +354,22 @@ function destinationShareShift({
   readonly current: Positions
   readonly previousBlendedPrice: number
 }): SessionCostShareShift | null {
-  let shift: SessionCostShareShift | null = null
+  let shift: Omit<SessionCostShareShift, "alsoMoved"> | null = null
   let widestEffect = 0
+  let gainers = 0
   for (const key of new Set([...previous.models.keys(), ...current.models.keys()])) {
     const previousShare = previous.models.get(key)?.share ?? 0
     const currentShare = current.models.get(key)?.share ?? 0
     const gain = currentShare - previousShare
     if (gain <= 0) continue
+    if (gain >= SHARE_MOVE_FLOOR) gainers++
     const price = previous.models.get(key)?.averagePrice ?? previousBlendedPrice
     const effect = Math.abs(gain * (price - previousBlendedPrice))
     if (effect < widestEffect) continue
     widestEffect = effect
     shift = { label: key, previousShare, currentShare }
   }
-  return shift
+  return shift === null ? null : { ...shift, alsoMoved: Math.max(0, gainers - 1) }
 }
 
 /** Prompt is the readable half of the split: the cheap side's share of the tokens. */
@@ -422,7 +385,8 @@ function promptShareShift({
     if (tokens <= 0) return 0
     return period.cells.reduce((sum, cell) => (cell.side === "prompt" ? sum + cell.tokens : sum), 0) / tokens
   }
-  return { label: "prompt tokens", previousShare: shareOf(previous), currentShare: shareOf(current) }
+  // Only two sides exist, so there is never another mover to count.
+  return { label: "prompt tokens", previousShare: shareOf(previous), currentShare: shareOf(current), alsoMoved: 0 }
 }
 
 const emptyResult = ({
@@ -439,23 +403,9 @@ const emptyResult = ({
   currentCostPerSessionMicrocents: costPerSession(input.current),
   changePct,
   totalMultiplier: changePct === null ? null : changePct / 100 + 1,
-  rowsMultiplyTo: null,
   rows: [],
   volume: { previousSessions: input.previous.sessions, currentSessions: input.current.sessions },
 })
-
-/**
- * Folds the factors that did not move into one trailing row carrying their
- * combined multiplier, so the visible rows still multiply to the headline while
- * the card shows only what changed.
- */
-function foldQuietFactors(rows: readonly SessionCostContribution[]): readonly SessionCostContribution[] {
-  const moved = rows.filter((row) => Math.abs(row.multiplier - 1) >= SESSION_COST_QUIET_BAND)
-  const quiet = rows.filter((row) => Math.abs(row.multiplier - 1) < SESSION_COST_QUIET_BAND)
-  if (quiet.length === 0) return moved
-  const combined = quiet.reduce((product, row) => product * row.multiplier, 1)
-  return [...moved, { factor: null, multiplier: combined, values: null, shareShift: null, foldedFactors: quiet.length }]
-}
 
 export function decomposeCostPerSession(input: DecomposeCostPerSessionInput): CostPerSessionDecomposition {
   const { previous, current } = input
@@ -497,7 +447,6 @@ export function decomposeCostPerSession(input: DecomposeCostPerSessionInput): Co
       multiplier: currentFactors[factor] / previousFactors[factor],
       values: { previous: previousFactors[factor], current: currentFactors[factor] },
       shareShift: null,
-      foldedFactors: 0,
     }),
   )
   const priceRows: readonly SessionCostContribution[] = [
@@ -510,17 +459,15 @@ export function decomposeCostPerSession(input: DecomposeCostPerSessionInput): Co
         current: currentPositions,
         previousBlendedPrice: previousFactors.costPerToken,
       }),
-      foldedFactors: 0,
     },
     {
       factor: "tokenMix",
       multiplier: Math.exp(tokenMixLog),
       values: null,
       shareShift: promptShareShift({ previous, current }),
-      foldedFactors: 0,
     },
-    { factor: "promptRate", multiplier: Math.exp(promptRateLog), values: null, shareShift: null, foldedFactors: 0 },
-    { factor: "outputRate", multiplier: Math.exp(outputRateLog), values: null, shareShift: null, foldedFactors: 0 },
+    { factor: "promptRate", multiplier: Math.exp(promptRateLog), values: null, shareShift: null },
+    { factor: "outputRate", multiplier: Math.exp(outputRateLog), values: null, shareShift: null },
   ]
 
   const ordered = [...volumeRows, ...priceRows].sort(
@@ -533,7 +480,7 @@ export function decomposeCostPerSession(input: DecomposeCostPerSessionInput): Co
     currentCostPerSessionMicrocents: currentCost,
     changePct,
     totalMultiplier,
-    ...reconcile({ rows: foldQuietFactors(ordered), totalMultiplier }),
+    rows: ordered,
     volume: { previousSessions: previous.sessions, currentSessions: current.sessions },
   }
 }

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
@@ -270,9 +270,11 @@ interface PriceEffects {
  * per-side prices, so growing the prompt while output holds shows up here rather
  * than as a rate cut. What is left is the two sides' prices actually changing.
  *
- * A price list with no previous tokens is baselined at the previous blended price,
- * and its side split at its current one, so a brand-new model contributes to mix
- * and not to either rate.
+ * A price list with no previous tokens is baselined at the previous blended price, and
+ * its side split at its current one. So taking share is mix-neutral for it and it adds
+ * nothing to `tokenMix`, while however far its own prices sit from that old blend lands
+ * on the rate factors — a new model is only a "price change" to the extent it costs
+ * something other than what the traffic used to average.
  */
 function priceEffects({
   previous,

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
@@ -1,0 +1,332 @@
+/**
+ * Why average cost per session moved, as contributions in percentage points that
+ * add up to the move itself.
+ *
+ * Cost per session is a product — `turns/session x steps/turn x tokens/step x
+ * price/token` — and a product decomposes exactly in log space: each factor's
+ * share of `ln(C_c / C_p)` is its share of the change, with no regression and no
+ * double counting. A correlation would attribute the same rise twice, since
+ * tokens grow with turns.
+ *
+ * Nothing here reads a repository or the pricing registry: every input is a
+ * number, so the whole thing is exhaustively testable and safe for the browser
+ * entry. It is also the shape the API/MCP surface will expose, so it must stay
+ * independent of how the rows are rendered.
+ */
+
+/**
+ * `turnsPerSession`, `stepsPerTurn` and `tokensPerStep` are the volume factors —
+ * how much work a session does. The last three are all price: `modelMix` is
+ * which models the tokens went to, `cacheEfficiency` is how much of the prompt
+ * was charged at the read rate, and `pricePerToken` is whatever within-model
+ * rate change is left after those two.
+ */
+const SESSION_COST_FACTORS = [
+  "turnsPerSession",
+  "stepsPerTurn",
+  "tokensPerStep",
+  "modelMix",
+  "cacheEfficiency",
+  "pricePerToken",
+] as const
+export type SessionCostFactor = (typeof SESSION_COST_FACTORS)[number]
+
+/**
+ * Sessions a period needs before its cost per session may be compared to another
+ * period's. Below this one expensive session moves the average by tens of points,
+ * so the decomposition would be arithmetic over noise — the same trap the
+ * breakdown table's `278x avg` chip fell into.
+ */
+export const SESSION_COST_MIN_SESSIONS = 20
+
+// Below this the cost is flat and the weights would divide by ~0, so every row reads 0.
+const SESSION_COST_FLAT_LOG_EPSILON = 1e-6
+
+// Sub-effects this close to cancelling each other out leave the factor they split
+// with no change to divide by, whatever their individual sizes.
+const NEGLIGIBLE_EFFECT_SHARE = 1e-9
+
+/** Per price-list, so the same model slug served by two providers is two entries. */
+export interface SessionCostModelSlice {
+  readonly provider: string
+  readonly model: string
+  readonly tokens: number
+  readonly costMicrocents: number
+}
+
+/**
+ * One period's raw counts. `sessions` counts the session key the rollups use —
+ * `session_id` where present, the trace id otherwise — so traffic that reported
+ * no session id is a single-trace pseudo-session rather than being dropped.
+ * `traceKeyedSessions` is how many of them are that, which is what lets the
+ * caller say so instead of quietly renaming cost per trace.
+ */
+export interface SessionCostPeriod {
+  readonly sessions: number
+  readonly traceKeyedSessions: number
+  /** Traces with a billable call: one turn of a conversation. */
+  readonly turns: number
+  /** Billable LLM calls: the steps a single turn took. */
+  readonly steps: number
+  readonly tokens: number
+  readonly costMicrocents: number
+  /** Calls whose model has no known pricing, so this period's cost is understated. */
+  readonly unpricedCalls: number
+  readonly models: readonly SessionCostModelSlice[]
+}
+
+export interface SessionCostContribution {
+  readonly factor: SessionCostFactor
+  /** Percentage points of the headline change, rounded so the rows sum to it exactly. */
+  readonly points: number
+  /** The factor's own before/after values, absent for the price sub-factors, which are not ratios. */
+  readonly values: { readonly previous: number; readonly current: number } | null
+}
+
+/**
+ * `notEnoughData` means no comparison is possible and only the headline should
+ * render; `flat` means the comparison held still, which is a real answer and not
+ * an error. Both leave `rows` empty rather than shipping zeros that look measured.
+ */
+export type SessionCostDecompositionStatus = "ok" | "flat" | "notEnoughData"
+
+export interface CostPerSessionDecomposition {
+  readonly status: SessionCostDecompositionStatus
+  readonly previousCostPerSessionMicrocents: number
+  readonly currentCostPerSessionMicrocents: number
+  /** Null when the periods cannot be compared. Unrounded; `totalPoints` is what the rows sum to. */
+  readonly changePct: number | null
+  /** The headline change as shown, to the whole point. Every row's `points` sums to this. */
+  readonly totalPoints: number
+  /** Largest contribution first, so the row that explains the move reads first. */
+  readonly rows: readonly SessionCostContribution[]
+  /**
+   * Session-count change, deliberately not a row: sessions are the denominator,
+   * so growth in them does not move cost per session at all. Shown as context
+   * because "we are simply busier" is the one cost story that is good news.
+   */
+  readonly volume: { readonly previousSessions: number; readonly currentSessions: number }
+}
+
+export interface DecomposeCostPerSessionInput {
+  readonly previous: SessionCostPeriod
+  readonly current: SessionCostPeriod
+  /**
+   * Change in price per token attributable to cache efficiency, in microcents per
+   * token, signed the same way as the mix and rate effects. Its own row when
+   * supplied; folded into `pricePerToken` when not.
+   */
+  readonly cacheEfficiencyEffect?: number | undefined
+}
+
+const costPerSession = (period: SessionCostPeriod): number =>
+  period.sessions > 0 ? period.costMicrocents / period.sessions : 0
+
+interface Factors {
+  readonly turnsPerSession: number
+  readonly stepsPerTurn: number
+  readonly tokensPerStep: number
+  readonly pricePerToken: number
+}
+
+/** Null when any denominator is empty, which is what makes the whole product unusable. */
+function factorsOf(period: SessionCostPeriod): Factors | null {
+  if (period.sessions <= 0 || period.turns <= 0 || period.steps <= 0 || period.tokens <= 0) return null
+  if (period.costMicrocents <= 0) return null
+  return {
+    turnsPerSession: period.turns / period.sessions,
+    stepsPerTurn: period.steps / period.turns,
+    tokensPerStep: period.tokens / period.steps,
+    pricePerToken: period.costMicrocents / period.tokens,
+  }
+}
+
+const priceListKey = (slice: SessionCostModelSlice): string => `${slice.provider}/${slice.model}`
+
+interface ModelPosition {
+  readonly share: number
+  readonly price: number
+}
+
+const positionsOf = (period: SessionCostPeriod): Map<string, ModelPosition> => {
+  const positions = new Map<string, ModelPosition>()
+  for (const slice of period.models) {
+    if (slice.tokens <= 0) continue
+    positions.set(priceListKey(slice), {
+      share: slice.tokens / period.tokens,
+      price: slice.costMicrocents / slice.tokens,
+    })
+  }
+  return positions
+}
+
+/**
+ * How much of the price move came from tokens shifting between price lists rather
+ * than from any price changing: `sum((share_c - share_p) * price_p)`.
+ *
+ * A price list with no previous tokens is baselined at the previous period's
+ * blended price, so simply routing traffic somewhere new is mix-neutral and only
+ * that destination's deviation from the old average shows up as a rate change.
+ */
+function modelMixEffect({
+  previous,
+  current,
+  previousBlendedPrice,
+}: {
+  readonly previous: Map<string, ModelPosition>
+  readonly current: Map<string, ModelPosition>
+  readonly previousBlendedPrice: number
+}): number {
+  let effect = 0
+  for (const key of new Set([...previous.keys(), ...current.keys()])) {
+    const previousPosition = previous.get(key)
+    const shareDelta = (current.get(key)?.share ?? 0) - (previousPosition?.share ?? 0)
+    effect += shareDelta * (previousPosition?.price ?? previousBlendedPrice)
+  }
+  return effect
+}
+
+/**
+ * Splits one factor's contribution across sub-effects that sum to the factor's own
+ * change, so the parts still add up to the whole. When the change is negligible
+ * next to the sub-effects — a mix shift cancelled by a rate move — the factor
+ * contributed nothing, and an even split keeps every part at that same nothing
+ * instead of dividing by it.
+ */
+function allocate({
+  contribution,
+  effects,
+}: {
+  readonly contribution: number
+  readonly effects: readonly number[]
+}): readonly number[] {
+  const total = effects.reduce((sum, effect) => sum + effect, 0)
+  const magnitude = effects.reduce((sum, effect) => sum + Math.abs(effect), 0)
+  if (total === 0 || Math.abs(total) <= NEGLIGIBLE_EFFECT_SHARE * magnitude) {
+    return effects.map(() => contribution / effects.length)
+  }
+  return effects.map((effect) => (contribution * effect) / total)
+}
+
+/**
+ * Whole points that still sum to the headline. The residual lands on the largest
+ * contribution, where a one-point adjustment is proportionally smallest — if the
+ * rows do not add up to the number above them, the card reads as decoration.
+ */
+function toWholePoints({
+  raw,
+  totalPoints,
+}: {
+  readonly raw: readonly { readonly factor: SessionCostFactor; readonly value: number }[]
+  readonly totalPoints: number
+}): readonly { readonly factor: SessionCostFactor; readonly points: number; readonly value: number }[] {
+  const rounded = raw.map((entry) => ({ ...entry, points: Math.round(entry.value) }))
+  const residual = totalPoints - rounded.reduce((sum, entry) => sum + entry.points, 0)
+  if (residual === 0 || rounded.length === 0) return rounded
+
+  let largest = 0
+  for (let index = 1; index < rounded.length; index++) {
+    const candidate = rounded[index]
+    const incumbent = rounded[largest]
+    if (candidate && incumbent && Math.abs(candidate.value) > Math.abs(incumbent.value)) largest = index
+  }
+  return rounded.map((entry, index) => (index === largest ? { ...entry, points: entry.points + residual } : entry))
+}
+
+const emptyResult = ({
+  status,
+  input,
+  changePct,
+}: {
+  readonly status: SessionCostDecompositionStatus
+  readonly input: DecomposeCostPerSessionInput
+  readonly changePct: number | null
+}): CostPerSessionDecomposition => ({
+  status,
+  previousCostPerSessionMicrocents: costPerSession(input.previous),
+  currentCostPerSessionMicrocents: costPerSession(input.current),
+  changePct,
+  totalPoints: changePct === null ? 0 : Math.round(changePct),
+  rows: [],
+  volume: { previousSessions: input.previous.sessions, currentSessions: input.current.sessions },
+})
+
+export function decomposeCostPerSession(input: DecomposeCostPerSessionInput): CostPerSessionDecomposition {
+  const { previous, current, cacheEfficiencyEffect } = input
+  const previousFactors = factorsOf(previous)
+  const currentFactors = factorsOf(current)
+  const previousCost = costPerSession(previous)
+  const currentCost = costPerSession(current)
+
+  if (
+    !previousFactors ||
+    !currentFactors ||
+    previous.sessions < SESSION_COST_MIN_SESSIONS ||
+    current.sessions < SESSION_COST_MIN_SESSIONS
+  ) {
+    return emptyResult({ status: "notEnoughData", input, changePct: null })
+  }
+
+  const changePct = (currentCost / previousCost - 1) * 100
+  const totalLog = Math.log(currentCost / previousCost)
+  if (Math.abs(totalLog) < SESSION_COST_FLAT_LOG_EPSILON) return emptyResult({ status: "flat", input, changePct })
+
+  const totalPoints = Math.round(changePct)
+  const contributionOf = (factor: keyof Factors): number =>
+    (Math.log(currentFactors[factor] / previousFactors[factor]) / totalLog) * changePct
+
+  const priceContribution = contributionOf("pricePerToken")
+  const mixEffect = modelMixEffect({
+    previous: positionsOf(previous),
+    current: positionsOf(current),
+    previousBlendedPrice: previousFactors.pricePerToken,
+  })
+  const cacheEffect = cacheEfficiencyEffect ?? 0
+  // The rate effect is the remainder rather than its own sum, so the three price
+  // sub-effects always close on the price change however the cache one is defined.
+  const rateEffect = currentFactors.pricePerToken - previousFactors.pricePerToken - mixEffect - cacheEffect
+  const priceEffects =
+    cacheEfficiencyEffect === undefined ? [mixEffect, rateEffect] : [mixEffect, cacheEffect, rateEffect]
+  const priceParts = allocate({ contribution: priceContribution, effects: priceEffects })
+
+  const values = (factor: keyof Factors): { previous: number; current: number } => ({
+    previous: previousFactors[factor],
+    current: currentFactors[factor],
+  })
+  const valuesByFactor = new Map<SessionCostFactor, { previous: number; current: number }>([
+    ["turnsPerSession", values("turnsPerSession")],
+    ["stepsPerTurn", values("stepsPerTurn")],
+    ["tokensPerStep", values("tokensPerStep")],
+  ])
+
+  const raw: { readonly factor: SessionCostFactor; readonly value: number }[] = [
+    { factor: "turnsPerSession", value: contributionOf("turnsPerSession") },
+    { factor: "stepsPerTurn", value: contributionOf("stepsPerTurn") },
+    { factor: "tokensPerStep", value: contributionOf("tokensPerStep") },
+    { factor: "modelMix", value: priceParts[0] ?? 0 },
+    ...(cacheEfficiencyEffect === undefined
+      ? []
+      : [{ factor: "cacheEfficiency" as SessionCostFactor, value: priceParts[1] ?? 0 }]),
+    { factor: "pricePerToken", value: priceParts[priceParts.length - 1] ?? 0 },
+  ]
+
+  const rows = toWholePoints({ raw, totalPoints })
+    .map(
+      (entry): SessionCostContribution => ({
+        factor: entry.factor,
+        points: entry.points,
+        values: valuesByFactor.get(entry.factor) ?? null,
+      }),
+    )
+    .sort((a, b) => Math.abs(b.points) - Math.abs(a.points))
+
+  return {
+    status: "ok",
+    previousCostPerSessionMicrocents: previousCost,
+    currentCostPerSessionMicrocents: currentCost,
+    changePct,
+    totalPoints,
+    rows,
+    volume: { previousSessions: previous.sessions, currentSessions: current.sessions },
+  }
+}

--- a/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
+++ b/packages/domain/spans/src/helpers/decompose-cost-per-session.ts
@@ -367,24 +367,43 @@ function reconcile({
   return { rows: settled, rowsMultiplyTo: round(settled.reduce((product, row) => product * row.multiplier, 1)) }
 }
 
-/** The model whose token share moved most, so the mix row names a cause. */
-function dominantShareShift({
+/**
+ * Where the tokens went: among the price lists that gained share, the one whose
+ * gain moved the blended price most.
+ *
+ * Two decisions, both about how the row reads. Only gainers are eligible, because
+ * naming whichever model moved furthest tends to name the one traffic drained *out*
+ * of — a falling share printed beside a rising multiplier, which the reader has to
+ * mentally invert. And gainers are ranked by `share moved x how far the price sits
+ * from the blend`, not by share alone: taking a tenth of the traffic to a model at
+ * triple the average price outweighs taking a third of it to one at average, and it
+ * is the former that explains the row.
+ *
+ * A model absent from the previous period has no price of its own to judge, so it
+ * is treated as having sat at the blend — mix-neutral, matching `priceEffects`.
+ *
+ * Null when nothing gained, which means no share moved and the row is quiet anyway.
+ */
+function destinationShareShift({
   previous,
   current,
+  previousBlendedPrice,
 }: {
   readonly previous: Positions
   readonly current: Positions
+  readonly previousBlendedPrice: number
 }): SessionCostShareShift | null {
   let shift: SessionCostShareShift | null = null
-  let widest = 0
+  let widestEffect = 0
   for (const key of new Set([...previous.models.keys(), ...current.models.keys()])) {
     const previousShare = previous.models.get(key)?.share ?? 0
     const currentShare = current.models.get(key)?.share ?? 0
-    const move = Math.abs(currentShare - previousShare)
-    // A swap moves both models equally; the one that gained share names the cause.
-    const incumbentLost = shift !== null && shift.currentShare < shift.previousShare
-    if (move < widest || (move === widest && !(currentShare > previousShare && incumbentLost))) continue
-    widest = move
+    const gain = currentShare - previousShare
+    if (gain <= 0) continue
+    const price = previous.models.get(key)?.averagePrice ?? previousBlendedPrice
+    const effect = Math.abs(gain * (price - previousBlendedPrice))
+    if (effect < widestEffect) continue
+    widestEffect = effect
     shift = { label: key, previousShare, currentShare }
   }
   return shift
@@ -486,7 +505,11 @@ export function decomposeCostPerSession(input: DecomposeCostPerSessionInput): Co
       factor: "modelMix",
       multiplier: Math.exp(modelMixLog),
       values: null,
-      shareShift: dominantShareShift({ previous: previousPositions, current: currentPositions }),
+      shareShift: destinationShareShift({
+        previous: previousPositions,
+        current: currentPositions,
+        previousBlendedPrice: previousFactors.costPerToken,
+      }),
       foldedFactors: 0,
     },
     {

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -115,13 +115,22 @@ export {
 export type {
   CostPerSessionDecomposition,
   DecomposeCostPerSessionInput,
+  SessionCostCell,
   SessionCostContribution,
   SessionCostDecompositionStatus,
   SessionCostFactor,
-  SessionCostModelSlice,
   SessionCostPeriod,
+  SessionCostShareShift,
+  TokenSide,
 } from "./helpers/decompose-cost-per-session.ts"
-export { decomposeCostPerSession, SESSION_COST_MIN_SESSIONS } from "./helpers/decompose-cost-per-session.ts"
+export {
+  decomposeCostPerSession,
+  SESSION_COST_MIN_SESSIONS,
+  SESSION_COST_QUIET_BAND,
+  sessionCostMicrocents,
+  sessionCostTokens,
+  TOKEN_SIDES,
+} from "./helpers/decompose-cost-per-session.ts"
 export { resolveSpanCost, usdToMicrocents } from "./helpers/estimate-span-cost.ts"
 export type { CacheModelJudgment, JudgedCacheModel } from "./helpers/judge-cache-economics.ts"
 export { judgeCacheEconomics, promptCacheTtlSeconds } from "./helpers/judge-cache-economics.ts"
@@ -201,6 +210,7 @@ export type {
   ModelUsageMeasures,
   ModelUsageSeries,
   ModelUsageSlice,
+  SessionCostBucket,
   SessionCostFactorsPair,
   SessionCostFactorsScope,
 } from "./ports/cost-analytics-repository.ts"

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -112,6 +112,16 @@ export {
   summarizeUnpricedUsage,
   UNPRICED_CAUSES,
 } from "./helpers/classify-unpriced-cost.ts"
+export type {
+  CostPerSessionDecomposition,
+  DecomposeCostPerSessionInput,
+  SessionCostContribution,
+  SessionCostDecompositionStatus,
+  SessionCostFactor,
+  SessionCostModelSlice,
+  SessionCostPeriod,
+} from "./helpers/decompose-cost-per-session.ts"
+export { decomposeCostPerSession, SESSION_COST_MIN_SESSIONS } from "./helpers/decompose-cost-per-session.ts"
 export { resolveSpanCost, usdToMicrocents } from "./helpers/estimate-span-cost.ts"
 export type { CacheModelJudgment, JudgedCacheModel } from "./helpers/judge-cache-economics.ts"
 export { judgeCacheEconomics, promptCacheTtlSeconds } from "./helpers/judge-cache-economics.ts"
@@ -191,6 +201,8 @@ export type {
   ModelUsageMeasures,
   ModelUsageSeries,
   ModelUsageSlice,
+  SessionCostFactorsPair,
+  SessionCostFactorsScope,
 } from "./ports/cost-analytics-repository.ts"
 export {
   CACHE_ECONOMICS_ROW_LIMIT,

--- a/packages/domain/spans/src/ports/cost-analytics-repository.ts
+++ b/packages/domain/spans/src/ports/cost-analytics-repository.ts
@@ -1,6 +1,7 @@
 import type { ChSqlClient, OrganizationId, ProjectId, RepositoryError } from "@domain/shared"
 import { Context, type Effect } from "effect"
 import type { CostSource } from "../entities/span.ts"
+import type { SessionCostPeriod } from "../helpers/decompose-cost-per-session.ts"
 
 /**
  * Repository port for cost analytics (ClickHouse spans table).
@@ -58,6 +59,15 @@ export interface CostAnalyticsRepositoryShape {
    * pay a round trip per lifetime.
    */
   getCacheEconomics(input: CostAnalyticsScope): Effect.Effect<CacheEconomics, RepositoryError, ChSqlClient>
+
+  /**
+   * The counts behind cost per session for two adjacent windows, so the log-space
+   * decomposition can be computed from one scan rather than from two round trips
+   * that could disagree about their filters.
+   */
+  getSessionCostFactors(
+    input: SessionCostFactorsScope,
+  ): Effect.Effect<SessionCostFactorsPair, RepositoryError, ChSqlClient>
 }
 
 export interface CostAnalyticsScope {
@@ -272,6 +282,20 @@ export interface CacheEconomics {
    */
   readonly cadence: readonly CacheCadenceRow[]
   readonly totals: CacheUsageMeasures & { readonly distinctModels: number }
+}
+
+/**
+ * `from`/`to` bound the current window; `previousFrom` opens the comparison window
+ * that runs up to `from`. The caller sets the two lengths equal — the repository
+ * only reads the bounds it is given.
+ */
+export interface SessionCostFactorsScope extends CostAnalyticsScope {
+  readonly previousFrom: Date
+}
+
+export interface SessionCostFactorsPair {
+  readonly previous: SessionCostPeriod
+  readonly current: SessionCostPeriod
 }
 
 export interface CostModelSpend {

--- a/packages/domain/spans/src/ports/cost-analytics-repository.ts
+++ b/packages/domain/spans/src/ports/cost-analytics-repository.ts
@@ -291,11 +291,26 @@ export interface CacheEconomics {
  */
 export interface SessionCostFactorsScope extends CostAnalyticsScope {
   readonly previousFrom: Date
+  /** Bucket width for the headline sparklines, which span both windows. */
+  readonly bucketSeconds: number
+}
+
+/**
+ * One sparkline point. Only the two headline measures: a session count is a clean
+ * series, whereas a per-bucket ratio of two small counts swings on volume alone and
+ * would read as an event rather than as noise.
+ */
+export interface SessionCostBucket {
+  readonly bucketStart: Date
+  readonly sessions: number
+  readonly costMicrocents: number
 }
 
 export interface SessionCostFactorsPair {
   readonly previous: SessionCostPeriod
   readonly current: SessionCostPeriod
+  /** Both windows, oldest first. */
+  readonly buckets: readonly SessionCostBucket[]
 }
 
 export interface CostModelSpend {

--- a/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.ts
@@ -18,6 +18,8 @@ import type {
   ModelUsageBucket,
   ModelUsageSeries,
   ModelUsageSlice,
+  SessionCostFactorsPair,
+  SessionCostPeriod,
 } from "@domain/spans"
 import {
   CACHE_CEILING_LIFETIME_SECONDS,
@@ -52,6 +54,12 @@ const SCOPE_FILTER = `organization_id = {organizationId:String}
 // dedup by span_id: same convention as the other span aggregates.
 const BILLABLE_FILTER = `${SCOPE_FILTER}
   AND operation IN ${USAGE_OPERATIONS_SQL}`
+
+// Same prefix, opened back to the comparison window so both periods come off one scan.
+const SCOPE_PREVIOUS_FILTER = `organization_id = {organizationId:String}
+  AND project_id = {projectId:String}
+  AND start_time >= {previousFrom:DateTime64(9, 'UTC')}
+  AND start_time < {to:DateTime64(9, 'UTC')}`
 
 const COST_SOURCE_VALUES_SQL = `(${costSourceSchema.options.map((value) => `'${value}'`).join(", ")})`
 
@@ -164,6 +172,27 @@ const CACHE_CADENCE_SOURCE = `SELECT
         WHERE ${BILLABLE_FILTER}
       )`
 
+// The session key the traces/sessions rollups aggregate on. Traffic that reported
+// no session id keys on its trace id instead, so it becomes a single-trace
+// pseudo-session rather than dropping out of every per-session figure.
+const SESSION_KEY = `coalesce(nullIf(session_id, ''), toString(trace_id))`
+
+// Splits one scan into the two adjacent windows. `is_current` is the bound the
+// spans filter already narrowed to, so both periods read identical filters.
+const SESSION_FACTORS_SOURCE = `SELECT
+        start_time >= {from:DateTime64(9, 'UTC')} AS is_current,
+        ${SESSION_KEY} AS session_key,
+        session_id,
+        trace_id,
+        provider,
+        model,
+        tokens_total,
+        cost_total_microcents,
+        ${COST_SOURCE} AS cost_source
+      FROM spans
+      WHERE ${SCOPE_PREVIOUS_FILTER}
+        AND operation IN ${USAGE_OPERATIONS_SQL}`
+
 const BUCKET_START = `toDateTime(
   intDiv(toUnixTimestamp(start_time), {bucketSeconds:UInt32}) * {bucketSeconds:UInt32},
   'UTC'
@@ -271,6 +300,61 @@ const CACHE_CADENCE_BUCKETS = CACHE_CEILING_LIFETIME_SECONDS.map(
     `sumIf(call_tokens, gap_seconds <= ${lifetimeSeconds}) AS ${cadenceBucketAlias(lifetimeSeconds)},
         countIf(gap_seconds <= ${lifetimeSeconds}) AS ${cadenceCallsAlias(lifetimeSeconds)}`,
 ).join(",\n        ")
+
+type SessionFactorsRow = {
+  is_current: number
+  sessions: string
+  trace_keyed_sessions: string
+  turns: string
+  steps: string
+  tokens: string
+  cost_microcents: string
+  unpriced_calls: string
+}
+
+type SessionFactorsModelRow = {
+  is_current: number
+  provider: string
+  model: string
+  tokens: string
+  cost_microcents: string
+}
+
+const EMPTY_SESSION_PERIOD: SessionCostPeriod = {
+  sessions: 0,
+  traceKeyedSessions: 0,
+  turns: 0,
+  steps: 0,
+  tokens: 0,
+  costMicrocents: 0,
+  unpricedCalls: 0,
+  models: [],
+}
+
+const toSessionPeriod = ({
+  row,
+  models,
+}: {
+  row: SessionFactorsRow | undefined
+  models: readonly SessionFactorsModelRow[]
+}): SessionCostPeriod =>
+  row === undefined
+    ? EMPTY_SESSION_PERIOD
+    : {
+        sessions: num(row.sessions),
+        traceKeyedSessions: num(row.trace_keyed_sessions),
+        turns: num(row.turns),
+        steps: num(row.steps),
+        tokens: num(row.tokens),
+        costMicrocents: num(row.cost_microcents),
+        unpricedCalls: num(row.unpriced_calls),
+        models: models.map((slice) => ({
+          provider: normalizeCHString(slice.provider),
+          model: normalizeCHString(slice.model),
+          tokens: num(slice.tokens),
+          costMicrocents: num(slice.cost_microcents),
+        })),
+      }
 
 type ModelUsageMeasuresDraft = { cost: number; tokens: number }
 
@@ -761,6 +845,62 @@ export const CostAnalyticsRepositoryLive = Layer.effect(
                   },
                 }),
               ),
+            )
+        }),
+
+      getSessionCostFactors: (input) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const params = { ...scopeParams(input), previousFrom: formatCHDate(input.previousFrom) }
+              const [countsResult, modelsResult] = await Promise.all([
+                client.query({
+                  // A session straddling the boundary counts in both periods, the
+                  // same convention the per-trace series uses for bucket edges.
+                  query: `SELECT
+                        is_current,
+                        uniqExact(session_key) AS sessions,
+                        uniqExactIf(session_key, session_id = '') AS trace_keyed_sessions,
+                        uniqExact(trace_id) AS turns,
+                        count() AS steps,
+                        sum(tokens_total) AS tokens,
+                        sum(cost_total_microcents) AS cost_microcents,
+                        countIf(cost_source IN ('unpriced', 'unknown')) AS unpriced_calls
+                      FROM (${SESSION_FACTORS_SOURCE})
+                      GROUP BY is_current`,
+                  query_params: params,
+                  format: "JSONEachRow",
+                }),
+                client.query({
+                  // Never truncated: the mix and rate effects are shares of the
+                  // whole, so a missing price list would silently land in the wrong row.
+                  query: `SELECT
+                        is_current,
+                        provider,
+                        model,
+                        sum(tokens_total) AS tokens,
+                        sum(cost_total_microcents) AS cost_microcents
+                      FROM (${SESSION_FACTORS_SOURCE})
+                      GROUP BY is_current, provider, model
+                      HAVING tokens > 0`,
+                  query_params: params,
+                  format: "JSONEachRow",
+                }),
+              ])
+              const countRows = await countsResult.json<SessionFactorsRow>()
+              const modelRows = await modelsResult.json<SessionFactorsModelRow>()
+              return { countRows, modelRows }
+            })
+            .pipe(
+              Effect.map(({ countRows, modelRows }): SessionCostFactorsPair => {
+                const periodOf = (isCurrent: boolean) =>
+                  toSessionPeriod({
+                    row: countRows.find((row) => Boolean(row.is_current) === isCurrent),
+                    models: modelRows.filter((row) => Boolean(row.is_current) === isCurrent),
+                  })
+                return { previous: periodOf(false), current: periodOf(true) }
+              }),
             )
         }),
     }

--- a/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.ts
@@ -18,8 +18,10 @@ import type {
   ModelUsageBucket,
   ModelUsageSeries,
   ModelUsageSlice,
+  SessionCostCell,
   SessionCostFactorsPair,
   SessionCostPeriod,
+  TokenSide,
 } from "@domain/spans"
 import {
   CACHE_CEILING_LIFETIME_SECONDS,
@@ -179,14 +181,24 @@ const SESSION_KEY = `coalesce(nullIf(session_id, ''), toString(trace_id))`
 
 // Splits one scan into the two adjacent windows. `is_current` is the bound the
 // spans filter already narrowed to, so both periods read identical filters.
+//
+// The prompt side carries cache reads and writes because providers charge them on
+// the input side, and `tokens_input` is the uncached remainder — the three are
+// additive. Prompt cost is `total - output` rather than `cost_input` so the two
+// sides always close on the total: a provider-reported total need not equal the
+// sum of the sides it reports, and the price decomposition cannot absorb a gap.
 const SESSION_FACTORS_SOURCE = `SELECT
+        start_time,
         start_time >= {from:DateTime64(9, 'UTC')} AS is_current,
         ${SESSION_KEY} AS session_key,
         session_id,
         trace_id,
         provider,
         model,
-        tokens_total,
+        tokens_input + tokens_cache_read + tokens_cache_create AS prompt_tokens,
+        tokens_output + tokens_reasoning AS output_tokens,
+        cost_total_microcents - cost_output_microcents AS prompt_cost,
+        cost_output_microcents AS output_cost,
         cost_total_microcents,
         ${COST_SOURCE} AS cost_source
       FROM spans
@@ -301,59 +313,71 @@ const CACHE_CADENCE_BUCKETS = CACHE_CEILING_LIFETIME_SECONDS.map(
         countIf(gap_seconds <= ${lifetimeSeconds}) AS ${cadenceCallsAlias(lifetimeSeconds)}`,
 ).join(",\n        ")
 
+// `is_period` marks the WITH ROLLUP subtotal, which carries the window's own
+// `uniqExact` rather than a sum of the buckets' — a session straddling a bucket
+// edge belongs to one window but to two buckets, so the counts do not add up.
 type SessionFactorsRow = {
+  is_period: number
+  is_everything: number
   is_current: number
+  bucket_start: string
   sessions: string
   trace_keyed_sessions: string
-  turns: string
-  steps: string
-  tokens: string
-  cost_microcents: string
+  traces: string
+  calls: string
   unpriced_calls: string
+  cost_microcents: string
 }
 
-type SessionFactorsModelRow = {
+type SessionFactorsCellRow = {
   is_current: number
   provider: string
   model: string
-  tokens: string
-  cost_microcents: string
+  prompt_tokens: string
+  prompt_cost: string
+  output_tokens: string
+  output_cost: string
 }
 
 const EMPTY_SESSION_PERIOD: SessionCostPeriod = {
   sessions: 0,
   traceKeyedSessions: 0,
-  turns: 0,
-  steps: 0,
-  tokens: 0,
-  costMicrocents: 0,
+  traces: 0,
+  calls: 0,
   unpricedCalls: 0,
-  models: [],
+  cells: [],
 }
+
+const toSessionCells = (rows: readonly SessionFactorsCellRow[]): SessionCostCell[] =>
+  rows.flatMap((row) => {
+    const provider = normalizeCHString(row.provider)
+    const model = normalizeCHString(row.model)
+    return (
+      [
+        { side: "prompt" as const, tokens: num(row.prompt_tokens), costMicrocents: num(row.prompt_cost) },
+        { side: "output" as const, tokens: num(row.output_tokens), costMicrocents: num(row.output_cost) },
+      ] satisfies { side: TokenSide; tokens: number; costMicrocents: number }[]
+    )
+      .filter((cell) => cell.tokens > 0)
+      .map((cell) => ({ provider, model, ...cell }))
+  })
 
 const toSessionPeriod = ({
   row,
-  models,
+  cells,
 }: {
   row: SessionFactorsRow | undefined
-  models: readonly SessionFactorsModelRow[]
+  cells: readonly SessionFactorsCellRow[]
 }): SessionCostPeriod =>
   row === undefined
     ? EMPTY_SESSION_PERIOD
     : {
         sessions: num(row.sessions),
         traceKeyedSessions: num(row.trace_keyed_sessions),
-        turns: num(row.turns),
-        steps: num(row.steps),
-        tokens: num(row.tokens),
-        costMicrocents: num(row.cost_microcents),
+        traces: num(row.traces),
+        calls: num(row.calls),
         unpricedCalls: num(row.unpriced_calls),
-        models: models.map((slice) => ({
-          provider: normalizeCHString(slice.provider),
-          model: normalizeCHString(slice.model),
-          tokens: num(slice.tokens),
-          costMicrocents: num(slice.cost_microcents),
-        })),
+        cells: toSessionCells(cells),
       }
 
 type ModelUsageMeasuresDraft = { cost: number; tokens: number }
@@ -853,22 +877,32 @@ export const CostAnalyticsRepositoryLive = Layer.effect(
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
           return yield* chSqlClient
             .query(async (client) => {
-              const params = { ...scopeParams(input), previousFrom: formatCHDate(input.previousFrom) }
-              const [countsResult, modelsResult] = await Promise.all([
+              const params = {
+                ...scopeParams(input),
+                previousFrom: formatCHDate(input.previousFrom),
+                bucketSeconds: input.bucketSeconds,
+              }
+              const [countsResult, cellsResult] = await Promise.all([
                 client.query({
-                  // A session straddling the boundary counts in both periods, the
-                  // same convention the per-trace series uses for bucket edges.
+                  // One pass yields the sparkline buckets and the two window
+                  // subtotals: `WITH ROLLUP` merges the `uniqExact` states at both
+                  // levels, which summing bucket counts could not do. A session
+                  // straddling the window boundary counts in both, the same
+                  // convention the per-trace series uses for bucket edges.
                   query: `SELECT
+                        GROUPING(bucket_start) AS is_period,
+                        GROUPING(is_current) AS is_everything,
                         is_current,
+                        bucket_start,
                         uniqExact(session_key) AS sessions,
                         uniqExactIf(session_key, session_id = '') AS trace_keyed_sessions,
-                        uniqExact(trace_id) AS turns,
-                        count() AS steps,
-                        sum(tokens_total) AS tokens,
-                        sum(cost_total_microcents) AS cost_microcents,
-                        countIf(cost_source IN ('unpriced', 'unknown')) AS unpriced_calls
-                      FROM (${SESSION_FACTORS_SOURCE})
-                      GROUP BY is_current`,
+                        uniqExact(trace_id) AS traces,
+                        count() AS calls,
+                        countIf(cost_source IN ('unpriced', 'unknown')) AS unpriced_calls,
+                        sum(cost_total_microcents) AS cost_microcents
+                      FROM (SELECT ${BUCKET_START} AS bucket_start, * FROM (${SESSION_FACTORS_SOURCE}))
+                      GROUP BY is_current, bucket_start WITH ROLLUP
+                      ORDER BY bucket_start ASC`,
                   query_params: params,
                   format: "JSONEachRow",
                 }),
@@ -879,27 +913,42 @@ export const CostAnalyticsRepositoryLive = Layer.effect(
                         is_current,
                         provider,
                         model,
-                        sum(tokens_total) AS tokens,
-                        sum(cost_total_microcents) AS cost_microcents
+                        sum(prompt_tokens) AS prompt_tokens,
+                        sum(prompt_cost) AS prompt_cost,
+                        sum(output_tokens) AS output_tokens,
+                        sum(output_cost) AS output_cost
                       FROM (${SESSION_FACTORS_SOURCE})
                       GROUP BY is_current, provider, model
-                      HAVING tokens > 0`,
+                      HAVING prompt_tokens + output_tokens > 0`,
                   query_params: params,
                   format: "JSONEachRow",
                 }),
               ])
               const countRows = await countsResult.json<SessionFactorsRow>()
-              const modelRows = await modelsResult.json<SessionFactorsModelRow>()
-              return { countRows, modelRows }
+              const cellRows = await cellsResult.json<SessionFactorsCellRow>()
+              return { countRows, cellRows }
             })
             .pipe(
-              Effect.map(({ countRows, modelRows }): SessionCostFactorsPair => {
+              Effect.map(({ countRows, cellRows }): SessionCostFactorsPair => {
+                // The grand-total row rolls `is_current` up to a default 0, which
+                // collides with the previous window's own subtotal; drop it.
+                const scoped = countRows.filter((row) => !Number(row.is_everything))
                 const periodOf = (isCurrent: boolean) =>
                   toSessionPeriod({
-                    row: countRows.find((row) => Boolean(row.is_current) === isCurrent),
-                    models: modelRows.filter((row) => Boolean(row.is_current) === isCurrent),
+                    row: scoped.find((row) => Number(row.is_period) === 1 && Boolean(row.is_current) === isCurrent),
+                    cells: cellRows.filter((row) => Boolean(row.is_current) === isCurrent),
                   })
-                return { previous: periodOf(false), current: periodOf(true) }
+                return {
+                  previous: periodOf(false),
+                  current: periodOf(true),
+                  buckets: scoped
+                    .filter((row) => Number(row.is_period) === 0)
+                    .map((row) => ({
+                      bucketStart: parseCHDate(row.bucket_start),
+                      sessions: num(row.sessions),
+                      costMicrocents: num(row.cost_microcents),
+                    })),
+                }
               }),
             )
         }),

--- a/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
@@ -1,0 +1,223 @@
+import { type ChSqlClient, OrganizationId, ProjectId } from "@domain/shared"
+import { createSeedScope, SEED_API_KEY_ID } from "@domain/shared/seeding"
+import {
+  CostAnalyticsRepository,
+  type CostAnalyticsRepositoryShape,
+  decomposeCostPerSession,
+  type SessionCostFactor,
+} from "@domain/spans"
+import { setupTestClickHouse } from "@platform/testkit"
+import { Effect } from "effect"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { ChSqlClientLive } from "../ch-sql-client.ts"
+import { buildCohortsSpans, type CostCohort } from "../seeds/spans/cost-archetypes/cohorts.ts"
+import { GPT_5_MINI } from "../seeds/spans/cost-archetypes/models.ts"
+import { REGRESSION_COHORTS } from "../seeds/spans/cost-archetypes/regression.ts"
+import type { SpanRow } from "../seeds/spans/span-builders.ts"
+import { insertJsonEachRow } from "../sql.ts"
+import { CostAnalyticsRepositoryLive } from "./cost-analytics-repository.ts"
+
+const ORG_ID = OrganizationId("o".repeat(24))
+
+// Archetype D split three ways: each cause on its own project so the row that has
+// to carry it can be asserted in isolation, plus the blend the project really shows.
+const BLENDED_PROJECT_ID = ProjectId("sessionfactorsblended000")
+const MIX_PROJECT_ID = ProjectId("sessionfactorsmix0000000")
+const PROMPT_PROJECT_ID = ProjectId("sessionfactorsprompt0000")
+const PARITY_PROJECT_ID = ProjectId("sessionfactorsparity0000")
+
+const ANCHOR = new Date("2026-06-16T12:00:00.000Z")
+const DAY_MS = 24 * 60 * 60 * 1000
+const HOUR_MS = 60 * 60 * 1000
+
+/**
+ * The boundary sits halfway through the 24h gap between the newest "before" call
+ * and the oldest "after" one, so neither period can steal a cluster from the
+ * other, and `previousFrom` clears the oldest cluster's own few minutes of spread.
+ * Both windows are the same length by construction, which is what the card claims.
+ */
+const PERIOD_MS = 28 * DAY_MS
+const TO = new Date(ANCHOR.getTime() + 12 * HOUR_MS)
+const FROM = new Date(TO.getTime() - PERIOD_MS)
+const PREVIOUS_FROM = new Date(FROM.getTime() - PERIOD_MS)
+
+const scopeFor = (projectId: ProjectId) =>
+  createSeedScope({ organizationId: ORG_ID, projectId, timelineAnchor: ANCHOR, apiKeyId: SEED_API_KEY_ID })
+
+const cohortsOf = (serviceName: string): readonly CostCohort[] =>
+  REGRESSION_COHORTS.filter((cohort) => cohort.serviceName === serviceName)
+
+const spansOf = (cohorts: readonly CostCohort[], projectId: ProjectId): SpanRow[] =>
+  buildCohortsSpans(cohorts, scopeFor(projectId), ANCHOR.getTime())
+
+/** Half the calls report no session id, so both keying paths run in one project. */
+const PARITY_COHORTS: readonly CostCohort[] = [
+  {
+    key: "parity-sessioned",
+    serviceName: "parity",
+    modelConfig: GPT_5_MINI,
+    cadence: { endDaysAgo: 0, clusters: 20, clusterSpacingHours: 24, callsPerCluster: 3, gapWithinClusterSeconds: 60 },
+    cache: { kind: "off" },
+    promptTokens: 2_000,
+    completionTokens: 100,
+    callsPerSession: 3,
+  },
+  {
+    key: "parity-sessionless",
+    serviceName: "parity",
+    modelConfig: GPT_5_MINI,
+    cadence: { endDaysAgo: 0, clusters: 20, clusterSpacingHours: 24, callsPerCluster: 3, gapWithinClusterSeconds: 60 },
+    cache: { kind: "off" },
+    promptTokens: 2_000,
+    completionTokens: 100,
+    callsPerSession: 0,
+  },
+]
+
+const ch = setupTestClickHouse()
+
+const runCh = <A, E>(effect: Effect.Effect<A, E, ChSqlClient>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(ChSqlClientLive(ch.client, ORG_ID))))
+
+const scopeOf = (projectId: ProjectId) => ({
+  organizationId: ORG_ID,
+  projectId,
+  from: FROM,
+  to: TO,
+  previousFrom: PREVIOUS_FROM,
+})
+
+const pointsFor = (rows: readonly { factor: SessionCostFactor; points: number }[], factor: SessionCostFactor): number =>
+  rows.find((row) => row.factor === factor)?.points ?? 0
+
+const decompositionFor = async (projectId: ProjectId) =>
+  decomposeCostPerSession(await runCh(repo.getSessionCostFactors(scopeOf(projectId))))
+
+let repo: CostAnalyticsRepositoryShape
+
+beforeAll(async () => {
+  repo = await Effect.runPromise(
+    Effect.gen(function* () {
+      return yield* CostAnalyticsRepository
+    }).pipe(Effect.provide(CostAnalyticsRepositoryLive)),
+  )
+})
+
+// The testkit truncates between tests, so the fixtures are re-inserted per test.
+beforeEach(async () => {
+  await Effect.runPromise(
+    insertJsonEachRow(ch.client, "spans", [
+      ...spansOf(REGRESSION_COHORTS, BLENDED_PROJECT_ID),
+      ...spansOf(cohortsOf("router"), MIX_PROJECT_ID),
+      ...spansOf(cohortsOf("context-grader"), PROMPT_PROJECT_ID),
+      ...spansOf(PARITY_COHORTS, PARITY_PROJECT_ID),
+    ]),
+  )
+})
+
+describe("getSessionCostFactors", () => {
+  it("splits one scan into two adjacent periods of equal shape", async () => {
+    const { previous, current } = await runCh(repo.getSessionCostFactors(scopeOf(MIX_PROJECT_ID)))
+
+    // Archetype D's router holds volume flat across the shift and moves only which
+    // model serves it, so every count except spend matches period to period.
+    expect(current.steps).toBe(previous.steps)
+    expect(current.turns).toBe(previous.turns)
+    expect(current.sessions).toBe(previous.sessions)
+    expect(current.tokens).toBe(previous.tokens)
+    expect(current.costMicrocents).toBeGreaterThan(previous.costMicrocents)
+    expect(current.models.length).toBe(2)
+  })
+
+  it("puts archetype D's traffic shift on the model mix row, with no volume row moving", async () => {
+    const result = await decompositionFor(MIX_PROJECT_ID)
+
+    expect(result.status).toBe("ok")
+    expect(result.totalPoints).toBeGreaterThan(0)
+    expect(result.rows[0]?.factor).toBe("modelMix")
+    expect(pointsFor(result.rows, "modelMix")).toBeGreaterThan(0)
+    expect(pointsFor(result.rows, "tokensPerStep")).toBe(0)
+    expect(pointsFor(result.rows, "turnsPerSession")).toBe(0)
+    expect(pointsFor(result.rows, "stepsPerTurn")).toBe(0)
+    // Rerouting also changed how many calls per cluster each model gets, so its
+    // write-to-read ratio moved too: a real within-model rate effect, opposite in
+    // sign to the mix one. The two still close on the headline.
+    expect(pointsFor(result.rows, "pricePerToken")).toBeLessThan(0)
+    expect(result.rows.reduce((sum, row) => sum + row.points, 0)).toBe(result.totalPoints)
+  })
+
+  it("puts archetype D's prompt growth on the tokens per step row and not on model mix", async () => {
+    const result = await decompositionFor(PROMPT_PROJECT_ID)
+
+    expect(result.status).toBe("ok")
+    expect(result.rows[0]?.factor).toBe("tokensPerStep")
+    expect(pointsFor(result.rows, "tokensPerStep")).toBeGreaterThan(0)
+    // One model throughout, so no share can have moved.
+    expect(pointsFor(result.rows, "modelMix")).toBe(0)
+    expect(pointsFor(result.rows, "turnsPerSession")).toBe(0)
+  })
+
+  it("keeps both causes visible, and summing, on the project that carries them together", async () => {
+    const result = await decompositionFor(BLENDED_PROJECT_ID)
+
+    expect(pointsFor(result.rows, "modelMix")).toBeGreaterThan(0)
+    expect(pointsFor(result.rows, "tokensPerStep")).toBeGreaterThan(0)
+    expect(result.rows.reduce((sum, row) => sum + row.points, 0)).toBe(result.totalPoints)
+  })
+
+  it("prices each model against its own tokens, so the mix effect has real prices to use", async () => {
+    const { previous } = await runCh(repo.getSessionCostFactors(scopeOf(MIX_PROJECT_ID)))
+    const prices = previous.models.map((slice) => slice.costMicrocents / slice.tokens)
+
+    expect(previous.models.map((slice) => slice.model).sort()).toEqual(["claude-opus-4-5", "gpt-5-mini"])
+    expect(Math.max(...prices)).toBeGreaterThan(Math.min(...prices))
+    expect(previous.models.reduce((sum, slice) => sum + slice.tokens, 0)).toBe(previous.tokens)
+  })
+})
+
+/**
+ * The session denominator has to be the key the rollups aggregate on, or a
+ * sessionless project reports a different session count on this card than in the
+ * sessions list. `00055` had to restate both materialized-view bodies verbatim to
+ * add a column, which is exactly where the `coalesce` fallback gets dropped by
+ * accident and silently changes every per-session figure.
+ */
+describe("session denominator parity with the sessions rollup", () => {
+  const rollupSessionIds = async (): Promise<readonly string[]> => {
+    const result = await ch.client.query({
+      query: `SELECT DISTINCT session_id FROM sessions
+        WHERE organization_id = {organizationId:String} AND project_id = {projectId:String}
+        ORDER BY session_id`,
+      query_params: { organizationId: ORG_ID as string, projectId: PARITY_PROJECT_ID as string },
+      format: "JSONEachRow",
+    })
+    return (await result.json<{ session_id: string }>()).map((row) => row.session_id)
+  }
+
+  it("keys spans that reported no session id on their trace id instead of dropping them", async () => {
+    const spans = spansOf(PARITY_COHORTS, PARITY_PROJECT_ID)
+    const sessionless = spans.filter((span) => span.session_id === "")
+    const rollupIds = await rollupSessionIds()
+
+    expect(sessionless.length).toBeGreaterThan(0)
+    for (const span of sessionless) expect(rollupIds).toContain(span.trace_id)
+  })
+
+  it("counts exactly the sessions the rollup keys on, pseudo-sessions included", async () => {
+    const { current } = await runCh(repo.getSessionCostFactors(scopeOf(PARITY_PROJECT_ID)))
+    const rollupIds = await rollupSessionIds()
+
+    expect(current.sessions).toBe(rollupIds.length)
+    // Every sessionless call is its own single-trace session: 20 clusters x 3 calls.
+    expect(current.traceKeyedSessions).toBe(60)
+    expect(current.sessions).toBe(60 + 20)
+  })
+
+  it("declines to compare a project whose comparison window is empty", async () => {
+    const result = await decompositionFor(PARITY_PROJECT_ID)
+
+    expect(result.status).toBe("notEnoughData")
+    expect(result.changePct).toBeNull()
+    expect(result.rows).toEqual([])
+  })
+})

--- a/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
@@ -5,6 +5,8 @@ import {
   type CostAnalyticsRepositoryShape,
   decomposeCostPerSession,
   type SessionCostFactor,
+  sessionCostMicrocents,
+  sessionCostTokens,
 } from "@domain/spans"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
@@ -85,10 +87,16 @@ const scopeOf = (projectId: ProjectId) => ({
   from: FROM,
   to: TO,
   previousFrom: PREVIOUS_FROM,
+  bucketSeconds: DAY_MS / 1000,
 })
 
-const pointsFor = (rows: readonly { factor: SessionCostFactor; points: number }[], factor: SessionCostFactor): number =>
-  rows.find((row) => row.factor === factor)?.points ?? 0
+const multiplierFor = (
+  rows: readonly { factor: SessionCostFactor | null; multiplier: number }[],
+  factor: SessionCostFactor,
+): number | undefined => rows.find((row) => row.factor === factor)?.multiplier
+
+const factorsOf = (rows: readonly { factor: SessionCostFactor | null }[]): readonly (SessionCostFactor | null)[] =>
+  rows.map((row) => row.factor)
 
 const decompositionFor = async (projectId: ProjectId) =>
   decomposeCostPerSession(await runCh(repo.getSessionCostFactors(scopeOf(projectId))))
@@ -121,55 +129,87 @@ describe("getSessionCostFactors", () => {
 
     // Archetype D's router holds volume flat across the shift and moves only which
     // model serves it, so every count except spend matches period to period.
-    expect(current.steps).toBe(previous.steps)
-    expect(current.turns).toBe(previous.turns)
+    expect(current.calls).toBe(previous.calls)
+    expect(current.traces).toBe(previous.traces)
     expect(current.sessions).toBe(previous.sessions)
-    expect(current.tokens).toBe(previous.tokens)
-    expect(current.costMicrocents).toBeGreaterThan(previous.costMicrocents)
-    expect(current.models.length).toBe(2)
+    expect(sessionCostTokens(current)).toBe(sessionCostTokens(previous))
+    expect(sessionCostMicrocents(current)).toBeGreaterThan(sessionCostMicrocents(previous))
+    // Two models, each split prompt and output.
+    expect(current.cells.length).toBe(4)
   })
 
-  it("puts archetype D's traffic shift entirely on the model mix row", async () => {
+  it("returns sparkline buckets spanning both windows off the same scan", async () => {
+    const { buckets } = await runCh(repo.getSessionCostFactors(scopeOf(MIX_PROJECT_ID)))
+
+    expect(buckets.length).toBeGreaterThan(1)
+    const starts = buckets.map((bucket) => bucket.bucketStart.getTime())
+    expect(starts).toEqual([...starts].sort((a, b) => a - b))
+    expect(Math.min(...starts)).toBeGreaterThanOrEqual(PREVIOUS_FROM.getTime())
+    expect(Math.max(...starts)).toBeLessThan(TO.getTime())
+    expect(buckets.every((bucket) => bucket.sessions > 0)).toBe(true)
+  })
+
+  it("puts archetype D's traffic shift on model mix and nothing else", async () => {
     const result = await decompositionFor(MIX_PROJECT_ID)
 
     expect(result.status).toBe("ok")
-    expect(result.totalPoints).toBeGreaterThan(0)
-    expect(pointsFor(result.rows, "modelMix")).toBe(result.totalPoints)
-    expect(pointsFor(result.rows, "tokensPerStep")).toBe(0)
-    expect(pointsFor(result.rows, "turnsPerSession")).toBe(0)
-    expect(pointsFor(result.rows, "stepsPerTurn")).toBe(0)
+    expect(result.totalMultiplier).toBeGreaterThan(1)
+    expect(multiplierFor(result.rows, "modelMix")).toBeGreaterThan(1)
     // The fixture holds each model's own calls per cluster — and so its write-to-read
-    // ratio, and so its price per token — fixed across the shift, which is what leaves
-    // nothing for the within-model rate row to carry.
-    expect(pointsFor(result.rows, "pricePerToken")).toBe(0)
+    // ratio, and so each side's price per token — fixed across the shift. Nothing is
+    // left for the rate rows, and volume never moved, so all of it folds away.
+    expect(factorsOf(result.rows)).not.toContain("promptRate")
+    expect(factorsOf(result.rows)).not.toContain("outputRate")
+    expect(factorsOf(result.rows)).not.toContain("tokensPerCall")
+    expect(factorsOf(result.rows)).not.toContain("tracesPerSession")
   })
 
-  it("puts archetype D's prompt growth on the tokens per step row and not on model mix", async () => {
+  it("puts archetype D's prompt growth on tokens per call and not on model mix", async () => {
     const result = await decompositionFor(PROMPT_PROJECT_ID)
 
     expect(result.status).toBe("ok")
-    expect(result.rows[0]?.factor).toBe("tokensPerStep")
-    expect(pointsFor(result.rows, "tokensPerStep")).toBeGreaterThan(0)
-    // One model throughout, so no share can have moved.
-    expect(pointsFor(result.rows, "modelMix")).toBe(0)
-    expect(pointsFor(result.rows, "turnsPerSession")).toBe(0)
+    expect(result.rows[0]?.factor).toBe("tokensPerCall")
+    expect(multiplierFor(result.rows, "tokensPerCall")).toBeGreaterThan(1)
+    // One model throughout, so no share between price lists can have moved.
+    expect(factorsOf(result.rows)).not.toContain("modelMix")
+    expect(factorsOf(result.rows)).not.toContain("tracesPerSession")
   })
 
-  it("keeps both causes visible, and summing, on the project that carries them together", async () => {
+  /**
+   * The grader's output holds at 120 tokens while its prompt grows fourfold, so the
+   * cheap prompt side takes a larger share and the blended per-token price falls with
+   * no price changing. That belongs to token mix; a rate row claiming it would read as
+   * "we got a better deal".
+   */
+  it("charges the grader's blended price fall to token mix, not to a rate row", async () => {
+    const result = await decompositionFor(PROMPT_PROJECT_ID)
+
+    expect(multiplierFor(result.rows, "tokenMix")).toBeLessThan(1)
+    expect(factorsOf(result.rows)).not.toContain("promptRate")
+    expect(factorsOf(result.rows)).not.toContain("outputRate")
+  })
+
+  it("keeps both causes visible, and reconciling, on the project that carries them together", async () => {
     const result = await decompositionFor(BLENDED_PROJECT_ID)
 
-    expect(pointsFor(result.rows, "modelMix")).toBeGreaterThan(0)
-    expect(pointsFor(result.rows, "tokensPerStep")).toBeGreaterThan(0)
-    expect(result.rows.reduce((sum, row) => sum + row.points, 0)).toBe(result.totalPoints)
+    expect(multiplierFor(result.rows, "modelMix")).toBeGreaterThan(1)
+    expect(multiplierFor(result.rows, "tokensPerCall")).toBeGreaterThan(1)
+    expect(result.rows.reduce((product, row) => product * row.multiplier, 1)).toBeCloseTo(result.rowsMultiplyTo ?? 0, 2)
   })
 
-  it("prices each model against its own tokens, so the mix effect has real prices to use", async () => {
+  it("prices each side of each model separately, so the mix effects have real prices", async () => {
     const { previous } = await runCh(repo.getSessionCostFactors(scopeOf(MIX_PROJECT_ID)))
-    const prices = previous.models.map((slice) => slice.costMicrocents / slice.tokens)
+    const models = [...new Set(previous.cells.map((cell) => cell.model))].sort()
+    const priceOf = (model: string, side: string) => {
+      const cell = previous.cells.find((candidate) => candidate.model === model && candidate.side === side)
+      return cell ? cell.costMicrocents / cell.tokens : 0
+    }
 
-    expect(previous.models.map((slice) => slice.model).sort()).toEqual(["claude-opus-4-5", "gpt-5-mini"])
-    expect(Math.max(...prices)).toBeGreaterThan(Math.min(...prices))
-    expect(previous.models.reduce((sum, slice) => sum + slice.tokens, 0)).toBe(previous.tokens)
+    expect(models).toEqual(["claude-opus-4-5", "gpt-5-mini"])
+    // Output costs strictly more per token than prompt on both, which is the whole
+    // reason a prompt/output shift must not be read as a rate change.
+    for (const model of models) expect(priceOf(model, "output")).toBeGreaterThan(priceOf(model, "prompt"))
+    expect(priceOf("claude-opus-4-5", "prompt")).toBeGreaterThan(priceOf("gpt-5-mini", "prompt"))
   })
 })
 

--- a/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
@@ -243,6 +243,9 @@ describe("session denominator parity with the sessions rollup", () => {
   })
 
   it("counts exactly the sessions the rollup keys on, pseudo-sessions included", async () => {
+    // Parity of the *key*, which is what a restated view body can silently break. The
+    // populations differ by design: this repository gates to billable operations, so a
+    // session of nothing but tool spans has a rollup row and no place in a cost average.
     const { current } = await runCh(repo.getSessionCostFactors(scopeOf(PARITY_PROJECT_ID)))
     const rollupIds = await rollupSessionIds()
 

--- a/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
@@ -129,21 +129,19 @@ describe("getSessionCostFactors", () => {
     expect(current.models.length).toBe(2)
   })
 
-  it("puts archetype D's traffic shift on the model mix row, with no volume row moving", async () => {
+  it("puts archetype D's traffic shift entirely on the model mix row", async () => {
     const result = await decompositionFor(MIX_PROJECT_ID)
 
     expect(result.status).toBe("ok")
     expect(result.totalPoints).toBeGreaterThan(0)
-    expect(result.rows[0]?.factor).toBe("modelMix")
-    expect(pointsFor(result.rows, "modelMix")).toBeGreaterThan(0)
+    expect(pointsFor(result.rows, "modelMix")).toBe(result.totalPoints)
     expect(pointsFor(result.rows, "tokensPerStep")).toBe(0)
     expect(pointsFor(result.rows, "turnsPerSession")).toBe(0)
     expect(pointsFor(result.rows, "stepsPerTurn")).toBe(0)
-    // Rerouting also changed how many calls per cluster each model gets, so its
-    // write-to-read ratio moved too: a real within-model rate effect, opposite in
-    // sign to the mix one. The two still close on the headline.
-    expect(pointsFor(result.rows, "pricePerToken")).toBeLessThan(0)
-    expect(result.rows.reduce((sum, row) => sum + row.points, 0)).toBe(result.totalPoints)
+    // The fixture holds each model's own calls per cluster — and so its write-to-read
+    // ratio, and so its price per token — fixed across the shift, which is what leaves
+    // nothing for the within-model rate row to carry.
+    expect(pointsFor(result.rows, "pricePerToken")).toBe(0)
   })
 
   it("puts archetype D's prompt growth on the tokens per step row and not on model mix", async () => {

--- a/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
@@ -91,12 +91,11 @@ const scopeOf = (projectId: ProjectId) => ({
 })
 
 const multiplierFor = (
-  rows: readonly { factor: SessionCostFactor | null; multiplier: number }[],
+  rows: readonly { factor: SessionCostFactor; multiplier: number }[],
   factor: SessionCostFactor,
 ): number | undefined => rows.find((row) => row.factor === factor)?.multiplier
 
-const factorsOf = (rows: readonly { factor: SessionCostFactor | null }[]): readonly (SessionCostFactor | null)[] =>
-  rows.map((row) => row.factor)
+const factorsOf = (rows: readonly { factor: SessionCostFactor }[]): SessionCostFactor[] => rows.map((row) => row.factor)
 
 const decompositionFor = async (projectId: ProjectId) =>
   decomposeCostPerSession(await runCh(repo.getSessionCostFactors(scopeOf(projectId))))
@@ -153,15 +152,16 @@ describe("getSessionCostFactors", () => {
     const result = await decompositionFor(MIX_PROJECT_ID)
 
     expect(result.status).toBe("ok")
+    expect(factorsOf(result.rows).length).toBe(7)
     expect(result.totalMultiplier).toBeGreaterThan(1)
     expect(multiplierFor(result.rows, "modelMix")).toBeGreaterThan(1)
     // The fixture holds each model's own calls per cluster — and so its write-to-read
     // ratio, and so each side's price per token — fixed across the shift. Nothing is
     // left for the rate rows, and volume never moved, so all of it folds away.
-    expect(factorsOf(result.rows)).not.toContain("promptRate")
-    expect(factorsOf(result.rows)).not.toContain("outputRate")
-    expect(factorsOf(result.rows)).not.toContain("tokensPerCall")
-    expect(factorsOf(result.rows)).not.toContain("tracesPerSession")
+    expect(multiplierFor(result.rows, "promptRate")).toBeCloseTo(1, 2)
+    expect(multiplierFor(result.rows, "outputRate")).toBeCloseTo(1, 2)
+    expect(multiplierFor(result.rows, "tokensPerCall")).toBeCloseTo(1, 2)
+    expect(multiplierFor(result.rows, "tracesPerSession")).toBeCloseTo(1, 2)
   })
 
   it("puts archetype D's prompt growth on tokens per call and not on model mix", async () => {
@@ -171,8 +171,8 @@ describe("getSessionCostFactors", () => {
     expect(result.rows[0]?.factor).toBe("tokensPerCall")
     expect(multiplierFor(result.rows, "tokensPerCall")).toBeGreaterThan(1)
     // One model throughout, so no share between price lists can have moved.
-    expect(factorsOf(result.rows)).not.toContain("modelMix")
-    expect(factorsOf(result.rows)).not.toContain("tracesPerSession")
+    expect(multiplierFor(result.rows, "modelMix")).toBeCloseTo(1, 2)
+    expect(multiplierFor(result.rows, "tracesPerSession")).toBeCloseTo(1, 2)
   })
 
   /**
@@ -185,8 +185,8 @@ describe("getSessionCostFactors", () => {
     const result = await decompositionFor(PROMPT_PROJECT_ID)
 
     expect(multiplierFor(result.rows, "tokenMix")).toBeLessThan(1)
-    expect(factorsOf(result.rows)).not.toContain("promptRate")
-    expect(factorsOf(result.rows)).not.toContain("outputRate")
+    expect(multiplierFor(result.rows, "promptRate")).toBeCloseTo(1, 2)
+    expect(multiplierFor(result.rows, "outputRate")).toBeCloseTo(1, 2)
   })
 
   it("keeps both causes visible, and reconciling, on the project that carries them together", async () => {
@@ -194,7 +194,8 @@ describe("getSessionCostFactors", () => {
 
     expect(multiplierFor(result.rows, "modelMix")).toBeGreaterThan(1)
     expect(multiplierFor(result.rows, "tokensPerCall")).toBeGreaterThan(1)
-    expect(result.rows.reduce((product, row) => product * row.multiplier, 1)).toBeCloseTo(result.rowsMultiplyTo ?? 0, 2)
+    const closes = result.rows.reduce((product, row) => product * row.multiplier, 1) / (result.totalMultiplier ?? 1)
+    expect(closes).toBeCloseTo(1, 9)
   })
 
   it("prices each side of each model separately, so the mix effects have real prices", async () => {

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/archetypes.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/archetypes.test.ts
@@ -325,11 +325,8 @@ describe("archetype D — spend regression", () => {
   })
 
   it("holds each router model's own price per token exactly flat across the shift", () => {
-    // The whole point of the variant: under `prefixReuse` a model's price per token is
-    // fixed by its calls per cluster, so resizing clusters to move traffic would change
-    // each model's write-to-read ratio too and the decomposition would — correctly —
-    // report a large within-model rate effect next to the mix one. The fixture could
-    // then no longer tell "mix carried it" from "mix and rate both moved".
+    // Guards the equal calls-per-cluster: without it, resizing clusters to move traffic
+    // moves each model's own price per token too and the mix effect stops being isolable.
     const { before, after } = forAgent("router")
     const pricePerToken = (rows: readonly SpanRow[], model: string) => {
       const forModel = rows.filter((span) => span.model === model)

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/archetypes.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/archetypes.test.ts
@@ -312,6 +312,36 @@ describe("archetype D — spend regression", () => {
     expect(new Set(before.map(promptOf))).toEqual(new Set(after.map(promptOf)))
   })
 
+  it("leaves the router's every volume factor identical, so only the mix moved", () => {
+    const { before, after } = forAgent("router")
+    const shape = (rows: readonly SpanRow[]) => ({
+      calls: rows.length,
+      turns: new Set(rows.map((span) => span.trace_id)).size,
+      sessions: new Set(rows.map((span) => span.session_id || span.trace_id)).size,
+      tokens: rows.reduce((sum, span) => sum + promptOf(span) + span.tokens_output, 0),
+    })
+
+    expect(shape(after)).toEqual(shape(before))
+  })
+
+  it("holds each router model's own price per token exactly flat across the shift", () => {
+    // The whole point of the variant: under `prefixReuse` a model's price per token is
+    // fixed by its calls per cluster, so resizing clusters to move traffic would change
+    // each model's write-to-read ratio too and the decomposition would — correctly —
+    // report a large within-model rate effect next to the mix one. The fixture could
+    // then no longer tell "mix carried it" from "mix and rate both moved".
+    const { before, after } = forAgent("router")
+    const pricePerToken = (rows: readonly SpanRow[], model: string) => {
+      const forModel = rows.filter((span) => span.model === model)
+      const tokens = forModel.reduce((sum, span) => sum + promptOf(span) + span.tokens_output, 0)
+      return forModel.reduce((sum, span) => sum + span.cost_total_microcents, 0) / tokens
+    }
+
+    for (const model of new Set(before.map((span) => span.model))) {
+      expect(pricePerToken(after, model), model).toBe(pricePerToken(before, model))
+    }
+  })
+
   it("attributes the grader's rise to prompt growth, with model and turns held flat", () => {
     const { before, after } = forAgent("context-grader")
     expect(spendOf(after)).toBeGreaterThan(spendOf(before) * 2)

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/lifetime-coverage.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/lifetime-coverage.test.ts
@@ -15,6 +15,7 @@ import type { CostCohort } from "./cohorts.ts"
 import { buildCohortsSpans, cohortCalls } from "./cohorts.ts"
 import { FINDINGS_FIRE_COHORTS } from "./findings-fire.ts"
 import { HEALTHY_COHORTS } from "./healthy.ts"
+import { REGRESSION_COHORTS } from "./regression.ts"
 import { SINGLE_TURN_COHORTS } from "./single-turn.ts"
 
 /**
@@ -118,6 +119,17 @@ describe("seed coverage for the lifetime control", () => {
     for (const cohort of [...HEALTHY_COHORTS, ...SINGLE_TURN_COHORTS]) {
       const realistic = new Set([300, 1_800, 3_600].map((lifetimeSeconds) => stateAt(cohort, lifetimeSeconds)))
       expect(realistic.size).toBe(1)
+    }
+  })
+
+  it("raises no cache finding anywhere in the regression archetype", () => {
+    // Archetype D exists to be read as a spend regression with a decomposable cause. A
+    // cache recommendation on any of its cohorts is noise competing with that story, so
+    // every cohort has to sit inside the material-gap band at every plausible lifetime.
+    for (const cohort of REGRESSION_COHORTS) {
+      for (const lifetimeSeconds of [300, 1_800, 3_600]) {
+        expect(stateAt(cohort, lifetimeSeconds), `${cohort.key} @ ${lifetimeSeconds}s`).toBe("optimal")
+      }
     }
   })
 })

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/lifetime-coverage.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/lifetime-coverage.test.ts
@@ -123,9 +123,7 @@ describe("seed coverage for the lifetime control", () => {
   })
 
   it("raises no cache finding anywhere in the regression archetype", () => {
-    // Archetype D exists to be read as a spend regression with a decomposable cause. A
-    // cache recommendation on any of its cohorts is noise competing with that story, so
-    // every cohort has to sit inside the material-gap band at every plausible lifetime.
+    // A cache finding here would compete with the spend-regression story D exists to tell.
     for (const cohort of REGRESSION_COHORTS) {
       for (const lifetimeSeconds of [300, 1_800, 3_600]) {
         expect(stateAt(cohort, lifetimeSeconds), `${cohort.key} @ ${lifetimeSeconds}s`).toBe("optimal")

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/regression.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/regression.ts
@@ -24,71 +24,98 @@ import { CLAUDE_OPUS_4_5, GPT_5_4, GPT_5_MINI } from "./models.ts"
 const BEFORE_ENDS_DAYS_AGO = 28
 const PERIOD_CLUSTERS = 28
 
+/**
+ * Calls per cluster, held identical across every router cohort so the shift is a
+ * *pure* mix effect.
+ *
+ * Under `prefixReuse` the first call of a cluster writes the prefix and the rest
+ * read it, so a model's own price per token is fixed by this number alone. Varying
+ * it between the two periods — which is what shifting traffic by resizing clusters
+ * does — changes each model's write-to-read ratio as well as its share, and the
+ * decomposition then correctly reports a large within-model rate effect alongside
+ * the mix one. That is arithmetically right and useless as a fixture: it can no
+ * longer distinguish "mix carried it" from "mix and rate both moved".
+ *
+ * So traffic moves by cluster *count* instead, with spacing scaled to keep each
+ * cohort spread across its whole period.
+ */
+const ROUTER_CALLS_PER_CLUSTER = 11
+
+// Leaves each router model ~6 points under its own ceiling, inside the healthy band
+// the material-gap threshold was calibrated on, so no cache finding fires here.
+const ROUTER_CACHE = { kind: "prefixReuse", share: 0.93 } as const
+
+const ROUTER_PROMPT_TOKENS = 7_000
+const ROUTER_COMPLETION_TOKENS = 200
+
+// Cluster counts sum to the same total per period, so every volume factor — steps,
+// turns and sessions per period — is identical on both sides and only the share
+// each model takes has moved. Both counts stay odd in each period, which is what
+// keeps the session totals equal under `callsPerSession: 2`.
+const CHEAP_CLUSTERS_BEFORE = 25
+const PREMIUM_CLUSTERS_BEFORE = 3
+const CHEAP_CLUSTERS_AFTER = 5
+const PREMIUM_CLUSTERS_AFTER = 23
+
+// Spacing spreads `clusters` across the 27 days between a period's oldest and
+// newest cluster anchors, so a cohort with few clusters is sparse rather than
+// bunched into one corner of its period. Every value stays above the longest
+// ceiling lifetime, so between-cluster gaps are cold at every lifetime.
+const PERIOD_SPAN_HOURS = 27 * 24
+const spacingFor = (clusters: number): number => PERIOD_SPAN_HOURS / (clusters - 1)
+
+const routerCohort = ({
+  key,
+  modelConfig,
+  endDaysAgo,
+  clusters,
+}: {
+  key: string
+  modelConfig: CostCohort["modelConfig"]
+  endDaysAgo: number
+  clusters: number
+}): CostCohort => ({
+  key,
+  serviceName: "router",
+  modelConfig,
+  cadence: {
+    endDaysAgo,
+    clusters,
+    clusterSpacingHours: spacingFor(clusters),
+    callsPerCluster: ROUTER_CALLS_PER_CLUSTER,
+    gapWithinClusterSeconds: 60,
+  },
+  cache: ROUTER_CACHE,
+  promptTokens: ROUTER_PROMPT_TOKENS,
+  completionTokens: ROUTER_COMPLETION_TOKENS,
+  callsPerSession: 2,
+})
+
 export const REGRESSION_COHORTS: readonly CostCohort[] = [
-  {
+  routerCohort({
     key: "regression-router-cheap-before",
-    serviceName: "router",
     modelConfig: GPT_5_MINI,
-    cadence: {
-      endDaysAgo: BEFORE_ENDS_DAYS_AGO,
-      clusters: PERIOD_CLUSTERS,
-      clusterSpacingHours: 24,
-      callsPerCluster: 20,
-      gapWithinClusterSeconds: 60,
-    },
-    cache: { kind: "prefixReuse", share: 0.9 },
-    promptTokens: 7_000,
-    completionTokens: 200,
-    callsPerSession: 2,
-  },
-  {
+    endDaysAgo: BEFORE_ENDS_DAYS_AGO,
+    clusters: CHEAP_CLUSTERS_BEFORE,
+  }),
+  routerCohort({
     key: "regression-router-premium-before",
-    serviceName: "router",
     modelConfig: CLAUDE_OPUS_4_5,
-    cadence: {
-      endDaysAgo: BEFORE_ENDS_DAYS_AGO,
-      clusters: PERIOD_CLUSTERS,
-      clusterSpacingHours: 24,
-      callsPerCluster: 2,
-      gapWithinClusterSeconds: 60,
-    },
-    cache: { kind: "prefixReuse", share: 0.9 },
-    promptTokens: 7_000,
-    completionTokens: 200,
-    callsPerSession: 2,
-  },
-  {
+    endDaysAgo: BEFORE_ENDS_DAYS_AGO,
+    clusters: PREMIUM_CLUSTERS_BEFORE,
+  }),
+  routerCohort({
     key: "regression-router-cheap-after",
-    serviceName: "router",
     modelConfig: GPT_5_MINI,
-    cadence: {
-      endDaysAgo: 0,
-      clusters: PERIOD_CLUSTERS,
-      clusterSpacingHours: 24,
-      callsPerCluster: 8,
-      gapWithinClusterSeconds: 60,
-    },
-    cache: { kind: "prefixReuse", share: 0.9 },
-    promptTokens: 7_000,
-    completionTokens: 200,
-    callsPerSession: 2,
-  },
-  {
+    endDaysAgo: 0,
+    clusters: CHEAP_CLUSTERS_AFTER,
+  }),
+  routerCohort({
     key: "regression-router-premium-after",
-    serviceName: "router",
     modelConfig: CLAUDE_OPUS_4_5,
-    cadence: {
-      endDaysAgo: 0,
-      clusters: PERIOD_CLUSTERS,
-      clusterSpacingHours: 24,
-      callsPerCluster: 14,
-      gapWithinClusterSeconds: 60,
-    },
-    cache: { kind: "prefixReuse", share: 0.9 },
-    promptTokens: 7_000,
-    completionTokens: 200,
-    callsPerSession: 2,
-  },
+    endDaysAgo: 0,
+    clusters: PREMIUM_CLUSTERS_AFTER,
+  }),
   {
     key: "regression-grader-before",
     serviceName: "context-grader",
@@ -100,7 +127,7 @@ export const REGRESSION_COHORTS: readonly CostCohort[] = [
       callsPerCluster: 12,
       gapWithinClusterSeconds: 120,
     },
-    cache: { kind: "prefixReuse", share: 0.88 },
+    cache: { kind: "prefixReuse", share: 0.93 },
     promptTokens: 4_000,
     completionTokens: 120,
     callsPerSession: 3,
@@ -116,7 +143,7 @@ export const REGRESSION_COHORTS: readonly CostCohort[] = [
       callsPerCluster: 12,
       gapWithinClusterSeconds: 120,
     },
-    cache: { kind: "prefixReuse", share: 0.88 },
+    cache: { kind: "prefixReuse", share: 0.93 },
     promptTokens: 16_000,
     completionTokens: 120,
     callsPerSession: 3,

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/regression.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/regression.ts
@@ -24,43 +24,26 @@ import { CLAUDE_OPUS_4_5, GPT_5_4, GPT_5_MINI } from "./models.ts"
 const BEFORE_ENDS_DAYS_AGO = 28
 const PERIOD_CLUSTERS = 28
 
-/**
- * Calls per cluster, held identical across every router cohort so the shift is a
- * *pure* mix effect.
- *
- * Under `prefixReuse` the first call of a cluster writes the prefix and the rest
- * read it, so a model's own price per token is fixed by this number alone. Varying
- * it between the two periods — which is what shifting traffic by resizing clusters
- * does — changes each model's write-to-read ratio as well as its share, and the
- * decomposition then correctly reports a large within-model rate effect alongside
- * the mix one. That is arithmetically right and useless as a fixture: it can no
- * longer distinguish "mix carried it" from "mix and rate both moved".
- *
- * So traffic moves by cluster *count* instead, with spacing scaled to keep each
- * cohort spread across its whole period.
- */
+// Equal across every router cohort: under `prefixReuse` this alone fixes a model's
+// write-to-read ratio, so moving traffic by resizing clusters would move each model's
+// own price per token too and the fixture would stop isolating the mix effect.
 const ROUTER_CALLS_PER_CLUSTER = 11
 
-// Leaves each router model ~6 points under its own ceiling, inside the healthy band
-// the material-gap threshold was calibrated on, so no cache finding fires here.
+// Below ~0.95 a cohort drifts past the material-gap band and fires a cache finding.
 const ROUTER_CACHE = { kind: "prefixReuse", share: 0.93 } as const
 
 const ROUTER_PROMPT_TOKENS = 7_000
 const ROUTER_COMPLETION_TOKENS = 200
 
-// Cluster counts sum to the same total per period, so every volume factor — steps,
-// turns and sessions per period — is identical on both sides and only the share
-// each model takes has moved. Both counts stay odd in each period, which is what
-// keeps the session totals equal under `callsPerSession: 2`.
+// Counts sum equally per period so every volume factor is flat, and each stays odd so
+// the two periods round to the same session total under `callsPerSession: 2`.
 const CHEAP_CLUSTERS_BEFORE = 25
 const PREMIUM_CLUSTERS_BEFORE = 3
 const CHEAP_CLUSTERS_AFTER = 5
 const PREMIUM_CLUSTERS_AFTER = 23
 
-// Spacing spreads `clusters` across the 27 days between a period's oldest and
-// newest cluster anchors, so a cohort with few clusters is sparse rather than
-// bunched into one corner of its period. Every value stays above the longest
-// ceiling lifetime, so between-cluster gaps are cold at every lifetime.
+// Every spacing this yields must stay above the longest ceiling lifetime, or
+// between-cluster gaps turn warm and the cohorts' ceilings change.
 const PERIOD_SPAN_HOURS = 27 * 24
 const spacingFor = (clusters: number): number => PERIOD_SPAN_HOURS / (clusters - 1)
 


### PR DESCRIPTION
LAT-799 — PR 3b of the cost dashboard project. Based on `development`; #4322 (seeds) and #4323 (cache ceiling) have both landed, so this is no longer stacked.

Answers one question: **why did a session get more expensive?** It is the only panel in the section with no Figma frame, and the only one whose output is a sentence rather than a shape.

> Cost per session tripled. Tokens per call doubled, and a fifth of the tokens moved onto Opus. Nothing repriced.

## The idea

Cost per session is a product, so it splits exactly — no regression, no correlation, no double counting of the tokens that grow with turns:

```
cost/session  =  traces/session  ×  calls/trace  ×  tokens/call  ×  cost/token
```

Each factor's own before/after ratio is a multiplier, and the multipliers multiply to the headline ratio. That is the whole unit system: every figure stays in the unit its factor is measured in, and the arithmetic reconciles because the logs sum.

`cost/token` splits four ways, because a blended per-token price moves for reasons that are not price changes:

| factor | what moves it |
| --- | --- |
| **Which models** | tokens shifting between price lists, each list's own prices held fixed |
| **Prompt vs output split** | tokens shifting between the cheap prompt side and the dear output side |
| **Prompt price** / **Output price** | a price list actually changing |

The middle one is not decoration. A prompt that grows while the answer stays the same length makes the average token cheaper with nothing repriced — earlier revisions of this panel reported that as a **saving, in green, directly beneath the red row that caused it.** Splitting it out is what stops the card claiming you got a better deal when you did not.

Cells are keyed `(provider, model, side)` rather than by side alone, because per-side blended prices move with model mix too: on the seeded regression project both sides roughly double while no price list changes at all.

## What it looks like

Two measures on the left, the seven factors filling a 3×3 grid on the right:

```
┌─ Sessions ─────┐ ┌ What changed              Which models        Tokens per call ┐
│ 292            │ │ Each of these pushed      23.8%  ↑ ×2.31      11K  ↑ ×2.04    │
│ ▲21% from 242  │ │ the cost of a session     …/claude-opus-4-5                   │
│ ╭─╮╭───╮╱      │ │ up or down.                                                   │
├────────────────┤ │ ┌───────────────┬───────────────┬───────────────┐             │
│ Cost/session   │ │ │Prompt vs      │Traces/session │LLM calls/trace│             │
│ $0.03          │ │ │output  ↓×0.75 │2.39  — ×0.99  │1.00  — ×1.00  │             │
│ ▲249%          │ │ │98.6% prompt   │               │               │             │
│ ╱───╯╱         │ │ ├───────────────┼───────────────┴───────────────┤             │
└────────────────┘ │ │Prompt price   │Output price                   │             │
                   │ │$0.72/1M —×1.00│$14.20/1M — ×1.00              │             │
                   │ │over all models│over all models                │             │
                   └─┴───────────────┴───────────────────────────────┘             │
```

Every tile leads with **where that factor stands now**, then an arrow and a marker for the direction and size of its push. Never a before-and-after pair: for the two price tiles the pair would be a blended per-side figure, which moves with model mix, so it would contradict a marker that holds the mix fixed.

All seven show every period, even the still ones. Which seven things the card accounts for is part of what it says, and a list that changes shape between periods hides it. It also removes a bug outright — collapsing the quiet factors meant four moving 4% apiece compounded into a 17% rise that rendered as `7 factors unchanged ×1.17`.

**Sessions** is a peer of cost per session, not one of its factors: it is the *denominator*, so more of them cannot move what each one costs. That separation is what tells "we are busier" apart from "each session got dearer". Sparklines only on those two — a per-bucket ratio of two small counts swings on volume alone and would read as an event.

## Correctness

- **Rows reconcile exactly.** Each multiplier is `exp` of its log share, and the shares sum to the total's log, so the product is the total to 1e-9. Asserted, not asserted-ish.
- **Sample floor of 20 sessions per period.** Earned its keep immediately: the demo project has 2 sessions in the comparison window, and without the floor the card would have announced "cost per session fell 88%" off that baseline. Same trap as the `278x avg` chip in #4313.
- **Empty states say which side is thin**, and distinguish *thin* from *empty* — a window with no history before it will never get one by widening the range.
- **Sparklines are zero-baselined**, never scaled to their own minimum, and smoothed with a **monotone cubic**. A cardinal spline overshoots, so a flat run at 10 with one 16 in it would bulge past 16 and dip under 10, drawing values the series never held; zero-baselined those dips cross the floor and imply zero sessions on a day that had ten. Tested on the property — a Bézier stays inside its control points' convex hull, so bounding each segment's controls by its endpoints proves no overshoot.
- **All computation server-side.** The panel formats; it never derives. This is the seam LAT-811 exposes over MCP.

## The LAT-797 correction

LAT-797 (a session-unit union query) is **cancelled** and its dependency was stale: `sessions_mv` has keyed on `coalesce(nullIf(s.session_id, ''), toString(s.trace_id))` since migration `00016`, so the trace-as-session fallback already exists. Two pieces of its scope landed here instead:

1. **The labelling decision.** Sessionless traffic becomes cheap single-trace pseudo-sessions, pulling the average *down*. The card discloses the share above 10%.
2. **A parity regression test.** `00055` had to restate both materialized-view bodies verbatim to add a column — exactly where that `coalesce` gets dropped silently. The test asserts sessionless spans key on their trace id in the rollup *and* that this repository counts those keys. It guards the **key**, not the population: this repository gates to billable operations and the rollup does not, and the test says so rather than implying parity it cannot check.

## Archetype D now isolates its causes

The seeded router cohorts moved traffic by **resizing clusters**, and under `prefixReuse` calls-per-cluster is exactly what fixes a model's write-to-read ratio — so resizing moved each model's own price per token as well as its share. The decomposition read that correctly and reported both (mix `+459`, rate `−286`, net `+173`), which is arithmetically right and useless as a fixture: it could no longer distinguish *"mix carried it"* from *"mix and rate both moved"*.

Traffic now moves by cluster **count** at a fixed 11 calls per cluster. Verified against ClickHouse after reseeding:

```
router   calls 308 -> 308   turns/session 1.987097 -> 1.987097   tokens/call 7200 -> 7200
  gpt-5-mini        share 89.3% -> 17.9%   price/token 11.366793 -> 11.366793
  claude-opus-4-5   share 10.7% -> 82.1%   price/token 195.943813 -> 195.943813
```

Spend rises 5.2× and **100% of it lands on model mix**. Both invariants are asserted now, not left to reading.

Also raises both grader cohorts' prefix-reuse share from 0.88 to 0.93. At 0.88 the grader sat 11 points under its ceiling, past `CACHE_CEILING_MIN_MATERIAL_GAP`, so it fired an `investigate/underusing` recommendation — contradicting the archetype's own promise that caching is healthy throughout. Pre-existing and uncovered: `lifetime-coverage.test.ts` did not include archetype D. It does now.

## One page-wide change

With the picker on **All time**, this section compares the last 30 days against the 30 before — `trendRange` clamps to 30 days and the cost page feeds that clamped range to *every* figure, not just its charts. That is by design (#4290) but "All time" describes it wrongly, and wrongly for the whole page.

So `TimeFilterDropdown` takes an optional placeholder and the cost page says **"Recent activity"** — the same words `ChartHeader` already uses, and accurate in a way "Last 30 days" would not be, since the clamp anchors to the project's last activity rather than to now. Every other section leaves its list unbounded and clamps only its charts, so "All time" stays true there and their default is untouched.

## Tests

- **20** unit tests on the pure function: single-factor attribution, mix vs rate, exact reconciliation across four shapes, the always-seven contract, every guard rail, the destination-naming rule in both directions, the broad-shift count, and a new model's price gap landing on rate.
- **6** on the sparkline interpolation, including no-overshoot across six shapes.
- **10** ClickHouse tests against archetype D, split three ways so attribution is verified rather than merely summing: `router` alone → all of it on model mix; `context-grader` alone → tokens per call leads and model mix is flat; the grader's blended-price fall charged to prompt/output split rather than a price row; both together still reconciling.

`pnpm typecheck` 90/90, `pnpm knip`, `pnpm format`, `@domain/spans` 1972, `@platform/db-clickhouse` 601, `@app/web` 899. No migration — `getSessionCostFactors` reads `spans` with the same billable-operation allowlist as every other cost figure, and takes both windows off one scan via `WITH ROLLUP` (17 ms against 18 ms for the single-window query it replaced, 46,034 rows read either way).

## Known limitations, surfaced in the UI

**A share can move for reasons that are not a decision.** *Which models* fires when someone switches a model **and** when a busier agent happens to use a dearer one — the card cannot tell those apart, and its tooltip says so. Telling them apart needs the per-agent view (LAT-808).

**The two price tiles are blended over every model** while their markers hold the mix fixed. Both figures are right for the question they answer — one is what was paid, the other is whether anything repriced — so each tile says `averaged over all models` on its face. The consequence: `$0.72 /1M` is your effective rate and will match no provider's price list.

## Where to focus review

1. **One open thread, and two reviewers agree on it** (Codex and the Claude review): `sessions` and `traces` are gated to billable operations, so a session of nothing but tool spans has a row in `sessions_mv` and no place here. I declined it — every cost denominator in this section works that way, `getCostOverview` documents why, and the KPI row's *Avg per trace* divides by the same population, so counting them here would make the page's two headline averages disagree. Reasonable to overrule; it is a section-wide convention, not a local choice.
2. **The near-zero-`ΔP` allocation** — an even split, which keeps each part at the ~0 the factor actually contributed.
3. **The new-price-list baseline** — a model with no previous tokens is baselined at the previous *blended* price, so its arrival is mix-neutral and its distance from that blend lands on rate.
4. **`SESSION_COST_MIN_SESSIONS = 20`** — archetype E (tiny) sits deliberately below it.
5. **`placeholder="Recent activity"`** is a page-wide label change beyond this card. One prop and one string if you want it scoped differently.

## Out of scope

Per-row subtext notes (each needs its own groupby per factor; when they land, every annotation must be a groupby, never an LLM guess), shape curves (LAT-807), segment heatmap (LAT-808), cache-cost column split (LAT-800), API/MCP (LAT-811).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
