### PR TITLE
fix(mcp): accept only OAuth bearers on /v1/mcp

### DIFF
--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -8,6 +8,8 @@ import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
 import {
   type ApiTestContext,
+  createOAuthAuthHeaders,
+  createOAuthTenantSetup,
   createTenantSetup,
   setupTestApi,
   TEST_ENCRYPTION_KEY,
@@ -27,6 +29,9 @@ import {
  * We use `Accept: application/json, text/event-stream` (per the MCP spec)
  * which lets the transport pick. In our stateless setup it returns SSE; the
  * tests parse a single `data:` event.
+ *
+ * The transport is OAuth-only, so the happy-path tests seed an OAuth access
+ * token via `createOAuthTenantSetup`; organization API keys must 401.
  */
 
 const insertApiKey = async (database: InMemoryPostgres, organizationId: string, token: string) => {
@@ -57,7 +62,7 @@ const sendMcpRequest = async (app: ApiTestContext["app"], authToken: string, bod
     new Request("http://localhost/v1/mcp", {
       method: "POST",
       headers: {
-        ...createApiKeyAuthHeaders(authToken),
+        ...createOAuthAuthHeaders(authToken),
         "Content-Type": "application/json",
         Accept: "application/json, text/event-stream",
       },
@@ -99,9 +104,38 @@ describe("/v1/mcp", () => {
     expect(res.status).toBe(401)
   })
 
-  it<ApiTestContext>("initialize returns the server info + capabilities", async ({ app, database }) => {
+  it<ApiTestContext>("rejects a valid organization API key with 401", async ({ app, database }) => {
     const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await app.fetch(
+      new Request("http://localhost/v1/mcp", {
+        method: "POST",
+        headers: {
+          ...createApiKeyAuthHeaders(tenant.apiKeyToken),
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: { protocolVersion: PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: "t", version: "0" } },
+        }),
+      }),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it<ApiTestContext>("still serves REST routes to an API key the transport rejects", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const res = await app.fetch(
+      new Request("http://localhost/v1/api-keys", { headers: createApiKeyAuthHeaders(tenant.apiKeyToken) }),
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it<ApiTestContext>("initialize returns the server info + capabilities", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 1,
       method: "initialize",
@@ -116,8 +150,8 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/list returns the registered API-key tools", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 2,
       method: "tools/list",
@@ -129,8 +163,8 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/list includes the tool-analytics tools", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 20, method: "tools/list" })
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, { jsonrpc: "2.0", id: 20, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -138,8 +172,8 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/list includes the monitor tools", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 24, method: "tools/list" })
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, { jsonrpc: "2.0", id: 24, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -158,8 +192,8 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/list includes the experiment tools", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 26, method: "tools/list" })
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, { jsonrpc: "2.0", id: 26, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -175,8 +209,8 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/list includes the user-analytics tools", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, { jsonrpc: "2.0", id: 22, method: "tools/list" })
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, { jsonrpc: "2.0", id: 22, method: "tools/list" })
     expect(res.status).toBe(200)
     const payload = (await readSseJsonRpc(res)) as { result?: { tools?: ReadonlyArray<{ name: string }> } }
     const toolNames = payload.result?.tools?.map((t) => t.name) ?? []
@@ -189,10 +223,10 @@ describe("/v1/mcp", () => {
     app,
     database,
   }) => {
-    const tenant = await createTenantSetup(database)
+    const tenant = await createOAuthTenantSetup(database)
     const project = await insertProject(database, tenant.organizationId)
 
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 23,
       method: "tools/call",
@@ -212,10 +246,10 @@ describe("/v1/mcp", () => {
     app,
     database,
   }) => {
-    const tenant = await createTenantSetup(database)
+    const tenant = await createOAuthTenantSetup(database)
     const project = await insertProject(database, tenant.organizationId)
 
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 21,
       method: "tools/call",
@@ -238,13 +272,13 @@ describe("/v1/mcp", () => {
     app,
     database,
   }) => {
-    const tenant = await createTenantSetup(database)
+    const tenant = await createOAuthTenantSetup(database)
     // Seed two extra API keys so the listApiKeys tool returns >= 3 entries
-    // (the auth key from `createTenantSetup` plus these two).
+    // (the org's own key from `createOAuthTenantSetup` plus these two).
     await insertApiKey(database, tenant.organizationId, generateApiKeyToken())
     await insertApiKey(database, tenant.organizationId, generateApiKeyToken())
 
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 3,
       method: "tools/call",
@@ -266,10 +300,10 @@ describe("/v1/mcp", () => {
   })
 
   it<ApiTestContext>("tools/call creates and reads a monitor with structured content", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
+    const tenant = await createOAuthTenantSetup(database)
     const project = await insertProject(database, tenant.organizationId)
 
-    const createRes = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const createRes = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 25,
       method: "tools/call",
@@ -301,7 +335,7 @@ describe("/v1/mcp", () => {
     expect(createdPayload.result?.structuredContent?.target?.stream).toBe("sessions")
     expect(createdPayload.result?.structuredContent?.target?.metric?.kind).toBe("count")
 
-    const listRes = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const listRes = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 26,
       method: "tools/call",
@@ -319,8 +353,8 @@ describe("/v1/mcp", () => {
     app,
     database,
   }) => {
-    const tenant = await createTenantSetup(database)
-    const res = await sendMcpRequest(app, tenant.apiKeyToken, {
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await sendMcpRequest(app, tenant.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 4,
       method: "tools/call",
@@ -346,11 +380,11 @@ describe("/v1/mcp", () => {
     app,
     database,
   }) => {
-    const tenantA = await createTenantSetup(database)
+    const tenantA = await createOAuthTenantSetup(database)
     const tenantB = await createTenantSetup(database)
     // Try to revoke tenant B's API key with tenant A's bearer — the inner
     // route's org-scoped repository returns 404, which surfaces as isError.
-    const res = await sendMcpRequest(app, tenantA.apiKeyToken, {
+    const res = await sendMcpRequest(app, tenantA.oauthAccessToken, {
       jsonrpc: "2.0",
       id: 5,
       method: "tools/call",

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedError } from "@domain/shared"
 import type { OpenAPIHono, z } from "@hono/zod-openapi"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js"
@@ -8,12 +9,15 @@ import type { AppEnv, ProtectedEnv } from "../types.ts"
 
 /**
  * Mounts the MCP transport endpoint on `routes` (which already lives behind
- * the unified auth + org-context middleware). Tool dispatch re-enters the
- * root Hono app via `app.fetch(internalRequest)` so every tool call runs
- * through the same middleware chain (validation, rate-limit, auth,
- * organization context). The outer `Authorization` and `X-Forwarded-For`
- * headers are forwarded so the inner request authenticates as the same
- * caller and counts against the same rate-limit bucket.
+ * the unified auth + org-context middleware). The transport narrows that ring
+ * to OAuth bearers only — organization API keys are rejected even though they
+ * authenticate fine on the REST routes, so consent, org binding, and token
+ * revocation always sit on the transport. Tool dispatch re-enters the root
+ * Hono app via `app.fetch(internalRequest)` so every tool call runs through
+ * the same middleware chain (validation, rate-limit, auth, organization
+ * context). The outer `Authorization` and `X-Forwarded-For` headers are
+ * forwarded so the inner request authenticates as the same caller and counts
+ * against the same rate-limit bucket.
  *
  * The MCP mount path (`/mcp`) is internal to this function — when `routes`
  * is mounted at `/${API_VERSION}` on the root, the public URL becomes
@@ -62,6 +66,12 @@ export const registerMcpRoute = ({
   const toolDescriptors = collectToolDescriptors()
 
   routes.all("/mcp", async (c) => {
+    // 401, not 403, so a client pointed here with an API key starts the OAuth
+    // dance instead of failing hard.
+    if (c.get("auth")?.method !== "oauth") {
+      throw new UnauthorizedError({ message: "The MCP endpoint requires an OAuth access token" })
+    }
+
     const mcpServer = new McpServer(MCP_INFO, { instructions: MCP_INFO.instructions, capabilities: { tools: {} } })
 
     for (const tool of toolDescriptors) {

--- a/dev-docs/api.md
+++ b/dev-docs/api.md
@@ -29,6 +29,8 @@ authenticate(c) → AuthContext | 401
 
 Both validators have a short negative-cache TTL (~5s), so an unknown bearer hits each underlying datastore at most once per cache window.
 
+The one exception is `/v1/mcp`, which admits OAuth bearers only — see [`mcp.md`](./mcp.md). It runs in the same protected ring; the transport handler rejects an `api-key` `AuthContext` with a 401 before it starts a session.
+
 ### `AuthContext` shape
 
 ```ts
@@ -70,7 +72,7 @@ attachSharedContext(db, redis, clickhouse, queue)   ← all routes
     createOrganizationContextMiddleware()
 
       /v1/...   ← all REST routes, with per-endpoint tier limiters
-      /v1/mcp   ← MCP transport, per-request McpServer
+      /v1/mcp   ← MCP transport, per-request McpServer (OAuth bearers only)
 ```
 
 Public routes are bodyless metadata documents — never product data. Everything that touches an organization runs under the protected ring.

--- a/dev-docs/mcp.md
+++ b/dev-docs/mcp.md
@@ -2,6 +2,8 @@
 
 Latitude exposes an [MCP](https://modelcontextprotocol.io/) server so AI agents (Claude Code, Cursor, Codex, custom CLIs) can use Latitude's machine-facing capabilities as typed tools instead of curling raw HTTP. The server is mounted at `/v1/mcp` **inside the existing `apps/api` process** — there is no separate MCP service.
 
+Auth is OAuth-only. An organization API key that works on every REST `/v1/...` route gets a 401 here, so consent, org binding, and per-client revocation always apply to a tool call — a long-lived org-wide key can't skip them.
+
 ## Tools are derived from API routes
 
 Every operation declared via `defineOperation(...)` is registered as an MCP tool by default. Tool name = route `name` (camelCase), tool description = route `description`, tool input schema = the flattened union of `route.request.{params, query, body}`, tool output schema = the 2xx-JSON response schema.
@@ -46,7 +48,7 @@ The MCP server is the protected resource; the web app is the authorization serve
 │ (TanStack Start)                     │      │ (Hono / OpenAPIHono)               │
 │                                      │      │                                    │
 │  /login              sign-in UI      │      │  /v1/...   REST + ApiKey/OAuth     │
-│  /welcome            org-picker      │      │  /v1/mcp   MCP transport           │
+│  /welcome            org-picker      │      │  /v1/mcp   MCP transport, OAuth    │
 │  /auth/consent       OAuth consent   │      │                                    │
 │  /api/auth/*         BA handler      │      │  /.well-known/oauth-protected-     │
 │    (incl. mcp/authorize, mcp/token,  │      │     resource                       │


### PR DESCRIPTION
## Problem

`/v1/mcp` is a route inside the protected ring (`routes` in `apps/api/src/routes/index.ts`), so it inherited that ring's unified auth: `createAuthMiddleware` tries the API-key validator first, then OAuth. An organization-scoped API key therefore authenticated the MCP transport exactly like it authenticates a REST route.

That's a hole in the MCP authorization model. Pasting a long-lived org-wide key into an MCP client config skips consent, org binding, and per-client revocation — the three things the OAuth flow exists to enforce. Nothing in the public docs ever advertised it (`docs/getting-started/mcp.mdx` only documents the OAuth flow), so this closes a path users shouldn't have had rather than removing a supported one.

## Fix

The auth middleware already resolves the bearer and writes the `method` discriminant onto `c.var.auth` before the transport handler body runs, so this is a guard at the top of that handler:

```ts
routes.all("/mcp", async (c) => {
  if (c.get("auth")?.method !== "oauth") {
    throw new UnauthorizedError({ message: "The MCP endpoint requires an OAuth access token" })
  }
  …
```

Two decisions worth flagging for review:

**401, not 403.** `requireOAuthUserId` uses 403 for REST endpoints that need a human actor, but on the MCP transport a 401 is what makes a client fall back to `/.well-known/oauth-protected-resource` and complete consent. A 403 would just dead-end it.

**One protected ring, not two.** The alternative is a second sub-app at `/v1/mcp` with its own `validationErrorMiddleware` + auth + org-context stack. That works, but it duplicates the ring — anything added to `routes.use("*", …)` later (the IP-based auth rate limiter the docs already describe, request logging, a Host-header check) would silently not apply to the transport. Guarding inside the handler keeps exactly one ring, which is also what keeps the ring diagram in `dev-docs/api.md` true.

Tool dispatch needs no change: it forwards the caller's `Authorization` header into `app.fetch()`, and past the guard that bearer is an OAuth token by construction.

## Trade-off it accepts

An API key sent to `/v1/mcp` is still validated before being rejected, so the touch buffer bumps its `lastUsedAt`. Cosmetic — a rejected request records the key as used. Avoiding it would need the second ring above; not worth it.

## Not in scope

No 401 on the API emits `WWW-Authenticate: Bearer resource_metadata="…"`. `dev-docs/mcp.md` claims it and `cors.ts` already exposes the header, but nothing sets it. Pre-existing, affects the no-token path too, and belongs in the shared auth middleware — worth a follow-up. Cursor and Zed both work today by probing the well-known paths directly.

## Tests

`apps/api/src/mcp/server.test.ts` drove the transport with an API key throughout, so the happy-path tests move to `createOAuthTenantSetup` / `createOAuthAuthHeaders` (both already in the harness). That's most of the diff. Two new cases:

- a **valid** organization API key gets 401 on `/v1/mcp`
- that same key still gets 200 on `GET /v1/api-keys`, pinning the blast radius to the transport

Full `apps/api` suite green (279 tests, 26 files); `pnpm --filter @app/api typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * MCP connections now require OAuth bearer authentication.
  * Organization API keys are rejected for MCP requests with a `401` response, while remaining valid for REST API routes.

* **Documentation**
  * Updated API and MCP documentation to describe OAuth-only authentication and request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->