### PR TITLE
feat(agent-dispatch): accept webhook run metadata

### DIFF
--- a/dev-docs/agent-dispatch.md
+++ b/dev-docs/agent-dispatch.md
@@ -36,6 +36,11 @@ Packages:
 
 **MCP:** The dispatcher never mints or forwards Latitude MCP credentials. The customer's Cursor environment or Claude routine must already have MCP connected (OAuth, once, out of band).
 
+Webhook receivers can return a successful JSON acknowledgement with optional `externalAgentId`, `externalRunId`, and
+`deepLinkUrl` fields. The adapter records valid non-empty IDs and absolute HTTP(S) links through the same dispatch ledger
+path as the built-in adapters. Acknowledgement parsing is best-effort: empty, non-JSON, malformed, or partially invalid
+success responses remain accepted, and the configured webhook URL is the fallback deep link.
+
 ## Configuration
 
 Settings → Integrations:

--- a/docs/agent-dispatch/webhooks.mdx
+++ b/docs/agent-dispatch/webhooks.mdx
@@ -64,6 +64,24 @@ function verifyLatitudeSignature(rawBody: string, signatureHeader: string, secre
 
 Verify the signature against the raw request body before parsing JSON.
 
+## Return external run metadata
+
+A successful handler can return an optional JSON body that identifies the agent run it started:
+
+```json
+{
+  "externalAgentId": "agent-scope",
+  "externalRunId": "run_123",
+  "deepLinkUrl": "https://agents.example.com/runs/run_123"
+}
+```
+
+All fields are optional. IDs must be non-empty strings, and `deepLinkUrl` must be an absolute HTTP or HTTPS URL.
+Latitude records each valid field in dispatch history and uses `deepLinkUrl` as the link to the external run.
+
+An empty body, a non-JSON body, or invalid fields do not reject an otherwise successful dispatch. When the response does
+not include a valid `deepLinkUrl`, Latitude links to the configured webhook URL instead.
+
 ## Retry behavior
 
 Latitude retries transport failures, `429`, and `5xx` responses. A `4xx` response other than `429` is treated as a configuration or authentication failure and is not retried indefinitely.

--- a/packages/platform/agent-dispatch/package.json
+++ b/packages/platform/agent-dispatch/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@domain/agent-dispatch": "workspace:*",
-    "effect": "catalog:"
+    "effect": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "vitest": "catalog:"

--- a/packages/platform/agent-dispatch/src/adapters/webhook-adapter.test.ts
+++ b/packages/platform/agent-dispatch/src/adapters/webhook-adapter.test.ts
@@ -121,4 +121,39 @@ describe("createWebhookAdapter", () => {
 
     await expect(dispatchWebhook()).resolves.toEqual({ status: "accepted", deepLinkUrl: webhookUrl })
   })
+
+  it("discards metadata when the acknowledgement body exceeds the read limit", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ externalRunId: "run-123" }) + "x".repeat(64 * 1024), {
+            status: 202,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    )
+
+    await expect(dispatchWebhook()).resolves.toEqual({ status: "accepted", deepLinkUrl: webhookUrl })
+  })
+
+  it("discards metadata and cancels a response that never finishes", async () => {
+    let cancelled = false
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(JSON.stringify({ externalRunId: "run-123" })))
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 202 })),
+    )
+
+    await expect(dispatchWebhook()).resolves.toEqual({ status: "accepted", deepLinkUrl: webhookUrl })
+    await vi.waitFor(() => expect(cancelled).toBe(true))
+  })
 })

--- a/packages/platform/agent-dispatch/src/adapters/webhook-adapter.test.ts
+++ b/packages/platform/agent-dispatch/src/adapters/webhook-adapter.test.ts
@@ -62,8 +62,8 @@ describe("createWebhookAdapter", () => {
         async () =>
           new Response(
             JSON.stringify({
-              externalAgentId: "agent-scope",
-              externalRunId: "run-123",
+              externalAgentId: "  agent-scope  ",
+              externalRunId: "  run-123  ",
               deepLinkUrl: "https://agents.example.com/runs/run-123",
             }),
             { status: 202, headers: { "Content-Type": "application/json" } },

--- a/packages/platform/agent-dispatch/src/adapters/webhook-adapter.test.ts
+++ b/packages/platform/agent-dispatch/src/adapters/webhook-adapter.test.ts
@@ -1,8 +1,35 @@
 import { createHmac } from "node:crypto"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { createWebhookAdapter } from "./webhook-adapter.ts"
 
+const webhookUrl = "https://hooks.example.com/run"
+
+const dispatchWebhook = async () => {
+  const adapter = createWebhookAdapter(async () => ["8.8.8.8"])
+  const { Effect } = await import("effect")
+
+  return Effect.runPromise(
+    adapter.dispatch({
+      idempotencyKey: "webhook:incident.opened:src1",
+      prompt: "fix it",
+      context: {
+        trigger: "incident.opened",
+        organizationName: "Acme",
+        projectName: "App",
+        projectSlug: "app",
+        deepLinkUrl: "https://example.com",
+      },
+      config: { kind: "webhook", webhookUrl },
+      credential: { webhookSecret: "test-secret" },
+    }),
+  )
+}
+
 describe("createWebhookAdapter", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it("signs the payload with HMAC-SHA256", async () => {
     const secret = "test-secret"
     const calls: { headers: Headers; body: string }[] = []
@@ -18,26 +45,7 @@ describe("createWebhookAdapter", () => {
       }),
     )
 
-    const adapter = createWebhookAdapter(async () => ["8.8.8.8"])
-    const context = {
-      trigger: "incident.opened" as const,
-      organizationName: "Acme",
-      projectName: "App",
-      projectSlug: "app",
-      deepLinkUrl: "https://example.com",
-    }
-
-    await import("effect").then(({ Effect }) =>
-      Effect.runPromise(
-        adapter.dispatch({
-          idempotencyKey: "webhook:incident.opened:src1",
-          prompt: "fix it",
-          context,
-          config: { kind: "webhook", webhookUrl: "https://hooks.example.com/run" },
-          credential: { webhookSecret: secret },
-        }),
-      ),
-    )
+    await dispatchWebhook()
 
     expect(calls).toHaveLength(1)
     const call = calls[0]
@@ -45,7 +53,68 @@ describe("createWebhookAdapter", () => {
     const expectedSig = createHmac("sha256", secret).update(call.body).digest("hex")
     expect(call.headers.get("X-Latitude-Signature")).toBe(`sha256=${expectedSig}`)
     expect(call.headers.get("X-Latitude-Delivery")).toBe("webhook:incident.opened:src1")
+  })
 
-    vi.unstubAllGlobals()
+  it("returns external run metadata from a successful JSON acknowledgement", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              externalAgentId: "agent-scope",
+              externalRunId: "run-123",
+              deepLinkUrl: "https://agents.example.com/runs/run-123",
+            }),
+            { status: 202, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    )
+
+    await expect(dispatchWebhook()).resolves.toEqual({
+      status: "accepted",
+      externalAgentId: "agent-scope",
+      externalRunId: "run-123",
+      deepLinkUrl: "https://agents.example.com/runs/run-123",
+    })
+  })
+
+  it("keeps valid acknowledgement fields when other fields are invalid", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              externalAgentId: "agent-scope",
+              externalRunId: "   ",
+              deepLinkUrl: "javascript:alert(1)",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    )
+
+    await expect(dispatchWebhook()).resolves.toEqual({
+      status: "accepted",
+      externalAgentId: "agent-scope",
+      deepLinkUrl: webhookUrl,
+    })
+  })
+
+  it.each([
+    { name: "empty", response: () => new Response(null, { status: 204 }) },
+    { name: "plain-text", response: () => new Response("accepted", { status: 202 }) },
+    {
+      name: "malformed JSON",
+      response: () => new Response("{", { status: 200, headers: { "Content-Type": "application/json" } }),
+    },
+  ])("accepts a $name success response without metadata", async ({ response }) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response()),
+    )
+
+    await expect(dispatchWebhook()).resolves.toEqual({ status: "accepted", deepLinkUrl: webhookUrl })
   })
 })

--- a/packages/platform/agent-dispatch/src/adapters/webhook-adapter.test.ts
+++ b/packages/platform/agent-dispatch/src/adapters/webhook-adapter.test.ts
@@ -79,7 +79,11 @@ describe("createWebhookAdapter", () => {
     })
   })
 
-  it("keeps valid acknowledgement fields when other fields are invalid", async () => {
+  it.each([
+    "javascript:alert(1)",
+    "not a url",
+    "   ",
+  ])("keeps valid acknowledgement fields when the deep link %j is invalid", async (deepLinkUrl) => {
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -88,7 +92,7 @@ describe("createWebhookAdapter", () => {
             JSON.stringify({
               externalAgentId: "agent-scope",
               externalRunId: "   ",
-              deepLinkUrl: "javascript:alert(1)",
+              deepLinkUrl,
             }),
             { status: 200, headers: { "Content-Type": "application/json" } },
           ),

--- a/packages/platform/agent-dispatch/src/adapters/webhook-adapter.ts
+++ b/packages/platform/agent-dispatch/src/adapters/webhook-adapter.ts
@@ -12,8 +12,12 @@ const httpUrlSchema = z
   .trim()
   .url()
   .refine((value) => {
-    const protocol = new URL(value).protocol
-    return protocol === "http:" || protocol === "https:"
+    try {
+      const protocol = new URL(value).protocol
+      return protocol === "http:" || protocol === "https:"
+    } catch {
+      return false
+    }
   })
 
 const webhookAcknowledgementSchema = z.object({

--- a/packages/platform/agent-dispatch/src/adapters/webhook-adapter.ts
+++ b/packages/platform/agent-dispatch/src/adapters/webhook-adapter.ts
@@ -7,6 +7,9 @@ import { type HostLookup, resolvePublicWebhookUrl } from "../host-guard.ts"
 
 const signPayload = (secret: string, body: string): string => createHmac("sha256", secret).update(body).digest("hex")
 
+const WEBHOOK_ACK_MAX_BYTES = 64 * 1024
+const WEBHOOK_ACK_READ_TIMEOUT_MS = 1_000
+
 const httpUrlSchema = z
   .string()
   .trim()
@@ -29,6 +32,73 @@ const webhookAcknowledgementSchema = z.object({
 const parseWebhookAcknowledgement = (value: unknown) => {
   const parsed = webhookAcknowledgementSchema.safeParse(value)
   return parsed.success ? parsed.data : {}
+}
+
+const cancelReader = (reader: ReadableStreamDefaultReader<Uint8Array>): void => {
+  try {
+    void reader.cancel().catch(() => undefined)
+  } catch {}
+}
+
+const readWebhookAcknowledgement = (response: Response, signal: AbortSignal): Promise<unknown> => {
+  if (!response.body) return Promise.resolve(undefined)
+
+  const reader = response.body.getReader()
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let bytesRead = 0
+    const chunks: Uint8Array[] = []
+
+    const removeAbortListener = () => signal.removeEventListener("abort", onAbort)
+    const fail = (cause: unknown) => {
+      if (settled) return
+      settled = true
+      removeAbortListener()
+      cancelReader(reader)
+      reject(cause)
+    }
+    const onAbort = () => fail(new Error("webhook acknowledgement read interrupted"))
+
+    signal.addEventListener("abort", onAbort, { once: true })
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+
+    void (async () => {
+      try {
+        while (!settled) {
+          const { done, value } = await reader.read()
+          if (done) {
+            if (settled) return
+            const payload = new Uint8Array(bytesRead)
+            let offset = 0
+            for (const chunk of chunks) {
+              payload.set(chunk, offset)
+              offset += chunk.byteLength
+            }
+            resolve(JSON.parse(new TextDecoder().decode(payload)))
+            settled = true
+            removeAbortListener()
+            return
+          }
+
+          bytesRead += value.byteLength
+          if (bytesRead > WEBHOOK_ACK_MAX_BYTES) {
+            fail(new Error("webhook acknowledgement body exceeded the size limit"))
+            return
+          }
+          chunks.push(value)
+        }
+      } catch (cause) {
+        fail(cause)
+      } finally {
+        try {
+          reader.releaseLock()
+        } catch {}
+      }
+    })()
+  })
 }
 
 export const createWebhookAdapter = (lookupHost?: HostLookup): AgentDispatchAdapter => ({
@@ -89,7 +159,11 @@ export const createWebhookAdapter = (lookupHost?: HostLookup): AgentDispatchAdap
         return yield* Effect.fail(new DispatchAdapterError({ reason: "config", cause: detail || response.status }))
       }
 
-      const responseBody = yield* Effect.tryPromise(() => response.json() as Promise<unknown>).pipe(
+      const responseBody = yield* Effect.tryPromise((signal) => readWebhookAcknowledgement(response, signal)).pipe(
+        Effect.timeoutOrElse({
+          duration: WEBHOOK_ACK_READ_TIMEOUT_MS,
+          orElse: () => Effect.succeed(undefined),
+        }),
         Effect.orElseSucceed(() => undefined),
       )
       const acknowledgement = parseWebhookAcknowledgement(responseBody)

--- a/packages/platform/agent-dispatch/src/adapters/webhook-adapter.ts
+++ b/packages/platform/agent-dispatch/src/adapters/webhook-adapter.ts
@@ -2,9 +2,30 @@ import { createHmac } from "node:crypto"
 import type { AgentDispatchAdapter } from "@domain/agent-dispatch"
 import { DispatchAdapterError } from "@domain/agent-dispatch"
 import { Effect } from "effect"
+import { z } from "zod"
 import { type HostLookup, resolvePublicWebhookUrl } from "../host-guard.ts"
 
 const signPayload = (secret: string, body: string): string => createHmac("sha256", secret).update(body).digest("hex")
+
+const httpUrlSchema = z
+  .string()
+  .trim()
+  .url()
+  .refine((value) => {
+    const protocol = new URL(value).protocol
+    return protocol === "http:" || protocol === "https:"
+  })
+
+const webhookAcknowledgementSchema = z.object({
+  externalAgentId: z.string().trim().min(1).optional().catch(undefined),
+  externalRunId: z.string().trim().min(1).optional().catch(undefined),
+  deepLinkUrl: httpUrlSchema.optional().catch(undefined),
+})
+
+const parseWebhookAcknowledgement = (value: unknown) => {
+  const parsed = webhookAcknowledgementSchema.safeParse(value)
+  return parsed.success ? parsed.data : {}
+}
 
 export const createWebhookAdapter = (lookupHost?: HostLookup): AgentDispatchAdapter => ({
   kind: "webhook",
@@ -64,6 +85,16 @@ export const createWebhookAdapter = (lookupHost?: HostLookup): AgentDispatchAdap
         return yield* Effect.fail(new DispatchAdapterError({ reason: "config", cause: detail || response.status }))
       }
 
-      return { status: "accepted" as const, deepLinkUrl: target.webhookUrl }
+      const responseBody = yield* Effect.tryPromise(() => response.json() as Promise<unknown>).pipe(
+        Effect.orElseSucceed(() => undefined),
+      )
+      const acknowledgement = parseWebhookAcknowledgement(responseBody)
+
+      return {
+        status: "accepted" as const,
+        ...(acknowledgement.externalAgentId !== undefined ? { externalAgentId: acknowledgement.externalAgentId } : {}),
+        ...(acknowledgement.externalRunId !== undefined ? { externalRunId: acknowledgement.externalRunId } : {}),
+        deepLinkUrl: acknowledgement.deepLinkUrl ?? target.webhookUrl,
+      }
     }),
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2261,6 +2261,9 @@ importers:
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.57
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       vitest:
         specifier: 'catalog:'


### PR DESCRIPTION
## What does this PR do?

Accepts optional JSON metadata returned by successful agent dispatch webhooks:

- `externalAgentId`
- `externalRunId`
- `deepLinkUrl`

Each field is validated independently. IDs are trimmed and must be non-empty; `deepLinkUrl` must be an absolute HTTP(S) URL. Empty, non-JSON, malformed, or partially invalid response bodies do not turn a successful dispatch into a failure. When no valid link is returned, Latitude continues using the configured webhook URL.

This lets custom receivers correlate Latitude dispatch records with the external agent run they start and link operators directly to that run. The response contract is documented in the public webhook guide and the agent dispatch developer documentation.

## Related issue (if applicable)

Closes #4368

## How was this tested?

- `pnpm --filter @platform/agent-dispatch check`
- `pnpm --filter @platform/agent-dispatch typecheck`
- `pnpm --filter @platform/agent-dispatch test` (5 files, 21 tests)
- `pnpm check` (88 tasks)
- `pnpm typecheck` (92 tasks)
- `pnpm knip`
- `git diff --check`

A full `pnpm test` run completed 80 of 87 workspace tasks. `@app/workers` could not load the local `chdb_node.node` native binding, and two PGlite setup hooks timed out. Building the required binding with `pnpm --filter @platform/testkit chdb:build` was attempted, but the GitHub release asset remained at 0 bytes in this environment.

## Checklist

- [ ] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook responses can include external agent and run identifiers.
  * Valid deep links are recorded with dispatch history; the configured webhook URL is used when no valid link is provided.
  * Missing, empty, malformed, oversized, or partially invalid acknowledgement responses remain successful.
  * Webhook acknowledgement processing handles slow or interrupted responses without blocking indefinitely.

* **Documentation**
  * Added guidance on supported acknowledgement fields, validation, recording, fallback behavior, and response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->