### PR TITLE
fix(experiments): keep period popover above comparison metrics

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/comparison-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/comparison-table.tsx
@@ -687,6 +687,7 @@ function VariantTimeRangePicker({
       selectedPresetId={selectedPresetId}
       placeholder="Select range"
       clearLabel="Reset to default"
+      portalTarget="body"
       fullWidth
       onChange={({ range, source, presetId }) => {
         if (source === "clear" || !range) {

--- a/packages/ui/src/components/date-range-picker/date-range-picker.test.tsx
+++ b/packages/ui/src/components/date-range-picker/date-range-picker.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { DateRangePicker } from "./date-range-picker.tsx"
+
+const mountedRoots: Array<{ root: ReturnType<typeof createRoot>; host: HTMLDivElement }> = []
+
+async function renderOpenPicker(portalTarget?: "local" | "body") {
+  const host = document.createElement("div")
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  mountedRoots.push({ root, host })
+
+  await act(async () => {
+    root.render(
+      <DateRangePicker
+        value={undefined}
+        selectedPresetId={undefined}
+        {...(portalTarget ? { portalTarget } : {})}
+        onChange={() => undefined}
+      />,
+    )
+  })
+
+  const wrapper = host.firstElementChild
+  const trigger = wrapper?.querySelector("button")
+  expect(wrapper).toBeInstanceOf(HTMLDivElement)
+  expect(trigger).toBeInstanceOf(HTMLButtonElement)
+
+  await act(async () => {
+    trigger?.click()
+  })
+
+  const popover = document.querySelector('[data-state="open"][data-side]')
+  expect(popover).toBeInstanceOf(HTMLDivElement)
+
+  return { popover: popover as HTMLDivElement, wrapper: wrapper as HTMLDivElement }
+}
+
+afterEach(async () => {
+  for (const { root, host } of mountedRoots.splice(0)) {
+    await act(async () => root.unmount())
+    host.remove()
+  }
+})
+
+describe("DateRangePicker portal target", () => {
+  it("renders the popover under the local wrapper by default", async () => {
+    const { popover, wrapper } = await renderOpenPicker()
+
+    expect(wrapper.contains(popover)).toBe(true)
+  })
+
+  it("renders the popover under document.body outside the local wrapper", async () => {
+    const { popover, wrapper } = await renderOpenPicker("body")
+
+    expect(document.body.contains(popover)).toBe(true)
+    expect(wrapper.contains(popover)).toBe(false)
+  })
+})

--- a/packages/ui/src/components/date-range-picker/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker/date-range-picker.tsx
@@ -35,6 +35,7 @@ interface DateRangePickerProps {
   readonly clearLabel?: string
   readonly disabled?: boolean
   readonly align?: "start" | "center" | "end"
+  readonly portalTarget?: "local" | "body"
   /** Fill the available width, pushing the chevron to the far end (defaults to sizing to content). */
   readonly fullWidth?: boolean
   readonly onChange: (change: DateRangePickerChange) => void
@@ -212,13 +213,13 @@ export function DateRangePicker({
   clearLabel = "Clear dates",
   disabled = false,
   align = "start",
+  portalTarget = "local",
   fullWidth = false,
   onChange,
 }: DateRangePickerProps) {
   const [open, setOpen] = useState(false)
   const [draftRange, setDraftRange] = useState<DateRange | undefined>(() => copyRange(value))
-  // Portal target next to the trigger, as in Select: body-portaled content inside a modal sits
-  // outside the dialog's pointer-events/focus scope and becomes non-interactive.
+  // Local portals stay within modal interaction scopes; body portals escape ancestor stacking and overflow contexts.
   const [popoverContainer, setPopoverContainer] = useState<HTMLDivElement | null>(null)
 
   const selection = formatSelectionLabel({
@@ -300,7 +301,7 @@ export function DateRangePicker({
           </Button>
         </PopoverTrigger>
         <PopoverContent
-          container={popoverContainer ?? undefined}
+          container={portalTarget === "local" ? (popoverContainer ?? undefined) : undefined}
           align={align}
           className="w-[min(100vw-2rem,360px)] p-0 sm:w-auto"
         >


### PR DESCRIPTION
## What does this PR do?

<!-- Briefly describe the change for a reviewer with no prior context. -->

Adds an explicit portal target to the shared `DateRangePicker` while preserving its modal-safe local portal by default.

The experiment period picker uses a body-level portal so the calendar escapes the comparison table's sticky stacking and overflow contexts. This prevents metric cards from covering or clipping the popover.

Adds regression coverage for both portal targets.

## Related issue (if applicable)

Closes #4376

## How was this tested?

- Ran `pnpm check`
- Added jsdom tests covering the default local portal and opt-in body portal.
- Manually verified on the dev server that the experiment period popover remains fully visible above the comparison metrics.

<!-- Describe the tests you ran or the steps to verify the change. -->

| Before | After |
| ------ | ------ |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/86de7595-7d8b-4ad8-9aff-2e3b720f0fd2" /> | <img width="300" alt="Screenshot 2026-08-06 at 14 42 29@2x" src="https://github.com/user-attachments/assets/2acd4d0e-8872-478f-9daf-fc68c8c404d5" /> |


## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date range pickers can now render their popover content directly under the document body, improving display in constrained layouts.
  * Existing behavior remains unchanged by default, with popovers rendered locally.

* **Bug Fixes**
  * Improved date range picker positioning and layering in experiment comparison views.

* **Tests**
  * Added coverage verifying both local and body-level popover rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->