### PR TITLE
fix(ai): price a generate call against the model that actually served it

### DIFF
--- a/packages/domain/ai/src/index.ts
+++ b/packages/domain/ai/src/index.ts
@@ -80,6 +80,8 @@ export interface GenerateResult<T> {
   readonly object: T
   readonly tokens: number
   readonly duration: number // nanoseconds
+  /** Provider/model that actually served the call, the requested pair unless a fallback answered; price against this, not the input. */
+  readonly servedBy?: { readonly provider: string; readonly model: string }
   readonly tokenUsage?: {
     readonly input: number
     readonly output: number

--- a/packages/domain/evaluations/src/runtime/evaluation-execution.test.ts
+++ b/packages/domain/evaluations/src/runtime/evaluation-execution.test.ts
@@ -1,6 +1,11 @@
+import { estimateCost } from "@domain/models"
 import { getEncoding } from "js-tiktoken"
 import { describe, expect, it } from "vitest"
-import { fitPromptToJudgeContextWindow } from "./evaluation-execution.ts"
+import {
+  EVALUATION_DEFAULT_SCRIPT_RUNTIME_MODEL,
+  estimateEvaluationScriptCostMicrocents,
+  fitPromptToJudgeContextWindow,
+} from "./evaluation-execution.ts"
 
 const encoder = getEncoding("o200k_base")
 const countTokens = (text: string) => encoder.encode(text).length
@@ -77,5 +82,44 @@ describe("fitPromptToJudgeContextWindow", () => {
 
     expect(fitted.length).toBeLessThan(prompt.length)
     expect(fitted.startsWith(longInstructions)).toBe(false)
+  })
+})
+
+describe("estimateEvaluationScriptCostMicrocents", () => {
+  const usage = { input: 100_000, output: 20_000 }
+  const toMicrocents = (provider: string, model: string) =>
+    Math.round(estimateCost(provider, model, usage) * 100_000_000)
+
+  it("prices a fallback-served call with the fallback model's rates", () => {
+    const cost = estimateEvaluationScriptCostMicrocents(
+      {
+        tokens: 120_000,
+        tokenUsage: usage,
+        servedBy: { provider: "amazon-bedrock", model: "openai.gpt-oss-120b-1:0" },
+      },
+      EVALUATION_DEFAULT_SCRIPT_RUNTIME_MODEL,
+    )
+
+    expect(cost).toBe(toMicrocents("amazon-bedrock", "openai.gpt-oss-120b-1:0"))
+    expect(cost).not.toBe(toMicrocents("amazon-bedrock", "minimax.minimax-m2.5"))
+  })
+
+  it("prices a call served by the requested model with the requested model's rates", () => {
+    const cost = estimateEvaluationScriptCostMicrocents(
+      {
+        tokens: 120_000,
+        tokenUsage: usage,
+        servedBy: { provider: "amazon-bedrock", model: "minimax.minimax-m2.5" },
+      },
+      EVALUATION_DEFAULT_SCRIPT_RUNTIME_MODEL,
+    )
+
+    expect(cost).toBe(toMicrocents("amazon-bedrock", "minimax.minimax-m2.5"))
+  })
+
+  it("falls back to the requested model when the adapter reports no served model", () => {
+    const cost = estimateEvaluationScriptCostMicrocents({ tokens: 120_000, tokenUsage: usage })
+
+    expect(cost).toBe(toMicrocents("amazon-bedrock", "minimax.minimax-m2.5"))
   })
 })

--- a/packages/domain/evaluations/src/runtime/evaluation-execution.ts
+++ b/packages/domain/evaluations/src/runtime/evaluation-execution.ts
@@ -159,9 +159,11 @@ export const toEvaluationConversationMessages = (
     content: formatGenAIMessage(message),
   }))
 
+/** Prices with `result.servedBy` when the adapter reports it, so a fallback-served call is not costed at the requested rates. */
 export const estimateEvaluationScriptCostMicrocents = (
   result: {
     readonly tokens: number
+    readonly servedBy?: { readonly provider: string; readonly model: string }
     readonly tokenUsage?: {
       readonly input: number
       readonly output: number
@@ -170,12 +172,13 @@ export const estimateEvaluationScriptCostMicrocents = (
       readonly cacheWrite?: number | undefined
     }
   },
-  costModel: { readonly provider: string; readonly model: string } = EVALUATION_DEFAULT_SCRIPT_RUNTIME_MODEL,
+  requestedModel: { readonly provider: string; readonly model: string } = EVALUATION_DEFAULT_SCRIPT_RUNTIME_MODEL,
 ): number => {
   const usage = result.tokenUsage ?? {
     input: 0,
     output: result.tokens,
   }
+  const costModel = result.servedBy ?? requestedModel
 
   return Math.round(estimateCost(costModel.provider, costModel.model, usage) * 100_000_000)
 }

--- a/packages/platform/ai-vercel/src/ai.test.ts
+++ b/packages/platform/ai-vercel/src/ai.test.ts
@@ -224,6 +224,52 @@ describe("AIGenerateLive", () => {
     expect(generateTextMock.mock.calls[1]?.[0].model).toEqual({ modelId: "openai.gpt-oss-120b-1:0" })
   })
 
+  it("reports the fallback as the model that served a fallen-back call", async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error("Bedrock is unable to process your request."))
+      .mockResolvedValueOnce({ output: { ok: true }, usage: { totalTokens: 3, inputTokens: 2, outputTokens: 1 } })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ai = yield* AIGenerate
+
+        return yield* ai.generate({
+          provider: "amazon-bedrock",
+          model: "minimax.minimax-m2.5",
+          system: "Return JSON.",
+          prompt: "Say ok.",
+          schema: { parse: (value: unknown) => value } as never,
+        })
+      }).pipe(Effect.provide(AIGenerateLive)),
+    )
+
+    expect(result.servedBy).toEqual({ provider: "amazon-bedrock", model: "openai.gpt-oss-120b-1:0" })
+  })
+
+  it("reports the requested model as the model that served a normal call", async () => {
+    generateTextMock.mockResolvedValueOnce({
+      output: { ok: true },
+      usage: { totalTokens: 3, inputTokens: 2, outputTokens: 1 },
+    })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ai = yield* AIGenerate
+
+        return yield* ai.generate({
+          provider: "amazon-bedrock",
+          model: "minimax.minimax-m2.5",
+          system: "Return JSON.",
+          prompt: "Say ok.",
+          schema: { parse: (value: unknown) => value } as never,
+        })
+      }).pipe(Effect.provide(AIGenerateLive)),
+    )
+
+    expect(result.servedBy).toEqual({ provider: "amazon-bedrock", model: "minimax.minimax-m2.5" })
+    expect(generateTextMock).toHaveBeenCalledTimes(1)
+  })
+
   it("reports the failed primary attempt in the duration and records why it fell back", async () => {
     let clockMs = 0
     const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clockMs)

--- a/packages/platform/ai-vercel/src/ai.ts
+++ b/packages/platform/ai-vercel/src/ai.ts
@@ -369,12 +369,14 @@ export const AIGenerateLive = Layer.effect(
       const fallback = resolveGenerateFallback(input)
       const fallbackProviderModel = fallback ? yield* createProviderModel(fallback.provider, fallback.model) : undefined
 
-      // Started before the primary attempt so a fallback-served call reports the
-      // latency the caller actually waited, not just the winning attempt's.
+      // Started before the primary attempt so a fallback-served call reports the caller's total wait.
       const startTime = performance.now()
       const outcome = yield* Effect.tryPromise({
         try: async () => {
-          const generateWithModel = async (model: ProviderModel) => {
+          const generateWithModel = async (
+            model: ProviderModel,
+            servedBy: { readonly provider: string; readonly model: string },
+          ) => {
             const providerOptions = normalizeProviderOptions(input.providerOptions)
 
             const call: GenerateTextCall = {
@@ -404,6 +406,7 @@ export const AIGenerateLive = Layer.effect(
             return {
               object: result.output,
               tokens: usage?.totalTokens ?? 0,
+              servedBy,
               tokenUsage: {
                 input: usage?.inputTokens ?? 0,
                 output: usage?.outputTokens ?? 0,
@@ -416,7 +419,10 @@ export const AIGenerateLive = Layer.effect(
 
           const execute = async () => {
             try {
-              return { result: await generateWithModel(providerModel), fallback: null }
+              return {
+                result: await generateWithModel(providerModel, { provider: input.provider, model: input.model }),
+                fallback: null,
+              }
             } catch (primaryError) {
               if (!fallback || fallbackProviderModel === undefined) {
                 throw primaryError
@@ -424,7 +430,7 @@ export const AIGenerateLive = Layer.effect(
 
               try {
                 return {
-                  result: await generateWithModel(fallbackProviderModel),
+                  result: await generateWithModel(fallbackProviderModel, fallback),
                   fallback: {
                     model: `${fallback.provider}/${fallback.model}`,
                     primaryError: formatGenerateError(primaryError),

--- a/packages/platform/ai/src/cache.ts
+++ b/packages/platform/ai/src/cache.ts
@@ -23,6 +23,12 @@ const generateResultSchema = Schema.Struct({
   object: Schema.Unknown,
   tokens: Schema.Number,
   duration: Schema.Number,
+  servedBy: Schema.optional(
+    Schema.Struct({
+      provider: Schema.String,
+      model: Schema.String,
+    }),
+  ),
   tokenUsage: Schema.optional(
     Schema.Struct({
       input: Schema.Number,
@@ -95,8 +101,9 @@ const invalidGenerateResult = (source: "cached" | "provider", cause: unknown) =>
     cause,
   })
 
-type GenerateResultForValidation = Omit<GenerateResult<unknown>, "tokenUsage"> & {
+type GenerateResultForValidation = Omit<GenerateResult<unknown>, "tokenUsage" | "servedBy"> & {
   readonly tokenUsage?: GenerateResult<unknown>["tokenUsage"] | undefined
+  readonly servedBy?: GenerateResult<unknown>["servedBy"] | undefined
 }
 
 const validateGenerateResult = <T>(
@@ -110,6 +117,7 @@ const validateGenerateResult = <T>(
         object: parsed.data,
         tokens: result.tokens,
         duration: result.duration,
+        ...(result.servedBy === undefined ? {} : { servedBy: result.servedBy }),
         ...(result.tokenUsage === undefined ? {} : { tokenUsage: result.tokenUsage }),
       } satisfies GenerateResult<T>)
     : Effect.fail(invalidGenerateResult(source, parsed.error))

--- a/packages/platform/ai/src/metering.test.ts
+++ b/packages/platform/ai/src/metering.test.ts
@@ -93,6 +93,86 @@ describe("withAIMetering", () => {
     ])
   })
 
+  it("bills a fallback-served generation with the serving model's pricing, not the requested model's", async () => {
+    const usage = { input: 100_000, output: 20_000 }
+    const servedSpec = getCostSpec("amazon-bedrock", "openai.gpt-oss-120b-1:0")
+    const requestedSpec = getCostSpec("amazon-bedrock", "minimax.minimax-m2.5")
+    expect(servedSpec.costImplemented).toBe(true)
+    expect(estimateTotalCost(servedSpec.cost, usage)).not.toBe(estimateTotalCost(requestedSpec.cost, usage))
+
+    const { scope, recorded } = createScope()
+    const ai = withAIMetering(
+      createFakeAI({
+        generateResult: {
+          object: { ok: true },
+          tokens: 120_000,
+          duration: 1,
+          tokenUsage: usage,
+          servedBy: { provider: "amazon-bedrock", model: "openai.gpt-oss-120b-1:0" },
+        },
+      }),
+    )
+
+    await Effect.runPromise(
+      ai
+        .generate(generateInput("amazon-bedrock", "minimax.minimax-m2.5"))
+        .pipe(Effect.provideService(AIMeteringScope, scope)),
+    )
+
+    const estimatedCostUsd = estimateTotalCost(servedSpec.cost, usage)
+    expect(recorded).toEqual([
+      {
+        action: "llm-call",
+        credits: creditsForLlmGenerationCost(estimatedCostUsd),
+        metadata: {
+          provider: "amazon-bedrock",
+          model: "openai.gpt-oss-120b-1:0",
+          requestedModel: "amazon-bedrock/minimax.minimax-m2.5",
+          pricing: "cost-based",
+          estimatedCostUsd,
+          tokensInput: 100_000,
+          tokensOutput: 20_000,
+        },
+      },
+    ])
+  })
+
+  it("leaves a normally served generation billed against the requested model", async () => {
+    const usage = { input: 100_000, output: 4_000 }
+    const costSpec = getCostSpec("openai", "gpt-4o")
+    const { scope, recorded } = createScope()
+    const ai = withAIMetering(
+      createFakeAI({
+        generateResult: {
+          object: { ok: true },
+          tokens: 104_000,
+          duration: 1,
+          tokenUsage: usage,
+          servedBy: { provider: "openai", model: "gpt-4o" },
+        },
+      }),
+    )
+
+    await Effect.runPromise(
+      ai.generate(generateInput("openai", "gpt-4o")).pipe(Effect.provideService(AIMeteringScope, scope)),
+    )
+
+    expect(recorded).toEqual([
+      {
+        action: "llm-call",
+        credits: creditsForLlmGenerationCost(estimateTotalCost(costSpec.cost, usage)),
+        metadata: {
+          provider: "openai",
+          model: "gpt-4o",
+          pricing: "cost-based",
+          estimatedCostUsd: estimateTotalCost(costSpec.cost, usage),
+          tokensInput: 100_000,
+          tokensOutput: 4_000,
+        },
+      },
+    ])
+  })
+
   it("falls back to the flat llm-call price when the registry has no pricing for the model", async () => {
     const { scope, recorded } = createScope()
     const ai = withAIMetering(

--- a/packages/platform/ai/src/metering.ts
+++ b/packages/platform/ai/src/metering.ts
@@ -22,11 +22,12 @@ import { Effect, Option } from "effect"
 const toAIError = (cause: AIMeteringRecordError): AIError => new AIError({ message: cause.httpMessage, cause })
 
 /**
- * Charges AI primitives against the ambient `AIMeteringScope`. Generations bill
- * their estimated provider cost (registry pricing x reported token usage) through
- * `creditsForLlmGenerationCost`; when the registry has no pricing for the model or
- * the provider reported no usage, the flat `llm-call` price applies instead. Each
- * query-time embedding bills one `semantic-query` at its estimated embed cost through
+ * Charges AI primitives against the ambient `AIMeteringScope`. Generations bill their
+ * estimated provider cost (registry pricing of the model that served the call, per
+ * `result.servedBy`, x reported token usage) through `creditsForLlmGenerationCost`;
+ * when the registry has no pricing for the model or the provider reported no usage,
+ * the flat `llm-call` price applies instead.
+ * Each query-time embedding bills one `semantic-query` at its estimated embed cost through
  * `creditsForSemanticQueryCost`, falling back to the flat price when the adapter
  * reports no token count. Document embeddings and reranking ride on the charge of
  * the operation that produced them. Without a scope in context the call passes
@@ -107,20 +108,25 @@ const recordGeneration = <T>(
   result: GenerateResult<T>,
 ): Effect.Effect<void, AIError> => {
   const usage = result.tokenUsage
-  const costSpec = getCostSpec(input.provider, input.model)
+  const servedBy = result.servedBy ?? { provider: input.provider, model: input.model }
+  const costSpec = getCostSpec(servedBy.provider, servedBy.model)
+  const requestedModel =
+    servedBy.provider === input.provider && servedBy.model === input.model
+      ? {}
+      : { requestedModel: `${input.provider}/${input.model}` }
 
   if (usage === undefined || !costSpec.costImplemented) {
     return reportPricingFallback({
       action: "llm-call",
-      provider: input.provider,
-      model: input.model,
+      provider: servedBy.provider,
+      model: servedBy.model,
       reason: "no usage or registry pricing for model",
-      details: { hasUsage: usage !== undefined, costImplemented: costSpec.costImplemented },
+      details: { hasUsage: usage !== undefined, costImplemented: costSpec.costImplemented, ...requestedModel },
     }).pipe(
       Effect.andThen(
         recordScoped(scope, {
           action: "llm-call",
-          metadata: { provider: input.provider, model: input.model, pricing: "flat-fallback" },
+          metadata: { provider: servedBy.provider, model: servedBy.model, pricing: "flat-fallback", ...requestedModel },
         }),
       ),
     )
@@ -131,8 +137,9 @@ const recordGeneration = <T>(
     action: "llm-call",
     credits: creditsForLlmGenerationCost(estimatedCostUsd),
     metadata: {
-      provider: input.provider,
-      model: input.model,
+      provider: servedBy.provider,
+      model: servedBy.model,
+      ...requestedModel,
       pricing: "cost-based",
       estimatedCostUsd,
       tokensInput: usage.input,

--- a/packages/platform/ai/src/with-ai.test.ts
+++ b/packages/platform/ai/src/with-ai.test.ts
@@ -206,6 +206,37 @@ describe("createAiLayer", () => {
     expect(generateCalls.count).toBe(3)
   })
 
+  it("keeps the served model on a cached generate result so a cache hit prices the same as the miss", async () => {
+    const redis = createRedisClient()
+    const generateCalls = { count: 0 }
+    const servedBy = { provider: "amazon-bedrock", model: "openai.gpt-oss-120b-1:0" } as const
+    const layer = Layer.succeed(AIGenerate, {
+      generate: <T>(_input: GenerateInput<T>) => {
+        generateCalls.count += 1
+        return Effect.succeed({ object: {} as T, tokens: 3, duration: 1, servedBy })
+      },
+    })
+
+    const ai = await Effect.runPromise(getAI(createAiLayer(layer, redis)))
+    const input = {
+      provider: "amazon-bedrock",
+      model: "minimax.minimax-m2.5",
+      system: "system",
+      prompt: "prompt",
+      schema: { safeParse: (value: unknown) => ({ success: true, data: value }) } as never,
+    } as const
+
+    const miss = await Effect.runPromise(ai.generate(input))
+    expect(generateCalls.count).toBe(1)
+
+    const hit = await Effect.runPromise(ai.generate(input))
+    // Still 1, so `hit` came back through the cache's encode/decode rather than the provider.
+    expect(generateCalls.count).toBe(1)
+
+    expect(miss.servedBy).toEqual(servedBy)
+    expect(hit.servedBy).toEqual(servedBy)
+  })
+
   it("caches rerank keyed on provider, model, query, and documents", async () => {
     const rerankCalls = { count: 0 }
     const redis = createRedisClient()


### PR DESCRIPTION
> Follow-up to #4339, which has merged; this branch is rebased onto `development` and stands alone.
>
> Review feedback from #4339 and the first push of this PR is applied: the multi-line timing comment both bots flagged is now one line, the `servedBy` contract doc is one line, and the cache test now counts provider calls so the second call is *proven* to be a cache hit rather than just matching.

## The bug

`AIGenerateLive.generate` falls back from `minimax.minimax-m2.5` to `openai.gpt-oss-120b-1:0` when Bedrock rejects the primary. The fallback happens entirely inside `generate`, and the result never said which model answered — so callers priced the call with the model they *asked for*. Tokens and duration came from the real call, the rates came from the primary.

The registry lists MiniMax on Bedrock at **$0.30 / $1.20** per 1M input/output tokens and GPT-OSS 120B at **$0.15 / $0.60**. Exactly 2x. So every fallback-served call was costed and billed at double what it actually cost, and MiniMax is the default model for evaluations, flaggers, annotations, signals, conversation intelligence and taxonomy naming — the fallback exists precisely because Bedrock rejects it under load, so this recurs.

## The change

`GenerateResult` gains an optional `servedBy: { provider, model }`. The Vercel adapter always sets it: the requested pair on a normal call, the fallback pair when the fallback answered. Optional so existing callers and test fakes are untouched; honest because the adapter never leaves it unset.

Then the sites that turn a generate result into money read it:

| Site | What it produces | Before | After |
| --- | --- | --- | --- |
| `evaluation-execution.ts` → `sandbox-execution.ts:77` | persisted `scores.cost` (microcents) | requested model's rates | `result.servedBy` rates, falling back to the requested model |
| `metering.ts` `recordGeneration` | org billing credits (`creditsForLlmGenerationCost`) | requested model's rates | `result.servedBy` rates; metadata reports the serving pair plus `requestedModel` when they differ |
| `cache.ts` `withAICache` | cached generate results | dropped `servedBy` | round-trips it, so a cache hit prices identically to the miss |

The cache change is load-bearing, not cosmetic: `withAICache` is the **outermost** wrapper (`with-ai.ts`), so without it every cache hit would have silently reverted the evaluations fix.

Pricing is preferred inside `estimateEvaluationScriptCostMicrocents` rather than at the `sandbox-execution.ts:77` call site, so no current or future caller can forget to pass the served model. The second parameter is now named `requestedModel` to make the precedence obvious.

## Audit: other cost/metering sites

**Fixed** — the two sites above are the only ones that price a generate result and persist or bill the number.

**Deliberately left alone:**

- `packages/domain/spans/src/otlp/resolvers/usage.ts` — prices *customer-reported* spans from the model in the span attributes. Our Bedrock fallback is not involved; the customer's own model is the served model.
- `packages/domain/spans/src/helpers/{classify-unpriced-cost,model-registry-pricing,cache-economics}.ts` and `cost-analytics-repository` — read-side dashboard analytics over rows already persisted in ClickHouse. Nothing to re-attribute at query time.
- `withAIMetering`'s error-path flat record — the provider call failed, so there is no result and no `servedBy`; the requested pair is all that exists, and the charge is the flat `llm-call` price rather than a pricing-derived one.
- `AIAgentLive.runAgent` and its caller (`apps/workers/src/workers/signals-generate-signal.ts`) — no fallback is wired into the agent loop, and the caller does not price or persist a per-call cost.
- The other `ai.generate` callers (signals, annotations, taxonomy, conversation intelligence, flaggers, `evaluation-optimization-activities`) — none compute a cost of their own; they ride on `withAIMetering`, which is fixed centrally here.

## Streaming and embedding paths

- **Streaming: not affected, because there is no first-party streaming generate.** The platform adapter only calls `generateText`; the `ai.streamText` / `ai.streamObject` strings in `packages/domain/spans/src/otlp/resolvers/operation.ts` are operation names on *ingested customer* spans, not our own calls. If a streaming generate is added later it must set `servedBy` the same way.
- **Embedding: no fallback exists today**, so requested == served for `embedWithVercel` and `rerankWithVercel`, and `EmbedResult` / `RerankResult` carry no `servedBy`. Worth knowing before one is added: `recordSemanticQuery` bills `semanticQueryEmbedCostUsd(tokens)`, which is model-*independent*, so an embed fallback would mis-attribute the metering **metadata** (`provider` / `model`) but not the charge. A `servedBy` on `EmbedResult` would be the fix, out of scope here.

## Tests

- `ai-vercel/src/ai.test.ts` — a fallen-back call reports `servedBy` = the fallback pair; a normal call reports the requested pair and calls the provider once.
- `evaluations/src/runtime/evaluation-execution.test.ts` — a fallback-served result is priced at GPT-OSS rates and provably *not* at MiniMax's; a result served by the requested model, and one with no `servedBy` at all, are unchanged.
- `platform/ai/src/metering.test.ts` — a fallback-served generation bills the serving model's credits with `requestedModel` recorded; a normally served one bills exactly as before.
- `platform/ai/src/with-ai.test.ts` — `servedBy` survives the cache round-trip, so hit and miss price alike.

Verified: `pnpm turbo typecheck` for `@domain/ai`, `@platform/ai`, `@platform/ai-vercel`, `@domain/evaluations` (32 tasks green); `pnpm --filter <pkg> test` for all four (23 + 32 + 23 + 183 passing); `pnpm knip` and `pnpm biome check` on the changed paths clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI generation results now identify the provider and model that served each request, including fallback responses.
  - Cached results preserve serving-model information across subsequent requests.

- **Bug Fixes**
  - Evaluation cost estimates and usage metering now use the model that actually served the request.
  - Fallback generations report accurate pricing while retaining the originally requested model for visibility.

- **Reliability**
  - Improved fallback handling and telemetry for successful fallback attempts, with clearer error reporting when all attempts fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->