### PR TITLE
fix(ai): report the failed primary attempt when a generate falls back

### DIFF
--- a/packages/platform/ai-vercel/src/ai.test.ts
+++ b/packages/platform/ai-vercel/src/ai.test.ts
@@ -1,6 +1,6 @@
 import { AICredentialError, AIGenerate, EMBEDDING_DIMENSIONS } from "@domain/ai"
-import { Effect, Result } from "effect"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { Effect, Logger, Result } from "effect"
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest"
 
 const {
   bedrockModelFactoryMock,
@@ -222,6 +222,44 @@ describe("AIGenerateLive", () => {
     expect(generateTextMock).toHaveBeenCalledTimes(2)
     expect(generateTextMock.mock.calls[0]?.[0].model).toEqual({ modelId: "minimax.minimax-m2.5" })
     expect(generateTextMock.mock.calls[1]?.[0].model).toEqual({ modelId: "openai.gpt-oss-120b-1:0" })
+  })
+
+  it("reports the failed primary attempt in the duration and records why it fell back", async () => {
+    let clockMs = 0
+    const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clockMs)
+    onTestFinished(() => nowSpy.mockRestore())
+
+    generateTextMock
+      .mockImplementationOnce(() => {
+        clockMs += 500
+        return Promise.reject(new Error("Bedrock is unable to process your request."))
+      })
+      .mockImplementationOnce(() => {
+        clockMs += 200
+        return Promise.resolve({ output: { ok: true }, usage: { totalTokens: 3, inputTokens: 2, outputTokens: 1 } })
+      })
+
+    const logs: string[] = []
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ai = yield* AIGenerate
+
+        return yield* ai.generate({
+          provider: "amazon-bedrock",
+          model: "minimax.minimax-m2.5",
+          system: "Return JSON.",
+          prompt: "Say ok.",
+          schema: { parse: (value: unknown) => value } as never,
+        })
+      }).pipe(
+        Effect.provide(AIGenerateLive),
+        Effect.provide(Logger.layer([Logger.make(({ message }) => logs.push(String(message)))])),
+      ),
+    )
+
+    expect(result.duration).toBe(700_000_000)
+    expect(logs.join("\n")).toContain("Bedrock is unable to process your request.")
+    expect(logs.join("\n")).toContain("amazon-bedrock/openai.gpt-oss-120b-1:0")
   })
 })
 

--- a/packages/platform/ai-vercel/src/ai.ts
+++ b/packages/platform/ai-vercel/src/ai.ts
@@ -369,10 +369,12 @@ export const AIGenerateLive = Layer.effect(
       const fallback = resolveGenerateFallback(input)
       const fallbackProviderModel = fallback ? yield* createProviderModel(fallback.provider, fallback.model) : undefined
 
-      return yield* Effect.tryPromise({
+      // Started before the primary attempt so a fallback-served call reports the
+      // latency the caller actually waited, not just the winning attempt's.
+      const startTime = performance.now()
+      const outcome = yield* Effect.tryPromise({
         try: async () => {
           const generateWithModel = async (model: ProviderModel) => {
-            const startTime = performance.now()
             const providerOptions = normalizeProviderOptions(input.providerOptions)
 
             const call: GenerateTextCall = {
@@ -414,14 +416,20 @@ export const AIGenerateLive = Layer.effect(
 
           const execute = async () => {
             try {
-              return await generateWithModel(providerModel)
+              return { result: await generateWithModel(providerModel), fallback: null }
             } catch (primaryError) {
               if (!fallback || fallbackProviderModel === undefined) {
                 throw primaryError
               }
 
               try {
-                return await generateWithModel(fallbackProviderModel)
+                return {
+                  result: await generateWithModel(fallbackProviderModel),
+                  fallback: {
+                    model: `${fallback.provider}/${fallback.model}`,
+                    primaryError: formatGenerateError(primaryError),
+                  },
+                }
               } catch (fallbackError) {
                 throw new Error(
                   `Primary model ${input.provider}/${input.model} failed: ${formatGenerateError(primaryError)}; ` +
@@ -439,6 +447,16 @@ export const AIGenerateLive = Layer.effect(
             cause: error,
           }),
       })
+
+      if (outcome.fallback !== null) {
+        yield* Effect.annotateCurrentSpan("effect.ai.fallback_model", outcome.fallback.model)
+        yield* Effect.annotateCurrentSpan("effect.ai.fallback_reason", outcome.fallback.primaryError)
+        yield* Effect.logWarning(
+          `AI generation fell back from ${input.provider}/${input.model} to ${outcome.fallback.model}: ${outcome.fallback.primaryError}`,
+        )
+      }
+
+      return outcome.result
     })
 
     return {


### PR DESCRIPTION
Audit of one observability shape across `apps/*` and `packages/*`: a degrading path where the failure costs us the timing or the reason. Motivated by #4334, where the adaptive taxonomy build recovered *outside* `Effect.timed`, so a build killed by the 300s clustering-worker deadline reported `durationMs: 0` with no error — indistinguishable from "threw on arrival", and six days of misdiagnosis.

One site cleared the bar and is fixed here. Everything else I found is listed below with why it stays as it is.

## what was wrong

`AIGenerateLive.generate` (`@platform/ai-vercel`) has one fallback pairing: Bedrock `minimax.minimax-m2.5` → `openai.gpt-oss-120b-1:0`, wired in `resolveGenerateFallback`. MiniMax is the default model for evaluations, flaggers, annotations, signals, conversation intelligence, and taxonomy naming, so this path is live across most of the product.

`generateWithModel` started its own clock per attempt. When the primary failed and the fallback answered, two things were lost:

- **The duration covered only the winning attempt.** A primary that hung for 55s before failing, plus a 3s fallback, reported 3s. That number is not discarded: `run-live-evaluation` passes it to `writeScoreUseCase` as `duration`, so it is persisted on the score row in nanoseconds. Same wrong-`0`-shape as the taxonomy bug, except it lands in a table.
- **The primary error was dropped entirely** when the fallback succeeded — no log, no span attribute. The span still carried `effect.ai.model = minimax.minimax-m2.5`, and cost is estimated with the primary model's prices, so a MiniMax outage looks like normal MiniMax traffic that merely got faster and cheaper. Nothing anywhere answers "why did this degrade?".

Both are recurring-production-event territory: the fallback exists because Bedrock rejects MiniMax requests under load.

## the change

The clock now starts before the primary attempt, so `duration` is the latency the caller actually waited regardless of which model answered. When the fallback serves the call, the primary failure is recorded on the `ai.generate` span (`effect.ai.fallback_model`, `effect.ai.fallback_reason`) and as a warning log — the span for the Datadog view, the log for the un-sampled CloudWatch record. This follows the existing precedent in `run-flagger.ts:581`, which already annotates `flagger.instructionExtractionFallback` on its degrade path.

Cost attribution on a fallback-served call is still the primary model's estimate. Out of scope here, but now detectable from the span.

The new test drives the fallback with a stubbed `performance.now`: a 500ms primary failure plus a 200ms fallback must report 700ms and must surface the primary error. Against the old code it reports 200ms.

## sites deliberately left alone

Every other candidate fails at least one of: the value is never reported, the failure can't realistically happen, or the degrade already records its reason.

**`Effect.timed` composed with recovery** has exactly two occurrences repo-wide, both in `build-hierarchical-taxonomy.ts`. The adaptive one (`packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts:687`) is #4334's. The static build at `:675` has no recovery at all (a static failure is fatal by design), so its duration is never reported as a fake zero.

**Manual `Date.now()` timing that is logged** — `runGardenStep` (`apps/workflows/src/activities/taxonomy-gardening-activities.ts:443`), `analyzeSessionActivity` (`apps/workflows/src/activities/analyze-session-activities.ts:281`), `apps/workers/src/workers/projects.ts:28`, `apps/workers/src/services/provisioning.ts:11`, `apps/{api,ingest}/src/middleware/touch-buffer.ts:109`, `apps/workflows/src/workflows/flagger-classification-workflow.ts:28`. Each computes the elapsed time on the failure path too, or lets the error propagate to a framework that logs it. None reports a zero.

**Timing that is never reported** — `enforceMinimumTime` in `validate-api-key.ts:111` and `validate-oauth-token.ts:151` is constant-time-auth padding, not telemetry. `healthcheckPostgres` / `healthcheckClickhouse` (`packages/platform/db-{postgres,clickhouse}/src/health.ts:13`) return `latencyMs` only on success and currently have no callers. `get-cluster-session-intelligence.ts:82` logs `queryLatencyMs` at debug on the success path only; a query failure propagates.

**Degrades that already record their reason** — the trace-search worker (`apps/workers/src/workers/trace-search.ts:69,106,137,231,255,329`), `packages/platform/ai/src/cache.ts:74-90`, `apps/workers/src/workers/destinations.ts:188`, `apps/workers/src/workers/notifications.ts:138`, `seed-demo-project-activities.ts:226,269`, `run-flagger.ts:581`. `Effect.tapError(log)` before `orElseSucceed` is the established idiom here and these follow it.

**Swallows whose failure is not an operator question** — `create-custom-behavior.ts:149` and `update-custom-behavior.ts:129` (a dropped garden enqueue is picked up by the next sweep, and the row's null `last_gardened_at` is the record), `failCustomBehaviorRun` / `cleanupGardenTaxonomyStaging` (`taxonomy-gardening-activities.ts:1297,1326`, deleted-mid-run no-ops), `get-trace-search-highlights.ts:101,111,122` and `traces.functions.ts:460` (decorative highlight layer, documented as such), `behaviour-catalog.functions.ts:148` (an unbuilt tree is a normal waiting card), `posthog-analytics.ts:36`, `span-ingestion.ts:78`.

**Failure counters that drop the reason** — `sweep-destinations.ts:63`, `request-destination-backfill.ts:69`, `sweep-escalating-signals.ts:74` tally `failed` into a span attribute without the error. A real gap, but a different one: the reported number is correct, it just isn't self-explanatory, so nobody gets pointed at a wrong hypothesis the way `durationMs: 0` pointed us at "threw on arrival". Not worth churning three use cases and their tests here.

The plan-retention fallbacks (`destinations.functions.ts:97`, `destinations.ts:154`) silently widen to `MAX_RETENTION_MS` when billing is unreachable. That is a correctness question about backfill windows rather than lost timing, and out of this audit's scope.

Refs #4334

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reporting for AI requests that require a fallback model.
  * Request duration now includes time spent on both the primary and fallback attempts.
  * Fallback events now provide clearer diagnostic details, including the selected model and primary failure.
  * Added additional tracing and warning information when fallback generation succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->