### PR TITLE
fix(agent-dispatch): classify all host-guard webhook failures as config errors

### DIFF
--- a/packages/platform/agent-dispatch/src/adapters/webhook-adapter.test.ts
+++ b/packages/platform/agent-dispatch/src/adapters/webhook-adapter.test.ts
@@ -1,6 +1,21 @@
 import { createHmac } from "node:crypto"
+import { DispatchAdapterError } from "@domain/agent-dispatch"
+import { Effect } from "effect"
 import { describe, expect, it, vi } from "vitest"
 import { createWebhookAdapter } from "./webhook-adapter.ts"
+
+const baseInput = {
+  idempotencyKey: "webhook:incident.opened:src1",
+  prompt: "fix it",
+  context: {
+    trigger: "incident.opened" as const,
+    organizationName: "Acme",
+    projectName: "App",
+    projectSlug: "app",
+    deepLinkUrl: "https://example.com",
+  },
+  credential: { webhookSecret: "test-secret" },
+}
 
 describe("createWebhookAdapter", () => {
   it("signs the payload with HMAC-SHA256", async () => {
@@ -47,5 +62,28 @@ describe("createWebhookAdapter", () => {
     expect(call.headers.get("X-Latitude-Delivery")).toBe("webhook:incident.opened:src1")
 
     vi.unstubAllGlobals()
+  })
+
+  describe("host-guard rejections", () => {
+    it.each([
+      ["malformed URL", "not-a-url", async () => ["8.8.8.8"]],
+      ["non-https URL", "http://hooks.example.com/run", async () => ["8.8.8.8"]],
+      ["unresolvable host", "https://hooks.example.com/run", async () => []],
+      ["host resolving to a private IP", "https://hooks.example.com/run", async () => ["127.0.0.1"]],
+    ] as const)("classifies %s as a config error, not a retryable transport error", async (_case, webhookUrl, lookupHost) => {
+      const adapter = createWebhookAdapter(lookupHost)
+
+      const error = await Effect.runPromise(
+        adapter
+          .dispatch({
+            ...baseInput,
+            config: { kind: "webhook", webhookUrl },
+          })
+          .pipe(Effect.flip),
+      )
+
+      expect(error).toBeInstanceOf(DispatchAdapterError)
+      expect((error as DispatchAdapterError).reason).toBe("config")
+    })
   })
 })

--- a/packages/platform/agent-dispatch/src/adapters/webhook-adapter.ts
+++ b/packages/platform/agent-dispatch/src/adapters/webhook-adapter.ts
@@ -16,13 +16,12 @@ export const createWebhookAdapter = (lookupHost?: HostLookup): AgentDispatchAdap
         return yield* Effect.fail(new DispatchAdapterError({ reason: "config", cause: "missing webhook secret" }))
       }
 
+      // Every resolvePublicWebhookUrl failure (bad URL, non-https, DNS failure, private-IP target) is a
+      // deterministic property of the stored webhookUrl, not a network blip — always "config" so
+      // send-agent-dispatch.ts acknowledges it instead of retrying a permanently-broken URL.
       const url = yield* Effect.tryPromise({
         try: () => resolvePublicWebhookUrl(target.webhookUrl, lookupHost),
-        catch: (cause) =>
-          new DispatchAdapterError({
-            reason: cause instanceof Error && cause.message.startsWith("webhook_") ? "config" : "transport",
-            cause,
-          }),
+        catch: (cause) => new DispatchAdapterError({ reason: "config", cause }),
       })
 
       const body = JSON.stringify({ trigger: context.trigger, context, prompt })

--- a/packages/platform/agent-dispatch/src/host-guard.test.ts
+++ b/packages/platform/agent-dispatch/src/host-guard.test.ts
@@ -27,4 +27,14 @@ describe("resolvePublicWebhookUrl", () => {
       "webhook_host_resolved_to_non_public_ip",
     )
   })
+
+  it("rejects malformed webhook URLs", async () => {
+    await expect(resolvePublicWebhookUrl("not-a-url")).rejects.toThrow("invalid_webhook_url")
+  })
+
+  it("rejects hosts that fail DNS resolution", async () => {
+    await expect(resolvePublicWebhookUrl("https://hooks.example.com/run", async () => [])).rejects.toThrow(
+      "dns_resolution_failed",
+    )
+  })
 })


### PR DESCRIPTION
## What does this PR do?

Fixes a misclassification bug in the webhook agent-dispatch adapter that causes permanently-broken webhook configs to be retried as if they were transient network failures.

**Datadog issue addressed:** [`DispatchAdapterError: Agent dispatch adapter failed (transport)`](https://app.datadoghq.eu/error-tracking/issue/a1ed690a-82c8-11f1-8874-da7ad0900005) (9 occurrences in the last 7 days, `workers` service).

This issue already carries a prior triage comment (2026-07-20) that classified the *reported* occurrences as Class B (genuine transient network failures reaching a customer's webhook — correctly not a bug). That same comment flagged an adjacent, not-yet-fixed bug it found while investigating, which is what this PR fixes.

**Root cause:** `resolvePublicWebhookUrl` (`packages/platform/agent-dispatch/src/host-guard.ts:47-68`) throws four distinct `Error` messages for four validation failures: `invalid_webhook_url`, `webhook_url_not_https`, `dns_resolution_failed`, and `webhook_host_resolved_to_non_public_ip`. All four are deterministic for a given static `webhookUrl` — retrying won't help any of them.

The adapter's catch handler (`packages/platform/agent-dispatch/src/adapters/webhook-adapter.ts:20-26`, pre-fix) classified these via `cause.message.startsWith("webhook_")`, which only matches 2 of the 4 messages. `invalid_webhook_url` and `dns_resolution_failed` fell through to `reason: "transport"`, which `send-agent-dispatch.ts`'s `isAckError` (and the BullMQ retry logic in `apps/workers/src/workers/agent-dispatch.ts`) treats as retryable — wasting `SEND_JOB_ATTEMPTS` retries (with exponential backoff) on a webhook URL that can never succeed, instead of failing fast like the other two cases already do.

**Fix:** since `resolvePublicWebhookUrl`'s only failure modes are these four static-validation cases (real network failures are a separate `fetch()` call further down that already correctly uses `reason: "transport"`), the catch handler now unconditionally maps any `resolvePublicWebhookUrl` failure to `reason: "config"`, instead of pattern-matching on message text.

## Related issue (if applicable)

Closes #

## How was this tested?

- Added `host-guard.test.ts` coverage for the two previously-untested failure modes (`invalid_webhook_url`, `dns_resolution_failed`).
- Added a parametrized `webhook-adapter.test.ts` suite exercising all four host-guard failure modes end-to-end through `createWebhookAdapter(...).dispatch(...)`, asserting `DispatchAdapterError.reason === "config"` for each. Confirmed the two previously-broken cases (`invalid_webhook_url`, `dns_resolution_failed`) fail against the pre-fix code (`reason: "transport"`) and pass after the fix.
- `pnpm --filter @platform/agent-dispatch test` — 22/22 passing.
- `pnpm --filter @platform/agent-dispatch typecheck` (tsgo) — clean.
- `pnpm exec biome check` on changed files — clean.

**Verification in production:** after deploy, no new occurrences of this issue should have `reason: "transport"` originate from a `resolvePublicWebhookUrl` failure (distinguishable by cross-referencing dispatch job retry counts — a config-classified failure is acknowledged on the first attempt).

**Remaining risk:** low — single-file behavioral change, scoped to one call site with no other callers of `resolvePublicWebhookUrl`, full test coverage of all four failure modes, and the classification change only affects retry behavior (fail-fast vs. retry-then-fail), not dispatch success paths.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_019SnWVFNEcWWAZm9CUzRUE3)_