### PR TITLE
fix(taxonomy): keep the last good tree when a rebuild collapses to a bare root (LAT-772)

### DIFF
--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -160,7 +160,7 @@ export interface GardenTaxonomyBuildPlanResult extends GardenTaxonomyLineageResu
   readonly clustersDeprecated: number
   readonly leavesAssigned: number
   readonly maxDepthReached: number
-  /** Zero ⇒ the build collapsed to a bare root; the workflow keeps the prior tree serving. */
+  /** Root child count; zero ⇒ the build collapsed to a bare root. */
   readonly topLevelClustersBuilt: number
   readonly planKey: string
 }
@@ -719,14 +719,13 @@ const annotateAdaptiveTelemetrySpan = (input: GardenTaxonomyStepInput, plan: Hie
         }
       }).pipe(Effect.withSpan("taxonomy.gardenTaxonomyWorkflow.shadow"))
 
-// A rebuild that produced no top-level behaviour while a tree was serving reads.
-// Emitted for every mode (the adaptive telemetry above is silent on `off`, which
-// is what most projects run) because it is the fleet-wide signal for a project
-// whose corpus thinned below the density any split needs.
+// Emitted for every mode: the adaptive telemetry above returns early on `off`, which is what most projects run.
+// Detection only — whether the run then keeps the prior tree is the workflow's call, not this activity's.
 const emitDegenerateRebuildTelemetry = (input: GardenTaxonomyStepInput, plan: HierarchicalTaxonomyPlan): void => {
-  const priorTreeSize = plan.deprecatedClusterIds.length + plan.supersededClusterIds.length
-  if (plan.topLevelClustersBuilt > 0 || priorTreeSize === 0) return
-  logger.info("Taxonomy degenerate rebuild kept the prior tree", {
+  // The two sets overlap on the adaptive path, where superseded is the whole prior tree.
+  const priorClustersAtRisk = new Set([...plan.deprecatedClusterIds, ...plan.supersededClusterIds]).size
+  if (plan.topLevelClustersBuilt > 0 || priorClustersAtRisk === 0) return
+  logger.info("Taxonomy degenerate rebuild detected", {
     metric: "taxonomy.gardenTaxonomyWorkflow.degenerateRebuild",
     mode: plan.mode,
     organizationId: input.organizationId,
@@ -735,7 +734,7 @@ const emitDegenerateRebuildTelemetry = (input: GardenTaxonomyStepInput, plan: Hi
     facetId: input.facetId,
     observationsAvailable: plan.observationsAvailable,
     observationsSampled: plan.observationsSampled,
-    priorTreeSize,
+    priorClustersAtRisk,
   })
 }
 

--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -160,6 +160,8 @@ export interface GardenTaxonomyBuildPlanResult extends GardenTaxonomyLineageResu
   readonly clustersDeprecated: number
   readonly leavesAssigned: number
   readonly maxDepthReached: number
+  /** Zero ⇒ the build collapsed to a bare root; the workflow keeps the prior tree serving. */
+  readonly topLevelClustersBuilt: number
   readonly planKey: string
 }
 
@@ -717,12 +719,33 @@ const annotateAdaptiveTelemetrySpan = (input: GardenTaxonomyStepInput, plan: Hie
         }
       }).pipe(Effect.withSpan("taxonomy.gardenTaxonomyWorkflow.shadow"))
 
+// A rebuild that produced no top-level behaviour while a tree was serving reads.
+// Emitted for every mode (the adaptive telemetry above is silent on `off`, which
+// is what most projects run) because it is the fleet-wide signal for a project
+// whose corpus thinned below the density any split needs.
+const emitDegenerateRebuildTelemetry = (input: GardenTaxonomyStepInput, plan: HierarchicalTaxonomyPlan): void => {
+  const priorTreeSize = plan.deprecatedClusterIds.length + plan.supersededClusterIds.length
+  if (plan.topLevelClustersBuilt > 0 || priorTreeSize === 0) return
+  logger.info("Taxonomy degenerate rebuild kept the prior tree", {
+    metric: "taxonomy.gardenTaxonomyWorkflow.degenerateRebuild",
+    mode: plan.mode,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    customBehaviorId: input.customBehaviorId,
+    facetId: input.facetId,
+    observationsAvailable: plan.observationsAvailable,
+    observationsSampled: plan.observationsSampled,
+    priorTreeSize,
+  })
+}
+
 // Telemetry + persist the staged plan artifact + shape the activity result. No
 // repository requirements (Redis + sync only), so both the topic and facet
 // planning paths reuse it after computing the plan under their own layers.
 const finalizeGardenPlan = (input: GardenTaxonomyStepInput, plan: HierarchicalTaxonomyPlan) =>
   Effect.gen(function* () {
     yield* Effect.sync(() => emitAdaptivePlanTelemetry(input, plan))
+    yield* Effect.sync(() => emitDegenerateRebuildTelemetry(input, plan))
     yield* annotateAdaptiveTelemetrySpan(input, plan)
     const planKey = yield* storeGardenTaxonomyPlan(input, {
       clusters: plan.clusters,
@@ -757,6 +780,7 @@ const finalizeGardenPlan = (input: GardenTaxonomyStepInput, plan: HierarchicalTa
       clustersDeprecated: plan.clustersDeprecated,
       leavesAssigned: plan.leavesAssigned,
       maxDepthReached: plan.maxDepthReached,
+      topLevelClustersBuilt: plan.topLevelClustersBuilt,
       lineage: plan.lineage,
       planKey,
     } satisfies GardenTaxonomyBuildPlanResult

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.test.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.test.ts
@@ -77,8 +77,7 @@ const scopedInput = { ...globalInput, customBehaviorId: "b".repeat(24) }
 describe("taxonomy gardening workflow (divisive build)", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // `clearAllMocks` keeps implementations, so restore the all-markers-on default
-    // the mock factory sets — a test that flips one marker off must not leak.
+    // `clearAllMocks` keeps implementations, so a test that flips one marker off must not leak.
     vi.mocked(patched).mockImplementation(() => true)
   })
 
@@ -152,10 +151,7 @@ describe("taxonomy gardening workflow (divisive build)", () => {
     expect(result).toEqual(expect.objectContaining({ status: "completed" }))
   })
 
-  // Above the gardening minimum (so not a cold start) but split into nothing: the
-  // build produced a bare root. Publishing it retires the tree that is serving and
-  // activates an empty one, which is how a low-traffic project lost all 18 of its
-  // behaviours after a week of thin data (project w7hv60cisk5n2r96c5ix5y1w).
+  // Above the gardening minimum but split into nothing: a bare root, with 18 prior clusters to retire.
   const degenerateBuildResult = {
     observationsScanned: 69,
     observationsAvailable: 69,
@@ -181,14 +177,12 @@ describe("taxonomy gardening workflow (divisive build)", () => {
     const result = await gardenTaxonomyWorkflow(input)
 
     expect(patched).toHaveBeenCalledWith("taxonomy-gardening-keep-tree-on-degenerate-rebuild-v1")
-    // The guard reads the plan before any persist branch, so nothing is saved,
-    // reassigned, named or deprecated — whichever tree this mode would publish.
+    // Gated before any persist branch, so nothing is saved, reassigned, named or deprecated.
     expect(mockActivities.saveGardenTaxonomyClustersActivity).not.toHaveBeenCalled()
     expect(mockActivities.reassignGardenTaxonomyObservationsActivity).not.toHaveBeenCalled()
     expect(mockActivities.deprecateGardenTaxonomyClustersActivity).not.toHaveBeenCalled()
     expect(mockActivities.planGardenTaxonomyNamingActivity).not.toHaveBeenCalled()
     expect(mockActivities.cleanupGardenTaxonomyStagingActivity).not.toHaveBeenCalled()
-    // The run completes (it is not a failure), recording that it retired nothing.
     expect(mockActivities.completeGardenTaxonomyRunActivity).toHaveBeenCalledWith(
       expect.objectContaining({ clustersBorn: 0, clustersDeprecated: 0, observationsSampled: 69 }),
     )
@@ -201,8 +195,7 @@ describe("taxonomy gardening workflow (divisive build)", () => {
 
     await gardenTaxonomyWorkflow(globalInput)
 
-    // An in-flight history recorded the full publish sequence, so replay must keep
-    // issuing it; the guard only applies to executions that started with it.
+    // An in-flight history recorded the full publish sequence, so replay must keep issuing it.
     expect(mockActivities.saveGardenTaxonomyClustersActivity).toHaveBeenCalledTimes(1)
     expect(mockActivities.deprecateGardenTaxonomyClustersActivity).toHaveBeenCalledTimes(1)
   })

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.test.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.test.ts
@@ -12,6 +12,7 @@ const { mockActivities } = vi.hoisted(() => {
     clustersDeprecated: 2,
     leavesAssigned: 7,
     maxDepthReached: 2,
+    topLevelClustersBuilt: 2,
     lineage: ["birth"],
     planKey: "org:oooooooooooooooooooooooo:taxonomy:gardenPlan:rrrrrrrrrrrrrrrrrrrrrrrr",
   }
@@ -76,6 +77,9 @@ const scopedInput = { ...globalInput, customBehaviorId: "b".repeat(24) }
 describe("taxonomy gardening workflow (divisive build)", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // `clearAllMocks` keeps implementations, so restore the all-markers-on default
+    // the mock factory sets — a test that flips one marker off must not leak.
+    vi.mocked(patched).mockImplementation(() => true)
   })
 
   it("builds the tree once, names clusters deepest-first, and completes the run", async () => {
@@ -146,6 +150,61 @@ describe("taxonomy gardening workflow (divisive build)", () => {
       expect.objectContaining({ clustersBorn: 0, clustersDeprecated: 0 }),
     )
     expect(result).toEqual(expect.objectContaining({ status: "completed" }))
+  })
+
+  // Above the gardening minimum (so not a cold start) but split into nothing: the
+  // build produced a bare root. Publishing it retires the tree that is serving and
+  // activates an empty one, which is how a low-traffic project lost all 18 of its
+  // behaviours after a week of thin data (project w7hv60cisk5n2r96c5ix5y1w).
+  const degenerateBuildResult = {
+    observationsScanned: 69,
+    observationsAvailable: 69,
+    observationsSampled: 69,
+    sampleStrategy: "day_stratified_hash_round_robin",
+    sampleCap: 1500,
+    clustersBorn: 1,
+    clustersContinued: 0,
+    clustersDeprecated: 18,
+    leavesAssigned: 69,
+    maxDepthReached: 0,
+    topLevelClustersBuilt: 0,
+    lineage: ["death"],
+    planKey: "org:oooooooooooooooooooooooo:taxonomy:gardenPlan:rrrrrrrrrrrrrrrrrrrrrrrr",
+  }
+
+  it.each([
+    ["global", globalInput],
+    ["scoped", scopedInput],
+  ] as const)("keeps the prior tree serving when a %s rebuild collapses to a bare root", async (_label, input) => {
+    mockActivities.planHierarchicalGardenTaxonomyActivity.mockResolvedValueOnce(degenerateBuildResult as never)
+
+    const result = await gardenTaxonomyWorkflow(input)
+
+    expect(patched).toHaveBeenCalledWith("taxonomy-gardening-keep-tree-on-degenerate-rebuild-v1")
+    // The guard reads the plan before any persist branch, so nothing is saved,
+    // reassigned, named or deprecated — whichever tree this mode would publish.
+    expect(mockActivities.saveGardenTaxonomyClustersActivity).not.toHaveBeenCalled()
+    expect(mockActivities.reassignGardenTaxonomyObservationsActivity).not.toHaveBeenCalled()
+    expect(mockActivities.deprecateGardenTaxonomyClustersActivity).not.toHaveBeenCalled()
+    expect(mockActivities.planGardenTaxonomyNamingActivity).not.toHaveBeenCalled()
+    expect(mockActivities.cleanupGardenTaxonomyStagingActivity).not.toHaveBeenCalled()
+    // The run completes (it is not a failure), recording that it retired nothing.
+    expect(mockActivities.completeGardenTaxonomyRunActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ clustersBorn: 0, clustersDeprecated: 0, observationsSampled: 69 }),
+    )
+    expect(result).toEqual(expect.objectContaining({ status: "completed" }))
+  })
+
+  it("still publishes a degenerate rebuild when replaying a pre-change history (marker off)", async () => {
+    vi.mocked(patched).mockImplementation((id) => id !== "taxonomy-gardening-keep-tree-on-degenerate-rebuild-v1")
+    mockActivities.planHierarchicalGardenTaxonomyActivity.mockResolvedValueOnce(degenerateBuildResult as never)
+
+    await gardenTaxonomyWorkflow(globalInput)
+
+    // An in-flight history recorded the full publish sequence, so replay must keep
+    // issuing it; the guard only applies to executions that started with it.
+    expect(mockActivities.saveGardenTaxonomyClustersActivity).toHaveBeenCalledTimes(1)
+    expect(mockActivities.deprecateGardenTaxonomyClustersActivity).toHaveBeenCalledTimes(1)
   })
 
   it("a post-build (naming) failure leaves the prior clusters active — no whole-tree wipe (#4036)", async () => {

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
@@ -104,8 +104,7 @@ export const gardenTaxonomyWorkflow = async (
     useStagingSwap = patched("taxonomy-gardening-staging-swap-v1")
     // Fixed position, like the marker above: reads hide "Pending" names, so name before publishing.
     const nameBeforePublish = patched("taxonomy-gardening-name-before-publish-v1")
-    // Same fixed position: the degenerate-rebuild guard below skips the whole
-    // publish sequence, so an in-flight pre-change history must not take it.
+    // Same fixed position: the guard below skips the publish sequence, so a pre-change history must not take it.
     const keepTreeOnDegenerateRebuild = patched("taxonomy-gardening-keep-tree-on-degenerate-rebuild-v1")
     const built = await planHierarchicalGardenTaxonomyActivity(started)
     // Scoped cold-start: the plan sampled below the gardening minimum and built
@@ -114,15 +113,10 @@ export const gardenTaxonomyWorkflow = async (
     // sweep gates it on the same minimum before it ever starts.
     const scopedColdStart =
       started.customBehaviorId !== undefined && built.clustersBorn === 0 && built.clustersContinued === 0
-    // Degenerate rebuild: the build cleared the minimum but split into nothing, so
-    // its tree is a bare root with no behaviour under it. Publishing it retires the
-    // tree that is serving reads and activates an empty one, which is how a project
-    // whose traffic thins for a week loses every behaviour it had. Complete the run
-    // empty instead, like the cold start. Gated here — before any persist branch —
-    // so it protects the static tree (off/shadow) and the adaptive one (enforced)
-    // alike, and on a plan field a pre-change result does not carry.
-    const degenerateRebuild = keepTreeOnDegenerateRebuild && built.topLevelClustersBuilt === 0
-    if (scopedColdStart || degenerateRebuild) {
+    // A bare root has no behaviour to publish, and publishing it retires the tree that is serving.
+    // Gated before the persist branches, so it covers static (off/shadow) and adaptive (enforced) alike.
+    const builtNoBehaviours = keepTreeOnDegenerateRebuild && built.topLevelClustersBuilt === 0
+    if (scopedColdStart || builtNoBehaviours) {
       return await completeGardenTaxonomyRunActivity({
         ...started,
         observationsScanned: built.observationsScanned,

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
@@ -104,12 +104,25 @@ export const gardenTaxonomyWorkflow = async (
     useStagingSwap = patched("taxonomy-gardening-staging-swap-v1")
     // Fixed position, like the marker above: reads hide "Pending" names, so name before publishing.
     const nameBeforePublish = patched("taxonomy-gardening-name-before-publish-v1")
+    // Same fixed position: the degenerate-rebuild guard below skips the whole
+    // publish sequence, so an in-flight pre-change history must not take it.
+    const keepTreeOnDegenerateRebuild = patched("taxonomy-gardening-keep-tree-on-degenerate-rebuild-v1")
     const built = await planHierarchicalGardenTaxonomyActivity(started)
     // Scoped cold-start: the plan sampled below the gardening minimum and built
     // no tree, so complete the run empty and leave any prior scoped tree serving
     // (never reaching save/deprecate). Global stays on the full sequence — the
     // sweep gates it on the same minimum before it ever starts.
-    if (started.customBehaviorId !== undefined && built.clustersBorn === 0 && built.clustersContinued === 0) {
+    const scopedColdStart =
+      started.customBehaviorId !== undefined && built.clustersBorn === 0 && built.clustersContinued === 0
+    // Degenerate rebuild: the build cleared the minimum but split into nothing, so
+    // its tree is a bare root with no behaviour under it. Publishing it retires the
+    // tree that is serving reads and activates an empty one, which is how a project
+    // whose traffic thins for a week loses every behaviour it had. Complete the run
+    // empty instead, like the cold start. Gated here — before any persist branch —
+    // so it protects the static tree (off/shadow) and the adaptive one (enforced)
+    // alike, and on a plan field a pre-change result does not carry.
+    const degenerateRebuild = keepTreeOnDegenerateRebuild && built.topLevelClustersBuilt === 0
+    if (scopedColdStart || degenerateRebuild) {
       return await completeGardenTaxonomyRunActivity({
         ...started,
         observationsScanned: built.observationsScanned,

--- a/packages/domain/taxonomy/src/use-cases/adaptive-gardening.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/adaptive-gardening.test.ts
@@ -407,10 +407,7 @@ describe("shadow guardrails hold across contrasting corpora", () => {
   })
 })
 
-// One vector repeated: every candidate split has identical sibling centroids, so
-// neither builder can accept a split and both collapse to a bare root. This is the
-// shape a project whose traffic thinned to a handful of near-identical sessions
-// produces (project w7hv60cisk5n2r96c5ix5y1w, 2026-08-04).
+// One vector repeated: identical sibling centroids, so no candidate split is accepted and both builders bare-root.
 const unsplittableCorpus = (at: Date): TaxonomyMomentObservation[] =>
   Array.from({ length: 40 }, (_, index) => ({ ...makeObservation(index, 0, at), embedding: groupVector(0, 0) }))
 
@@ -455,14 +452,12 @@ describe("a degenerate rebuild is detectable before any publish branch runs", ()
       { now, mode },
     )
 
-    // Above the gardening minimum, so this is NOT a cold start: the build ran and
-    // produced a tree — a bare root with no behaviour under it.
+    // Above the gardening minimum, so not a cold start: the build ran and produced a bare root.
     expect(plan.observationsSampled).toBe(40)
     expect(plan.topLevelClustersBuilt).toBe(0)
     expect(plan.clusters).toHaveLength(1)
     expect(plan.maxDepthReached).toBe(0)
-    // And this is what publishing it would cost, on whichever branch this mode
-    // takes: the two behaviours the customer could see are retired either way.
+    // What publishing would retire, on whichever branch this mode takes.
     const retired = [...plan.deprecatedClusterIds, ...plan.supersededClusterIds]
     expect(retired).toContain("2".repeat(24))
     expect(retired).toContain("3".repeat(24))

--- a/packages/domain/taxonomy/src/use-cases/adaptive-gardening.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/adaptive-gardening.test.ts
@@ -407,6 +407,79 @@ describe("shadow guardrails hold across contrasting corpora", () => {
   })
 })
 
+// One vector repeated: every candidate split has identical sibling centroids, so
+// neither builder can accept a split and both collapse to a bare root. This is the
+// shape a project whose traffic thinned to a handful of near-identical sessions
+// produces (project w7hv60cisk5n2r96c5ix5y1w, 2026-08-04).
+const unsplittableCorpus = (at: Date): TaxonomyMomentObservation[] =>
+  Array.from({ length: 40 }, (_, index) => ({ ...makeObservation(index, 0, at), embedding: groupVector(0, 0) }))
+
+const priorTree = (): TaxonomyCluster[] => {
+  const root = "1".repeat(24)
+  return [
+    { id: root, parentClusterId: null, depth: 0, path: "" },
+    { id: "2".repeat(24), parentClusterId: root, depth: 1, path: `${root}/` },
+    { id: "3".repeat(24), parentClusterId: root, depth: 1, path: `${root}/` },
+  ].map((node) =>
+    taxonomyClusterSchema.parse({
+      ...node,
+      organizationId,
+      projectId,
+      customBehaviorId: null,
+      dimension: "topic",
+      splitLinkThreshold: null,
+      name: `Prior ${node.depth}`,
+      description: "A prior behaviour.",
+      centroid: { base: groupVector(0, 0), mass: 1, model: "m", decay: 1, weights: { default: 1 } },
+      observationCount: 10,
+      state: "active",
+      mergedIntoClusterId: null,
+      firstObservedAt: now,
+      lastObservedAt: now,
+      clusteredAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }),
+  )
+}
+
+describe("a degenerate rebuild is detectable before any publish branch runs", () => {
+  it.each([
+    "off",
+    "shadow",
+    "enforced",
+  ] as const)("reports topLevelClustersBuilt 0 and would retire the whole prior tree (%s)", async (mode) => {
+    const plan = await runPlan(
+      createFakeTaxonomyObservationRepository(unsplittableCorpus(now)),
+      createFakeTaxonomyClusterRepository(priorTree()),
+      { now, mode },
+    )
+
+    // Above the gardening minimum, so this is NOT a cold start: the build ran and
+    // produced a tree — a bare root with no behaviour under it.
+    expect(plan.observationsSampled).toBe(40)
+    expect(plan.topLevelClustersBuilt).toBe(0)
+    expect(plan.clusters).toHaveLength(1)
+    expect(plan.maxDepthReached).toBe(0)
+    // And this is what publishing it would cost, on whichever branch this mode
+    // takes: the two behaviours the customer could see are retired either way.
+    const retired = [...plan.deprecatedClusterIds, ...plan.supersededClusterIds]
+    expect(retired).toContain("2".repeat(24))
+    expect(retired).toContain("3".repeat(24))
+  })
+
+  it("a healthy rebuild reports its top-level count, so the guard stays out of the way", async () => {
+    const plan = await runPlan(
+      createFakeTaxonomyObservationRepository(twoGroupCorpus(now)),
+      createFakeTaxonomyClusterRepository(priorTree()),
+      { now, mode: "shadow" },
+    )
+
+    expect(plan.topLevelClustersBuilt).toBeGreaterThanOrEqual(2)
+    expect(plan.topLevelClustersBuilt).toBe(plan.comparison?.static.rootChildCount)
+  })
+})
+
 describe("taxonomy cluster entity accepts the widened staging state", () => {
   it("round-trips a staging row through the Zod schema", () => {
     const staging: TaxonomyCluster = taxonomyClusterSchema.parse({

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
@@ -135,11 +135,7 @@ export interface BuildHierarchicalTaxonomyResult {
   readonly clustersDeprecated: number
   readonly leavesAssigned: number
   readonly maxDepthReached: number
-  /**
-   * Children of the single depth-0 root — the rows the Behaviours read hoists as
-   * its top-level list. Zero means this build produced a bare root: a tree with
-   * no behaviour in it, whatever else the counters say.
-   */
+  /** Children of the single depth-0 root — the rows the Behaviours read hoists as its top-level list. */
   readonly topLevelClustersBuilt: number
   readonly lineage: readonly TaxonomyClusterLineage[]
 }

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
@@ -135,6 +135,12 @@ export interface BuildHierarchicalTaxonomyResult {
   readonly clustersDeprecated: number
   readonly leavesAssigned: number
   readonly maxDepthReached: number
+  /**
+   * Children of the single depth-0 root — the rows the Behaviours read hoists as
+   * its top-level list. Zero means this build produced a bare root: a tree with
+   * no behaviour in it, whatever else the counters say.
+   */
+  readonly topLevelClustersBuilt: number
   readonly lineage: readonly TaxonomyClusterLineage[]
 }
 
@@ -654,6 +660,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
         clustersDeprecated: 0,
         leavesAssigned: 0,
         maxDepthReached: 0,
+        topLevelClustersBuilt: 0,
         lineage: [],
         clusters: [],
         observationAssignments: [],
@@ -941,6 +948,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       clustersDeprecated: deprecatedClusterIds.length,
       leavesAssigned: bornLeaves.reduce((sum, leaf) => sum + leaf.observationIndices.length, 0),
       maxDepthReached: maxDepth,
+      topLevelClustersBuilt: tree.children.length,
       lineage,
       clusters: bornClusters,
       observationAssignments,


### PR DESCRIPTION
## the bug

A garden run that rebuilds a project's global topic tree can produce a **root-only tree**: the sample clears `TAXONOMY_GARDENING_MIN_OBSERVATIONS`, the build runs, but no candidate split survives the gates, so `buildStaticHierarchicalClusters` (or the adaptive builder) returns a root with zero children. The publish path had no opinion about that shape — it retired every previously active cluster and activated the bare root. The Behaviours read hoists the root's depth-1 children as its top-level rows, so the customer's list goes empty.

Real case: project `w7hv60cisk5n2r96c5ix5y1w` (org `yui6tm02fenuli8c3p5hzkfc`, `mode=shadow`, so the **static** tree is what is live). It ran `rootChildCount` 2–3 through Aug 3. Its daily observations fell from ~30–40/day (through Jul 27) to ~5–15/day after Jul 28, shrinking the 7-day clustering window to ~69 sparse observations. On Aug 4 the run reported `rootChildCount=0`, `nodeCount=1`, `clustersBorn=0`, `clustersDeprecated=18`: the previous 18-cluster tree was deprecated and the empty one activated. Fleet-wide this is not happening (projects-with-behaviours is steady at 34–46/day); it hits low-activity projects that dip.

This is **not** the below-minimum cold start. The existing guard in `gardenTaxonomyWorkflow` fires on `clustersBorn === 0 && clustersContinued === 0` and only for a **scoped** run; this build sampled 69 observations and did produce a tree, and the run was global, so nothing caught it.

## static vs adaptive: both

The requester asked whether this is specific to today's production static clustering. It is not — the gap is in the shared publication path, and each mode reaches it by its own branch:

| mode | tree persisted | how the prior tree dies |
| --- | --- | --- |
| `off` / `shadow` | static | `deprecatedClusterIds` (every previously-active cluster no new node continued) → `publishStagedTree` → `swapActiveTree` |
| `enforced` | adaptive | a root-only adaptive tree passes `adaptiveFallbackReason` (`nodeCount < 1` is the only structural floor, and a bare root has `nodeCount === 1`), so `persistAdaptive` stays true; the root is itself a leaf, so `leafClusters` is non-empty and `planPersistsAdaptive` routes to `swapAndCatchUp`, which supersedes the **whole** old tree |

So `enforced` is if anything worse: static keeps continued rows alive by id reuse, adaptive supersedes everything. The static path also does real damage before the swap — its sample reassignment points the observations at the only leaf, which is the root, so ClickHouse membership drains out of the behaviours too.

Because both branches are downstream of the plan, the fix belongs upstream of the split rather than in either persist branch.

## the guard

`planHierarchicalTaxonomyUseCase` now reports `topLevelClustersBuilt` (the root's child count) on the plan, and the activity result carries it through. The workflow completes the run empty when it is zero, before `save` / `reassign` / `deprecate` / naming run at all — the prior tree keeps serving, exactly like the scoped cold-start branch it now sits beside.

Threshold: **zero top-level behaviours**, not a drop ratio. A tree with no behaviour in it has no product value under any reading, so the guard needs no tuning and cannot mis-fire on a legitimately reshaped tree. A regression guard (say, "reject a rebuild that loses more than half its behaviours") would also have caught this case, but it needs a product decision about how much churn is normal for a tree that legitimately reorganizes, and a wrong threshold freezes trees that should move. Left out deliberately; worth a follow-up if we see one-behaviour collapses in the wild.

Command-sequence change, so the new branch is gated on `patched("taxonomy-gardening-keep-tree-on-degenerate-rebuild-v1")` read at the same fixed position as the other two markers. An in-flight pre-change history replays the full publish sequence (and its plan result carries no `topLevelClustersBuilt` anyway).

Side effect worth knowing: a **global** below-minimum run now short-circuits too, instead of walking the whole sequence with an empty plan. Same outcome, fewer no-op activities.

## observability

New `taxonomy.gardenTaxonomyWorkflow.degenerateRebuild` log, emitted from the planning activity for every mode (the adaptive `gardenRun` telemetry returns early on `off`, which is what most projects run) whenever a build produces no top-level behaviour while a tree was serving. Carries the sample size and the size of the tree that was kept.

## tests

- `adaptive-gardening.test.ts`: a corpus of 40 identical embeddings (the shape a thinned-out project produces) collapses to a bare root in `off`, `shadow` **and** `enforced`; each case asserts `topLevelClustersBuilt === 0` and that the prior tree's two behaviours appear in `deprecatedClusterIds`/`supersededClusterIds` — that is, what publishing would have cost on whichever branch that mode takes. Plus a healthy rebuild reporting its real count, tied to `comparison.static.rootChildCount`.
- `taxonomy-gardening-workflow.test.ts`: a degenerate rebuild (global and scoped) saves, reassigns, deprecates and names nothing, completes the run, and leaks no staging; a pre-change replay with the marker off still publishes; the existing healthy-path and command-sequence tests carry the new field and still pass.

`pnpm typecheck` (90/90), `@domain/taxonomy` (261), `@app/workflows` (96), biome clean.

Refs LAT-772. Spec: `specs/taxonomy-adaptive-clustering.md` § "Full live-window reassignment and publication" (branch `docs/taxonomy-adaptive-clustering-spec`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented degenerate taxonomy rebuilds from replacing an existing taxonomy with an empty or root-only structure.
  - When a rebuild cannot create meaningful top-level clusters, publishing is skipped and the existing taxonomy is preserved.
  - Completed runs now accurately report zero changes for collapsed rebuilds.

- **Improvements**
  - Taxonomy build results now include the number of top-level clusters created, improving run status and outcome reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->