### PR TITLE
feat(filters): group the session and trace filters by function

### DIFF
--- a/apps/web/src/components/filters-builder/constants.ts
+++ b/apps/web/src/components/filters-builder/constants.ts
@@ -4,6 +4,7 @@ import {
   type PercentileSessionFilterField,
   type PercentileTraceFilterField,
   TRACE_FILTER_FIELDS,
+  type TraceFilterGroupId,
 } from "@domain/shared"
 import type { FilterMode } from "./multi-select-filter.tsx"
 
@@ -11,11 +12,13 @@ const TEXT_FIELDS = TRACE_FILTER_FIELDS.filter((f) => f.type === "text").map((f)
   field: f.field,
   label: f.label,
   placeholder: f.placeholder ?? "Enter value...",
+  group: f.group,
 }))
 
 const ALL_MULTI_SELECT_FIELDS = TRACE_FILTER_FIELDS.filter((f) => f.type === "multiSelect").map((f) => ({
   field: f.field,
   label: f.label,
+  group: f.group,
   sessionOnly: "sessionOnly" in f && f.sessionOnly === true,
 }))
 
@@ -26,6 +29,7 @@ export function getMultiSelectFieldsForMode(mode: FilterMode) {
 export const STATUS_FIELDS = TRACE_FILTER_FIELDS.filter((f) => f.type === "status").map((f) => ({
   field: f.field,
   label: f.label,
+  group: f.group,
 }))
 
 export type PercentileFieldName = PercentileTraceFilterField | PercentileSessionFilterField
@@ -33,6 +37,7 @@ export type PercentileFieldName = PercentileTraceFilterField | PercentileSession
 interface NumberRangeFieldDefinition {
   readonly field: string
   readonly label: string
+  readonly group: TraceFilterGroupId
   readonly tooltip: string | undefined
   readonly percentile?: {
     readonly field?: PercentileFieldName
@@ -55,6 +60,7 @@ export const NUMBER_RANGE_FIELDS: readonly NumberRangeFieldDefinition[] = TRACE_
   return {
     field: f.field,
     label: f.label,
+    group: f.group,
     tooltip: "tooltip" in f ? f.tooltip : undefined,
     ...(supportsPercentile ? { percentile: isPercentileField ? { field: f.field } : {} } : {}),
     ...(displayScale !== undefined ? { displayScale } : {}),

--- a/apps/web/src/components/filters-builder/filters-builder-fields.tsx
+++ b/apps/web/src/components/filters-builder/filters-builder-fields.tsx
@@ -1,8 +1,8 @@
 import { MOMENT_KINDS } from "@domain/conversation-intelligence"
 import type { FilterCondition, FilterSet, TraceFilterGroupId } from "@domain/shared"
-import { Button, Input, Switch, Tabs, Text, Tooltip, useMountEffect } from "@repo/ui"
+import { Button, cn, Input, Switch, Tabs, Text, Tooltip } from "@repo/ui"
 import { ChevronDown, ChevronUp, InfoIcon, SearchIcon, XIcon } from "lucide-react"
-import { type ComponentProps, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { type ComponentProps, type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
 import { useProjectMembersCollection } from "../../domains/members/members.collection.ts"
 import { isHasLlmActivityFilterOn } from "../../domains/sessions/sessions.collection.ts"
 import { useTopicFilterOptions } from "../../domains/taxonomy/taxonomy.collection.ts"
@@ -153,7 +153,6 @@ function DebouncedInput({
     () => {
       if (pendingChange === null) return
       onDebouncedChange(pendingChange)
-      setPendingChange(null)
     },
     300,
     [pendingChange, onDebouncedChange],
@@ -164,21 +163,6 @@ function DebouncedInput({
     setLocal(value)
     setPendingChange(null)
   }, [value])
-
-  // Search-filtering unmounts non-matching sections before the debounce above
-  // fires, which would otherwise clear the pending timeout and silently drop
-  // the edit. Flush whatever's still pending straight to the caller on unmount;
-  // `pendingChange` is reset to null as soon as the debounce delivers it, so a
-  // delivered value can't be flushed a second time here.
-  const pendingChangeRef = useRef(pendingChange)
-  pendingChangeRef.current = pendingChange
-  const onDebouncedChangeRef = useRef(onDebouncedChange)
-  onDebouncedChangeRef.current = onDebouncedChange
-  useMountEffect(() => {
-    return () => {
-      if (pendingChangeRef.current !== null) onDebouncedChangeRef.current(pendingChangeRef.current)
-    }
-  })
 
   return (
     <div className="relative">
@@ -211,14 +195,16 @@ function DebouncedInput({
 function NumberRangeFilter({
   minValue,
   maxValue,
-  onRangeChange,
+  onMinChange,
+  onMaxChange,
   minPlaceholder = "Min",
   maxPlaceholder = "Max",
   step,
 }: {
   readonly minValue: number | undefined
   readonly maxValue: number | undefined
-  readonly onRangeChange: (min: number | undefined, max: number | undefined) => void
+  readonly onMinChange: (v: number | undefined) => void
+  readonly onMaxChange: (v: number | undefined) => void
   readonly minPlaceholder?: string
   readonly maxPlaceholder?: string
   /** HTML `step` for both inputs; defaults to integer step when omitted. */
@@ -232,21 +218,19 @@ function NumberRangeFilter({
   useDebounce(
     () => {
       if (pendingMin === null) return
-      onRangeChange(pendingMin, maxValue)
-      setPendingMin(null)
+      onMinChange(pendingMin)
     },
     400,
-    [pendingMin, maxValue, onRangeChange],
+    [pendingMin, onMinChange],
   )
 
   useDebounce(
     () => {
       if (pendingMax === null) return
-      onRangeChange(minValue, pendingMax)
-      setPendingMax(null)
+      onMaxChange(pendingMax)
     },
     400,
-    [pendingMax, minValue, onRangeChange],
+    [pendingMax, onMaxChange],
   )
 
   // TODO(frontend-use-effect-policy): keep local range inputs in sync with externally-controlled filter updates.
@@ -259,31 +243,6 @@ function NumberRangeFilter({
     setLocalMax(maxValue?.toString() ?? "")
     setPendingMax(null)
   }, [maxValue])
-
-  // Search-filtering unmounts non-matching sections before the debounces above
-  // fire, which would otherwise clear the pending timeouts and silently drop
-  // the edits. Flush both endpoints in a single call on unmount — `onRangeChange`
-  // replaces both conditions at once, so two sequential calls would let the
-  // second overwrite the first. `pendingMin`/`pendingMax` are reset to null as
-  // soon as their debounce delivers, so a delivered value can't be re-flushed.
-  const minValueRef = useRef(minValue)
-  minValueRef.current = minValue
-  const maxValueRef = useRef(maxValue)
-  maxValueRef.current = maxValue
-  const pendingMinRef = useRef(pendingMin)
-  pendingMinRef.current = pendingMin
-  const pendingMaxRef = useRef(pendingMax)
-  pendingMaxRef.current = pendingMax
-  const onRangeChangeRef = useRef(onRangeChange)
-  onRangeChangeRef.current = onRangeChange
-  useMountEffect(() => {
-    return () => {
-      if (pendingMinRef.current === null && pendingMaxRef.current === null) return
-      const min = pendingMinRef.current !== null ? pendingMinRef.current : minValueRef.current
-      const max = pendingMaxRef.current !== null ? pendingMaxRef.current : maxValueRef.current
-      onRangeChangeRef.current(min, max)
-    }
-  })
 
   const hasValue = minValue !== undefined || maxValue !== undefined
 
@@ -436,7 +395,8 @@ function NumberFilterSection({
         <NumberRangeFilter
           minValue={minValue}
           maxValue={maxValue}
-          onRangeChange={onRangeChange}
+          onMinChange={(min) => onRangeChange(min, maxValue)}
+          onMaxChange={(max) => onRangeChange(minValue, max)}
           {...(step !== undefined ? { step } : {})}
         />
       )}
@@ -800,20 +760,23 @@ export function FiltersBuilderFields({
         </div>
       </div>
 
-      {groups.length === 0 ? (
+      {groups.every((group) => group.hidden) && (
         <Text.H6 color="foregroundMuted" className="py-3">
           No filter matches “{search.trim()}”.
         </Text.H6>
-      ) : (
-        groups.map((group) => (
-          <div key={group.id} className="flex flex-col">
-            <Text.H6 color="foregroundMuted" weight="medium" className="pt-3 pb-0.5 uppercase tracking-wide">
-              {group.label}
-            </Text.H6>
-            {group.sections.map((section) => section.node)}
-          </div>
-        ))
       )}
+      {groups.map((group) => (
+        <div key={group.id} className={cn("flex flex-col", group.hidden && "hidden")}>
+          <Text.H6 color="foregroundMuted" weight="medium" className="pt-3 pb-0.5 uppercase tracking-wide">
+            {group.label}
+          </Text.H6>
+          {group.sections.map((section) => (
+            <div key={section.label} className={cn(section.hidden && "hidden")}>
+              {section.node}
+            </div>
+          ))}
+        </div>
+      ))}
     </>
   )
 }

--- a/apps/web/src/components/filters-builder/filters-builder-fields.tsx
+++ b/apps/web/src/components/filters-builder/filters-builder-fields.tsx
@@ -1,6 +1,6 @@
 import { MOMENT_KINDS } from "@domain/conversation-intelligence"
 import type { FilterCondition, FilterSet, TraceFilterGroupId } from "@domain/shared"
-import { Button, Input, Switch, Tabs, Text, Tooltip } from "@repo/ui"
+import { Button, Input, Switch, Tabs, Text, Tooltip, useMountEffect } from "@repo/ui"
 import { ChevronDown, ChevronUp, InfoIcon, SearchIcon, XIcon } from "lucide-react"
 import { type ComponentProps, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useProjectMembersCollection } from "../../domains/members/members.collection.ts"
@@ -153,6 +153,7 @@ function DebouncedInput({
     () => {
       if (pendingChange === null) return
       onDebouncedChange(pendingChange)
+      setPendingChange(null)
     },
     300,
     [pendingChange, onDebouncedChange],
@@ -166,16 +167,18 @@ function DebouncedInput({
 
   // Search-filtering unmounts non-matching sections before the debounce above
   // fires, which would otherwise clear the pending timeout and silently drop
-  // the edit. Flush whatever's pending straight to the caller on unmount.
+  // the edit. Flush whatever's still pending straight to the caller on unmount;
+  // `pendingChange` is reset to null as soon as the debounce delivers it, so a
+  // delivered value can't be flushed a second time here.
   const pendingChangeRef = useRef(pendingChange)
   pendingChangeRef.current = pendingChange
   const onDebouncedChangeRef = useRef(onDebouncedChange)
   onDebouncedChangeRef.current = onDebouncedChange
-  useEffect(() => {
+  useMountEffect(() => {
     return () => {
       if (pendingChangeRef.current !== null) onDebouncedChangeRef.current(pendingChangeRef.current)
     }
-  }, [])
+  })
 
   return (
     <div className="relative">
@@ -208,16 +211,14 @@ function DebouncedInput({
 function NumberRangeFilter({
   minValue,
   maxValue,
-  onMinChange,
-  onMaxChange,
+  onRangeChange,
   minPlaceholder = "Min",
   maxPlaceholder = "Max",
   step,
 }: {
   readonly minValue: number | undefined
   readonly maxValue: number | undefined
-  readonly onMinChange: (v: number | undefined) => void
-  readonly onMaxChange: (v: number | undefined) => void
+  readonly onRangeChange: (min: number | undefined, max: number | undefined) => void
   readonly minPlaceholder?: string
   readonly maxPlaceholder?: string
   /** HTML `step` for both inputs; defaults to integer step when omitted. */
@@ -231,19 +232,21 @@ function NumberRangeFilter({
   useDebounce(
     () => {
       if (pendingMin === null) return
-      onMinChange(pendingMin)
+      onRangeChange(pendingMin, maxValue)
+      setPendingMin(null)
     },
     400,
-    [pendingMin, onMinChange],
+    [pendingMin, maxValue, onRangeChange],
   )
 
   useDebounce(
     () => {
       if (pendingMax === null) return
-      onMaxChange(pendingMax)
+      onRangeChange(minValue, pendingMax)
+      setPendingMax(null)
     },
     400,
-    [pendingMax, onMaxChange],
+    [pendingMax, minValue, onRangeChange],
   )
 
   // TODO(frontend-use-effect-policy): keep local range inputs in sync with externally-controlled filter updates.
@@ -259,21 +262,28 @@ function NumberRangeFilter({
 
   // Search-filtering unmounts non-matching sections before the debounces above
   // fire, which would otherwise clear the pending timeouts and silently drop
-  // the edits. Flush whatever's pending straight to the callers on unmount.
+  // the edits. Flush both endpoints in a single call on unmount — `onRangeChange`
+  // replaces both conditions at once, so two sequential calls would let the
+  // second overwrite the first. `pendingMin`/`pendingMax` are reset to null as
+  // soon as their debounce delivers, so a delivered value can't be re-flushed.
+  const minValueRef = useRef(minValue)
+  minValueRef.current = minValue
+  const maxValueRef = useRef(maxValue)
+  maxValueRef.current = maxValue
   const pendingMinRef = useRef(pendingMin)
   pendingMinRef.current = pendingMin
   const pendingMaxRef = useRef(pendingMax)
   pendingMaxRef.current = pendingMax
-  const onMinChangeRef = useRef(onMinChange)
-  onMinChangeRef.current = onMinChange
-  const onMaxChangeRef = useRef(onMaxChange)
-  onMaxChangeRef.current = onMaxChange
-  useEffect(() => {
+  const onRangeChangeRef = useRef(onRangeChange)
+  onRangeChangeRef.current = onRangeChange
+  useMountEffect(() => {
     return () => {
-      if (pendingMinRef.current !== null) onMinChangeRef.current(pendingMinRef.current)
-      if (pendingMaxRef.current !== null) onMaxChangeRef.current(pendingMaxRef.current)
+      if (pendingMinRef.current === null && pendingMaxRef.current === null) return
+      const min = pendingMinRef.current !== null ? pendingMinRef.current : minValueRef.current
+      const max = pendingMaxRef.current !== null ? pendingMaxRef.current : maxValueRef.current
+      onRangeChangeRef.current(min, max)
     }
-  }, [])
+  })
 
   const hasValue = minValue !== undefined || maxValue !== undefined
 
@@ -426,8 +436,7 @@ function NumberFilterSection({
         <NumberRangeFilter
           minValue={minValue}
           maxValue={maxValue}
-          onMinChange={(min) => onRangeChange(min, maxValue)}
-          onMaxChange={(max) => onRangeChange(minValue, max)}
+          onRangeChange={onRangeChange}
           {...(step !== undefined ? { step } : {})}
         />
       )}

--- a/apps/web/src/components/filters-builder/filters-builder-fields.tsx
+++ b/apps/web/src/components/filters-builder/filters-builder-fields.tsx
@@ -2,7 +2,7 @@ import { MOMENT_KINDS } from "@domain/conversation-intelligence"
 import type { FilterCondition, FilterSet, TraceFilterGroupId } from "@domain/shared"
 import { Button, Input, Switch, Tabs, Text, Tooltip } from "@repo/ui"
 import { ChevronDown, ChevronUp, InfoIcon, SearchIcon, XIcon } from "lucide-react"
-import { type ComponentProps, type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
+import { type ComponentProps, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useProjectMembersCollection } from "../../domains/members/members.collection.ts"
 import { isHasLlmActivityFilterOn } from "../../domains/sessions/sessions.collection.ts"
 import { useTopicFilterOptions } from "../../domains/taxonomy/taxonomy.collection.ts"
@@ -164,6 +164,19 @@ function DebouncedInput({
     setPendingChange(null)
   }, [value])
 
+  // Search-filtering unmounts non-matching sections before the debounce above
+  // fires, which would otherwise clear the pending timeout and silently drop
+  // the edit. Flush whatever's pending straight to the caller on unmount.
+  const pendingChangeRef = useRef(pendingChange)
+  pendingChangeRef.current = pendingChange
+  const onDebouncedChangeRef = useRef(onDebouncedChange)
+  onDebouncedChangeRef.current = onDebouncedChange
+  useEffect(() => {
+    return () => {
+      if (pendingChangeRef.current !== null) onDebouncedChangeRef.current(pendingChangeRef.current)
+    }
+  }, [])
+
   return (
     <div className="relative">
       <Input
@@ -243,6 +256,24 @@ function NumberRangeFilter({
     setLocalMax(maxValue?.toString() ?? "")
     setPendingMax(null)
   }, [maxValue])
+
+  // Search-filtering unmounts non-matching sections before the debounces above
+  // fire, which would otherwise clear the pending timeouts and silently drop
+  // the edits. Flush whatever's pending straight to the callers on unmount.
+  const pendingMinRef = useRef(pendingMin)
+  pendingMinRef.current = pendingMin
+  const pendingMaxRef = useRef(pendingMax)
+  pendingMaxRef.current = pendingMax
+  const onMinChangeRef = useRef(onMinChange)
+  onMinChangeRef.current = onMinChange
+  const onMaxChangeRef = useRef(onMaxChange)
+  onMaxChangeRef.current = onMaxChange
+  useEffect(() => {
+    return () => {
+      if (pendingMinRef.current !== null) onMinChangeRef.current(pendingMinRef.current)
+      if (pendingMaxRef.current !== null) onMaxChangeRef.current(pendingMaxRef.current)
+    }
+  }, [])
 
   const hasValue = minValue !== undefined || maxValue !== undefined
 
@@ -411,7 +442,6 @@ const MOMENT_FILTER_ITEMS: readonly StaticFilterItem[] = MOMENT_KINDS.map((kind)
   label: humanizeKind(kind),
 }))
 
-/** One rendered filter section, tagged with the group it renders under and the label the search box matches on. */
 interface FilterSectionEntry {
   readonly group: TraceFilterGroupId
   readonly label: string

--- a/apps/web/src/components/filters-builder/filters-builder-fields.tsx
+++ b/apps/web/src/components/filters-builder/filters-builder-fields.tsx
@@ -1,7 +1,7 @@
 import { MOMENT_KINDS } from "@domain/conversation-intelligence"
-import type { FilterCondition, FilterSet } from "@domain/shared"
+import type { FilterCondition, FilterSet, TraceFilterGroupId } from "@domain/shared"
 import { Button, Input, Switch, Tabs, Text, Tooltip } from "@repo/ui"
-import { ChevronDown, ChevronUp, InfoIcon, XIcon } from "lucide-react"
+import { ChevronDown, ChevronUp, InfoIcon, SearchIcon, XIcon } from "lucide-react"
 import { type ComponentProps, type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
 import { useProjectMembersCollection } from "../../domains/members/members.collection.ts"
 import { isHasLlmActivityFilterOn } from "../../domains/sessions/sessions.collection.ts"
@@ -15,6 +15,7 @@ import {
   type PercentileFieldName,
   STATUS_FIELDS,
 } from "./constants.ts"
+import { groupFilterSections } from "./group-sections.ts"
 import { MetadataFilter } from "./metadata-filter/metadata-filter.tsx"
 import { type FilterMode, MultiSelectFilter, type StaticFilterItem } from "./multi-select-filter.tsx"
 import { PercentileFilter } from "./percentile-filter.tsx"
@@ -410,11 +411,23 @@ const MOMENT_FILTER_ITEMS: readonly StaticFilterItem[] = MOMENT_KINDS.map((kind)
   label: humanizeKind(kind),
 }))
 
+/** One rendered filter section, tagged with the group it renders under and the label the search box matches on. */
+interface FilterSectionEntry {
+  readonly group: TraceFilterGroupId
+  readonly label: string
+  readonly node: ReactNode
+}
+
 /**
  * The full session/trace filter builder body, minus any surrounding chrome. Both
  * the Sessions/Traces `FiltersSidebar` and the custom-behavior modal render this;
  * the consumer supplies its own scroll container. `excludeFields` drops fields the
  * consumer must not offer (custom behaviors hide `topics`).
+ *
+ * Sections render under the functional headings of `TRACE_FILTER_GROUPS`, in that
+ * order; a group with no visible section (mode, `excludeFields`, or the search box)
+ * drops its heading too. Within a group, order follows the control type: status,
+ * text, multi-select, number range, then the UI-only controls.
  */
 export function FiltersBuilderFields({
   mode,
@@ -423,6 +436,7 @@ export function FiltersBuilderFields({
   onFiltersChange,
   excludeFields,
 }: FiltersBuilderFieldsProps) {
+  const [search, setSearch] = useState("")
   const isExcluded = useCallback((field: string) => excludeFields?.includes(field) ?? false, [excludeFields])
 
   // Topic options come from the taxonomy tree, parents before children;
@@ -542,97 +556,123 @@ export function FiltersBuilderFields({
     [filters, onFiltersChange],
   )
 
-  return (
-    <>
-      {STATUS_FIELDS.filter(({ field }) => !isExcluded(field)).map(({ label, field }) => {
-        const selected = getStatusValues(filters, field)
-        return (
+  const entries: FilterSectionEntry[] = []
+
+  for (const { label, field, group } of STATUS_FIELDS.filter(({ field }) => !isExcluded(field))) {
+    const selected = getStatusValues(filters, field)
+    entries.push({
+      group,
+      label,
+      node: (
+        <CollapsibleSection key={field} label={label} defaultOpen={selected.length > 0}>
+          <StatusFilter
+            selected={selected}
+            onChange={(values) => setField(field, values.length > 0 ? [{ op: "in", value: [...values] }] : [])}
+          />
+        </CollapsibleSection>
+      ),
+    })
+  }
+
+  for (const { label, field, placeholder, group } of textFields) {
+    const value = getTextFilterValue(filters, field)
+    const selectedValues = getInValues(filters, field)
+    if (field === "userId") {
+      const selected = selectedValues.length > 0 ? selectedValues : value ? [value] : []
+      entries.push({
+        group,
+        label,
+        node: (
           <CollapsibleSection key={field} label={label} defaultOpen={selected.length > 0}>
-            <StatusFilter
-              selected={selected}
-              onChange={(values) => setField(field, values.length > 0 ? [{ op: "in", value: [...values] }] : [])}
-            />
-          </CollapsibleSection>
-        )
-      })}
-
-      {textFields.map(({ label, field, placeholder }) => {
-        const value = getTextFilterValue(filters, field)
-        const selectedValues = getInValues(filters, field)
-        if (field === "userId") {
-          const selected = selectedValues.length > 0 ? selectedValues : value ? [value] : []
-          return (
-            <CollapsibleSection key={field} label={label} defaultOpen={selected.length > 0}>
-              <MultiSelectFilter
-                mode={mode}
-                projectId={projectId}
-                column={field as DistinctColumn}
-                selected={selected}
-                onChange={(values) => setField(field, values.length > 0 ? [{ op: "in", value: values }] : [])}
-                placeholder={placeholder}
-              />
-            </CollapsibleSection>
-          )
-        }
-        return (
-          <CollapsibleSection key={field} label={label} defaultOpen={!!value}>
-            <DebouncedInput
-              placeholder={placeholder}
-              size="sm"
-              value={value}
-              onDebouncedChange={(nextValue) => setContainsFilter(field, nextValue)}
-            />
-          </CollapsibleSection>
-        )
-      })}
-
-      {getMultiSelectFieldsForMode(mode)
-        .filter(({ field }) => !isExcluded(field))
-        .map(({ label, field }) => {
-          const selectedValues = getInValues(filters, field)
-          const staticItems = staticItemsByField[field]
-          return (
-            <CollapsibleSection key={field} label={label} defaultOpen={selectedValues.length > 0}>
-              <MultiSelectFilter
-                mode={mode}
-                projectId={projectId}
-                column={field as DistinctColumn}
-                selected={selectedValues}
-                onChange={(values) => setField(field, values.length > 0 ? [{ op: "in", value: values }] : [])}
-                {...(staticItems ? { staticItems } : {})}
-              />
-            </CollapsibleSection>
-          )
-        })}
-
-      {NUMBER_RANGE_FIELDS.filter(({ field }) => !isExcluded(field)).map(
-        ({ label, field, tooltip, percentile, displayScale, displayStep }) => {
-          const range = getRangeValues(filters, field)
-          const percentileValue = getPercentileValue(filters, field)
-          return (
-            <NumberFilterSection
-              key={field}
-              label={label}
-              field={field}
-              tooltip={tooltip}
-              percentileField={percentile?.field}
-              projectId={projectId}
+            <MultiSelectFilter
               mode={mode}
-              minValue={toDisplayUnit(range.min, displayScale)}
-              maxValue={toDisplayUnit(range.max, displayScale)}
-              percentileValue={percentileValue}
-              onRangeChange={(min, max) =>
-                setRangeFilter(field, toWireUnit(min, displayScale), toWireUnit(max, displayScale))
-              }
-              onPercentileChange={(p) => setPercentileFilter(field, p)}
-              {...(displayStep !== undefined ? { step: displayStep } : {})}
+              projectId={projectId}
+              column={field as DistinctColumn}
+              selected={selected}
+              onChange={(values) => setField(field, values.length > 0 ? [{ op: "in", value: values }] : [])}
+              placeholder={placeholder}
             />
-          )
-        },
-      )}
+          </CollapsibleSection>
+        ),
+      })
+      continue
+    }
+    entries.push({
+      group,
+      label,
+      node: (
+        <CollapsibleSection key={field} label={label} defaultOpen={!!value}>
+          <DebouncedInput
+            placeholder={placeholder}
+            size="sm"
+            value={value}
+            onDebouncedChange={(nextValue) => setContainsFilter(field, nextValue)}
+          />
+        </CollapsibleSection>
+      ),
+    })
+  }
 
-      {!isExcluded(ANNOTATOR_FIELD) && (
-        <CollapsibleSection label="Scored by" defaultOpen={getInValues(filters, ANNOTATOR_FIELD).length > 0}>
+  for (const { label, field, group } of getMultiSelectFieldsForMode(mode).filter(({ field }) => !isExcluded(field))) {
+    const selectedValues = getInValues(filters, field)
+    const staticItems = staticItemsByField[field]
+    entries.push({
+      group,
+      label,
+      node: (
+        <CollapsibleSection key={field} label={label} defaultOpen={selectedValues.length > 0}>
+          <MultiSelectFilter
+            mode={mode}
+            projectId={projectId}
+            column={field as DistinctColumn}
+            selected={selectedValues}
+            onChange={(values) => setField(field, values.length > 0 ? [{ op: "in", value: values }] : [])}
+            {...(staticItems ? { staticItems } : {})}
+          />
+        </CollapsibleSection>
+      ),
+    })
+  }
+
+  for (const { label, field, group, tooltip, percentile, displayScale, displayStep } of NUMBER_RANGE_FIELDS.filter(
+    ({ field }) => !isExcluded(field),
+  )) {
+    const range = getRangeValues(filters, field)
+    entries.push({
+      group,
+      label,
+      node: (
+        <NumberFilterSection
+          key={field}
+          label={label}
+          field={field}
+          tooltip={tooltip}
+          percentileField={percentile?.field}
+          projectId={projectId}
+          mode={mode}
+          minValue={toDisplayUnit(range.min, displayScale)}
+          maxValue={toDisplayUnit(range.max, displayScale)}
+          percentileValue={getPercentileValue(filters, field)}
+          onRangeChange={(min, max) =>
+            setRangeFilter(field, toWireUnit(min, displayScale), toWireUnit(max, displayScale))
+          }
+          onPercentileChange={(p) => setPercentileFilter(field, p)}
+          {...(displayStep !== undefined ? { step: displayStep } : {})}
+        />
+      ),
+    })
+  }
+
+  if (!isExcluded(ANNOTATOR_FIELD)) {
+    entries.push({
+      group: "scores",
+      label: "Scored by",
+      node: (
+        <CollapsibleSection
+          key={ANNOTATOR_FIELD}
+          label="Scored by"
+          defaultOpen={getInValues(filters, ANNOTATOR_FIELD).length > 0}
+        >
           <MultiSelectFilter
             mode={mode}
             projectId={projectId}
@@ -643,10 +683,13 @@ export function FiltersBuilderFields({
             placeholder="Search members..."
           />
         </CollapsibleSection>
-      )}
-
-      {!isExcluded(ANNOTATOR_FIELD) && (
-        <CollapsibleSection label="Has scores" defaultOpen={getHasAnnotationsOn(filters)}>
+      ),
+    })
+    entries.push({
+      group: "scores",
+      label: "Has scores",
+      node: (
+        <CollapsibleSection key="hasScores" label="Has scores" defaultOpen={getHasAnnotationsOn(filters)}>
           <div className="flex items-center justify-between gap-2">
             <Text.H7 color="foregroundMuted">
               {getHasAnnotationsOn(filters)
@@ -659,16 +702,29 @@ export function FiltersBuilderFields({
             />
           </div>
         </CollapsibleSection>
-      )}
+      ),
+    })
+  }
 
-      {!isExcluded("metadata") && (
-        <CollapsibleSection label="Metadata" defaultOpen={metadataEntries.length > 0}>
+  if (!isExcluded("metadata")) {
+    entries.push({
+      group: "custom",
+      label: "Metadata",
+      node: (
+        <CollapsibleSection key="metadata" label="Metadata" defaultOpen={metadataEntries.length > 0}>
           <MetadataFilter entries={metadataEntries} onChange={handleMetadataChange} />
         </CollapsibleSection>
-      )}
+      ),
+    })
+  }
 
-      {mode === "sessions" && !isExcluded("hasLlmActivity") && (
+  if (mode === "sessions" && !isExcluded("hasLlmActivity")) {
+    entries.push({
+      group: "status",
+      label: "Has LLM activity",
+      node: (
         <CollapsibleSection
+          key="hasLlmActivity"
           label="Has LLM activity"
           defaultOpen={filters.hasLlmActivity !== undefined && !isHasLlmActivityFilterOn(filters)}
         >
@@ -684,6 +740,40 @@ export function FiltersBuilderFields({
             />
           </div>
         </CollapsibleSection>
+      ),
+    })
+  }
+
+  const groups = groupFilterSections(entries, search)
+
+  return (
+    <>
+      <div className="sticky top-0 z-10 bg-background pt-3 pb-1">
+        <div className="relative">
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search filters"
+            size="sm"
+            className="pl-8 rounded-lg"
+          />
+          <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        </div>
+      </div>
+
+      {groups.length === 0 ? (
+        <Text.H6 color="foregroundMuted" className="py-3">
+          No filter matches “{search.trim()}”.
+        </Text.H6>
+      ) : (
+        groups.map((group) => (
+          <div key={group.id} className="flex flex-col">
+            <Text.H6 color="foregroundMuted" weight="medium" className="pt-3 pb-0.5 uppercase tracking-wide">
+              {group.label}
+            </Text.H6>
+            {group.sections.map((section) => section.node)}
+          </div>
+        ))
       )}
     </>
   )

--- a/apps/web/src/components/filters-builder/group-sections.test.ts
+++ b/apps/web/src/components/filters-builder/group-sections.test.ts
@@ -1,0 +1,43 @@
+import type { TraceFilterGroupId } from "@domain/shared"
+import { describe, expect, it } from "vitest"
+import { groupFilterSections } from "./group-sections.ts"
+
+const section = (group: TraceFilterGroupId, label: string) => ({ group, label })
+
+const SECTIONS = [
+  section("status", "Status"),
+  section("identity", "Name"),
+  section("identity", "Trace ID"),
+  section("performance", "Cost ($)"),
+  section("performance", "Tokens Input"),
+  section("status", "Error Count"),
+  section("custom", "Metadata"),
+]
+
+describe("groupFilterSections", () => {
+  it("orders groups by the registry and keeps source order within a group", () => {
+    const groups = groupFilterSections(SECTIONS, "")
+    expect(groups.map((g) => g.id)).toEqual(["identity", "status", "performance", "custom"])
+    expect(groups[1]?.sections.map((s) => s.label)).toEqual(["Status", "Error Count"])
+  })
+
+  it("drops groups with no section", () => {
+    const groups = groupFilterSections([section("scores", "Has scores")], "")
+    expect(groups.map((g) => g.id)).toEqual(["scores"])
+  })
+
+  it("matches a section label, case-insensitively and trimmed", () => {
+    const groups = groupFilterSections(SECTIONS, "  TOKENS ")
+    expect(groups.map((g) => g.id)).toEqual(["performance"])
+    expect(groups[0]?.sections.map((s) => s.label)).toEqual(["Tokens Input"])
+  })
+
+  it("matches a group label to keep the whole group", () => {
+    const groups = groupFilterSections(SECTIONS, "performance")
+    expect(groups[0]?.sections.map((s) => s.label)).toEqual(["Cost ($)", "Tokens Input"])
+  })
+
+  it("returns nothing when the query matches no label", () => {
+    expect(groupFilterSections(SECTIONS, "nonsense")).toEqual([])
+  })
+})

--- a/apps/web/src/components/filters-builder/group-sections.test.ts
+++ b/apps/web/src/components/filters-builder/group-sections.test.ts
@@ -14,6 +14,11 @@ const SECTIONS = [
   section("custom", "Metadata"),
 ]
 
+const visible = (groups: ReturnType<typeof groupFilterSections<(typeof SECTIONS)[number]>>) =>
+  groups
+    .filter((g) => !g.hidden)
+    .map((g) => ({ id: g.id, labels: g.sections.filter((s) => !s.hidden).map((s) => s.label) }))
+
 describe("groupFilterSections", () => {
   it("orders groups by the registry and keeps source order within a group", () => {
     const groups = groupFilterSections(SECTIONS, "")
@@ -26,18 +31,35 @@ describe("groupFilterSections", () => {
     expect(groups.map((g) => g.id)).toEqual(["scores"])
   })
 
+  it("shows nothing as hidden when the query is empty", () => {
+    const groups = groupFilterSections(SECTIONS, "")
+    expect(groups.some((g) => g.hidden)).toBe(false)
+    expect(groups.flatMap((g) => g.sections).some((s) => s.hidden)).toBe(false)
+  })
+
   it("matches a section label, case-insensitively and trimmed", () => {
-    const groups = groupFilterSections(SECTIONS, "  TOKENS ")
-    expect(groups.map((g) => g.id)).toEqual(["performance"])
-    expect(groups[0]?.sections.map((s) => s.label)).toEqual(["Tokens Input"])
+    expect(visible(groupFilterSections(SECTIONS, "  TOKENS "))).toEqual([
+      { id: "performance", labels: ["Tokens Input"] },
+    ])
   })
 
   it("matches a group label to keep the whole group", () => {
-    const groups = groupFilterSections(SECTIONS, "performance")
-    expect(groups[0]?.sections.map((s) => s.label)).toEqual(["Cost ($)", "Tokens Input"])
+    expect(visible(groupFilterSections(SECTIONS, "performance"))).toEqual([
+      { id: "performance", labels: ["Cost ($)", "Tokens Input"] },
+    ])
   })
 
-  it("returns nothing when the query matches no label", () => {
-    expect(groupFilterSections(SECTIONS, "nonsense")).toEqual([])
+  it("keeps non-matching sections mounted but hidden", () => {
+    const groups = groupFilterSections(SECTIONS, "trace")
+    // Every group and section still comes back so debounced edits survive the search.
+    expect(groups.map((g) => g.id)).toEqual(["identity", "status", "performance", "custom"])
+    expect(groups.flatMap((g) => g.sections)).toHaveLength(SECTIONS.length)
+    expect(visible(groups)).toEqual([{ id: "identity", labels: ["Trace ID"] }])
+  })
+
+  it("marks every group hidden when the query matches no label", () => {
+    const groups = groupFilterSections(SECTIONS, "nonsense")
+    expect(groups.every((g) => g.hidden)).toBe(true)
+    expect(visible(groups)).toEqual([])
   })
 })

--- a/apps/web/src/components/filters-builder/group-sections.ts
+++ b/apps/web/src/components/filters-builder/group-sections.ts
@@ -1,0 +1,28 @@
+import { TRACE_FILTER_GROUPS, type TraceFilterGroupId } from "@domain/shared"
+
+interface FilterSectionGroup<T> {
+  readonly id: TraceFilterGroupId
+  readonly label: string
+  readonly sections: readonly T[]
+}
+
+/**
+ * Splits filter sections into the functional groups of `TRACE_FILTER_GROUPS`, in that order,
+ * dropping groups left with no section. `query` matches a section label or its group label, so
+ * searching "performance" keeps the whole group and "cost" keeps just that section.
+ */
+export function groupFilterSections<T extends { readonly group: TraceFilterGroupId; readonly label: string }>(
+  sections: readonly T[],
+  query: string,
+): readonly FilterSectionGroup<T>[] {
+  const needle = query.trim().toLowerCase()
+  return TRACE_FILTER_GROUPS.map((group) => ({
+    id: group.id,
+    label: group.label,
+    sections: sections.filter(
+      (section) =>
+        section.group === group.id &&
+        (needle === "" || section.label.toLowerCase().includes(needle) || group.label.toLowerCase().includes(needle)),
+    ),
+  })).filter((group) => group.sections.length > 0)
+}

--- a/apps/web/src/components/filters-builder/group-sections.ts
+++ b/apps/web/src/components/filters-builder/group-sections.ts
@@ -3,26 +3,34 @@ import { TRACE_FILTER_GROUPS, type TraceFilterGroupId } from "@domain/shared"
 interface FilterSectionGroup<T> {
   readonly id: TraceFilterGroupId
   readonly label: string
-  readonly sections: readonly T[]
+  readonly sections: readonly (T & { readonly hidden: boolean })[]
+  readonly hidden: boolean
 }
 
 /**
  * Splits filter sections into the functional groups of `TRACE_FILTER_GROUPS`, in that order,
  * dropping groups left with no section. `query` matches a section label or its group label, so
  * searching "performance" keeps the whole group and "cost" keeps just that section.
+ *
+ * Search misses are marked `hidden` rather than dropped: the caller keeps them mounted so a
+ * half-typed value in a debounced control isn't discarded when the query stops matching it.
+ * Groups a mode never offers at all carry no section and are dropped outright.
  */
 export function groupFilterSections<T extends { readonly group: TraceFilterGroupId; readonly label: string }>(
   sections: readonly T[],
   query: string,
 ): readonly FilterSectionGroup<T>[] {
   const needle = query.trim().toLowerCase()
-  return TRACE_FILTER_GROUPS.map((group) => ({
-    id: group.id,
-    label: group.label,
-    sections: sections.filter(
-      (section) =>
-        section.group === group.id &&
-        (needle === "" || section.label.toLowerCase().includes(needle) || group.label.toLowerCase().includes(needle)),
-    ),
-  })).filter((group) => group.sections.length > 0)
+  return TRACE_FILTER_GROUPS.map((group) => {
+    const groupMatches = needle === "" || group.label.toLowerCase().includes(needle)
+    const groupSections = sections
+      .filter((section) => section.group === group.id)
+      .map((section) => ({ ...section, hidden: !groupMatches && !section.label.toLowerCase().includes(needle) }))
+    return {
+      id: group.id,
+      label: group.label,
+      sections: groupSections,
+      hidden: groupSections.every((section) => section.hidden),
+    }
+  }).filter((group) => group.sections.length > 0)
 }

--- a/packages/domain/shared/src/trace-filter-fields.ts
+++ b/packages/domain/shared/src/trace-filter-fields.ts
@@ -1,9 +1,27 @@
 export type TraceFilterFieldType = "status" | "text" | "multiSelect" | "numberRange"
 
+/**
+ * Functional groups the filter UI renders fields under, in this order. Groups
+ * also cover controls that exist only in the UI (scores, metadata, LLM
+ * activity), so not every group has a field in `TRACE_FILTER_FIELDS`.
+ */
+export const TRACE_FILTER_GROUPS = [
+  { id: "identity", label: "Identity" },
+  { id: "status", label: "Status" },
+  { id: "modelsAndTools", label: "Models & tools" },
+  { id: "performance", label: "Performance & cost" },
+  { id: "conversation", label: "Conversation" },
+  { id: "scores", label: "Scores" },
+  { id: "custom", label: "Custom" },
+] as const satisfies readonly { readonly id: string; readonly label: string }[]
+
+export type TraceFilterGroupId = (typeof TRACE_FILTER_GROUPS)[number]["id"]
+
 export interface TraceFilterField {
   readonly field: string
   readonly type: TraceFilterFieldType
   readonly label: string
+  readonly group: TraceFilterGroupId
   readonly placeholder?: string
   readonly tooltip?: string
   readonly percentile?: boolean // Numeric fields with this flag also support `gtePercentile` filtering
@@ -24,44 +42,55 @@ export interface TraceFilterField {
 }
 
 export const TRACE_FILTER_FIELDS = [
-  { field: "status", type: "status", label: "Status" },
-  { field: "name", type: "text", label: "Name", placeholder: "Enter name..." },
+  { field: "status", type: "status", label: "Status", group: "status" },
+  { field: "name", type: "text", label: "Name", placeholder: "Enter name...", group: "identity" },
   {
     field: "traceId",
     type: "text",
     label: "Trace ID",
     placeholder: "Filter by trace...",
+    group: "identity",
   },
   {
     field: "sessionId",
     type: "text",
     label: "Session ID",
     placeholder: "Filter by session...",
+    group: "identity",
   },
   {
     field: "simulationId",
     type: "text",
     label: "Simulation ID",
     placeholder: "Filter by simulation...",
+    group: "identity",
   },
   {
     field: "userId",
     type: "text",
     label: "User ID",
     placeholder: "Filter by user...",
+    group: "identity",
   },
-  { field: "tags", type: "multiSelect", label: "Tags" },
-  { field: "moments", type: "multiSelect", label: "Moments", sessionOnly: true },
-  { field: "topics", type: "multiSelect", label: "Behaviors", sessionOnly: true },
-  { field: "models", type: "multiSelect", label: "Models" },
-  { field: "providers", type: "multiSelect", label: "Providers" },
-  { field: "serviceNames", type: "multiSelect", label: "Services" },
-  { field: "tools", type: "multiSelect", label: "Tools", tooltip: "Traces with at least one call of the tool." },
+  { field: "tags", type: "multiSelect", label: "Tags", group: "custom" },
+  { field: "moments", type: "multiSelect", label: "Moments", sessionOnly: true, group: "conversation" },
+  { field: "topics", type: "multiSelect", label: "Behaviors", sessionOnly: true, group: "conversation" },
+  { field: "models", type: "multiSelect", label: "Models", group: "modelsAndTools" },
+  { field: "providers", type: "multiSelect", label: "Providers", group: "modelsAndTools" },
+  { field: "serviceNames", type: "multiSelect", label: "Services", group: "modelsAndTools" },
+  {
+    field: "tools",
+    type: "multiSelect",
+    label: "Tools",
+    tooltip: "Traces with at least one call of the tool.",
+    group: "modelsAndTools",
+  },
   {
     field: "definedTools",
     type: "multiSelect",
     label: "Defined tools",
     tooltip: "Traces where the tool was offered to the model, whether or not it was called.",
+    group: "modelsAndTools",
   },
   {
     field: "duration",
@@ -71,6 +100,7 @@ export const TRACE_FILTER_FIELDS = [
     percentile: true,
     displayScale: 1_000_000_000,
     displayStep: 0.001,
+    group: "performance",
   },
   {
     field: "ttft",
@@ -80,6 +110,7 @@ export const TRACE_FILTER_FIELDS = [
     percentile: true,
     displayScale: 1_000_000,
     displayStep: 1,
+    group: "performance",
   },
   {
     field: "cost",
@@ -89,11 +120,12 @@ export const TRACE_FILTER_FIELDS = [
     percentile: true,
     displayScale: 100_000_000,
     displayStep: 0.01,
+    group: "performance",
   },
-  { field: "spanCount", type: "numberRange", label: "Span Count" },
-  { field: "errorCount", type: "numberRange", label: "Error Count" },
-  { field: "tokensInput", type: "numberRange", label: "Tokens Input" },
-  { field: "tokensOutput", type: "numberRange", label: "Tokens Output" },
+  { field: "spanCount", type: "numberRange", label: "Span Count", group: "performance" },
+  { field: "errorCount", type: "numberRange", label: "Error Count", group: "status" },
+  { field: "tokensInput", type: "numberRange", label: "Tokens Input", group: "performance" },
+  { field: "tokensOutput", type: "numberRange", label: "Tokens Output", group: "performance" },
   {
     // Wire value is an integer percentage (0–100), not a 0–1 ratio: the
     // numberRange UI rounds wire values to integers, so a fractional scale
@@ -103,6 +135,7 @@ export const TRACE_FILTER_FIELDS = [
     label: "Cache Hit Rate (%)",
     tooltip: "Share of input tokens served from cache. Low values on large sessions often signal broken caching.",
     displayStep: 1,
+    group: "performance",
   },
 ] as const satisfies readonly TraceFilterField[]
 


### PR DESCRIPTION
## What

The Filters sidebar on Sessions and Traces listed 26 filters as one flat run of collapsible rows, ordered by control type (all the text fields, then all the multi-selects, then all the number ranges). Finding a specific filter meant scanning the whole list, and related filters sat far apart: `Error Count` was ten rows below `Status`, `Cost ($)` nowhere near `Tokens Input`.

Filters now render under functional headings, plus a search box at the top of the panel.

| Group | Filters |
| --- | --- |
| Identity | Name, Trace ID, Session ID, Simulation ID, User ID |
| Status | Status, Error Count, Has LLM activity |
| Models & tools | Models, Providers, Services, Tools, Defined tools |
| Performance & cost | Duration, TTFT, Cost, Span Count, Tokens Input, Tokens Output, Cache Hit Rate |
| Conversation | Moments, Behaviors |
| Scores | Scored by, Has scores |
| Custom | Tags, Metadata |

## How

`TRACE_FILTER_GROUPS` in `@domain/shared` holds the ordered id/label pairs, and `group` is a required field on every `TRACE_FILTER_FIELDS` entry, so a new filter cannot be added without picking a group. It sits with `label`, `placeholder`, and `tooltip` — the presentational metadata already in that registry.

`FiltersBuilderFields` builds a flat list of sections tagged with their group, then renders them under the headings in registry order. A group with no visible section drops its heading too, so Traces mode loses Conversation and Has LLM activity with no special case. The grouping and search selection are a pure function in `group-sections.ts`, unit-tested.

Search matches a filter label or its group label: "cost" keeps all of Performance & cost, "token" keeps just Tokens Input and Tokens Output.

## Testing

- 5 new unit tests over group ordering, empty-group dropping, and the three search behaviors
- `pnpm --filter @domain/shared test` (215 passing) and `pnpm --filter web typecheck` clean
- Manually in the local app: all 7 headings in order with 26 sections on Sessions; Traces mode drops Conversation and Has LLM activity; a `status` filter from the URL still auto-expands its section inside its group; `zzz` shows the no-match message

## Follow-up

The experiments comparison table uses the other builder (`FilterBuilder`) with a flat "Add a filter" dropdown. Matching this grouping there needs `Select` to render option groups first, so it is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organized filter groups for easier browsing.
  * Filter search now matches group and section names, ignores capitalization and extra spaces, and preserves the intended group order.
  * Added grouped controls for status, text, multi-select, numeric, score, metadata, and session-activity filters.
  * Empty groups are hidden, while unmatched filters remain searchable and a clear no-results message is shown.

* **Bug Fixes**
  * Improved consistency across filter categories and search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->