### PR TITLE
feat(cost): wasted spend — what this window spent on traces that errored

### DIFF
--- a/apps/web/src/domains/cost/cost.collection.ts
+++ b/apps/web/src/domains/cost/cost.collection.ts
@@ -8,6 +8,7 @@ import {
   getCostPerSessionDecomposition,
   getCostSeries,
   getModelUsageSeries,
+  getWastedSpend,
 } from "./cost.functions.ts"
 
 /** Time window shared by every cost query — lower bound inclusive, upper bound exclusive. */
@@ -98,6 +99,25 @@ export function useCacheEconomics({
   return useQuery({
     queryKey: [...projectScopeKey(scope), "cache-economics", projectId, range],
     queryFn: () => getCacheEconomics({ data: { ...projectScopeData(scope), projectId, ...range } }),
+    staleTime: COST_STALE_TIME_MS,
+    placeholderData: keepPreviousData,
+    enabled: enabled && projectId.length > 0,
+  })
+}
+
+export function useWastedSpend({
+  projectId,
+  range,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly range: CostTimeRange
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "wasted-spend", projectId, range],
+    queryFn: () => getWastedSpend({ data: { ...projectScopeData(scope), projectId, ...range } }),
     staleTime: COST_STALE_TIME_MS,
     placeholderData: keepPreviousData,
     enabled: enabled && projectId.length > 0,

--- a/apps/web/src/domains/cost/cost.functions.ts
+++ b/apps/web/src/domains/cost/cost.functions.ts
@@ -8,6 +8,7 @@ import type {
   JudgedCacheModel,
   ModelUsageMeasures,
   ModelUsageSlice,
+  WastedSpend,
 } from "@domain/spans"
 import {
   COST_BREAKDOWN_DIMENSIONS,
@@ -18,6 +19,7 @@ import {
   judgeCacheEconomics,
   sessionCostTokens,
   summarizeUnpricedUsage,
+  wastedSpendShare,
 } from "@domain/spans"
 import { CostAnalyticsRepositoryLive } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
@@ -116,6 +118,19 @@ export interface CostPerSessionRecord extends CostPerSessionDecomposition {
   readonly comparedToIso: string
   /** Sparkline points for the two headline blocks, spanning both windows, oldest first. */
   readonly buckets: readonly SessionCostSparkPoint[]
+}
+
+/** Every listed reason's spend, and the one row that holds whatever the list left off. */
+export interface WastedSpendOtherReasons {
+  readonly typeCount: number
+  readonly traces: number
+  readonly costMicrocents: number
+}
+
+export interface WastedSpendRecord extends WastedSpend {
+  /** Null where the window cannot support a share — the dollar figure is shown regardless. */
+  readonly wastedShare: number | null
+  readonly otherReasons: WastedSpendOtherReasons | null
 }
 
 /** Cost per session is derived here rather than in the panel: an empty bucket has none. */
@@ -299,6 +314,45 @@ export const getCostPerSessionDecomposition = createServerFn({ method: "GET" })
             costMicrocents: bucket.costMicrocents,
             costPerSessionMicrocents: bucket.sessions > 0 ? bucket.costMicrocents / bucket.sessions : null,
           })),
+        }
+      }).pipe(withScopedClickHouse(CostAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+  })
+
+/**
+ * Spend on traces that errored, plus the remainder of the reasons it truncated.
+ *
+ * The remainder is exact rather than decorative: reasons partition the errored traces, so
+ * whatever the listed ones do not account for is one honest "other reasons" row and the
+ * rows still sum to the headline.
+ */
+export const getWastedSpend = createServerFn({ method: "GET" })
+  .inputValidator(costScopeSchema)
+  .handler(async ({ data, context }): Promise<WastedSpendRecord> => {
+    const orgId = await resolveOrgScope(context)
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* CostAnalyticsRepository
+        const wasted = yield* repo.getWastedSpend(toScope(orgId, data))
+        const listed = wasted.reasons.reduce(
+          (sum, reason) => ({
+            costMicrocents: sum.costMicrocents + reason.costMicrocents,
+            traces: sum.traces + reason.traces,
+          }),
+          { costMicrocents: 0, traces: 0 },
+        )
+        const hiddenTypes = wasted.distinctErrorTypes - wasted.reasons.length
+        return {
+          ...wasted,
+          wastedShare: wastedSpendShare(wasted),
+          otherReasons:
+            hiddenTypes > 0
+              ? {
+                  typeCount: hiddenTypes,
+                  traces: wasted.erroredTraces - listed.traces,
+                  costMicrocents: wasted.erroredCostMicrocents - listed.costMicrocents,
+                }
+              : null,
         }
       }).pipe(withScopedClickHouse(CostAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/wasted-spend-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/wasted-spend-panel.tsx
@@ -1,0 +1,248 @@
+import { WASTED_SPEND_MIN_SAMPLE_TRACES } from "@domain/spans"
+import { Icon, Skeleton, Text, Tooltip, useChartCssTheme } from "@repo/ui"
+import { formatCount, formatPercentage } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
+import { ArrowUpRightIcon, CircleCheckIcon, InfoIcon } from "lucide-react"
+import type { WastedSpendRecord } from "../../../../../../domains/cost/cost.functions.ts"
+import { rollupCostDisplay } from "../../../../../../domains/spans/cost-display.ts"
+import { ChartHeader } from "../../-components/chart-header.tsx"
+import { serializeFilters } from "../../-components/trace-page-state.ts"
+import { formatSignedPrice, microcentsToUsd, shareOf } from "./cost-formatters.ts"
+import { otherSeriesColor } from "./cost-series-colors.ts"
+import { EmptyState } from "./empty-state.tsx"
+import { SplitValue } from "./split-value.tsx"
+
+// Named after the money, not the mechanism: a failure with no `error.type` attribute is a
+// row the user has to be able to act on, and "unknown" reads as a value the model returned.
+const UNLABELLED_REASON = "No error type recorded"
+
+/** Held outside the model ramp: these bars encode failure, not a model. red-400 / red-600. */
+const wastedBarColor = (isDark: boolean): string => (isDark ? "oklch(57.7% 0.245 27.325)" : "oklch(70.4% 0.191 22.216)")
+
+interface ReasonRow {
+  readonly key: string
+  readonly label: string
+  readonly traces: number
+  readonly costMicrocents: number
+  readonly isRemainder: boolean
+}
+
+function buildReasonRows(record: WastedSpendRecord): readonly ReasonRow[] {
+  const rows: ReasonRow[] = record.reasons.map((reason) => ({
+    key: reason.errorType || "__unlabelled__",
+    label: reason.errorType || UNLABELLED_REASON,
+    traces: reason.traces,
+    costMicrocents: reason.costMicrocents,
+    isRemainder: false,
+  }))
+  const other = record.otherReasons
+  if (!other) return rows
+  return [
+    ...rows,
+    {
+      key: "__other__",
+      label: other.typeCount === 1 ? "1 other reason" : `${other.typeCount} other reasons`,
+      traces: other.traces,
+      costMicrocents: other.costMicrocents,
+      isRemainder: true,
+    },
+  ]
+}
+
+/**
+ * The share of the panel's own total, never of the window: these bars answer "what was the
+ * money wasted on", and a row's share of total spend would be a second, smaller-looking
+ * number for the same fact.
+ */
+function ReasonBar({
+  share,
+  isRemainder,
+  isDark,
+}: {
+  readonly share: number
+  readonly isRemainder: boolean
+  readonly isDark: boolean
+}) {
+  return (
+    <div className="relative flex h-4 w-full items-center">
+      <div className="relative h-1 w-full overflow-hidden rounded-sm bg-muted">
+        <div
+          className="h-full min-w-[2px] rounded-sm"
+          style={{
+            width: `${Math.max(0, Math.min(100, share * 100))}%`,
+            backgroundColor: isRemainder ? otherSeriesColor(isDark) : wastedBarColor(isDark),
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Money that bought nothing: what this window spent on traces that errored.
+ *
+ * Whole-trace by decision, stated in the headline tooltip — a failed call usually records
+ * no usage of its own, so charging only the failed span would report ~$0 for exactly the
+ * traces that wasted the most. Nothing else on the page shows a per-span framing of the
+ * same claim; the two would not reconcile.
+ */
+export function WastedSpendPanel({
+  record,
+  projectSlug,
+  rangeFromIso,
+  rangeToIso,
+  isAllTime,
+  isLoading,
+}: {
+  readonly record: WastedSpendRecord | undefined
+  readonly projectSlug: string
+  readonly rangeFromIso: string
+  readonly rangeToIso: string
+  readonly isAllTime: boolean
+  readonly isLoading: boolean
+}) {
+  const { isDark } = useChartCssTheme()
+  const rows = record ? buildReasonRows(record) : []
+  const wasted = rollupCostDisplay({
+    costTotalMicrocents: record?.erroredCostMicrocents ?? 0,
+    unpricedSpanCount: record?.erroredUnpricedCalls ?? 0,
+    tokensTotal: record?.erroredTokens ?? 0,
+  })
+  // The same Status filter the traces list applies, so the drill-down returns the very
+  // traces this panel counted rather than a differently-defined subset.
+  const erroredTracesSearch = {
+    tab: "traces",
+    filters: serializeFilters({
+      status: [{ op: "in", value: ["error"] }],
+      startTime: [
+        { op: "gte", value: rangeFromIso },
+        { op: "lte", value: rangeToIso },
+      ],
+    }),
+  }
+
+  return (
+    <div className="flex flex-1 flex-col rounded-lg border border-border bg-background">
+      <ChartHeader
+        title="Wasted spend"
+        fromIso={rangeFromIso}
+        toIso={rangeToIso}
+        isAllTime={isAllTime}
+        // The picker above already states this window, the same as every sibling panel.
+        showWindow={false}
+        titleColor="foregroundMuted"
+      />
+      {isLoading || !record ? (
+        <div className="flex flex-col gap-3 px-4 py-3">
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      ) : record.erroredTraces === 0 ? (
+        <EmptyState
+          icon={CircleCheckIcon}
+          message={
+            record.tracesWithUsage === 0 ? "No spend recorded in this time window" : "No spend on traces that errored"
+          }
+        />
+      ) : (
+        <div className="flex flex-col gap-4 px-4 py-3">
+          <div className="flex flex-row flex-wrap items-start justify-between gap-3">
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="flex flex-row items-center gap-1">
+                <Text.H6M color="foregroundMuted" noWrap>
+                  Spent on traces that errored
+                </Text.H6M>
+                <Tooltip
+                  asChild
+                  trigger={
+                    <span className="inline-flex cursor-default">
+                      <Icon icon={InfoIcon} size="sm" color="foregroundMuted" />
+                    </span>
+                  }
+                >
+                  {`Everything these traces spent, not only their failed steps. A failed call usually records no usage of its own — the money went on the steps that succeeded and whose output was then discarded. A trace counts as errored when at least one of its spans failed, the same definition the traces list uses.${wasted.note ? ` ${wasted.note}` : ""}`}
+                </Tooltip>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <Text.H3M color="foreground" noWrap className="tabular-nums">
+                  <SplitValue formatted={wasted.label} />
+                </Text.H3M>
+                <Text.H6 color="foregroundMuted">
+                  {`${formatCount(record.erroredTraces)} of ${formatCount(record.tracesWithUsage)} traces with usage errored`}
+                </Text.H6>
+              </div>
+            </div>
+            <div className="flex flex-col items-end gap-1">
+              <Text.H6M color="foregroundMuted" noWrap>
+                Share of spend
+              </Text.H6M>
+              {record.wastedShare === null ? (
+                <Tooltip
+                  asChild
+                  trigger={
+                    <span className="inline-flex cursor-default">
+                      <Text.H3M color="foregroundMuted" noWrap>
+                        —
+                      </Text.H3M>
+                    </span>
+                  }
+                >
+                  {record.erroredCostMicrocents <= 0
+                    ? "These traces errored without recording any spend, so there is a count to act on but no share of the money."
+                    : `A share needs at least ${WASTED_SPEND_MIN_SAMPLE_TRACES} traces with usage — over ${formatCount(record.tracesWithUsage)}, one failure moves the figure by tens of points.`}
+                </Tooltip>
+              ) : (
+                <Text.H3M color="foreground" noWrap className="tabular-nums">
+                  <SplitValue formatted={formatPercentage(record.wastedShare)} />
+                </Text.H3M>
+              )}
+              <Link
+                to="/projects/$projectSlug"
+                params={{ projectSlug }}
+                search={erroredTracesSearch}
+                aria-label="View the errored traces in this window"
+                className="group inline-flex flex-row items-center gap-1"
+              >
+                <Text.H6 color="foregroundMuted" noWrap className="group-hover:text-primary">
+                  View errored traces
+                </Text.H6>
+                <Icon
+                  icon={ArrowUpRightIcon}
+                  size="xs"
+                  color="foregroundMuted"
+                  className="shrink-0 group-hover:text-primary"
+                />
+              </Link>
+            </div>
+          </div>
+          <div className="flex flex-col gap-2.5">
+            {rows.map((row) => (
+              <div key={row.key} className="flex flex-row items-center gap-3">
+                <div className="flex w-40 shrink-0 flex-col pr-2">
+                  <Text.H6 color={row.isRemainder ? "foregroundMuted" : "foreground"} ellipsis noWrap>
+                    {row.label}
+                  </Text.H6>
+                </div>
+                <ReasonBar
+                  share={shareOf(row.costMicrocents, record.erroredCostMicrocents) ?? 0}
+                  isRemainder={row.isRemainder}
+                  isDark={isDark}
+                />
+                <div className="flex w-16 shrink-0 justify-end">
+                  <Text.H6 color="foregroundMuted" noWrap className="tabular-nums">
+                    {formatSignedPrice(microcentsToUsd(row.costMicrocents))}
+                  </Text.H6>
+                </div>
+                <div className="flex w-20 shrink-0 justify-end">
+                  <Text.H6 color="foregroundMuted" noWrap className="tabular-nums">
+                    {`${formatCount(row.traces)} ${row.traces === 1 ? "trace" : "traces"}`}
+                  </Text.H6>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/wasted-spend-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/wasted-spend-panel.tsx
@@ -1,0 +1,212 @@
+import { WASTED_SPEND_MIN_SAMPLE_TRACES } from "@domain/spans"
+import { Icon, Skeleton, Text, Tooltip } from "@repo/ui"
+import { formatCount, formatPercentage } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
+import { ArrowRightIcon, InfoIcon } from "lucide-react"
+import type { WastedSpendRecord } from "../../../../../../domains/cost/cost.functions.ts"
+import { rollupCostDisplay } from "../../../../../../domains/spans/cost-display.ts"
+import { ChartHeader } from "../../-components/chart-header.tsx"
+import { serializeFilters } from "../../-components/trace-page-state.ts"
+import { formatSignedPrice, microcentsToUsd, shareOf } from "./cost-formatters.ts"
+import { OTHER_SERIES_COLOR } from "./cost-series-colors.ts"
+
+// Named after the money, not the mechanism: a failure with no `error.type` attribute is a
+// row the user has to be able to act on, and "unknown" reads as a value the model returned.
+const UNLABELLED_REASON = "No error type recorded"
+
+const WASTED_BAR_COLOR = "hsl(0 70% 55%)"
+
+interface ReasonRow {
+  readonly key: string
+  readonly label: string
+  readonly traces: number
+  readonly costMicrocents: number
+  readonly isRemainder: boolean
+}
+
+function buildReasonRows(record: WastedSpendRecord): readonly ReasonRow[] {
+  const rows: ReasonRow[] = record.reasons.map((reason) => ({
+    key: reason.errorType || "__unlabelled__",
+    label: reason.errorType || UNLABELLED_REASON,
+    traces: reason.traces,
+    costMicrocents: reason.costMicrocents,
+    isRemainder: false,
+  }))
+  const other = record.otherReasons
+  if (!other) return rows
+  return [
+    ...rows,
+    {
+      key: "__other__",
+      label: other.typeCount === 1 ? "1 other reason" : `${other.typeCount} other reasons`,
+      traces: other.traces,
+      costMicrocents: other.costMicrocents,
+      isRemainder: true,
+    },
+  ]
+}
+
+/**
+ * The share of the panel's own total, never of the window: these bars answer "what was the
+ * money wasted on", and a row's share of total spend would be a second, smaller-looking
+ * number for the same fact.
+ */
+function ReasonBar({ share, isRemainder }: { readonly share: number; readonly isRemainder: boolean }) {
+  return (
+    <div className="flex h-2.5 w-full overflow-hidden rounded-sm bg-muted">
+      <div
+        className="h-full min-w-[2px] rounded-sm"
+        style={{
+          width: `${Math.max(0, Math.min(100, share * 100))}%`,
+          backgroundColor: isRemainder ? OTHER_SERIES_COLOR : WASTED_BAR_COLOR,
+        }}
+      />
+    </div>
+  )
+}
+
+/**
+ * Money that bought nothing: what this window spent on traces that errored.
+ *
+ * Whole-trace by decision, stated in the headline tooltip — a failed call usually records
+ * no usage of its own, so charging only the failed span would report ~$0 for exactly the
+ * traces that wasted the most. Nothing else on the page shows a per-span framing of the
+ * same claim; the two would not reconcile.
+ */
+export function WastedSpendPanel({
+  record,
+  projectSlug,
+  rangeFromIso,
+  rangeToIso,
+  isAllTime,
+  isLoading,
+}: {
+  readonly record: WastedSpendRecord | undefined
+  readonly projectSlug: string
+  readonly rangeFromIso: string
+  readonly rangeToIso: string
+  readonly isAllTime: boolean
+  readonly isLoading: boolean
+}) {
+  const rows = record ? buildReasonRows(record) : []
+  const wasted = rollupCostDisplay({
+    costTotalMicrocents: record?.erroredCostMicrocents ?? 0,
+    unpricedSpanCount: record?.erroredUnpricedCalls ?? 0,
+    tokensTotal: record?.erroredTokens ?? 0,
+  })
+  // The same Status filter the traces list applies, so the drill-down returns the very
+  // traces this panel counted rather than a differently-defined subset.
+  const erroredTracesSearch = {
+    tab: "traces",
+    filters: serializeFilters({
+      status: [{ op: "in", value: ["error"] }],
+      startTime: [
+        { op: "gte", value: rangeFromIso },
+        { op: "lte", value: rangeToIso },
+      ],
+    }),
+  }
+
+  return (
+    <div className="flex flex-1 flex-col rounded-lg border border-border bg-background">
+      <ChartHeader
+        title="Wasted spend"
+        fromIso={rangeFromIso}
+        toIso={rangeToIso}
+        isAllTime={isAllTime}
+        showWindow={isAllTime}
+      />
+      {isLoading || !record ? (
+        <div className="flex flex-col gap-3 p-3">
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      ) : record.erroredTraces === 0 ? (
+        <div className="flex w-full min-h-[120px] items-center justify-center p-3">
+          <Text.H6 color="foregroundMuted">
+            {record.tracesWithUsage === 0 ? "No spend recorded in this time window" : "No spend on traces that errored"}
+          </Text.H6>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4 p-3">
+          <div className="flex flex-row flex-wrap items-end justify-between gap-3">
+            <div className="flex flex-col gap-1">
+              <div className="flex flex-row items-center gap-1.5">
+                <Text.H2 color="foreground" className="tabular-nums">
+                  {wasted.label}
+                </Text.H2>
+                <Tooltip
+                  asChild
+                  trigger={
+                    <span className="inline-flex cursor-default">
+                      <Icon icon={InfoIcon} size="sm" color="foregroundMuted" />
+                    </span>
+                  }
+                >
+                  {`Everything these traces spent, not only their failed steps. A failed call usually records no usage of its own — the money went on the steps that succeeded and whose output was then discarded. A trace counts as errored when at least one of its spans failed, the same definition the traces list uses.${wasted.note ? ` ${wasted.note}` : ""}`}
+                </Tooltip>
+              </div>
+              <Text.H6 color="foregroundMuted">
+                {`${formatCount(record.erroredTraces)} of ${formatCount(record.tracesWithUsage)} traces with usage errored`}
+              </Text.H6>
+            </div>
+            <div className="flex flex-col items-end gap-1">
+              {record.wastedShare === null ? (
+                <Tooltip
+                  asChild
+                  trigger={
+                    <span className="inline-flex cursor-default">
+                      <Text.H6 color="foregroundMuted">no share yet</Text.H6>
+                    </span>
+                  }
+                >
+                  {record.erroredCostMicrocents <= 0
+                    ? "These traces errored without recording any spend, so there is a count to act on but no share of the money."
+                    : `A share needs at least ${WASTED_SPEND_MIN_SAMPLE_TRACES} traces with usage — over ${formatCount(record.tracesWithUsage)}, one failure moves the figure by tens of points.`}
+                </Tooltip>
+              ) : (
+                <Text.H4 color="foreground" className="tabular-nums">
+                  {`${formatPercentage(record.wastedShare)} of spend`}
+                </Text.H4>
+              )}
+              <Link
+                to="/projects/$projectSlug"
+                params={{ projectSlug }}
+                search={erroredTracesSearch}
+                className="inline-flex flex-row items-center gap-1"
+              >
+                <Text.H6 color="primary">View errored traces</Text.H6>
+                <Icon icon={ArrowRightIcon} size="sm" color="primary" />
+              </Link>
+            </div>
+          </div>
+          <div className="flex flex-col gap-2.5">
+            {rows.map((row) => (
+              <div key={row.key} className="flex flex-row items-center gap-3">
+                <div className="flex w-40 shrink-0 flex-col">
+                  <Text.H6 color={row.isRemainder ? "foregroundMuted" : "foreground"} ellipsis noWrap>
+                    {row.label}
+                  </Text.H6>
+                </div>
+                <ReasonBar
+                  share={shareOf(row.costMicrocents, record.erroredCostMicrocents) ?? 0}
+                  isRemainder={row.isRemainder}
+                />
+                <div className="flex w-16 shrink-0 justify-end">
+                  <Text.H6 color="foregroundMuted" noWrap className="tabular-nums">
+                    {formatSignedPrice(microcentsToUsd(row.costMicrocents))}
+                  </Text.H6>
+                </div>
+                <div className="flex w-20 shrink-0 justify-end">
+                  <Text.H6 color="foregroundMuted" noWrap className="tabular-nums">
+                    {`${formatCount(row.traces)} ${row.traces === 1 ? "trace" : "traces"}`}
+                  </Text.H6>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
@@ -10,6 +10,7 @@ import {
   useCostPerSessionDecomposition,
   useCostSeries,
   useModelUsageSeries,
+  useWastedSpend,
 } from "../../../../../domains/cost/cost.collection.ts"
 import { useFeatureFlagGate } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
 import { useAnalyticsTimeWindow } from "../../../../../domains/projects/use-analytics-time-window.ts"
@@ -36,6 +37,7 @@ import { CostPerSessionPanel } from "./-components/cost-per-session-panel.tsx"
 import { ModelImpactPanel } from "./-components/model-impact-panel.tsx"
 import { ModelUsagePanel } from "./-components/model-usage-panel.tsx"
 import { PricingCoverageBadge } from "./-components/pricing-coverage-badge.tsx"
+import { WastedSpendPanel } from "./-components/wasted-spend-panel.tsx"
 
 function CostBreadcrumb() {
   return <BreadcrumbText variant="current">Cost</BreadcrumbText>
@@ -126,6 +128,11 @@ function CostPageContent() {
     projectId: project.id,
     range,
     bucketSeconds,
+    enabled,
+  })
+  const { data: wastedSpend, isLoading: wastedSpendLoading } = useWastedSpend({
+    projectId: project.id,
+    range,
     enabled,
   })
   const { data: cacheEconomics, isLoading: cacheEconomicsLoading } = useCacheEconomics({
@@ -226,6 +233,16 @@ function CostPageContent() {
             rangeToIso={range.toIso}
             isAllTime={tw.isAllTime}
             isLoading={seriesLoading}
+          />
+        </Section>
+        <Section heading="Waste">
+          <WastedSpendPanel
+            record={wastedSpend}
+            projectSlug={projectSlug}
+            rangeFromIso={range.fromIso}
+            rangeToIso={range.toIso}
+            isAllTime={tw.isAllTime}
+            isLoading={wastedSpendLoading}
           />
         </Section>
         <Section heading="Session">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
@@ -9,6 +9,7 @@ import {
   useCostPerSessionDecomposition,
   useCostSeries,
   useModelUsageSeries,
+  useWastedSpend,
 } from "../../../../../domains/cost/cost.collection.ts"
 import { useFeatureFlagGate } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
 import { useAnalyticsTimeWindow } from "../../../../../domains/projects/use-analytics-time-window.ts"
@@ -35,6 +36,7 @@ import { CostOverTimePanel } from "./-components/cost-over-time-panel.tsx"
 import { CostPerSessionPanel } from "./-components/cost-per-session-panel.tsx"
 import { ModelImpactPanel } from "./-components/model-impact-panel.tsx"
 import { ModelUsagePanel } from "./-components/model-usage-panel.tsx"
+import { WastedSpendPanel } from "./-components/wasted-spend-panel.tsx"
 
 function CostBreadcrumb() {
   return <BreadcrumbText variant="current">Cost</BreadcrumbText>
@@ -59,6 +61,7 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/cost
 })
 
 function CostPageContent() {
+  const { projectSlug } = Route.useParams()
   const project = useRouteProject()
   const { firstTraceAt } = useProjectFirstTraceAt({ projectId: project.id })
   const { lastTraceAt } = useProjectLastTraceAt({ projectId: project.id })
@@ -115,6 +118,11 @@ function CostPageContent() {
     projectId: project.id,
     range,
     bucketSeconds,
+    enabled,
+  })
+  const { data: wastedSpend, isLoading: wastedSpendLoading } = useWastedSpend({
+    projectId: project.id,
+    range,
     enabled,
   })
   const { data: cacheEconomics, isLoading: cacheEconomicsLoading } = useCacheEconomics({
@@ -212,6 +220,15 @@ function CostPageContent() {
           rangeToIso={range.toIso}
           isAllTime={tw.isAllTime}
           isLoading={seriesLoading}
+        />
+        <SectionHeading>Waste</SectionHeading>
+        <WastedSpendPanel
+          record={wastedSpend}
+          projectSlug={projectSlug}
+          rangeFromIso={range.fromIso}
+          rangeToIso={range.toIso}
+          isAllTime={tw.isAllTime}
+          isLoading={wastedSpendLoading}
         />
         <SectionHeading>Session</SectionHeading>
         <CostPerSessionPanel

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -107,6 +107,7 @@ export {
 } from "./helpers/resolve-last-llm-completion-span.ts"
 export { resolveScoreTraceContext } from "./helpers/resolve-score-trace-context.ts"
 export { resolveTraceIdFromRef, type TraceRef, traceRefSchema } from "./helpers/trace-ref.ts"
+export { wastedSpendShare } from "./helpers/wasted-spend.ts"
 export {
   alignUnixSecondsToHistogramBucket,
   denseTraceTimeHistogramBuckets,
@@ -133,12 +134,16 @@ export type {
   SessionCostBucket,
   SessionCostFactorsPair,
   SessionCostFactorsScope,
+  WastedSpend,
+  WastedSpendReason,
 } from "./ports/cost-analytics-repository.ts"
 export {
   CACHE_ECONOMICS_ROW_LIMIT,
   COST_BREAKDOWN_DIMENSIONS,
   COST_PER_CALL_MIN_SAMPLE_CALLS,
   COST_SERIES_METRICS,
+  WASTED_SPEND_MIN_SAMPLE_TRACES,
+  WASTED_SPEND_REASON_LIMIT,
 } from "./ports/cost-analytics-repository.ts"
 export type {
   MessageEmbedding,

--- a/packages/domain/spans/src/helpers/wasted-spend.test.ts
+++ b/packages/domain/spans/src/helpers/wasted-spend.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { WASTED_SPEND_MIN_SAMPLE_TRACES } from "../ports/cost-analytics-repository.ts"
+import { wastedSpendShare } from "./wasted-spend.ts"
+
+const AT_FLOOR = WASTED_SPEND_MIN_SAMPLE_TRACES
+
+describe("wastedSpendShare", () => {
+  it("divides errored spend by the window's spend once the sample clears the floor", () => {
+    expect(wastedSpendShare({ erroredCostMicrocents: 120, totalMicrocents: 1_000, tracesWithUsage: AT_FLOOR })).toBe(
+      0.12,
+    )
+  })
+
+  it("withholds the share one trace below the floor, where a single failure moves it by tens of points", () => {
+    expect(
+      wastedSpendShare({ erroredCostMicrocents: 120, totalMicrocents: 1_000, tracesWithUsage: AT_FLOOR - 1 }),
+    ).toBeNull()
+  })
+
+  it("withholds the share when the window spent nothing, rather than dividing by zero", () => {
+    expect(wastedSpendShare({ erroredCostMicrocents: 0, totalMicrocents: 0, tracesWithUsage: 500 })).toBeNull()
+  })
+
+  it("withholds the share when errored traces recorded no spend — that is a $0 claim, not a 0% one", () => {
+    expect(wastedSpendShare({ erroredCostMicrocents: 0, totalMicrocents: 1_000, tracesWithUsage: 500 })).toBeNull()
+  })
+})

--- a/packages/domain/spans/src/helpers/wasted-spend.ts
+++ b/packages/domain/spans/src/helpers/wasted-spend.ts
@@ -1,0 +1,28 @@
+import { WASTED_SPEND_MIN_SAMPLE_TRACES } from "../ports/cost-analytics-repository.ts"
+
+/**
+ * Wasted spend as a share of the window, or null when the window cannot support a share.
+ *
+ * Null on three counts, all of which would otherwise put a percentage where there is no
+ * finding: nothing was spent, so there is no denominator; fewer than
+ * `WASTED_SPEND_MIN_SAMPLE_TRACES` traces carried usage, where one failure moves the
+ * figure by tens of points; or the errored traces recorded no spend, which is a $0 claim
+ * rather than a 0% one. The dollar figure is shown either way — it is a sum, and true at
+ * any volume.
+ *
+ * The gate lives here rather than at the call site so a second reader cannot reintroduce
+ * the ungated ratio.
+ */
+export function wastedSpendShare({
+  erroredCostMicrocents,
+  totalMicrocents,
+  tracesWithUsage,
+}: {
+  readonly erroredCostMicrocents: number
+  readonly totalMicrocents: number
+  readonly tracesWithUsage: number
+}): number | null {
+  if (totalMicrocents <= 0 || erroredCostMicrocents <= 0) return null
+  if (tracesWithUsage < WASTED_SPEND_MIN_SAMPLE_TRACES) return null
+  return erroredCostMicrocents / totalMicrocents
+}

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -165,6 +165,7 @@ export {
   traceRefSchema,
   tracesRefSchema,
 } from "./helpers/trace-ref.ts"
+export { wastedSpendShare } from "./helpers/wasted-spend.ts"
 export {
   alignUnixSecondsToHistogramBucket,
   denseTraceTimeHistogramBuckets,
@@ -213,6 +214,8 @@ export type {
   SessionCostBucket,
   SessionCostFactorsPair,
   SessionCostFactorsScope,
+  WastedSpend,
+  WastedSpendReason,
 } from "./ports/cost-analytics-repository.ts"
 export {
   CACHE_ECONOMICS_ROW_LIMIT,
@@ -222,6 +225,8 @@ export {
   COST_SERIES_METRICS,
   CostAnalyticsRepository,
   MODEL_USAGE_SERIES_LIMIT,
+  WASTED_SPEND_MIN_SAMPLE_TRACES,
+  WASTED_SPEND_REASON_LIMIT,
 } from "./ports/cost-analytics-repository.ts"
 export type { EmbedBudgetLimits, EmbedBudgetResolverShape } from "./ports/embed-budget-resolver.ts"
 export { EmbedBudgetResolver } from "./ports/embed-budget-resolver.ts"

--- a/packages/domain/spans/src/ports/cost-analytics-repository.ts
+++ b/packages/domain/spans/src/ports/cost-analytics-repository.ts
@@ -68,6 +68,14 @@ export interface CostAnalyticsRepositoryShape {
   getSessionCostFactors(
     input: SessionCostFactorsScope,
   ): Effect.Effect<SessionCostFactorsPair, RepositoryError, ChSqlClient>
+
+  /**
+   * Spend on traces that failed, and what they failed on.
+   *
+   * The only figure in this port that names money which bought *nothing*, so it is
+   * whole-trace by construction: see `WastedSpend`.
+   */
+  getWastedSpend(input: CostAnalyticsScope): Effect.Effect<WastedSpend, RepositoryError, ChSqlClient>
 }
 
 export interface CostAnalyticsScope {
@@ -311,6 +319,60 @@ export interface SessionCostFactorsPair {
   readonly current: SessionCostPeriod
   /** Both windows, oldest first. */
   readonly buckets: readonly SessionCostBucket[]
+}
+
+/**
+ * Failure reasons listed on the wasted-spend panel. Beyond this the list stops being a
+ * ranking, and the remainder is exact because every errored trace lands in exactly one
+ * reason — see `WastedSpendReason`.
+ */
+export const WASTED_SPEND_REASON_LIMIT = 6
+
+/**
+ * Minimum traces with billable usage before wasted spend may be shown as a *share* of
+ * the window. The dollar figure needs no floor — it is a sum, true at any volume — but a
+ * percentage over a handful of traces swings between 0% and 100% on one failure.
+ */
+export const WASTED_SPEND_MIN_SAMPLE_TRACES = 20
+
+/**
+ * One failure reason and the spend behind it.
+ *
+ * A trace is attributed to the `error_type` of its *first* failed span, so the reasons
+ * partition the errored traces: their costs sum to `erroredCostMicrocents` exactly, which
+ * a trace counted under every error type it hit could not do.
+ */
+export interface WastedSpendReason {
+  /** Empty when the failing span recorded no `error.type` attribute. */
+  readonly errorType: string
+  readonly traces: number
+  readonly costMicrocents: number
+}
+
+/**
+ * Spend on traces that errored, against the window they sit in.
+ *
+ * **Whole-trace, deliberately.** A failed call usually records no usage at all — the
+ * provider rejected it — so the money in a failed trace was spent on the steps that
+ * *succeeded* and whose output was then thrown away. Charging only the failed span would
+ * report ~$0 for exactly the traces that wasted the most.
+ *
+ * Errored means at least one span with `status_code = 2`, the same definition the traces
+ * list's Status filter uses, so the panel's drill-down returns the traces it counted.
+ */
+export interface WastedSpend {
+  readonly erroredTraces: number
+  readonly erroredCostMicrocents: number
+  /** Denominator for the share: traces with at least one billable span, errored or not. */
+  readonly tracesWithUsage: number
+  readonly totalMicrocents: number
+  /** On errored traces only. Both feed the shared rollup cost display. */
+  readonly erroredUnpricedCalls: number
+  readonly erroredTokens: number
+  /** Highest spend first, capped at `WASTED_SPEND_REASON_LIMIT`. */
+  readonly reasons: readonly WastedSpendReason[]
+  /** Distinct reasons in the window, so a caller can tell whether `reasons` was truncated. */
+  readonly distinctErrorTypes: number
 }
 
 export interface CostModelSpend {

--- a/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.test.ts
@@ -20,6 +20,9 @@ const CACHE_PROJECT_ID = ProjectId("costcache00000000000000a")
 // Cadence lives on its own project: the ceiling is read from inter-call gaps, so it
 // needs timestamps chosen for their spacing rather than for the token columns.
 const CADENCE_PROJECT_ID = ProjectId("costcadence000000000000a")
+// Own project too: wasted spend rolls up per trace over *all* spans, so it needs traces
+// whose failure sits on a span the other fixtures deliberately keep out of the aggregates.
+const WASTED_PROJECT_ID = ProjectId("costwasted00000000000000")
 
 const DAY1 = new Date("2026-06-01T10:00:00.000Z")
 const DAY2 = new Date("2026-06-02T10:00:00.000Z")
@@ -52,6 +55,8 @@ type SpanOpts = {
   costSource?: string
   session?: string
   agentName?: string
+  statusCode?: number
+  errorType?: string
 }
 
 const span = (n: number, startTime: Date, opts: SpanOpts = {}): CostSpanRow =>
@@ -70,9 +75,9 @@ const span = (n: number, startTime: Date, opts: SpanOpts = {}): CostSpanRow =>
     name: "ca-span",
     service_name: opts.serviceName ?? "ca-service",
     kind: 0,
-    status_code: 0,
+    status_code: opts.statusCode ?? 0,
     status_message: "",
-    error_type: "",
+    error_type: opts.errorType ?? "",
     tags: [],
     metadata: {},
     operation: opts.operation ?? "chat",
@@ -121,6 +126,13 @@ const breakdownScope = { ...scope, projectId: BREAKDOWN_PROJECT_ID }
 const modelUsageScope = { ...scope, projectId: MODEL_USAGE_PROJECT_ID }
 const cacheScope = { ...scope, projectId: CACHE_PROJECT_ID }
 const cadenceScope = { ...scope, projectId: CADENCE_PROJECT_ID }
+const wastedScope = { ...scope, projectId: WASTED_PROJECT_ID }
+
+// Seconds after DAY1, so a trace's spans have a defined order for "first failure".
+const afterDay1 = (seconds: number): Date => new Date(DAY1.getTime() + seconds * 1_000)
+
+const wastedSpan = (n: number, startTime: Date, opts: Omit<SpanOpts, "project">): CostSpanRow =>
+  span(n, startTime, { ...opts, project: WASTED_PROJECT_ID })
 
 const cacheSpan = (n: number, startTime: Date, opts: Omit<SpanOpts, "project">): CostSpanRow =>
   span(n, startTime, { ...opts, project: CACHE_PROJECT_ID })
@@ -323,6 +335,66 @@ describe("CostAnalyticsRepositoryLive", () => {
         // unit when it is set, so neither call is warm.
         cadenceSpan(54, 0, { model: "named-agents", serviceName: "shared-service", agentName: "billing" }),
         cadenceSpan(55, 60, { model: "named-agents", serviceName: "shared-service", agentName: "support" }),
+
+        // Wasted-spend fixture. Every errored trace also did paid work, which is the case
+        // the whole-trace reading exists for.
+
+        // Trace 101: the provider rejected the second call, so it reports no usage at all
+        // — a per-span figure charges this trace nothing.
+        wastedSpan(101, DAY1, { trace: 101, costTotal: 500, costSource: "estimated", tokensInput: 1_000 }),
+        wastedSpan(102, afterDay1(1), {
+          trace: 101,
+          costSource: "no_tokens",
+          statusCode: 2,
+          errorType: "rate_limit_exceeded",
+        }),
+        // Trace 102: the failure is on a tool span. It decides the trace failed, and its
+        // own cost still stays out of every dollar figure.
+        wastedSpan(103, DAY1, { trace: 102, costTotal: 300, costSource: "estimated" }),
+        wastedSpan(104, afterDay1(1), {
+          trace: 102,
+          operation: "execute_tool",
+          costTotal: 9_999,
+          statusCode: 2,
+          errorType: "tool_failure",
+        }),
+        // Trace 103: two failures. Only the earlier one may name the trace, or a trace
+        // would be counted under every type it hit and the reasons would stop summing.
+        wastedSpan(105, DAY1, { trace: 103, costTotal: 200, costSource: "estimated" }),
+        wastedSpan(106, afterDay1(1), {
+          trace: 103,
+          costSource: "no_tokens",
+          statusCode: 2,
+          errorType: "deadline_exceeded",
+        }),
+        wastedSpan(107, afterDay1(2), {
+          trace: 103,
+          costSource: "no_tokens",
+          statusCode: 2,
+          errorType: "rate_limit_exceeded",
+        }),
+        // Trace 104: succeeded, and the largest spend in the window.
+        wastedSpan(108, DAY2, { trace: 104, costTotal: 1_000, costSource: "estimated" }),
+        // Trace 105: a failure with no billable span anywhere — out of both the numerator
+        // and the denominator, the same as any other usage-free trace.
+        wastedSpan(109, DAY2, {
+          trace: 105,
+          operation: "execute_tool",
+          costTotal: 7_777,
+          statusCode: 2,
+          errorType: "tool_failure",
+        }),
+        // Trace 106: errored, and its spend is understated because ingestion could not
+        // price the model — a wasted trace that contributes no dollars.
+        wastedSpan(110, DAY2, {
+          trace: 106,
+          costSource: "unpriced",
+          tokensInput: 700,
+          model: "mystery-1",
+          provider: "acme",
+          statusCode: 2,
+          errorType: "rate_limit_exceeded",
+        }),
       ]),
     )
   })
@@ -630,6 +702,77 @@ describe("CostAnalyticsRepositoryLive", () => {
       const { cadence } = await runCh(repo.getCacheEconomics(cadenceScope))
 
       expect(cadence.filter((row) => row.model === "single-turn")).toHaveLength(1)
+    })
+  })
+
+  describe("getWastedSpend", () => {
+    it("charges an errored trace everything it spent, not only its failed spans", async () => {
+      const wasted = await runCh(repo.getWastedSpend(wastedScope))
+
+      // Traces 101, 102, 103 and 106: 500 + 300 + 200 + 0. Every failing span in the
+      // fixture reported no priced usage of its own, so a per-span figure would read 0.
+      expect(wasted.erroredTraces).toBe(4)
+      expect(wasted.erroredCostMicrocents).toBe(1_000)
+    })
+
+    it("counts a trace as errored on a failure anywhere in it, including a tool span", async () => {
+      const { reasons } = await runCh(repo.getWastedSpend(wastedScope))
+
+      expect(reasons.find((reason) => reason.errorType === "tool_failure")).toEqual({
+        errorType: "tool_failure",
+        traces: 1,
+        costMicrocents: 300,
+      })
+    })
+
+    it("keeps the tool span's own cost out of the dollars, the same as every other figure", async () => {
+      const wasted = await runCh(repo.getWastedSpend(wastedScope))
+
+      // 9,999 on trace 102's tool span and 7,777 on trace 105's would both dwarf the panel.
+      expect(wasted.totalMicrocents).toBe(2_000)
+    })
+
+    it("shares the with-usage denominator with every other per-trace figure", async () => {
+      const wasted = await runCh(repo.getWastedSpend(wastedScope))
+
+      // Trace 105 failed but carries no billable span, so it reaches neither side.
+      expect(wasted.tracesWithUsage).toBe(5)
+    })
+
+    it("names a trace by its first failure, so the reasons partition the errored traces", async () => {
+      const { reasons } = await runCh(repo.getWastedSpend(wastedScope))
+
+      // Trace 103 failed twice; only `deadline_exceeded` came first.
+      expect(reasons).toEqual([
+        { errorType: "rate_limit_exceeded", traces: 2, costMicrocents: 500 },
+        { errorType: "tool_failure", traces: 1, costMicrocents: 300 },
+        { errorType: "deadline_exceeded", traces: 1, costMicrocents: 200 },
+      ])
+    })
+
+    it("sums its reasons to the headline exactly, which is what one-reason-per-trace buys", async () => {
+      const wasted = await runCh(repo.getWastedSpend(wastedScope))
+
+      const summed = wasted.reasons.reduce((total, reason) => total + reason.costMicrocents, 0)
+      expect(summed).toBe(wasted.erroredCostMicrocents)
+      expect(wasted.reasons.reduce((total, reason) => total + reason.traces, 0)).toBe(wasted.erroredTraces)
+    })
+
+    it("reports the errored traces' unpriced usage, so an understated total can say so", async () => {
+      const wasted = await runCh(repo.getWastedSpend(wastedScope))
+
+      expect(wasted.erroredUnpricedCalls).toBe(1)
+      expect(wasted.erroredTokens).toBe(1_700)
+      expect(wasted.distinctErrorTypes).toBe(3)
+    })
+
+    it("reads zero on a project with no failures at all", async () => {
+      const wasted = await runCh(repo.getWastedSpend(scope))
+
+      expect(wasted.erroredTraces).toBe(0)
+      expect(wasted.erroredCostMicrocents).toBe(0)
+      expect(wasted.reasons).toEqual([])
+      expect(wasted.tracesWithUsage).toBe(5)
     })
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.ts
@@ -22,6 +22,7 @@ import type {
   SessionCostFactorsPair,
   SessionCostPeriod,
   TokenSide,
+  WastedSpend,
 } from "@domain/spans"
 import {
   CACHE_CEILING_LIFETIME_SECONDS,
@@ -30,6 +31,7 @@ import {
   CostAnalyticsRepository,
   costSourceSchema,
   MODEL_USAGE_SERIES_LIMIT,
+  WASTED_SPEND_REASON_LIMIT,
 } from "@domain/spans"
 import { formatCHDate, normalizeCHString, parseCHDate } from "@repo/utils"
 import { Effect, Layer } from "effect"
@@ -205,6 +207,26 @@ const SESSION_FACTORS_SOURCE = `SELECT
       WHERE ${SCOPE_PREVIOUS_FILTER}
         AND operation IN ${USAGE_OPERATIONS_SQL}`
 
+// One row per trace, carrying its failure state alongside its billable spend.
+//
+// Deliberately *not* gated to billable operations: a trace fails on whichever span
+// errored, and that is usually a tool or wrapper span carrying no usage. Cost and tokens
+// are gated inside the aggregate instead, so the two questions read the same trace set
+// without one narrowing the other. `billable_calls` lets the caller keep the same
+// with-usage denominator every other per-trace figure on the page uses.
+const WASTED_TRACE_SOURCE = `SELECT
+        trace_id,
+        max(status_code) = 2 AS has_error,
+        argMinIf(error_type, start_time, status_code = 2) AS first_error_type,
+        countIf(operation IN ${USAGE_OPERATIONS_SQL}) AS billable_calls,
+        sumIf(cost_total_microcents, operation IN ${USAGE_OPERATIONS_SQL}) AS cost_microcents,
+        sumIf(tokens_total, operation IN ${USAGE_OPERATIONS_SQL}) AS tokens,
+        countIf(operation IN ${USAGE_OPERATIONS_SQL} AND ${COST_SOURCE} IN ('unpriced', 'unknown')) AS unpriced_calls
+      FROM spans
+      WHERE ${SCOPE_FILTER}
+      GROUP BY trace_id
+      HAVING billable_calls > 0`
+
 const BUCKET_START = `toDateTime(
   intDiv(toUnixTimestamp(start_time), {bucketSeconds:UInt32}) * {bucketSeconds:UInt32},
   'UTC'
@@ -379,6 +401,22 @@ const toSessionPeriod = ({
         unpricedCalls: num(row.unpriced_calls),
         cells: toSessionCells(cells),
       }
+
+type WastedTotalsRow = {
+  traces_with_usage: string
+  total_microcents: string
+  errored_traces: string
+  errored_cost_microcents: string
+  errored_unpriced_calls: string
+  errored_tokens: string
+  distinct_error_types: string
+}
+
+type WastedReasonRow = {
+  error_type: string
+  traces: string
+  cost_microcents: string
+}
 
 type ModelUsageMeasuresDraft = { cost: number; tokens: number }
 
@@ -948,6 +986,66 @@ export const CostAnalyticsRepositoryLive = Layer.effect(
                       sessions: num(row.sessions),
                       costMicrocents: num(row.cost_microcents),
                     })),
+                }
+              }),
+            )
+        }),
+
+      getWastedSpend: (input) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const params = scopeParams(input)
+              const [totalsResult, reasonsResult] = await Promise.all([
+                client.query({
+                  query: `SELECT
+                        count() AS traces_with_usage,
+                        sum(cost_microcents) AS total_microcents,
+                        countIf(has_error) AS errored_traces,
+                        sumIf(cost_microcents, has_error) AS errored_cost_microcents,
+                        sumIf(unpriced_calls, has_error) AS errored_unpriced_calls,
+                        sumIf(tokens, has_error) AS errored_tokens,
+                        uniqExactIf(first_error_type, has_error) AS distinct_error_types
+                      FROM (${WASTED_TRACE_SOURCE})`,
+                  query_params: params,
+                  format: "JSONEachRow",
+                }),
+                client.query({
+                  // Ranked by spend, not by trace count: the panel's claim is about money.
+                  query: `SELECT
+                        first_error_type AS error_type,
+                        count() AS traces,
+                        sum(cost_microcents) AS cost_microcents
+                      FROM (${WASTED_TRACE_SOURCE})
+                      WHERE has_error
+                      GROUP BY error_type
+                      ORDER BY cost_microcents DESC, traces DESC, error_type ASC
+                      LIMIT {reasonLimit:UInt16}`,
+                  query_params: { ...params, reasonLimit: WASTED_SPEND_REASON_LIMIT },
+                  format: "JSONEachRow",
+                }),
+              ])
+              const totalsRows = await totalsResult.json<WastedTotalsRow>()
+              const reasonRows = await reasonsResult.json<WastedReasonRow>()
+              return { totalsRows, reasonRows }
+            })
+            .pipe(
+              Effect.map(({ totalsRows, reasonRows }): WastedSpend => {
+                const row = totalsRows[0]
+                return {
+                  erroredTraces: num(row?.errored_traces),
+                  erroredCostMicrocents: num(row?.errored_cost_microcents),
+                  tracesWithUsage: num(row?.traces_with_usage),
+                  totalMicrocents: num(row?.total_microcents),
+                  erroredUnpricedCalls: num(row?.errored_unpriced_calls),
+                  erroredTokens: num(row?.errored_tokens),
+                  reasons: reasonRows.map((reason) => ({
+                    errorType: normalizeCHString(reason.error_type),
+                    traces: num(reason.traces),
+                    costMicrocents: num(reason.cost_microcents),
+                  })),
+                  distinctErrorTypes: num(row?.distinct_error_types),
                 }
               }),
             )

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/archetypes.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/archetypes.test.ts
@@ -6,7 +6,13 @@ import {
   SEED_ORG_ID,
   SEED_PROJECT_ID,
 } from "@domain/shared/seeding"
-import { type CacheState, classifyCacheState, modelCacheBreakEvenRate, modelRegistryPricing } from "@domain/spans"
+import {
+  type CacheState,
+  classifyCacheState,
+  modelCacheBreakEvenRate,
+  modelRegistryPricing,
+  WASTED_SPEND_MIN_SAMPLE_TRACES,
+} from "@domain/spans"
 import { cacheHitRate } from "@repo/utils"
 import { describe, expect, it } from "vitest"
 import type { SpanRow } from "../span-builders.ts"
@@ -109,7 +115,10 @@ describe("cost archetype fixtures", () => {
     let index = 0
     for (const cohort of cohorts) {
       for (let call = 0; call < cohortCalls(cohort); call++) {
-        expect(promptOf(spans[index++])).toBe(cohort.promptTokens)
+        const span = spans[index++]
+        // A call the provider rejected reported no usage at all, which is the one row
+        // where the three input columns sum to zero rather than to the declared prompt.
+        expect(promptOf(span)).toBe(span?.cost_source === "no_tokens" ? 0 : cohort.promptTokens)
       }
     }
   })
@@ -167,6 +176,11 @@ describe("archetype A — healthy at scale", () => {
 
   it("is multi-turn throughout", () => {
     for (const cohort of HEALTHY_COHORTS) expect(cohort.callsPerSession).toBeGreaterThan(1)
+  })
+
+  it("wastes nothing on errors, which is what a well-run project has to show", () => {
+    // A wasted-spend figure here would mean the definition, not the project, is wrong.
+    expect(spans.some((span) => span.status_code === 2)).toBe(false)
   })
 })
 
@@ -248,6 +262,70 @@ describe("archetype B — the project where findings fire", () => {
       "gpt-4.1",
     ])
     for (const cohort of FINDINGS_FIRE_COHORTS) expect(ambient.has(cohort.modelConfig.model)).toBe(false)
+  })
+})
+
+/**
+ * Archetype B read the way the wasted-spend panel reads it: roll spans up per trace, then
+ * split by whether the trace failed. Attribution is to the *first* failed span's error
+ * type, so the reasons partition the errored traces.
+ */
+const wastedOf = (spans: readonly SpanRow[]) => {
+  const traces = new Map<string, { failed: boolean; cost: number; failedSpanCost: number; errorType: string }>()
+  for (const span of [...spans].sort((a, b) => startMsOf(a) - startMsOf(b))) {
+    const trace = traces.get(span.trace_id) ?? { failed: false, cost: 0, failedSpanCost: 0, errorType: "" }
+    trace.cost += span.cost_total_microcents
+    if (span.status_code === 2) {
+      if (!trace.failed) trace.errorType = span.error_type
+      trace.failed = true
+      trace.failedSpanCost += span.cost_total_microcents
+    }
+    traces.set(span.trace_id, trace)
+  }
+  const failed = [...traces.values()].filter((trace) => trace.failed)
+  const byReason = new Map<string, number>()
+  for (const trace of failed) byReason.set(trace.errorType, (byReason.get(trace.errorType) ?? 0) + trace.cost)
+  return {
+    traces: traces.size,
+    erroredTraces: failed.length,
+    wholeTraceCost: failed.reduce((sum, trace) => sum + trace.cost, 0),
+    failedSpanCost: failed.reduce((sum, trace) => sum + trace.failedSpanCost, 0),
+    totalCost: [...traces.values()].reduce((sum, trace) => sum + trace.cost, 0),
+    byReason,
+  }
+}
+
+describe("archetype B — wasted spend", () => {
+  const wasted = wastedOf(findingsSpans)
+
+  it("spends real money on traces that errored, enough to be worth a headline", () => {
+    expect(wasted.erroredTraces).toBeGreaterThan(0)
+    expect(wasted.wholeTraceCost).toBeGreaterThan(0)
+    const share = wasted.wholeTraceCost / wasted.totalCost
+    expect(share).toBeGreaterThan(0.02)
+    expect(share).toBeLessThan(0.5)
+  })
+
+  it("makes the whole-trace and per-span readings visibly disagree, which is why the choice is stated", () => {
+    // The rejected cohort's failing call reported no usage, so a per-span figure charges
+    // it nothing while the paid steps before it were thrown away.
+    expect(wasted.failedSpanCost).toBeLessThan(wasted.wholeTraceCost / 2)
+  })
+
+  it("carries more than one failure reason, so the panel has something to rank", () => {
+    expect([...wasted.byReason.keys()].sort()).toEqual(["deadline_exceeded", "rate_limit_exceeded"])
+  })
+
+  it("attributes each errored trace to exactly one reason, so the rows sum to the headline", () => {
+    const summed = [...wasted.byReason.values()].reduce((sum, cost) => sum + cost, 0)
+    expect(summed).toBe(wasted.wholeTraceCost)
+  })
+
+  it("fails only whole traces that also did paid work, never a trace made only of failures", () => {
+    for (const cohort of FINDINGS_FIRE_COHORTS) {
+      if (!cohort.failure) continue
+      expect(cohort.callsPerTrace ?? 1).toBeGreaterThan(1)
+    }
   })
 })
 
@@ -353,6 +431,7 @@ describe("archetype E — tiny and new", () => {
 
   it("stays under every sample floor", () => {
     expect(spans.length).toBeLessThan(20)
+    expect(spans.length).toBeLessThan(WASTED_SPEND_MIN_SAMPLE_TRACES)
     expect(stateFor(spans, "gemini-2.5-flash-lite").state).toBe("notEnoughData")
   })
 

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/cohorts.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/cohorts.ts
@@ -44,6 +44,22 @@ export type CohortCache =
   | { readonly kind: "flat"; readonly profile: CacheProfile }
   | { readonly kind: "prefixReuse"; readonly share: number }
 
+/**
+ * A share of the cohort's traces whose last call fails.
+ *
+ * Stated as "one trace in every N" rather than a percentage so the wasted-spend figure
+ * stays computable by hand, the same reason the cadence is a cluster layout.
+ *
+ * `billed` is the interesting axis: a rejected call records no usage at all, which is the
+ * only fixture where the whole-trace and per-span readings of wasted spend disagree —
+ * per-span would report $0 on a trace that really did throw away paid work.
+ */
+export interface CohortFailure {
+  readonly everyNthTrace: number
+  readonly errorType: string
+  readonly billed: boolean
+}
+
 export interface CostCohort {
   readonly key: string
   readonly serviceName: string
@@ -54,6 +70,9 @@ export interface CostCohort {
   readonly completionTokens: number
   /** `1` is a single-turn workload; `0` writes no session id at all. */
   readonly callsPerSession: number
+  /** Calls sharing one trace id. Defaults to one, which is a trace per call. */
+  readonly callsPerTrace?: number
+  readonly failure?: CohortFailure
   /**
    * Overrides the builder's `estimated`. `""` is a row written before the column
    * existed, which reads back as `unknown` — the one bucket nothing else produces.
@@ -96,8 +115,27 @@ const applyCostSource = (span: SpanRow, source: CostSource | ""): void => {
   span.cost_is_estimated = 0
 }
 
+/** The trace failed and this is its last call, so the failure lands where a real one would. */
+const applyFailure = (span: SpanRow, failure: CohortFailure): void => {
+  span.status_code = 2
+  span.error_type = failure.errorType
+  span.status_message = `${failure.errorType} on ${span.model}`
+  if (failure.billed) return
+  span.tokens_input = 0
+  span.tokens_output = 0
+  span.tokens_cache_read = 0
+  span.tokens_cache_create = 0
+  span.tokens_reasoning = 0
+  span.cost_input_microcents = 0
+  span.cost_output_microcents = 0
+  span.cost_total_microcents = 0
+  span.cost_is_estimated = 0
+  span.cost_source = "no_tokens"
+}
+
 const buildCohortSpans = (cohort: CostCohort, scope: SeedScope, anchorMs: number): SpanRow[] => {
   const { cadence } = cohort
+  const callsPerTrace = cohort.callsPerTrace ?? 1
   const spans: SpanRow[] = []
   const newestCallMs = anchorMs - cadence.endDaysAgo * DAY_MS
   let index = 0
@@ -127,8 +165,9 @@ const buildCohortSpans = (cohort: CostCohort, scope: SeedScope, anchorMs: number
         metadata: {},
       }
 
+      const traceIndex = Math.floor(index / callsPerTrace)
       const span = makeLlmSpan({
-        base: toBase(ctx, scope.traceHex(cohort.key, index), "", start, 1_800),
+        base: toBase(ctx, scope.traceHex(cohort.key, traceIndex), "", start, 1_800),
         modelConfig: cohort.modelConfig,
         inputMessages: [userMessage(`${cohort.key} request ${index}`)],
         outputMessages: [assistantTextMessage(`${cohort.key} response ${index}`)],
@@ -142,6 +181,13 @@ const buildCohortSpans = (cohort: CostCohort, scope: SeedScope, anchorMs: number
       span.span_id = scope.spanHex(cohort.key, index)
       span.agent_name = cohort.serviceName
       if (cohort.costSource !== undefined) applyCostSource(span, cohort.costSource)
+      if (
+        cohort.failure &&
+        traceIndex % cohort.failure.everyNthTrace === 0 &&
+        index % callsPerTrace === callsPerTrace - 1
+      ) {
+        applyFailure(span, cohort.failure)
+      }
 
       spans.push(span)
       index++

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/findings-fire.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/findings-fire.ts
@@ -5,9 +5,11 @@ import {
   CLAUDE_OPUS_4_5,
   CLAUDE_OPUS_4_6,
   CLAUDE_OPUS_4_7,
+  CLAUDE_OPUS_4_8,
   COST_LONG_TAIL_MODELS,
   GEMINI_2_5_FLASH_LITE,
   GPT_5_4_MINI,
+  GPT_5_6,
   GPT_5_6_LUNA,
   GPT_5_MINI,
   GPT_5_NANO,
@@ -192,6 +194,50 @@ const MISSING_COST_COHORTS: readonly CostCohort[] = [
   },
 ]
 
+/**
+ * The wasted-spend cohorts: traces that spent real money and then failed.
+ *
+ * Both are multi-call traces, which is what makes them worth seeding at all — a
+ * one-call-per-trace cohort cannot tell the whole-trace reading apart from the per-span
+ * one. `b-errors-rejected` is the case the decision turns on: the failing call records no
+ * usage, so per-span sees $0 while the two calls before it were paid for and discarded.
+ *
+ * Two error types plus the unlabelled cohort give the reason list something to rank and a
+ * remainder to fold, and the failure rates are one-in-N so the resulting figure is
+ * checkable by hand rather than by rerunning the query.
+ */
+const WASTED_SPEND_COHORTS: readonly CostCohort[] = [
+  {
+    key: "b-errors-rejected",
+    serviceName: "invoice-parser",
+    modelConfig: CLAUDE_OPUS_4_8,
+    cadence: { endDaysAgo: 0, clusters: 40, clusterSpacingHours: 6, callsPerCluster: 9, gapWithinClusterSeconds: 40 },
+    // Same margin against its ceiling as `b-optimal`: these cohorts exist to move the
+    // wasted-spend panel, and a cache finding on them would add a state to a table that
+    // deliberately carries one model per state.
+    cache: { kind: "prefixReuse", share: 0.93 },
+    promptTokens: 18_000,
+    completionTokens: 300,
+    callsPerSession: 3,
+    callsPerTrace: 3,
+    failure: { everyNthTrace: 4, errorType: "rate_limit_exceeded", billed: false },
+  },
+  {
+    // The failing call did consume tokens — a timeout mid-stream — so both readings
+    // charge something and only the amount differs.
+    key: "b-errors-timeout",
+    serviceName: "report-writer",
+    modelConfig: GPT_5_6,
+    cadence: { endDaysAgo: 0, clusters: 30, clusterSpacingHours: 8, callsPerCluster: 8, gapWithinClusterSeconds: 50 },
+    cache: { kind: "prefixReuse", share: 0.93 },
+    promptTokens: 22_000,
+    completionTokens: 450,
+    callsPerSession: 4,
+    callsPerTrace: 2,
+    failure: { everyNthTrace: 5, errorType: "deadline_exceeded", billed: true },
+  },
+]
+
 const LONG_TAIL_COHORTS: readonly CostCohort[] = COST_LONG_TAIL_MODELS.map((modelConfig, index) => ({
   key: `b-long-tail-${index}`,
   serviceName: "experiments",
@@ -213,5 +259,6 @@ const LONG_TAIL_COHORTS: readonly CostCohort[] = COST_LONG_TAIL_MODELS.map((mode
 export const FINDINGS_FIRE_COHORTS: readonly CostCohort[] = [
   ...CACHE_STATE_COHORTS,
   ...MISSING_COST_COHORTS,
+  ...WASTED_SPEND_COHORTS,
   ...LONG_TAIL_COHORTS,
 ]

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/models.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/models.ts
@@ -49,6 +49,13 @@ export const GEMINI_2_5_FLASH = model({ provider: "google", model: "gemini-2.5-f
 export const GEMINI_2_5_FLASH_LITE = model({ provider: "google", model: "gemini-2.5-flash-lite" })
 
 /**
+ * The failing cohorts' models. Priced like any other, because wasted spend is about real
+ * dollars on traces that errored — a model with a pricing quirk would confound the two.
+ */
+export const CLAUDE_OPUS_4_8 = model({ provider: "anthropic", model: "claude-opus-4-8" })
+export const GPT_5_6 = model({ provider: "openai", model: "gpt-5.6" })
+
+/**
  * One-off models for the unhealthy archetype's long tail: enough distinct rows that
  * top-N + `Other models` has something to collapse, and thin enough that the
  * breakdown table's per-row averages are samples nobody should trust. All priced, so


### PR DESCRIPTION
Closes LAT-804 (flavour 1 of three; see **Scope** below).

The one figure on the cost page that names money which bought **nothing**. Everything else on the page names money that bought something you might have bought cheaper.

## The decision, stated

**A trace that errored is wasted in whole, not per failed span.**

Per-span sounds more honest but is the *less* accurate measure of waste: a failed call usually records no usage at all — the provider rejected it, or it never returned tokens. The money in a failed trace was spent on the steps that **succeeded** and whose output was then thrown away. Per-span would report ~\$0 for exactly the traces that wasted the most.

This is in the headline tooltip, and **no per-span framing of the same claim appears anywhere on the page** — the two would not reconcile, and this section has a hard rule against numbers that do not add up.

Errored means at least one span with `status_code = 2` — the same definition `if(error_count > 0, 'error', 'success')` gives the traces list's Status filter, so the panel's drill-down returns the very traces it counted. The alternative (root span only) would be a tighter definition that disagrees with the list it links to.

## Shape

One dollars-wasted headline with a path to the evidence, not a wide table (the LAT-795 lesson).

- **\$X wasted** via the shared `rollupCostDisplay`, so a zero reads as `-` with its unpriced note rather than as free.
- **N of M traces with usage errored** — same denominator as every other per-trace figure on the page.
- **Y% of spend**, gated behind `WASTED_SPEND_MIN_SAMPLE_TRACES = 20`. Dollars are a sum and shown at any volume; the *ratio* is withheld below the floor with a tooltip saying why. This is the LAT-795 `278x avg` lesson: a ratio needs a sample floor, not just a correct denominator.
- **Failure reasons ranked by cost**, each a bar of its share of the wasted total.
- **View errored traces** → the traces list, pre-filtered to Status = error over the same window.

**Arithmetic closes.** Each errored trace is attributed to its *first* failed span's `error_type` (`argMinIf`), so the reasons partition the errored traces: their costs sum to the headline exactly, and the truncation remainder is `total − listed` rather than a decorative "and others". A trace counted under every type it hit could not do that.

Placed directly under the spend chart, above Session — it is the strongest message on the page.

## Should this be a signal instead?

Raised before building, as asked. My answer is **split by flavour**:

- **Errored-trace spend (this PR) is a panel.** It is an accounting fact about a window, not a finding. There is nothing to validate or resolve — you do not "resolve" that 12% of last week's spend errored, you fix the errors, and the errors already have their own pipeline. As a signal it would never resolve and would re-fire every window.
- **Retry loops are a signal, not a dashboard row.** A specific agent looping on a specific tool has a beginning, an end, and something to annotate and resolve — exactly the argument LAT-822 is making for cache findings. **So I did not build it here**, and recommend it go to the signal/issue pipeline rather than becoming a row nobody revisits.

## Scope

- ✅ **Errored traces that still cost money** — this PR.
- ⏭️ **Retry loops** — assessed, recommended as a signal (above), not built.
- ⏭️ **Abandoned sessions** — out of scope, needs a definition that overlaps LAT-806.
- No public API operations (LAT-811 stays delayed).

## Seeds

Reuses the LAT-809 archetypes rather than parallel fixtures. `CostCohort` gains optional `callsPerTrace` + `failure` — both default off, so every existing cohort builds byte-identically.

Two failing cohorts on **archetype B**:
- `b-errors-rejected` — 3-call traces, 1 in 4 fails on its last call, which **reports no usage**. This is the fixture the decision turns on: per-span sees \$0 while two paid calls were discarded. A seed test asserts the two readings visibly disagree.
- `b-errors-timeout` — 2-call traces, 1 in 5 fails having consumed tokens, so both readings charge something.

Both sit at `b-optimal`'s cache margin so they add no cache finding to a table that deliberately carries one model per state. **Archetype A asserts zero errored spans** — if a well-run project showed a wasted-spend figure, the definition would be wrong.

## Where to focus review

1. **The decision itself** — whole-trace, and the "at least one span errored" definition that comes with it. A trace that errored on one step and recovered still counts. I chose consistency with the traces list over a tighter root-span rule so the drill-down reconciles; that trade is the main thing to push back on.
2. **`WASTED_TRACE_SOURCE`** (`cost-analytics-repository.ts`) — the one query that is deliberately *not* gated to billable operations, because a trace fails on whichever span errored (usually a tool span) while cost is gated inside the aggregate. Tool-span dollars stay out; tool-span failures count.
3. **The sample floor at 20** — matches `COST_PER_CALL_MIN_SAMPLE_CALLS`, but it is a guess.
4. **Panel placement** above Session.

## Verification

- Full `@platform/db-clickhouse` suite — 42 files / 628 tests, green (includes the 8 new `getWastedSpend` cases and the reused seed archetypes).
- `@domain/spans` — 2154/2154. `@app/web` — 96 files / 899 tests.
- `typecheck` clean on all three packages; `biome` and `knip` clean.

> An earlier revision of this description flagged the full ClickHouse suite as un-runnable here (OOM, exit 137). That was vitest's default parallelism against chdb on a shared machine, not this change — `--maxWorkers=2` runs it clean.

## Rebased onto the cost dashboard UI rework (#4389)

One conflict, in `cost/index.tsx`. Upstream's reworked body was taken wholesale and the Waste section re-expressed in the new idiom; the panel itself was rewritten to the new design language rather than merely made to compile:

- `SectionHeading` → the new `Section` wrapper (`heading="Waste"`).
- `projectSlug` now from `project.slug`, not `Route.useParams()` — dropped my duplicate.
- Shared `EmptyState` (with an icon) instead of a hand-rolled centered message.
- `SplitValue` on the headline figures, so the `$` and `%` mute like every other value in the section.
- `Text.H3M` headline over a `Text.H6M` label, matching the per-session cards; `px-4 py-3` padding.
- Theme-aware bar colour via `useChartCssTheme()`, alongside `otherSeriesColor` for the remainder — the fixed `hsl()` literals are gone.
- `ChartHeader` with `showWindow={false}` + `titleColor="foregroundMuted"`, as its siblings now do.
- Drill-down restyled to the section's `ArrowUpRightIcon` + `group-hover:text-primary` affordance. Kept as a `<Link>` rather than adopting `useGoToModelSessions`' button+`useNavigate`, since it targets a different page and the web-frontend skill wants a real anchor there.

The share and its sample floor, the whole-trace decision, and the reason-rows-sum-to-headline invariant are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Waste section to project cost analytics.
  * Shows total wasted spend, its share of overall spend, and breakdowns by error reason.
  * Includes trace counts, proportional cost indicators, “Other reasons,” and links to filtered errored traces.
  * Supports loading and empty states across selected time ranges.

* **Bug Fixes**
  * Improved attribution to the earliest error in each trace.
  * Excludes non-billable tool-span costs from wasted-spend totals.

* **Tests**
  * Added coverage for calculations, thresholds, pricing availability, and zero-failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
