### PR TITLE
fix(taxonomy): terminate the garden only when the cohort actually changes

### DIFF
--- a/apps/web/src/domains/taxonomy/custom-behaviors.functions.ts
+++ b/apps/web/src/domains/taxonomy/custom-behaviors.functions.ts
@@ -138,9 +138,10 @@ export const updateCustomBehaviorFn = createServerFn({ method: "POST" })
   )
   .handler(async ({ data, context }): Promise<CustomBehaviorRecord> => {
     const orgId = await resolveOrgScope(context)
-    // A cohort change re-gardens the view from scratch, so the use-case needs both the
-    // assignment slice (to purge) and a QueuePublisher (to enqueue the run).
-    const publisher = await getQueuePublisher()
+    // A cohort change re-gardens the view from scratch, so the use-case needs the
+    // assignment slice (to purge), a terminator (to stop the run holding the old
+    // filter) and a QueuePublisher (to enqueue the replacement run).
+    const [publisher, terminator] = await Promise.all([getQueuePublisher(), getWorkflowTerminator()])
 
     const updated = await Effect.runPromise(
       updateCustomBehavior({
@@ -149,6 +150,7 @@ export const updateCustomBehaviorFn = createServerFn({ method: "POST" })
         ...(data.filterSet !== undefined ? { filterSet: data.filterSet } : {}),
       }).pipe(
         Effect.provideService(QueuePublisher, publisher),
+        Effect.provideService(WorkflowTerminator, terminator),
         withScopedPostgres(CustomBehaviorRepositoryLive, getPostgresClient(), orgId),
         withScopedClickHouse(TaxonomyViewAssignmentRepositoryLive, getClickhouseClient(), orgId),
         withTracing,

--- a/packages/domain/taxonomy/src/use-cases/custom-behavior-crud.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/custom-behavior-crud.test.ts
@@ -1,4 +1,4 @@
-import { QueuePublisher, WorkflowTerminator } from "@domain/queue"
+import { QueuePublisher, type QueuePublisherShape, WorkflowTerminator } from "@domain/queue"
 import { createFakeQueuePublisher, createFakeWorkflowTerminator } from "@domain/queue/testing"
 import {
   ChSqlClient,
@@ -121,6 +121,30 @@ function makeLayer(facets: readonly TaxonomyFacet[] = []) {
     Layer.succeed(ChSqlClient, createFakeChSqlClient()),
   )
   return { layer, rows, queue, workflows, assignments, clusterRepo, runRepo, projectionRepo, facetRepo }
+}
+
+// Same fakes, but terminate and publish record into one list so their relative order
+// can be asserted: enqueueing first is what Temporal rejects as WorkflowAlreadyStarted.
+function makeOrderedLayer() {
+  const base = makeLayer()
+  const calls: string[] = []
+  const layer = Layer.mergeAll(
+    base.layer,
+    Layer.succeed(QueuePublisher, {
+      ...base.queue.publisher,
+      publish: (queue, task, payload, options) =>
+        Effect.sync(() => calls.push("publish")).pipe(
+          Effect.andThen(base.queue.publisher.publish(queue, task, payload, options)),
+        ),
+    } satisfies QueuePublisherShape),
+    Layer.succeed(WorkflowTerminator, {
+      terminate: (workflowId: string, reason?: string) =>
+        Effect.sync(() => calls.push("terminate")).pipe(
+          Effect.andThen(base.workflows.terminator.terminate(workflowId, reason)),
+        ),
+    }),
+  )
+  return { ...base, layer, calls }
 }
 
 describe("createCustomBehavior", () => {
@@ -317,31 +341,70 @@ describe("updateCustomBehavior", () => {
   })
 
   it("purges the assignment slice and re-gardens when the cohort changes", async () => {
-    const { layer, queue, assignments } = makeLayer()
-    await Effect.runPromise(
+    const { layer, queue, assignments, workflows } = makeLayer()
+    const behavior = await Effect.runPromise(
       Effect.gen(function* () {
         const created = yield* createCustomBehavior({ projectId: PROJECT_ID, name: "Refunds", filterSet: FILTER })
-        return yield* updateCustomBehavior({
+        yield* updateCustomBehavior({
           id: created.id,
           filterSet: { models: [{ op: "in", value: ["gpt-4o-mini"] }] },
         })
+        return created
       }).pipe(Effect.provide(layer)),
     )
     expect(assignments.deletedBehaviorIds).toHaveLength(1)
     // One enqueue from the create, one from the cohort change.
     expect(queue.published).toHaveLength(2)
+    expect(workflows.terminated).toEqual([
+      {
+        workflowId: taxonomyGardenCustomBehaviorDedupeKey({
+          organizationId: behavior.organizationId,
+          customBehaviorId: behavior.id,
+        }),
+        reason: "behavior cohort filter changed",
+      },
+    ])
+  })
+
+  it("terminates the in-flight garden before enqueueing the replacement, so it is not dropped as already-started", async () => {
+    const { layer, rows, calls } = makeOrderedLayer()
+    const behavior = makeBehavior()
+    rows.set(behavior.id, behavior)
+
+    await Effect.runPromise(
+      updateCustomBehavior({
+        id: behavior.id,
+        filterSet: { models: [{ op: "in", value: ["gpt-4o-mini"] }] },
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(calls).toEqual(["terminate", "publish"])
   })
 
   it("leaves the gardened tree alone when the filter is re-sent unchanged", async () => {
-    const { layer, queue, assignments } = makeLayer()
+    const { layer, queue, assignments, workflows } = makeLayer()
     await Effect.runPromise(
       Effect.gen(function* () {
         const created = yield* createCustomBehavior({ projectId: PROJECT_ID, name: "Refunds", filterSet: FILTER })
-        // Same conditions, keys in a different order: re-serialization must not read as a change.
+        // The edit modal always re-sends the current filter alongside the name, so a plain
+        // rename must not read as a cohort change and kill a healthy in-flight garden.
         return yield* updateCustomBehavior({ id: created.id, name: "Chargebacks", filterSet: { ...FILTER } })
       }).pipe(Effect.provide(layer)),
     )
     expect(assignments.deletedBehaviorIds).toHaveLength(0)
+    expect(queue.published).toHaveLength(1)
+    expect(workflows.terminated).toEqual([])
+  })
+
+  it("leaves the garden running on a name-only update", async () => {
+    const { layer, queue, workflows } = makeLayer()
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const created = yield* createCustomBehavior({ projectId: PROJECT_ID, name: "Refunds", filterSet: FILTER })
+        return yield* updateCustomBehavior({ id: created.id, name: "Chargebacks" })
+      }).pipe(Effect.provide(layer)),
+    )
+    expect(workflows.terminated).toEqual([])
     expect(queue.published).toHaveLength(1)
   })
 

--- a/packages/domain/taxonomy/src/use-cases/update-custom-behavior.ts
+++ b/packages/domain/taxonomy/src/use-cases/update-custom-behavior.ts
@@ -1,3 +1,4 @@
+import { WorkflowTerminator } from "@domain/queue"
 import { type CustomBehaviorId, type FilterSet, generateSlug, toSlug } from "@domain/shared"
 import { Effect } from "effect"
 import { CUSTOM_BEHAVIOR_NAME_MAX_LENGTH } from "../constants.ts"
@@ -14,6 +15,7 @@ import { CustomBehaviorFilterInvalidError, CustomBehaviorNameInvalidError } from
 import { CustomBehaviorRepository } from "../ports/custom-behavior-repository.ts"
 import { TaxonomyViewAssignmentRepository } from "../ports/taxonomy-view-assignment-repository.ts"
 import { generateCustomBehavior } from "./generate-custom-behavior.ts"
+import { taxonomyGardenCustomBehaviorDedupeKey } from "./trigger-project-gardening.ts"
 
 export interface UpdateCustomBehaviorInput {
   readonly id: CustomBehaviorId
@@ -93,6 +95,15 @@ export const updateCustomBehavior = Effect.fn("taxonomy.updateCustomBehavior")(f
     input.filterSet !== undefined && !customBehaviorFilterSetEquals(current.filterSet, nextFilterSet)
 
   if (cohortChanged) {
+    // Stop the in-flight run first. It holds the old FilterSet for its whole duration, so
+    // left alive it would both refill the slice this purge is about to empty and hold the
+    // workflow id, dropping the replacement enqueue below as WorkflowAlreadyStartedError.
+    const terminator = yield* WorkflowTerminator
+    yield* terminator.terminate(
+      taxonomyGardenCustomBehaviorDedupeKey({ organizationId: current.organizationId, customBehaviorId: current.id }),
+      "behavior cohort filter changed",
+    )
+
     // Purge BEFORE the save. Failing between the two then leaves an empty slice under
     // the old filter, which the next garden run rebuilds; the other order would leave
     // the new filter serving the old cohort's edges, and a retry would see the filter


### PR DESCRIPTION
## What does this PR do?

Fixes a stale-clustering race on custom behavior views, and supersedes #4289, which fixes the same race but over-terminates.

**The bug.** Changing a view's cohort filter while its scoped garden workflow is running leaves the in-flight run holding the old `FilterSet` for its whole duration. `updateCustomBehavior` purges the assignment slice, saves the new filter and enqueues a replacement run — but the replacement carries the same workflow id (`taxonomyGardenCustomBehaviorDedupeKey`), so Temporal drops it as `WorkflowAlreadyStartedError`. The old run then finishes and writes clusters and assignment edges for the *old* cohort, while Postgres already holds the new filter.

**Why #4289 over-terminates.** It terminates in `updateCustomBehaviorFn` whenever `data.filterSet` is present. But the only edit UI always sends both fields on every save — `behaviour-form-modal.tsx` seeds `filterSet` from the current behaviour and passes it through unconditionally:

```ts
// apps/web/src/routes/.../behaviours/-components/behaviour-form-modal.tsx:124
return await update.mutateAsync({ id: behaviour.id, name: value.name.trim(), filterSet })
```

So a plain **rename** sends an unchanged `filterSet`. #4289 kills the healthy in-flight garden, and then the use-case computes `cohortChanged === false` and enqueues nothing — the view is left aborted with no replacement run, and because a Temporal terminate skips cleanup it can orphan a staging tree. The terminate condition has to be the *same* condition as the re-garden.

**The fix.** Move the termination into `updateCustomBehavior` and gate it on the `cohortChanged` the use-case already computes (`filterSet` provided AND not `customBehaviorFilterSetEquals(current, next)`). It runs first inside that branch: before the purge, so the dying run can't refill the slice it's about to empty, and before the enqueue, so the replacement isn't dropped as already-started.

The terminator arrives as the existing `@domain/queue` `WorkflowTerminator` port — no new port needed, `deleteCustomBehavior` already consumes it the same way. `updateCustomBehaviorFn` just provides it alongside the `QueuePublisher` it already provides.

## How was this tested?

New/updated unit tests in `custom-behavior-crud.test.ts` using the domain fakes (`createFakeWorkflowTerminator` / `createFakeQueuePublisher`, no `vi.mock`):

- filter actually changed → terminate called once with the behavior's garden dedupe key, slice purged, re-garden enqueued
- terminate precedes the enqueue (a layer that records both calls into one ordered list — this is the `WorkflowAlreadyStartedError` guard)
- `filterSet` re-sent unchanged, the rename case → no terminate, no purge, no enqueue
- name-only update → no terminate

```
pnpm --filter @domain/taxonomy test      # 27 files, 247 tests pass
pnpm --filter @domain/taxonomy typecheck
pnpm --filter web typecheck
```

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a custom behavior with changed cohort filters now stops the existing gardening workflow before starting a replacement.
  * Prevents outdated data from being restored and ensures replacement gardening runs are processed correctly.
  * Updates that only change names or leave filters unchanged do not trigger unnecessary workflow activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->