### PR TITLE
fix(spans): stop clamping uncached input tokens to zero when cache exceeds them

### DIFF
--- a/packages/domain/spans/src/otlp/resolvers/usage/tokens.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage/tokens.test.ts
@@ -414,6 +414,79 @@ describe("resolveTokens", () => {
   })
 
   // ═══════════════════════════════════════════════════════
+  // STRATEGY 0: INCLUSIVE ARITHMETICALLY IMPOSSIBLE
+  //
+  // rawInput < cache cannot be an inclusive count, so the
+  // convention-level "always inclusive" keys must not clamp
+  // real uncached input to zero.
+  // ═══════════════════════════════════════════════════════
+
+  describe("strategy 0: inclusive impossible when rawInput < cache", () => {
+    it("keeps uncached input for an emitter that re-spells additive input under the normalized key", () => {
+      // Shape observed in production from @latitude-data/claude-code-telemetry:
+      // the additive (uncached-only) count emitted under both the native and
+      // the OTEL-normalized key, with no total to arbitrate.
+      const attrs = [
+        int("gen_ai.usage.input_tokens", 2),
+        int("input_tokens", 2),
+        int("gen_ai.usage.output_tokens", 3_202),
+        int("gen_ai.usage.cache_read.input_tokens", 127_967),
+        int("cache_creation_tokens", 1_050),
+      ]
+      const r = resolveTokens(attrs, "anthropic")
+      expect(r.input).toBe(2)
+      expect(r.cacheRead).toBe(127_967)
+      expect(r.cacheCreate).toBe(1_050)
+      expect(r.input + r.cacheRead + r.cacheCreate).toBe(129_019)
+    })
+
+    it("applies regardless of provider", () => {
+      const attrs = [
+        int("gen_ai.usage.input_tokens", 500),
+        int("gen_ai.usage.output_tokens", 200),
+        int("gen_ai.usage.cache_read.input_tokens", 8_000),
+        int("gen_ai.usage.cache_creation.input_tokens", 1_500),
+      ]
+      for (const provider of ["openai", "anthropic", "aws.bedrock", "google"]) {
+        expect(resolveTokens(attrs, provider).input).toBe(500)
+      }
+    })
+
+    it("does not fire when rawInput exactly equals cache", () => {
+      const attrs = [
+        int("gen_ai.usage.input_tokens", 9_500),
+        int("gen_ai.usage.output_tokens", 200),
+        int("gen_ai.usage.cache_read.input_tokens", 8_000),
+        int("gen_ai.usage.cache_creation.input_tokens", 1_500),
+      ]
+      expect(resolveTokens(attrs, "openai").input).toBe(0)
+    })
+
+    it("leaves the inclusive reading intact when rawInput exceeds cache", () => {
+      const attrs = [
+        int("gen_ai.usage.input_tokens", 10_000),
+        int("gen_ai.usage.output_tokens", 200),
+        int("gen_ai.usage.cache_read.input_tokens", 8_000),
+        int("gen_ai.usage.cache_creation.input_tokens", 1_500),
+      ]
+      expect(resolveTokens(attrs, "anthropic").input).toBe(EXPECTED.input)
+    })
+
+    it("does not touch the output side", () => {
+      const attrs = [
+        int("gen_ai.usage.input_tokens", 2),
+        int("gen_ai.usage.cache_read.input_tokens", 8_000),
+        int("gen_ai.usage.output_tokens", 200),
+        int("gen_ai.usage.reasoning_tokens", 60),
+      ]
+      const r = resolveTokens(attrs, "openai")
+      expect(r.input).toBe(2)
+      expect(r.output).toBe(EXPECTED.output)
+      expect(r.reasoning).toBe(EXPECTED.reasoning)
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════
   // CANDIDATE PRECEDENCE
   // ═══════════════════════════════════════════════════════
 
@@ -534,9 +607,9 @@ describe("resolveTokens", () => {
       expect(r.reasoning).toBe(0)
     })
 
-    it("clamps input at zero when cache exceeds raw (buggy instrumentation)", () => {
+    it("reads input as additive rather than clamping when cache exceeds raw", () => {
       const attrs = [int("gen_ai.usage.input_tokens", 50), int("gen_ai.usage.cache_read.input_tokens", 1_000)]
-      expect(resolveTokens(attrs, "openai").input).toBe(0)
+      expect(resolveTokens(attrs, "openai").input).toBe(50)
     })
 
     it("clamps output at zero when reasoning exceeds raw (buggy instrumentation)", () => {

--- a/packages/domain/spans/src/otlp/resolvers/usage/tokens.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage/tokens.ts
@@ -72,7 +72,11 @@ const totalCandidates = [
 //   Input:  sub-categories are cache_read + cache_create
 //   Output: sub-category is reasoning tokens
 //
-// Detection uses three strategies, in priority order:
+// Detection uses four strategies, in priority order:
+//
+// 0. IMPOSSIBILITY CHECK (input only) — an inclusive count cannot
+//    be smaller than the sub-categories it supposedly contains,
+//    so rawInput < cache rules inclusive out outright.
 //
 // 1. TOTAL-BASED INFERENCE — when a rawTotal attribute exists,
 //    we check which (inputModel × outputModel) arithmetic
@@ -83,6 +87,24 @@ const totalCandidates = [
 //
 // 3. PROVIDER-LEVEL — for passthrough conventions (OpenInference,
 //    OpenLLMetry), the raw API model determines it.
+
+// ── Strategy 0: inclusive is arithmetically impossible ────
+//
+// Inclusive semantics mean rawInput contains the cache
+// sub-categories, which forces rawInput >= cache. When an
+// emitter reports less input than cache, no arithmetic makes
+// the inclusive reading valid, so subtracting would clamp real
+// uncached input to zero. Emitters that re-spell Anthropic's
+// additive `input_tokens` under a normalized key (our own
+// Claude Code telemetry among them) land here and would
+// otherwise be misread as inclusive by strategy 2.
+//
+// This assumes rawInput covers both cache_read and
+// cache_create or neither; an emitter that folds only
+// cache_read into input is not representable either way.
+function isInclusiveInputPossible(rawInput: number, cache: number): boolean {
+  return rawInput >= cache
+}
 
 // ── Strategy 1: total-based arithmetic inference ──────────
 //
@@ -219,7 +241,10 @@ export function resolveTokens(attrs: readonly OtlpKeyValue[], provider: string):
   const inferred = rawTotal ? inferFromTotal(rawInput, rawOutput, cache, reasoning, rawTotal) : null
 
   // Strategy 2+3: convention/provider fallback for anything strategy 1 couldn't determine
-  const inputInclusive = inferred?.input ?? isInputInclusiveFallback(rawInputMatch?.key, provider)
+  const inputInclusive =
+    cache > 0 && !isInclusiveInputPossible(rawInput, cache)
+      ? false
+      : (inferred?.input ?? isInputInclusiveFallback(rawInputMatch?.key, provider))
   const outputInclusive = inferred?.output ?? isOutputInclusiveFallback(provider)
 
   return {


### PR DESCRIPTION
## What

An inclusive input token count contains the cache sub-categories by definition, so it can never be smaller than them. `resolveTokens` had no such check: when an emitter reported less input than cache, the convention-level "always inclusive" rule still fired and the subtraction clamped real uncached input to zero.

This adds an impossibility check ahead of the existing strategies, for the **input side only**: `rawInput < cache` rules the inclusive reading out outright.

## Why

Found while investigating a customer-reported cost/token discordance on production. `tokens_input` was **exactly 0 on 100% of priced spans** for a Claude Code project (3,561 spans on 3 Aug), while the raw attributes carried 238,029 real input tokens.

Our own `@latitude-data/claude-code-telemetry` triggers it on every span. It emits Anthropic's additive (uncached-only) count under *both* the native `input_tokens` key and the OTEL-normalized `gen_ai.usage.input_tokens`, and emits no total. So:

- Strategy 1 (total-based arithmetic) can't arbitrate — there's no total attribute.
- Strategy 2 sees `gen_ai.usage.input_tokens` in `ALWAYS_INCLUSIVE_INPUT_KEYS` and returns inclusive, before the provider check that would have correctly classified `anthropic` as additive.
- `toAdditive(2, 129017, true)` → `max(0, 2 - 129017)` → **0**.

A representative production span: `input_tokens: 2`, `cache_read_tokens: 127967`, `cache_creation_tokens: 1050`, stored `tokens_input: 0`.

## Why not just flip the provider/convention precedence

That was the first instinct, but it's wrong twice over. The existing tests assert "convention overrides provider" for `anthropic` deliberately (a spec-compliant Anthropic OTEL exporter *does* emit inclusive counts), and inverting the priority makes `ALWAYS_INCLUSIVE_INPUT_KEYS` entirely dead code — the key check becomes unreachable in all four cases. Treating a compliant exporter's inclusive count as additive would double-count cache.

The impossibility check is narrower and provable rather than heuristic: it only fires where the inclusive reading is arithmetically unsatisfiable, so compliant emitters keep subtracting exactly as before. Provider-vs-convention precedence is untouched.

## Scope and caveats

- **Input side only.** The symmetric argument holds for output vs reasoning, but I have no production evidence of that case and didn't want to change output semantics speculatively. The reasoning-side clamp behaviour is unchanged and there's a test pinning that.
- **Assumes `rawInput` covers both `cache_read` and `cache_create`, or neither.** An emitter folding only `cache_read` into input isn't representable in either reading; it was already mishandled before this change.
- **No backfill.** Already-ingested spans keep `tokens_input = 0`; this only fixes spans ingested from here on.
- Cost impact is small on its own ($0.62 on the day measured, since uncached input is a thin slice of a cache-heavy agent workload), but it made input tokens read as zero across the whole UI for these traces, and it would be severe on any workload with substantial uncached input.

## Test changes

One existing edge-case test asserted the clamp as intended behaviour, describing the emitter as "buggy instrumentation":

```
it("clamps input at zero when cache exceeds raw (buggy instrumentation)")
```

Production disproves that premise — our own telemetry emits exactly that shape and the input value is real and correct. Updated to assert the additive reading, and added a `strategy 0` block covering the exact production attribute shape, provider-independence, the `rawInput == cache` boundary (still inclusive), and that the output side is untouched.

`@domain/spans`: 1,952 tests pass. The `@domain/ai` typecheck error on `@latitude-data/telemetry` is pre-existing on `development` (unbuilt workspace dep) — verified identical with the change stashed.

## Follow-up, not in this PR

The much larger half of the reported discordance is unmodeled Anthropic pricing tiers, not lost tokens — our estimate reproduced to the cent from `models.dev` list prices, but ignores the long-context premium above 200K (34.6% of Sonnet 5 calls, up to 546K context) and always prices cache writes at the 5-minute 1.25x rate. Together those account for the customer's ~$231/day gap. `cost.ts` already supports tiers via `tokensRangeStart`, but 0 of 5,891 bundled models carry tiered pricing. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage calculations for inconsistent or impossible input and cache values.
  * Preserved reported input values instead of incorrectly reducing them to zero when cache amounts exceed input totals.
  * Added fallback handling to produce more accurate usage results in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->