### PR TITLE
fix(mcp): reject API keys on /v1/mcp, require OAuth only

### DIFF
--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -8,6 +8,8 @@ import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
 import {
   type ApiTestContext,
+  createOAuthAuthHeaders,
+  createOAuthTenantSetup,
   createTenantSetup,
   setupTestApi,
   TEST_ENCRYPTION_KEY,
@@ -27,6 +29,9 @@ import {
  * We use `Accept: application/json, text/event-stream` (per the MCP spec)
  * which lets the transport pick. In our stateless setup it returns SSE; the
  * tests parse a single `data:` event.
+ *
+ * Auth: the MCP transport is OAuth-only. Tests seed an OAuth access token via
+ * {@link createOAuthTenantSetup}; organization API keys must 401.
  */
 
 const insertApiKey = async (database: InMemoryPostgres, organizationId: string, token: string) => {
@@ -57,7 +62,7 @@ const sendMcpRequest = async (app: ApiTestContext["app"], authToken: string, bod
     new Request("http://localhost/v1/mcp", {
       method: "POST",
       headers: {
-        ...createApiKeyAuthHeaders(authToken),
+        ...createOAuthAuthHeaders(authToken),
         "Content-Type": "application/json",
         Accept: "application/json, text/event-stream",
       },
@@ -99,9 +104,30 @@ describe("/v1/mcp", () => {
     expect(res.status).toBe(401)
   })
 
-  it<ApiTestContext>("initialize returns the server info + capabilities", async ({ app, database }) => {
+  it<ApiTestContext>("rejects organization API keys with 401", async ({ app, database }) => {
     const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await app.fetch(
+      new Request("http://localhost/v1/mcp", {
+        method: "POST",
+        headers: {
+          ...createApiKeyAuthHeaders(tenant.apiKeyToken),
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: { protocolVersion: PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: "t", version: "0" } },
+        }),
+      }),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it<ApiTestContext>("initialize returns the server info + capabilities", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 1,
       method: "initialize",
@@ -116,8 +142,8 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/list returns the registered API-key tools", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 2,
       method: "tools/list",
@@ -129,8 +155,8 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/list includes the tool-analytics tools", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 20, method: "tools/list" })
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, { jsonrpc: "2.0", id: 20, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -138,8 +164,8 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/list includes the monitor tools", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 24, method: "tools/list" })
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, { jsonrpc: "2.0", id: 24, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -158,8 +184,8 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/list includes the experiment tools", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 26, method: "tools/list" })
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, { jsonrpc: "2.0", id: 26, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -175,8 +201,8 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/list includes the user-analytics tools", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 22, method: "tools/list" })
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, { jsonrpc: "2.0", id: 22, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -189,10 +215,10 @@ describe("/v1/mcp", () => {
     app,
     database,
   }) => {
-    const tenant = await createTenantSetup(database)
+    const tenant = await createOAuthTenantSetup(database)
     const project = await insertProject(database, tenant.organizationId)
 
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 23,
       method: "tools/call",
@@ -212,10 +238,10 @@ describe("/v1/mcp", () => {
     app,
     database,
   }) => {
-    const tenant = await createTenantSetup(database)
+    const tenant = await createOAuthTenantSetup(database)
     const project = await insertProject(database, tenant.organizationId)
 
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 21,
       method: "tools/call",
@@ -238,13 +264,13 @@ describe("/v1/mcp", () => {
     app,
     database,
   }) => {
-    const tenant = await createTenantSetup(database)
+    const tenant = await createOAuthTenantSetup(database)
     // Seed two extra API keys so the listApiKeys tool returns >= 3 entries
     // (the auth key from `createTenantSetup` plus these two).
     await insertApiKey(database, tenant.organizationId, generateApiKeyToken())
     await insertApiKey(database, tenant.organizationId, generateApiKeyToken())
 
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 3,
       method: "tools/call",
@@ -266,10 +292,10 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/call creates and reads a monitor with structured content", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
+    const tenant = await createOAuthTenantSetup(database)
     const project = await insertProject(database, tenant.organizationId)
 
-    const createRes = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const createRes = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 25,
       method: "tools/call",
@@ -301,7 +327,7 @@ describe("/v1/mcp", () => {
     expect(createdPayload.result?.structuredContent?.target?.stream).toBe("sessions")
     expect(createdPayload.result?.structuredContent?.target?.metric?.kind).toBe("count")
 
-    const listRes = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const listRes = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 26,
       method: "tools/call",
@@ -319,8 +345,8 @@ describe("/v1/mcp", () => {
     app,
     database,
   }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 4,
       method: "tools/call",
@@ -346,11 +372,11 @@ describe("/v1/mcp", () => {
     app,
     database,
   }) => {
-    const tenantA = await createTenantSetup(database)
-    const tenantB = await createTenantSetup(database)
+    const tenantA = await createOAuthTenantSetup(database)
+    const tenantB = await createOAuthTenantSetup(database)
     // Try to revoke tenant B's API key with tenant A's bearer — the inner
     // route's org-scoped repository returns 404, which surfaces as isError.
-    const res = await sendMcpRequest(app, tenantA.apiKeyToken, {
+    const res = await sendMcpRequest(app, tenantA.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 5,
       method: "tools/call",

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -16,11 +16,7 @@ import type { AppEnv, ProtectedEnv } from "../types.ts"
  * inner request authenticates as the same OAuth caller and counts against the
  * same rate-limit bucket.
  *
- * The handler is mounted at `/` on `routes`; callers mount that sub-app at
- * `/mcp` under `/${API_VERSION}` so the public URL is `/v1/mcp`. The
- * dispatcher prepends `/${API_VERSION}` to the descriptor's router prefix when
- * re-entering through `app.fetch()` — so a tool whose registry entry has
- * `routerPrefix: "/api-keys"` resolves to `/v1/api-keys`.
+ * MCP is mounted at `/v1/mcp`; internal dispatch prepends `/${API_VERSION}` to each tool router prefix.
  *
  * Each request gets its own `McpServer` + `WebStandardStreamableHTTPServerTransport`
  * + `connect()` + tool registration loop. This is an SDK invariant in stateless

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -8,12 +8,13 @@ import type { AppEnv, ProtectedEnv } from "../types.ts"
 
 /**
  * Mounts the MCP transport endpoint on `routes` (which already lives behind
- * the unified auth + org-context middleware). Tool dispatch re-enters the
- * root Hono app via `app.fetch(internalRequest)` so every tool call runs
- * through the same middleware chain (validation, rate-limit, auth,
- * organization context). The outer `Authorization` and `X-Forwarded-For`
- * headers are forwarded so the inner request authenticates as the same
- * caller and counts against the same rate-limit bucket.
+ * OAuth-only auth + org-context middleware — API keys are rejected at the
+ * transport). Tool dispatch re-enters the root Hono app via
+ * `app.fetch(internalRequest)` so every tool call runs through the REST
+ * middleware chain (validation, rate-limit, auth, organization context). The
+ * outer `Authorization` and `X-Forwarded-For` headers are forwarded so the
+ * inner request authenticates as the same OAuth caller and counts against the
+ * same rate-limit bucket.
  *
  * The MCP mount path (`/mcp`) is internal to this function — when `routes`
  * is mounted at `/${API_VERSION}` on the root, the public URL becomes

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -16,11 +16,11 @@ import type { AppEnv, ProtectedEnv } from "../types.ts"
  * inner request authenticates as the same OAuth caller and counts against the
  * same rate-limit bucket.
  *
- * The MCP mount path (`/mcp`) is internal to this function — when `routes`
- * is mounted at `/${API_VERSION}` on the root, the public URL becomes
- * `/v1/mcp`. The dispatcher prepends `/${API_VERSION}` to the descriptor's
- * router prefix when re-entering through `app.fetch()` — so a tool whose
- * registry entry has `routerPrefix: "/api-keys"` resolves to `/v1/api-keys`.
+ * The handler is mounted at `/` on `routes`; callers mount that sub-app at
+ * `/mcp` under `/${API_VERSION}` so the public URL is `/v1/mcp`. The
+ * dispatcher prepends `/${API_VERSION}` to the descriptor's router prefix when
+ * re-entering through `app.fetch()` — so a tool whose registry entry has
+ * `routerPrefix: "/api-keys"` resolves to `/v1/api-keys`.
  *
  * Each request gets its own `McpServer` + `WebStandardStreamableHTTPServerTransport`
  * + `connect()` + tool registration loop. This is an SDK invariant in stateless
@@ -62,7 +62,7 @@ export const registerMcpRoute = ({
 }): void => {
   const toolDescriptors = collectToolDescriptors()
 
-  routes.all("/mcp", async (c) => {
+  routes.all("/", async (c) => {
     const mcpServer = new McpServer(MCP_INFO, { instructions: MCP_INFO.instructions, capabilities: { tools: {} } })
 
     for (const tool of toolDescriptors) {

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -98,6 +98,56 @@ describe("auth middleware dispatch", () => {
     expect(res.status).toBe(401)
   })
 
+  it<ApiTestContext>("rejects a valid API-key bearer on the MCP transport", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const token = generateApiKeyToken()
+    await insertApiKey(database, tenant.organizationId, token)
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/mcp", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it<ApiTestContext>("authenticates a valid OAuth access-token bearer on the MCP transport", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createTenantSetup(database)
+    const token = crypto.randomUUID()
+    await insertOAuthApplicationAndToken(database, tenant.organizationId, tenant.userId, token)
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/mcp", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "t", version: "0" },
+          },
+        }),
+      }),
+    )
+    expect(res.status).toBe(200)
+  })
+
   it<ApiTestContext>("rejects an OAuth token whose application has no organization binding", async ({
     app,
     database,

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -23,12 +23,7 @@ type AuthMethod = AuthContext["method"]
 interface AuthMiddlewareOptions {
   adminClient: PostgresClient | undefined
   logTouchBuffer: boolean
-  /**
-   * Bearer validators to try, in registration order. Defaults to both
-   * (`api-key` then `oauth`). Pass `["oauth"]` for surfaces that must not
-   * accept organization API keys — notably the MCP transport, which is an
-   * OAuth protected resource.
-   */
+  /** Validators to try, in order. Defaults to `["api-key", "oauth"]`. */
   allowedMethods?: ReadonlyArray<AuthMethod>
 }
 
@@ -102,14 +97,12 @@ const authenticate = (c: Context, options: AuthMiddlewareOptions): Effect.Effect
     const redis = c.get("redis")
     const allowedMethods = options.allowedMethods ?? DEFAULT_ALLOWED_METHODS
 
-    if (allowedMethods.includes("api-key")) {
-      const apiKeyCtx = yield* authenticateWithApiKey(redis, bearerToken, options)
-      if (apiKeyCtx) return apiKeyCtx
-    }
-
-    if (allowedMethods.includes("oauth")) {
-      const oauthCtx = yield* authenticateWithOAuth(redis, bearerToken, options)
-      if (oauthCtx) return oauthCtx
+    for (const method of allowedMethods) {
+      const authContext =
+        method === "api-key"
+          ? yield* authenticateWithApiKey(redis, bearerToken, options)
+          : yield* authenticateWithOAuth(redis, bearerToken, options)
+      if (authContext) return authContext
     }
 
     return yield* new UnauthorizedError({ message: "Invalid credentials" })

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -18,9 +18,18 @@ const extractBearerToken = (c: Context): string | undefined => {
   return authHeader.slice(7)
 }
 
+type AuthMethod = AuthContext["method"]
+
 interface AuthMiddlewareOptions {
   adminClient: PostgresClient | undefined
   logTouchBuffer: boolean
+  /**
+   * Bearer validators to try, in registration order. Defaults to both
+   * (`api-key` then `oauth`). Pass `["oauth"]` for surfaces that must not
+   * accept organization API keys — notably the MCP transport, which is an
+   * OAuth protected resource.
+   */
+  allowedMethods?: ReadonlyArray<AuthMethod>
 }
 
 const apiKeyContext = (result: { keyId: string; organizationId: string }): AuthContext => ({
@@ -71,15 +80,17 @@ const authenticateWithOAuth = (
   }).pipe(Effect.orDie)
 }
 
+const DEFAULT_ALLOWED_METHODS: ReadonlyArray<AuthMethod> = ["api-key", "oauth"]
+
 /**
- * Authenticates a bearer token by trying both validators in sequence: API key
- * first, then OAuth, then 401. Both validators have a short negative-cache TTL,
- * so an unknown bearer hits each underlying DB at most once per cache window.
+ * Authenticates a bearer token by trying the allowed validators in sequence,
+ * then 401. Both validators have a short negative-cache TTL, so an unknown
+ * bearer hits each underlying DB at most once per cache window.
  *
  * No prefix-based dispatch — bearer tokens are opaque random strings, and
  * matching against the wrong validator just returns null cheaply. The trade-off
- * is one extra Redis + DB round-trip on the OAuth happy path; the user knows
- * their throughput envelope and the simplicity wins.
+ * is one extra Redis + DB round-trip on the OAuth happy path when both methods
+ * are allowed; the user knows their throughput envelope and the simplicity wins.
  */
 const authenticate = (c: Context, options: AuthMiddlewareOptions): Effect.Effect<AuthContext, UnauthorizedError> =>
   Effect.gen(function* () {
@@ -89,12 +100,17 @@ const authenticate = (c: Context, options: AuthMiddlewareOptions): Effect.Effect
     }
 
     const redis = c.get("redis")
+    const allowedMethods = options.allowedMethods ?? DEFAULT_ALLOWED_METHODS
 
-    const apiKeyCtx = yield* authenticateWithApiKey(redis, bearerToken, options)
-    if (apiKeyCtx) return apiKeyCtx
+    if (allowedMethods.includes("api-key")) {
+      const apiKeyCtx = yield* authenticateWithApiKey(redis, bearerToken, options)
+      if (apiKeyCtx) return apiKeyCtx
+    }
 
-    const oauthCtx = yield* authenticateWithOAuth(redis, bearerToken, options)
-    if (oauthCtx) return oauthCtx
+    if (allowedMethods.includes("oauth")) {
+      const oauthCtx = yield* authenticateWithOAuth(redis, bearerToken, options)
+      if (oauthCtx) return oauthCtx
+    }
 
     return yield* new UnauthorizedError({ message: "Invalid credentials" })
   })
@@ -102,9 +118,9 @@ const authenticate = (c: Context, options: AuthMiddlewareOptions): Effect.Effect
 /**
  * Create authentication middleware.
  *
- * Validates `Authorization: Bearer …` tokens against both the API-key store
- * and the OAuth access-token store, in that order. Public routes should be
- * excluded from this middleware.
+ * Validates `Authorization: Bearer …` tokens against the configured stores
+ * (`allowedMethods`, defaulting to API-key then OAuth). Public routes should
+ * be excluded from this middleware.
  */
 export const createAuthMiddleware = (options: AuthMiddlewareOptions): MiddlewareHandler => {
   return async (c: Context, next: Next) => {

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -37,14 +37,13 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
   registerBootstrapRoute({ app: v1, adminDatabase: options.adminDatabase })
   registerGithubRoute({ app: v1 })
 
+  const authOptions = {
+    adminClient: options.adminDatabase,
+    logTouchBuffer: options.logTouchBuffer,
+  } as const
+
   routes.use("*", validationErrorMiddleware)
-  routes.use(
-    "*",
-    createAuthMiddleware({
-      adminClient: options.adminDatabase,
-      logTouchBuffer: options.logTouchBuffer,
-    }),
-  )
+  routes.use("*", createAuthMiddleware(authOptions))
   routes.use("*", createOrganizationContextMiddleware())
 
   mountOperationModules(routes, operationModules, { middlewareForTier: createTierRateLimiter })
@@ -66,9 +65,17 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
     return c.redirect(url.toString(), 307)
   })
 
-  registerMcpRoute({ app, routes })
+  // MCP is an OAuth protected resource — organization API keys must not
+  // authenticate the transport (they'd skip consent / discovery). Inner tool
+  // dispatch still re-enters `routes` with the same OAuth bearer.
+  const mcpRoutes = new OpenAPIHono<ProtectedEnv>()
+  mcpRoutes.use("*", validationErrorMiddleware)
+  mcpRoutes.use("*", createAuthMiddleware({ ...authOptions, allowedMethods: ["oauth"] }))
+  mcpRoutes.use("*", createOrganizationContextMiddleware())
+  registerMcpRoute({ app, routes: mcpRoutes })
 
   v1.route("/", routes)
+  v1.route("/", mcpRoutes)
 
   app.route(`/${API_VERSION}`, v1)
 }

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -46,6 +46,7 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
   routes.use("*", createAuthMiddleware(authOptions))
   routes.use("*", createOrganizationContextMiddleware())
 
+  // Populate the operation/tool registry before snapshotting MCP descriptors.
   mountOperationModules(routes, operationModules, { middlewareForTier: createTierRateLimiter })
 
   // Back-compat: the Issues API moved to /signals. 307 preserves method + body so
@@ -65,17 +66,15 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
     return c.redirect(url.toString(), 307)
   })
 
-  // MCP is an OAuth protected resource — organization API keys must not
-  // authenticate the transport (they'd skip consent / discovery). Inner tool
-  // dispatch still re-enters `routes` with the same OAuth bearer.
+  // OAuth-only MCP ring, mounted at `/mcp` *before* the REST `*` ring so Hono
+  // never runs API-key auth (or the touch buffer) on the transport.
   const mcpRoutes = new OpenAPIHono<ProtectedEnv>()
   mcpRoutes.use("*", validationErrorMiddleware)
   mcpRoutes.use("*", createAuthMiddleware({ ...authOptions, allowedMethods: ["oauth"] }))
   mcpRoutes.use("*", createOrganizationContextMiddleware())
   registerMcpRoute({ app, routes: mcpRoutes })
-
+  v1.route("/mcp", mcpRoutes)
   v1.route("/", routes)
-  v1.route("/", mcpRoutes)
 
   app.route(`/${API_VERSION}`, v1)
 }

--- a/dev-docs/api.md
+++ b/dev-docs/api.md
@@ -17,7 +17,7 @@ There is no second registration step for any of those surfaces. The `defineOpera
 
 ## Authentication
 
-Routes under `/v1` accept **either** an organization-scoped API key **or** an OAuth2 access token. Both are opaque random strings carried as `Authorization: Bearer …`. The auth middleware tries validators in order:
+REST routes under `/v1` accept **either** an organization-scoped API key **or** an OAuth2 access token. Both are opaque random strings carried as `Authorization: Bearer …`. The auth middleware tries validators in order:
 
 ```
 authenticate(c) → AuthContext | 401
@@ -28,6 +28,8 @@ authenticate(c) → AuthContext | 401
 ```
 
 Both validators have a short negative-cache TTL (~5s), so an unknown bearer hits each underlying datastore at most once per cache window.
+
+**Exception — `/v1/mcp`:** the MCP transport is an OAuth protected resource. Its middleware passes `allowedMethods: ["oauth"]`, so organization API keys receive `401` even when valid. Clients must complete the OAuth consent flow (see [`mcp.md`](./mcp.md)). Inner tool dispatch re-enters the REST ring with the same OAuth bearer.
 
 ### `AuthContext` shape
 
@@ -63,17 +65,23 @@ attachSharedContext(db, redis, clickhouse, queue)   ← all routes
     /health
     /.well-known/oauth-protected-resource    ← static JSON discovery doc
 
-  RING 2 — protected (unified auth):
+  RING 2 — protected REST (unified auth):
     validationErrorMiddleware
     createAuthRateLimiter()              ← global IP-based brute-force guard
     createAuthMiddleware()               ← API-key OR OAuth dispatch
     createOrganizationContextMiddleware()
 
       /v1/...   ← all REST routes, with per-endpoint tier limiters
+
+  RING 3 — protected MCP (OAuth only):
+    validationErrorMiddleware
+    createAuthMiddleware({ allowedMethods: ["oauth"] })
+    createOrganizationContextMiddleware()
+
       /v1/mcp   ← MCP transport, per-request McpServer
 ```
 
-Public routes are bodyless metadata documents — never product data. Everything that touches an organization runs under the protected ring.
+Public routes are bodyless metadata documents — never product data. Everything that touches an organization runs under a protected ring.
 
 ## Per-route rate limiting
 

--- a/dev-docs/api.md
+++ b/dev-docs/api.md
@@ -29,7 +29,7 @@ authenticate(c) → AuthContext | 401
 
 Both validators have a short negative-cache TTL (~5s), so an unknown bearer hits each underlying datastore at most once per cache window.
 
-**Exception — `/v1/mcp`:** the MCP transport is an OAuth protected resource. Its middleware passes `allowedMethods: ["oauth"]`, so organization API keys receive `401` even when valid. Clients must complete the OAuth consent flow (see [`mcp.md`](./mcp.md)). Inner tool dispatch re-enters the REST ring with the same OAuth bearer.
+**Exception — `/v1/mcp`:** the MCP transport is an OAuth-protected resource. Its middleware passes `allowedMethods: ["oauth"]`, so organization API keys receive `401` even when valid. Clients must complete the OAuth consent flow (see [`mcp.md`](./mcp.md)). Inner tool dispatch re-enters the REST ring with the same OAuth bearer.
 
 ### `AuthContext` shape
 
@@ -65,23 +65,22 @@ attachSharedContext(db, redis, clickhouse, queue)   ← all routes
     /health
     /.well-known/oauth-protected-resource    ← static JSON discovery doc
 
-  RING 2 — protected REST (unified auth):
-    validationErrorMiddleware
-    createAuthRateLimiter()              ← global IP-based brute-force guard
-    createAuthMiddleware()               ← API-key OR OAuth dispatch
-    createOrganizationContextMiddleware()
-
-      /v1/...   ← all REST routes, with per-endpoint tier limiters
-
-  RING 3 — protected MCP (OAuth only):
+  RING 2 — protected MCP (OAuth only; mounted first at /mcp):
     validationErrorMiddleware
     createAuthMiddleware({ allowedMethods: ["oauth"] })
     createOrganizationContextMiddleware()
 
       /v1/mcp   ← MCP transport, per-request McpServer
+
+  RING 3 — protected REST (unified auth; mounted after MCP):
+    validationErrorMiddleware
+    createAuthMiddleware()               ← API-key OR OAuth dispatch
+    createOrganizationContextMiddleware()
+
+      /v1/...   ← all REST routes, with per-endpoint tier limiters
 ```
 
-Public routes are bodyless metadata documents — never product data. Everything that touches an organization runs under a protected ring.
+Public routes are bodyless metadata documents — never product data. Everything that touches an organization runs under a protected ring. MCP is mounted before the REST `*` middleware so API-key validation never runs on the transport.
 
 ## Per-route rate limiting
 

--- a/dev-docs/mcp.md
+++ b/dev-docs/mcp.md
@@ -2,6 +2,8 @@
 
 Latitude exposes an [MCP](https://modelcontextprotocol.io/) server so AI agents (Claude Code, Cursor, Codex, custom CLIs) can use Latitude's machine-facing capabilities as typed tools instead of curling raw HTTP. The server is mounted at `/v1/mcp` **inside the existing `apps/api` process** — there is no separate MCP service.
 
+**Auth is OAuth-only.** Organization API keys that work on REST `/v1/...` routes are rejected on `/v1/mcp` with `401`. MCP clients must complete the protected-resource OAuth flow below; that keeps consent, org binding, and token revocation on the transport itself rather than letting a long-lived API key skip them.
+
 ## Tools are derived from API routes
 
 Every operation declared via `defineOperation(...)` is registered as an MCP tool by default. Tool name = route `name` (camelCase), tool description = route `description`, tool input schema = the flattened union of `route.request.{params, query, body}`, tool output schema = the 2xx-JSON response schema.
@@ -46,7 +48,7 @@ The MCP server is the protected resource; the web app is the authorization serve
 │ (TanStack Start)                     │      │ (Hono / OpenAPIHono)               │
 │                                      │      │                                    │
 │  /login              sign-in UI      │      │  /v1/...   REST + ApiKey/OAuth     │
-│  /welcome            org-picker      │      │  /v1/mcp   MCP transport           │
+│  /welcome            org-picker      │      │  /v1/mcp   MCP transport (OAuth)   │
 │  /auth/consent       OAuth consent   │      │                                    │
 │  /api/auth/*         BA handler      │      │  /.well-known/oauth-protected-     │
 │    (incl. mcp/authorize, mcp/token,  │      │     resource                       │
@@ -59,6 +61,7 @@ The MCP server is the protected resource; the web app is the authorization serve
                                          │    │    ↓ Drizzle SELECT                │
                                          │    │  oauth_access_token JOIN           │
                                          │    │  oauth_application                 │
+                                         │    │  (API keys rejected on /v1/mcp)    │
                                          │    └────────────────────────┬───────────┘
                                          │                             │
                           ┌──────────────▼─────────────────────────────▼──────┐


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`/v1/mcp` sat on the same protected ring as REST, so a valid organization API key authenticated the MCP transport and skipped OAuth consent, org binding, and discovery. MCP is an OAuth-protected resource — API keys should not be a bypass.

## Change

- Auth middleware accepts `allowedMethods` (tried in the configured order; default still `api-key` then `oauth`).
- MCP mounts at `/mcp` **before** the REST sub-app, with `allowedMethods: ["oauth"]`, so Hono never runs API-key auth or the touch buffer on the transport. Valid API keys get `401`.
- Inner tool dispatch still re-enters the REST ring with the same OAuth bearer (REST continues to accept both methods).
- Tests cover API-key rejection and OAuth success on the transport; MCP integration tests seed OAuth tenants.
- Docs updated in `dev-docs/mcp.md` and `dev-docs/api.md`.

## Verification

- `pnpm --filter @app/api exec vitest run src/middleware/auth.test.ts src/mcp/server.test.ts` (21 passed)
- `pnpm --filter @app/api typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbcc2-b2c3-7086-88ad-ac762b7cb6a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbcc2-b2c3-7086-88ad-ac762b7cb6a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Authentication**
  * MCP connections now require OAuth access tokens.
  * Organization API keys are rejected with a `401 Unauthorized` response.
  * OAuth credentials and client IP information are preserved during MCP tool requests.
  * Standard API routes continue to support both API keys and OAuth tokens.

* **Documentation**
  * Updated API and MCP documentation to describe OAuth-only authentication and the revised request flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->