### PR TITLE
fix(imports): succeeded progress reads 100% and the wizard's date picker works in the modal

### DIFF
--- a/apps/web/src/components/imports/import-wizard.tsx
+++ b/apps/web/src/components/imports/import-wizard.tsx
@@ -699,7 +699,7 @@ function ImportWizardForm({
                   />
                 </div>
                 {/* The picker trigger is a `min-h-8` Button; pinned to the Select's `h-9` so the row lines up. */}
-                <div className="shrink-0 [&>button]:h-9">
+                <div className="shrink-0 [&>div>button]:h-9">
                   <TimeFilterDropdown
                     startTimeFrom={range.from}
                     startTimeTo={range.to}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/imports/import-jobs-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/imports/import-jobs-table.tsx
@@ -53,7 +53,9 @@ const isActiveStatus = (status: ImportRecord["status"]) =>
 /** Kept in step with `RESUMABLE_STATUSES` in retryImportUseCase, which is what enforces it. */
 const RESUMABLE_STATUSES: readonly ImportRecord["status"][] = ["failed", "cancelled", "capped"]
 
+/** A succeeded job drained the source, so it is complete even when that was fewer traces than the cap. */
 const progressPercent = (job: ImportRecord): number => {
+  if (job.status === "succeeded") return 100
   if (job.config.maxTraces <= 0) return 0
   return Math.min(100, Math.round((job.stats.tracesImported / job.config.maxTraces) * 100))
 }

--- a/packages/ui/src/components/date-range-picker/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker/date-range-picker.tsx
@@ -217,6 +217,9 @@ export function DateRangePicker({
 }: DateRangePickerProps) {
   const [open, setOpen] = useState(false)
   const [draftRange, setDraftRange] = useState<DateRange | undefined>(() => copyRange(value))
+  // Portal target next to the trigger, as in Select: body-portaled content inside a modal sits
+  // outside the dialog's pointer-events/focus scope and becomes non-interactive.
+  const [popoverContainer, setPopoverContainer] = useState<HTMLDivElement | null>(null)
 
   const selection = formatSelectionLabel({
     value,
@@ -267,60 +270,69 @@ export function DateRangePicker({
   }
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          size="default"
-          disabled={disabled}
-          // `[&>div]` targets Button's inner content wrapper so the chevron sits at the far end;
-          // Button packs its children into one content-width row, so plain `justify-between` can't.
-          className={cn("gap-2", fullWidth ? "w-full [&>div]:w-full [&>div]:justify-between" : "w-auto justify-start")}
-        >
-          <span className="flex items-center gap-2">
-            <Icon icon={CalendarIcon} size="sm" color={selection.selected ? "accentForeground" : "foreground"} />
-            <span
-              className={cn("whitespace-nowrap", {
-                "text-accent-foreground": selection.selected,
-                "text-foreground": !selection.selected,
-              })}
-            >
-              {selection.label}
+    <div ref={setPopoverContainer} className={fullWidth ? "w-full" : "w-auto"}>
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="default"
+            disabled={disabled}
+            // `[&>div]` targets Button's inner content wrapper so the chevron sits at the far end;
+            // Button packs its children into one content-width row, so plain `justify-between` can't.
+            className={cn(
+              "gap-2",
+              fullWidth ? "w-full [&>div]:w-full [&>div]:justify-between" : "w-auto justify-start",
+            )}
+          >
+            <span className="flex items-center gap-2">
+              <Icon icon={CalendarIcon} size="sm" color={selection.selected ? "accentForeground" : "foreground"} />
+              <span
+                className={cn("whitespace-nowrap", {
+                  "text-accent-foreground": selection.selected,
+                  "text-foreground": !selection.selected,
+                })}
+              >
+                {selection.label}
+              </span>
             </span>
-          </span>
-          <Icon icon={ChevronDown} size="sm" color="foregroundMuted" className="shrink-0" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align={align} className="w-[min(100vw-2rem,360px)] p-0 sm:w-auto">
-        <div className="flex flex-col gap-3 p-3">
-          {presets.length > 0 ? (
-            <Select
-              name="date-range-picker-preset"
-              options={presetOptions}
-              value={selectedPresetId}
-              placeholder="Custom range"
-              width="full"
-              contentWidth="trigger"
-              side="bottom"
-              onChange={(presetId) => {
-                const preset = presets.find((entry) => entry.id === presetId)
-                if (!preset) return
-                handlePresetSelect(preset)
-              }}
-            />
-          ) : null}
-          <RangeCalendar value={draftRange} onChange={setDraftRange} />
-          <div className="flex items-center justify-between gap-3">
-            <Text.H6 color="foregroundMuted" className="min-w-0 truncate">
-              {formatDraftSummary(draftRange)}
-            </Text.H6>
-            <Button type="button" variant="ghost" size="sm" disabled={!canClear} onClick={handleClear}>
-              {clearLabel}
-            </Button>
+            <Icon icon={ChevronDown} size="sm" color="foregroundMuted" className="shrink-0" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          container={popoverContainer ?? undefined}
+          align={align}
+          className="w-[min(100vw-2rem,360px)] p-0 sm:w-auto"
+        >
+          <div className="flex flex-col gap-3 p-3">
+            {presets.length > 0 ? (
+              <Select
+                name="date-range-picker-preset"
+                options={presetOptions}
+                value={selectedPresetId}
+                placeholder="Custom range"
+                width="full"
+                contentWidth="trigger"
+                side="bottom"
+                onChange={(presetId) => {
+                  const preset = presets.find((entry) => entry.id === presetId)
+                  if (!preset) return
+                  handlePresetSelect(preset)
+                }}
+              />
+            ) : null}
+            <RangeCalendar value={draftRange} onChange={setDraftRange} />
+            <div className="flex items-center justify-between gap-3">
+              <Text.H6 color="foregroundMuted" className="min-w-0 truncate">
+                {formatDraftSummary(draftRange)}
+              </Text.H6>
+              <Button type="button" variant="ghost" size="sm" disabled={!canClear} onClick={handleClear}>
+                {clearLabel}
+              </Button>
+            </div>
           </div>
-        </div>
-      </PopoverContent>
-    </Popover>
+        </PopoverContent>
+      </Popover>
+    </div>
   )
 }


### PR DESCRIPTION
Two fixes to the imports settings page.

## progress column stuck below 100% on succeeded imports

Progress is computed as `tracesImported / config.maxTraces`, but a succeeded import drained the source project — the cap is not a meaningful denominator once there's nothing left to fetch. Asking for 1,000 traces from a project holding 10 read as 1% forever. The progress cell now short-circuits to 100% for `succeeded` jobs; running/queued jobs keep showing real progress toward the cap, and failed/cancelled ones keep showing how far they got.

## date-range picker unusable inside the wizard modal

Opening the time-range filter in the import wizard modal and clicking any calendar day closed the popover without selecting anything. The picker's popover portals to `document.body`, where an open Radix dialog leaves `pointer-events: none`; the dialog and popover bundle two copies of `@radix-ui/react-dismissable-layer` (1.1.13 via dialog/select, 1.1.11 via popover), so the popover's layer never learns the dialog disabled outside pointer events and never re-enables its own. Every click fell through to the content behind the modal, which the popover treated as an outside press and dismissed on. Inline hosts (traces onboarding) were unaffected since there's no dialog.

`DateRangePicker` now portals its popover into a container div next to the trigger — the same pattern `Select` uses, which is why the project dropdown in the same modal already worked. Inside a modal the calendar stays within the dialog's pointer-events and focus scope; on full pages the behavior is unchanged. The wizard's trigger-height selector is adjusted for the new wrapper.

Verified in the running app: in the modal, day clicks build the range without closing the popover, outside click commits it, and the preview refetches for the new range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time filter dropdown sizing for more consistent display.
  * Import jobs that complete successfully now show 100% progress.
  * Date range picker popovers now remain properly scoped to their associated controls.
  * Preserved full-width date range picker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->