### PR TITLE
fix(models): resolve version-punctuation variants in cost lookup

### DIFF
--- a/packages/domain/models/src/registry.test.ts
+++ b/packages/domain/models/src/registry.test.ts
@@ -70,6 +70,36 @@ describe("findModel", () => {
   it("returns undefined when no prefix matches either", () => {
     expect(findModel(mockModels, "totally-different")).toBeUndefined()
   })
+
+  it("matches a version whose separator differs from the catalog key", () => {
+    const models: Model[] = [{ id: "claude-opus-4-8", name: "Claude Opus 4.8", provider: "anthropic" }]
+    // Claude Code reports the version with a dot; the catalog keys it with a dash.
+    expect(findModel(models, "claude-opus-4.8")?.id).toBe("claude-opus-4-8")
+  })
+
+  it("matches version punctuation in the other direction too", () => {
+    const models: Model[] = [{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }]
+    // Reported with a dash, catalog keyed with a dot.
+    expect(findModel(models, "gpt-4-1")?.id).toBe("gpt-4.1")
+  })
+
+  it("does not let a punctuation collapse pick between two different entries", () => {
+    const models: Model[] = [
+      { id: "claude-3-5-haiku", name: "Claude 3.5 Haiku", provider: "anthropic" },
+      { id: "claude-3.5-haiku", name: "Claude 3.5 Haiku (dup)", provider: "anthropic" },
+    ]
+    // Both normalise to the same form; an exact hit still resolves, an ambiguous one does not.
+    expect(findModel(models, "claude-3.5-haiku")?.id).toBe("claude-3.5-haiku")
+    expect(findModel(models, "claude-3-6-haiku")).toBeUndefined()
+  })
+
+  it("requires the whole normalised id to match, not just the version", () => {
+    const models: Model[] = [{ id: "gpt-5-3-instant", name: "GPT-5.3 Instant", provider: "openai" }]
+    // Normalising the version is not enough on its own: the rest of the id must still line up, so a
+    // different qualifier does not borrow this entry's price.
+    expect(findModel(models, "gpt-5.4-instant")).toBeUndefined()
+    expect(findModel(models, "gpt-5.3-instant")?.id).toBe("gpt-5-3-instant")
+  })
 })
 
 describe("getModelPricing", () => {

--- a/packages/domain/models/src/registry.ts
+++ b/packages/domain/models/src/registry.ts
@@ -77,21 +77,45 @@ export function getAllModels(): Model[] {
 }
 
 /**
+ * Providers spell a version with a different separator than models.dev keys it. Claude Code reports
+ * `claude-opus-4.8`; the catalog keys the same model `claude-opus-4-8`. Canonicalise a version dot
+ * (a `.` sitting between two digits) to a `-` so the two spellings of one version collapse to a
+ * single form. The lookahead keeps consecutive separators (`4.8.1`) all converting. This only ever
+ * rewrites punctuation inside a version, never a letter or a word, so it cannot rename the model.
+ */
+const VERSION_DOT_RE = /(\d)\.(?=\d)/g
+
+function normalizeVersionPunctuation(id: string): string {
+  return id.replace(VERSION_DOT_RE, "$1-")
+}
+
+/**
  * Find a model by ID (case-insensitive) with prefix fallback.
  *
- * First tries an exact match; if none is found, falls back to the
- * model whose ID is the longest prefix of the requested `modelId`.
+ * First tries an exact match; then a version-punctuation match, so an id that differs from its
+ * catalog key only in how a version is separated (`claude-opus-4.8` vs `claude-opus-4-8`) still
+ * resolves; then falls back to the model whose ID is the longest prefix of the requested `modelId`.
  * Useful for versioned model names like `gpt-4.1-2025-04-14` matching `gpt-4.1`.
  *
- * The fallback stops at a `:` modifier (`:free`, `:thinking`, a context size), which selects a
- * variant the catalog lists and prices separately. Matching past one would answer with the
- * unmodified model, and a free tier would come back at the paid rate.
+ * The punctuation match requires a single candidate: collapsing a dot must never pick between two
+ * genuinely different entries. The prefix fallback stops at a `:` modifier (`:free`, `:thinking`, a
+ * context size), which selects a variant the catalog lists and prices separately. Matching past one
+ * would answer with the unmodified model, and a free tier would come back at the paid rate.
  */
 export function findModel(models: Model[], modelId: string): Model | undefined {
   const needle = modelId.toLowerCase()
 
   const exact = models.find((m) => m.id.toLowerCase() === needle)
   if (exact) return exact
+
+  // Same version, different punctuation. Match on the normalised form so `claude-opus-4.8` finds the
+  // catalog's `claude-opus-4-8` (and the reverse), but only when exactly one entry normalises to it,
+  // so a punctuation-only collapse can never resolve one model to a different one.
+  const normalizedNeedle = normalizeVersionPunctuation(needle)
+  const punctuationMatches = models.filter(
+    (m) => normalizeVersionPunctuation(m.id.toLowerCase()) === normalizedNeedle,
+  )
+  if (punctuationMatches.length === 1) return punctuationMatches[0]
 
   let best: Model | undefined
   let bestLen = 0

--- a/packages/domain/models/src/registry.ts
+++ b/packages/domain/models/src/registry.ts
@@ -112,9 +112,7 @@ export function findModel(models: Model[], modelId: string): Model | undefined {
   // catalog's `claude-opus-4-8` (and the reverse), but only when exactly one entry normalises to it,
   // so a punctuation-only collapse can never resolve one model to a different one.
   const normalizedNeedle = normalizeVersionPunctuation(needle)
-  const punctuationMatches = models.filter(
-    (m) => normalizeVersionPunctuation(m.id.toLowerCase()) === normalizedNeedle,
-  )
+  const punctuationMatches = models.filter((m) => normalizeVersionPunctuation(m.id.toLowerCase()) === normalizedNeedle)
   if (punctuationMatches.length === 1) return punctuationMatches[0]
 
   let best: Model | undefined


### PR DESCRIPTION
Fixes #4298.

## Problem

`findModel` tries an exact match, then a longest-prefix fallback. Neither bridges a version separator, so a model id that differs from its catalog key only in how the version is punctuated goes unpriced. The production case is `claude-opus-4.8` (reported by Claude Code) against the catalog key `claude-opus-4-8`: exact match fails on `.` vs `-`, and the prefix fallback only reaches `claude-opus-4`, which no catalog entry keys. The span records zero cost for a model we have the exact rate for.

## Fix

A third tier in `findModel`, between exact match and the prefix fallback: canonicalise a version dot (a `.` between two digits) to a `-`, then match on the normalised form. `claude-opus-4.8` and the catalog's `claude-opus-4-8` collapse to one string and resolve; it works in the other direction too (`gpt-4-1` finding `gpt-4.1`).

Two guards keep this from repricing one model as another, the failure mode #4293 warned about:

- The whole normalised id must match, not just the version. `gpt-5.3-instant` does not become `gpt-5`; a trailing-word difference still misses.
- A single candidate is required. If two entries normalise to the same form, the lookup does not guess.

Only punctuation inside a version is rewritten, never a letter or a word, so the named model never changes.

## Blast radius

Measured against the bundled `models.dev.json` (175 providers, 5891 models), since `findModel` runs on a provider-scoped list:

- 2531 catalog ids carry a version dot, so they become reachable from a dash-spelled report (and vice versa).
- Normalising every id within its provider produces exactly one collision of two distinct ids: `cloudflare-ai-gateway` lists both `anthropic/claude-3.5-haiku` and `anthropic/claude-3-5-haiku`. Both are exact entries, so exact match resolves either spelling before the punctuation tier runs, and a novel ambiguous id (e.g. `claude-3-6-haiku`) returns undefined rather than picking one. No id resolves to a different model.

## Tests

`registry.test.ts` covers the production case, the reverse direction, the ambiguous-collision guard, and the whole-id requirement. Existing exact / prefix-fallback / vendor-prefix tests are unchanged and still pass.

## Out of scope

The ticket also notes `claude-opus-4-8 (1M)` pricing at the standard-context rate via the prefix fallback. That is a trailing-qualifier question in the prefix path, not a punctuation one, so it does not fall out of this change and is left alone here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model lookup by treating equivalent dot- and dash-separated version formats consistently.
  * Exact model ID matches now take precedence over normalized matches.
  * Prevented ambiguous or incomplete IDs from returning an incorrect model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->