### PR TITLE
fix(ci): exempt Dependabot from CLA checks

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,4 +27,4 @@ jobs:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/latitude-dev/latitude-llm/blob/latitude-v1/cla.md
           branch: signatures
-          allowlist: geclos,cesr,csansoon,andresgutgon,neoxelox,claude,cursoragent
+          allowlist: geclos,cesr,csansoon,andresgutgon,neoxelox,claude,cursoragent,dependabot[bot]


### PR DESCRIPTION
Dependabot pull requests fail the CLA check because the workflow evaluates the bot-authored dependency commit, but the bot cannot sign the CLA.

This adds the exact `dependabot[bot]` identity to the existing allowlist. Other contributors remain subject to the CLA check.

Validated by the pre-commit hook: `pnpm check`, `pnpm typecheck`, and `pnpm knip`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contribution checks to recognize automated dependency update submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->