### PR TITLE
fix(api): send WWW-Authenticate on 401 so MCP clients can discover the AS

### DIFF
--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -123,6 +123,11 @@ describe("/v1/mcp", () => {
       }),
     )
     expect(res.status).toBe(401)
+    // The client has to be told where to authorize, or it can't recover from
+    // having been pointed here with the wrong kind of credential.
+    expect(res.headers.get("WWW-Authenticate")).toBe(
+      `Bearer resource_metadata="${process.env.LAT_API_URL}/.well-known/oauth-protected-resource"`,
+    )
   })
 
   it<ApiTestContext>("still serves REST routes to an API key the transport rejects", async ({ app, database }) => {

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -98,6 +98,42 @@ describe("auth middleware dispatch", () => {
     expect(res.status).toBe(401)
   })
 
+  it<ApiTestContext>("points 401s at the protected-resource metadata document", async ({ app, database }) => {
+    await createTenantSetup(database)
+    const challenge = `Bearer resource_metadata="${process.env.LAT_API_URL}/.well-known/oauth-protected-resource"`
+
+    const noHeader = await app.fetch(new Request("http://localhost/v1/api-keys"))
+    expect(noHeader.headers.get("WWW-Authenticate")).toBe(challenge)
+
+    const unknownBearer = await app.fetch(
+      new Request("http://localhost/v1/api-keys", {
+        headers: { Authorization: `Bearer ${crypto.randomUUID()}` },
+      }),
+    )
+    expect(unknownBearer.headers.get("WWW-Authenticate")).toBe(challenge)
+  })
+
+  it<ApiTestContext>("leaves the challenge off non-401 responses", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const token = generateApiKeyToken()
+    await insertApiKey(database, tenant.organizationId, token)
+
+    const ok = await app.fetch(
+      new Request("http://localhost/v1/api-keys", { headers: { Authorization: `Bearer ${token}` } }),
+    )
+    expect(ok.status).toBe(200)
+    expect(ok.headers.get("WWW-Authenticate")).toBeNull()
+
+    const notFound = await app.fetch(
+      new Request("http://localhost/v1/api-keys/does-not-exist", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    )
+    expect(notFound.status).toBe(404)
+    expect(notFound.headers.get("WWW-Authenticate")).toBeNull()
+  })
+
   it<ApiTestContext>("rejects an OAuth token whose application has no organization binding", async ({
     app,
     database,

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -1,7 +1,22 @@
+import { parseEnv } from "@platform/env"
 import { isHttpError, LatitudeObservabilityTestError, toHttpResponse } from "@repo/utils"
-import type { ErrorHandler } from "hono"
+import { Effect } from "effect"
+import type { Context, ErrorHandler } from "hono"
 import { HTTPException } from "hono/http-exception"
 import { logger } from "../utils/logger.ts"
+
+/**
+ * Advertises where to find this resource server's OAuth metadata, per RFC 9728
+ * §5.1. MCP clients read the AS location out of this header to start the
+ * authorization flow; without it a spec-following client can't tell an
+ * OAuth-protected resource from plain bad credentials. Built from `LAT_API_URL`
+ * so the URL matches the `resource` identifier the metadata document itself
+ * advertises (see `routes/well-known.ts`).
+ */
+const setBearerChallenge = (c: Context) => {
+  const apiUrl = Effect.runSync(parseEnv("LAT_API_URL", "string", "http://localhost:3001"))
+  c.header("WWW-Authenticate", `Bearer resource_metadata="${apiUrl}/.well-known/oauth-protected-resource"`)
+}
 
 /**
  * Global error handler for Hono.
@@ -17,6 +32,7 @@ export const honoErrorHandler: ErrorHandler = (err, c) => {
   // If it's a domain HTTP-aware error, use its status and message.
   if (isHttpError(err)) {
     const { status, body } = toHttpResponse(err)
+    if (status === 401) setBearerChallenge(c)
     return c.json(body, status as 400 | 401 | 403 | 404 | 409 | 500)
   }
 
@@ -25,6 +41,7 @@ export const honoErrorHandler: ErrorHandler = (err, c) => {
   // Surface them with the status Hono chose instead of swallowing them
   // into the generic 500 branch below.
   if (err instanceof HTTPException) {
+    if (err.status === 401) setBearerChallenge(c)
     return c.json({ name: err.name, message: err.message }, err.status)
   }
 

--- a/dev-docs/api.md
+++ b/dev-docs/api.md
@@ -31,6 +31,8 @@ Both validators have a short negative-cache TTL (~5s), so an unknown bearer hits
 
 The one exception is `/v1/mcp`, which admits OAuth bearers only — see [`mcp.md`](./mcp.md). It runs in the same protected ring; the transport handler rejects an `api-key` `AuthContext` with a 401 before it starts a session.
 
+Every 401 the error handler emits carries `WWW-Authenticate: Bearer resource_metadata="<LAT_API_URL>/.well-known/oauth-protected-resource"` (RFC 9728 §5.1), which is how a spec-following MCP client discovers the authorization server instead of guessing the well-known path. The GitHub webhook's signature 401 returns its response directly and is deliberately not a bearer challenge.
+
 ### `AuthContext` shape
 
 ```ts


### PR DESCRIPTION
Follow-up to #4335, which closed the API-key path into `/v1/mcp`. That PR made a class of client hit a 401 they didn't hit before, which is when it matters that our 401s don't say where to authenticate.

## What was missing

RFC 9728 §5.1 — cited by the MCP authorization spec, which makes it a MUST — has a protected resource advertise its metadata location on a 401:

```
WWW-Authenticate: Bearer resource_metadata="https://api.latitude.so/.well-known/oauth-protected-resource"
```

We never sent it. Here are the three 401 shapes as they are on `development` today (captured through the real app, headers dumped verbatim):

```
no token   → 401 [["content-type","application/json"]] {"error":"Authentication required"}
api key    → 401 [["content-type","application/json"]] {"error":"The MCP endpoint requires an OAuth access token"}
bogus/REST → 401 [["content-type","application/json"]] {"error":"Invalid credentials"}
```

The OAuth flow works anyway because `routes/well-known.ts` serves the metadata document at *every* path suffix, so clients that guess the conventional path find it — the comment in that file notes Cursor probes the unscoped form and Zed the path-suffixed one. Both guess; both hit. A client that follows the spec instead of guessing gets a bare 401 and can't distinguish "this resource uses OAuth, go authorize" from "your credentials are wrong," so it surfaces a dead-end error instead of a login prompt.

Browser-hosted clients (MCP Inspector in a tab, a web-based agent) can't read the header at all unless CORS exposes it — and `cors.ts:48` already lists `WWW-Authenticate` in `exposeHeaders`. The intent was there; the header wasn't. `dev-docs/mcp.md:78` also documented this as existing behavior, so that line stops being a lie.

## The change

One helper in `honoErrorHandler`, called from the two branches that can produce a 401:

```ts
const setBearerChallenge = (c: Context, status: number) => {
  if (status !== 401) return
  const apiUrl = Effect.runSync(parseEnv("LAT_API_URL", "string", "http://localhost:3001"))
  c.header("WWW-Authenticate", `Bearer resource_metadata="${apiUrl}/.well-known/oauth-protected-resource"`)
}
```

**Every 401, not just `/v1/mcp`.** RFC 6750 wants a challenge on any 401, the API genuinely accepts OAuth tokens on every `/v1` route, and the error handler is one place instead of threading path-awareness through the shared auth middleware. The only consequence is that a REST caller with a bad API key now gets a pointer to a public discovery document.

**`LAT_API_URL` is the source** so the URL matches the `resource` identifier the metadata document itself advertises — a client comparing the two sees one origin. The fallback mirrors `server.ts:37` and exists so the error handler can never throw on unset env, which would turn every error response into a crash.

**The GitHub webhook 401 is deliberately excluded.** `webhooks-github.ts:50` returns `c.json({ error: "Invalid signature" }, 401)` directly rather than throwing, so it never reaches the error handler. An HMAC signature failure isn't a bearer challenge, and the error-handler placement gives us that exclusion for free rather than by special-casing.

## Tests

- `auth.test.ts`: both auth-middleware 401s (no header, unknown bearer) carry the exact challenge; a 200 and a 404 on the same route carry no challenge, pinning the `status !== 401` guard.
- `mcp/server.test.ts`: the API-key-rejected-by-the-transport 401 carries it — the case a user recovers from by authorizing.

Full `apps/api` suite green (281 tests, 26 files); `pnpm --filter @app/api typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added standard OAuth bearer challenge metadata to applicable `401 Unauthorized` responses.
  - Ensured successful and `404 Not Found` responses do not include authentication challenges.
  - Preserved direct handling for invalid GitHub webhook signatures.
  - Improved consistency of authentication responses across API endpoints.

- **Documentation**
  - Documented the `WWW-Authenticate` response behavior and protected-resource metadata endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->