### PR TITLE
fix(billing): stop double-counting overage in usage UI

### DIFF
--- a/apps/web/src/domains/billing/billing.functions.ts
+++ b/apps/web/src/domains/billing/billing.functions.ts
@@ -62,15 +62,11 @@ const loadBillingOverview = Effect.fn("web.billing.getOverview")(function* (orga
   const includedCredits = Number.isFinite(orgPlan.plan.includedCredits) ? orgPlan.plan.includedCredits : null
   const consumedCredits = period?.consumedCredits ?? 0
   const overageCredits = period?.overageCredits ?? 0
-  const includedUsedCredits =
-    includedCredits === null ? consumedCredits : Math.min(consumedCredits, includedCredits)
-  const remainingCredits =
-    includedCredits === null ? null : Math.max(includedCredits - consumedCredits, 0)
+  const includedUsedCredits = includedCredits === null ? consumedCredits : Math.min(consumedCredits, includedCredits)
+  const remainingCredits = includedCredits === null ? null : Math.max(includedCredits - consumedCredits, 0)
   const isAtIncludedLimit = includedCredits !== null && includedCredits > 0 && consumedCredits >= includedCredits
   const usageProgress =
-    includedCredits === null || includedCredits <= 0
-      ? 1
-      : Math.min(consumedCredits / includedCredits, 1)
+    includedCredits === null || includedCredits <= 0 ? 1 : Math.min(consumedCredits / includedCredits, 1)
 
   return {
     planSlug: orgPlan.plan.slug,

--- a/apps/web/src/domains/billing/billing.functions.ts
+++ b/apps/web/src/domains/billing/billing.functions.ts
@@ -32,8 +32,16 @@ interface BillingOverviewDto {
   periodEnd: string
   /** `null` when the plan entitlement is intentionally unbounded over JSON (Enterprise). */
   includedCredits: number | null
+  /** Authoritative period total from `billing_usage_periods.consumed_credits` (includes overage). */
   consumedCredits: number
   overageCredits: number
+  /** Portion of `consumedCredits` that counts against the included allowance. */
+  includedUsedCredits: number
+  /** Credits left in the included allowance; `null` when the entitlement is unbounded. */
+  remainingCredits: number | null
+  /** 0–1 fill for the usage ring; `1` when unbounded or at/over the included allowance. */
+  usageProgress: number
+  isAtIncludedLimit: boolean
   overageAmountMills: number
   overageAllowed: boolean
   hardCapped: boolean
@@ -51,14 +59,31 @@ const loadBillingOverview = Effect.fn("web.billing.getOverview")(function* (orga
     periodEnd: orgPlan.periodEnd,
   })
 
+  const includedCredits = Number.isFinite(orgPlan.plan.includedCredits) ? orgPlan.plan.includedCredits : null
+  const consumedCredits = period?.consumedCredits ?? 0
+  const overageCredits = period?.overageCredits ?? 0
+  const includedUsedCredits =
+    includedCredits === null ? consumedCredits : Math.min(consumedCredits, includedCredits)
+  const remainingCredits =
+    includedCredits === null ? null : Math.max(includedCredits - consumedCredits, 0)
+  const isAtIncludedLimit = includedCredits !== null && includedCredits > 0 && consumedCredits >= includedCredits
+  const usageProgress =
+    includedCredits === null || includedCredits <= 0
+      ? 1
+      : Math.min(consumedCredits / includedCredits, 1)
+
   return {
     planSlug: orgPlan.plan.slug,
     planSource: orgPlan.source as BillingOverviewDto["planSource"],
     periodStart: orgPlan.periodStart.toISOString(),
     periodEnd: orgPlan.periodEnd.toISOString(),
-    includedCredits: Number.isFinite(orgPlan.plan.includedCredits) ? orgPlan.plan.includedCredits : null,
-    consumedCredits: period?.consumedCredits ?? 0,
-    overageCredits: period?.overageCredits ?? 0,
+    includedCredits,
+    consumedCredits,
+    overageCredits,
+    includedUsedCredits,
+    remainingCredits,
+    usageProgress,
+    isAtIncludedLimit,
     overageAmountMills: period?.overageAmountMills ?? 0,
     overageAllowed: orgPlan.plan.overageAllowed,
     hardCapped: orgPlan.plan.hardCapped,

--- a/apps/web/src/routes/_authenticated/-components/billing-credit-counter.tsx
+++ b/apps/web/src/routes/_authenticated/-components/billing-credit-counter.tsx
@@ -47,9 +47,7 @@ export function BillingCreditCounter({
   const consumedLabel = numberFormatter.format(totalUsedCredits)
   const includedLabel = includedCredits === null ? "custom" : numberFormatter.format(includedCredits)
   const usageLabel = includedCredits === null ? consumedLabel : `${consumedLabel}/${includedLabel}`
-  const includedUsedCredits = hasIncludedCredits
-    ? Math.min(totalUsedCredits, includedCredits)
-    : totalUsedCredits
+  const includedUsedCredits = hasIncludedCredits ? Math.min(totalUsedCredits, includedCredits) : totalUsedCredits
   const tooltip = isOverage
     ? `${numberFormatter.format(totalUsedCredits)} credits used: ${numberFormatter.format(includedUsedCredits)} included credits plus ${numberFormatter.format(overview.overageCredits)} metered overage credits. Usage can exceed the included limit because this plan allows overage billing.`
     : `${numberFormatter.format(overview.consumedCredits)} of ${includedLabel} credits used this period`

--- a/apps/web/src/routes/_authenticated/-components/billing-credit-counter.tsx
+++ b/apps/web/src/routes/_authenticated/-components/billing-credit-counter.tsx
@@ -48,9 +48,7 @@ export function BillingCreditCounter({
     ? `${numberFormatter.format(overview.consumedCredits)} credits used: ${numberFormatter.format(overview.includedUsedCredits)} included credits plus ${numberFormatter.format(overview.overageCredits)} metered overage credits. Usage can exceed the included limit because this plan allows overage billing.`
     : `${numberFormatter.format(overview.consumedCredits)} of ${includedLabel} credits used this period`
   const showUpgradeCta =
-    overview.planSlug === "free" &&
-    hasIncludedCredits &&
-    overview.usageProgress >= FREE_PLAN_UPGRADE_USAGE_THRESHOLD
+    overview.planSlug === "free" && hasIncludedCredits && overview.usageProgress >= FREE_PLAN_UPGRADE_USAGE_THRESHOLD
 
   const openUpgrade = async () => {
     setIsUpgradePending(true)

--- a/apps/web/src/routes/_authenticated/-components/billing-credit-counter.tsx
+++ b/apps/web/src/routes/_authenticated/-components/billing-credit-counter.tsx
@@ -37,24 +37,20 @@ export function BillingCreditCounter({
   if (!overview) return null
 
   const includedCredits = overview.includedCredits
-  const totalUsedCredits = overview.consumedCredits
   const hasIncludedCredits = includedCredits !== null && includedCredits > 0
-  const progress = hasIncludedCredits ? Math.min(totalUsedCredits / includedCredits, 1) : 1
   const isOverage = overview.overageCredits > 0
-  const isAtIncludedLimit = hasIncludedCredits && totalUsedCredits >= includedCredits
-  const showLimitState = isOverage || (overview.planSlug === "free" && isAtIncludedLimit)
-  const strokeOffset = BILLING_COUNTER_CIRCUMFERENCE * (1 - progress)
-  const consumedLabel = numberFormatter.format(totalUsedCredits)
+  const showLimitState = isOverage || (overview.planSlug === "free" && overview.isAtIncludedLimit)
+  const strokeOffset = BILLING_COUNTER_CIRCUMFERENCE * (1 - overview.usageProgress)
+  const consumedLabel = numberFormatter.format(overview.consumedCredits)
   const includedLabel = includedCredits === null ? "custom" : numberFormatter.format(includedCredits)
   const usageLabel = includedCredits === null ? consumedLabel : `${consumedLabel}/${includedLabel}`
-  const includedUsedCredits = hasIncludedCredits ? Math.min(totalUsedCredits, includedCredits) : totalUsedCredits
   const tooltip = isOverage
-    ? `${numberFormatter.format(totalUsedCredits)} credits used: ${numberFormatter.format(includedUsedCredits)} included credits plus ${numberFormatter.format(overview.overageCredits)} metered overage credits. Usage can exceed the included limit because this plan allows overage billing.`
+    ? `${numberFormatter.format(overview.consumedCredits)} credits used: ${numberFormatter.format(overview.includedUsedCredits)} included credits plus ${numberFormatter.format(overview.overageCredits)} metered overage credits. Usage can exceed the included limit because this plan allows overage billing.`
     : `${numberFormatter.format(overview.consumedCredits)} of ${includedLabel} credits used this period`
   const showUpgradeCta =
     overview.planSlug === "free" &&
     hasIncludedCredits &&
-    totalUsedCredits / includedCredits >= FREE_PLAN_UPGRADE_USAGE_THRESHOLD
+    overview.usageProgress >= FREE_PLAN_UPGRADE_USAGE_THRESHOLD
 
   const openUpgrade = async () => {
     setIsUpgradePending(true)

--- a/apps/web/src/routes/_authenticated/-components/billing-credit-counter.tsx
+++ b/apps/web/src/routes/_authenticated/-components/billing-credit-counter.tsx
@@ -37,7 +37,7 @@ export function BillingCreditCounter({
   if (!overview) return null
 
   const includedCredits = overview.includedCredits
-  const totalUsedCredits = overview.consumedCredits + overview.overageCredits
+  const totalUsedCredits = overview.consumedCredits
   const hasIncludedCredits = includedCredits !== null && includedCredits > 0
   const progress = hasIncludedCredits ? Math.min(totalUsedCredits / includedCredits, 1) : 1
   const isOverage = overview.overageCredits > 0
@@ -47,8 +47,11 @@ export function BillingCreditCounter({
   const consumedLabel = numberFormatter.format(totalUsedCredits)
   const includedLabel = includedCredits === null ? "custom" : numberFormatter.format(includedCredits)
   const usageLabel = includedCredits === null ? consumedLabel : `${consumedLabel}/${includedLabel}`
+  const includedUsedCredits = hasIncludedCredits
+    ? Math.min(totalUsedCredits, includedCredits)
+    : totalUsedCredits
   const tooltip = isOverage
-    ? `${numberFormatter.format(totalUsedCredits)} credits used: ${numberFormatter.format(overview.consumedCredits)} included credits plus ${numberFormatter.format(overview.overageCredits)} metered overage credits. Usage can exceed the included limit because this plan allows overage billing.`
+    ? `${numberFormatter.format(totalUsedCredits)} credits used: ${numberFormatter.format(includedUsedCredits)} included credits plus ${numberFormatter.format(overview.overageCredits)} metered overage credits. Usage can exceed the included limit because this plan allows overage billing.`
     : `${numberFormatter.format(overview.consumedCredits)} of ${includedLabel} credits used this period`
   const showUpgradeCta =
     overview.planSlug === "free" &&

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/billing.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/billing.tsx
@@ -64,11 +64,7 @@ const formatPeriodDate = (value: string) =>
 
 function BillingOverviewCards() {
   const overview = Route.useLoaderData({ select: (data) => data.overview })
-  const totalUsedCredits = overview.consumedCredits
   const hasOverageCredits = overview.overageCredits > 0
-  const remainingCredits = Number.isFinite(overview.includedCredits)
-    ? Math.max(overview.includedCredits - totalUsedCredits, 0)
-    : Number.POSITIVE_INFINITY
 
   const cards = [
     {
@@ -85,7 +81,7 @@ function BillingOverviewCards() {
       label: "Credits used this period",
       value: (
         <div className="flex items-baseline gap-2">
-          <Text.H3 weight="bold">{numberFormatter.format(totalUsedCredits)}</Text.H3>
+          <Text.H3 weight="bold">{numberFormatter.format(overview.consumedCredits)}</Text.H3>
           <Text.H3 weight="medium" color="foregroundMuted">
             / {formatCredits(overview.includedCredits)} credits
           </Text.H3>
@@ -93,8 +89,8 @@ function BillingOverviewCards() {
       ),
       detail: hasOverageCredits
         ? `${compactNumberFormatter.format(overview.overageCredits)} overage credits this period`
-        : Number.isFinite(remainingCredits)
-          ? `${numberFormatter.format(remainingCredits)} credits remaining`
+        : overview.remainingCredits !== null
+          ? `${numberFormatter.format(overview.remainingCredits)} credits remaining`
           : "Unlimited / custom allowance",
     },
     {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/billing.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/billing.tsx
@@ -64,7 +64,7 @@ const formatPeriodDate = (value: string) =>
 
 function BillingOverviewCards() {
   const overview = Route.useLoaderData({ select: (data) => data.overview })
-  const totalUsedCredits = overview.consumedCredits + overview.overageCredits
+  const totalUsedCredits = overview.consumedCredits
   const hasOverageCredits = overview.overageCredits > 0
   const remainingCredits = Number.isFinite(overview.includedCredits)
     ? Math.max(overview.includedCredits - totalUsedCredits, 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Orgo showed **166k** credits used when the DB had ~**133k** consumed with **33k** overage. The sidebar usage counter and billing settings page were adding `consumedCredits + overageCredits`, but `consumedCredits` is already the authoritative period total from the DB and `overageCredits` is derived as `max(0, consumed - included)`.

## Fix

Billing overview now exposes usage display fields from the server:
- `consumedCredits` — straight from `billing_usage_periods`
- `includedUsedCredits`, `remainingCredits`, `usageProgress`, `isAtIncludedLimit` — derived once in the overview loader

The nav usage counter and billing settings page only format/render those fields; they no longer recompute credit totals.

## Verify

For a Pro period with `included=100_000`, `consumed=133_000`, `overage=33_000`:
- UI total should read **133,000** (not 166,000)
- overage detail still shows **33k** overage credits
- remaining credits stays **0** while overaging
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C0672DS68DD/p1785776328842369?thread_ts=1785776328.842369&cid=C0672DS68DD)

<div><a href="https://cursor.com/agents/bc-aff32ea4-272a-53d6-8ef4-7b44d5fb0eb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aff32ea4-272a-53d6-8ef4-7b44d5fb0eb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing usage calculations to distinguish consumed credits from overage credits.
  * Updated progress indicators, remaining-credit totals, and included-usage messaging for more accurate billing information.
  * Added clearer handling when plans have no defined credit limit or no remaining credits.
  * Overage usage continues to be displayed separately, with improved tooltip details.
  * Free-plan upgrade prompts now reflect the displayed usage progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->