### PR TITLE
Resolves LAT-JKIP: keep profanity out of extracted agent context

### DIFF
--- a/packages/domain/flaggers/src/flagger-strategies/nsfw.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/nsfw.ts
@@ -1,9 +1,11 @@
 import type { FlaggerConversation } from "../conversation.ts"
 import {
+  EXPLICIT_PROFANITY_PATTERN_SOURCE,
   extractTextOnlyMessages,
   MAX_SNIPPET_EXCERPT_LENGTH,
   MAX_STAGES_PER_PROMPT,
   MAX_SUSPICIOUS_SNIPPETS,
+  SLUR_PATTERN_SOURCE,
   type SuspiciousSnippet,
   truncateExcerpt,
 } from "./shared.ts"
@@ -91,8 +93,8 @@ export function extractNsfwSuspiciousSnippets(
 
   // Profanity/obscenity patterns
   const explicitPatterns = [
-    { pattern: /\b(?:fuck|shit|bitch|damn|asshole|cunt|dick|cock|pussy)\b/i, reason: "explicit profanity" },
-    { pattern: /\b(?:nigger|faggot|retard|kike|chink|spic|wetback)\b/i, reason: "hate speech/slur" },
+    { pattern: new RegExp(EXPLICIT_PROFANITY_PATTERN_SOURCE, "i"), reason: "explicit profanity" },
+    { pattern: new RegExp(SLUR_PATTERN_SOURCE, "i"), reason: "hate speech/slur" },
   ]
 
   // Sexual content patterns

--- a/packages/domain/flaggers/src/flagger-strategies/shared.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/shared.ts
@@ -8,6 +8,9 @@ export {
   MAX_SUSPICIOUS_SNIPPETS,
 } from "../constants.ts"
 
+export const EXPLICIT_PROFANITY_PATTERN_SOURCE = String.raw`\b(?:fuck|shit|bitch|damn|asshole|cunt|dick|cock|pussy)\b`
+export const SLUR_PATTERN_SOURCE = String.raw`\b(?:nigger|faggot|retard|kike|chink|spic|wetback)\b`
+
 // ---------------------------------------------------------------------------
 // SuspiciousSnippet - shared shape for snippet-based detection
 // ---------------------------------------------------------------------------

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -435,6 +435,10 @@ describe("runFlaggerUseCase", () => {
     expect(calls.generate).toHaveLength(2)
     expect(calls.generate[0]).toMatchObject(FLAGGER_DEFAULT_INSTRUCTION_EXTRACTOR_MODEL)
     expect(calls.generate[0].system).toContain("You extract agent context")
+    // Customer persona lines with profanity were copied verbatim into
+    // agentContext; the extractor must paraphrase crude wording professionally.
+    expect(calls.generate[0].system).toContain("Never reproduce profanity")
+    expect(calls.generate[0].system).toContain("neutral, professional wording")
     expect(calls.generate[1].prompt).toContain("EVALUATED AGENT CONTEXT")
     expect(calls.generate[1].prompt).toContain("dashboard design assistant")
     expect(calls.generate[1].prompt).not.toContain("Detailed rubric")
@@ -528,7 +532,7 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
 
   it("uses cached long-prompt extraction results", async () => {
     const longSystemPrompt = `You are a dashboard design assistant. ${"Detailed rubric. ".repeat(400)}`
-    const cacheKey = `org:${INPUT.organizationId}:flaggers:inspected-agent-context:v2:sha256:${createHash("sha256").update(normalizeSystemPromptForCacheKey(longSystemPrompt)).digest("hex")}`
+    const cacheKey = `org:${INPUT.organizationId}:flaggers:inspected-agent-context:v3:sha256:${createHash("sha256").update(normalizeSystemPromptForCacheKey(longSystemPrompt)).digest("hex")}`
     const cache = createMemoryCacheLayer(
       new Map([
         [
@@ -669,10 +673,10 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
   })
 
   const buildIndexKey = (organizationId: string, projectId: string) =>
-    `org:${organizationId}:flaggers:inspected-agent-context:v2:index:${projectId}`
+    `org:${organizationId}:flaggers:inspected-agent-context:v3:index:${projectId}`
 
   const buildContentKey = (organizationId: string, systemPrompt: string) =>
-    `org:${organizationId}:flaggers:inspected-agent-context:v2:sha256:${createHash("sha256").update(normalizeSystemPromptForCacheKey(systemPrompt)).digest("hex")}`
+    `org:${organizationId}:flaggers:inspected-agent-context:v3:sha256:${createHash("sha256").update(normalizeSystemPromptForCacheKey(systemPrompt)).digest("hex")}`
 
   const buildRephrasedSupportPrompt = (variant: "a" | "b") => {
     const intro =

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -489,6 +489,46 @@ describe("runFlaggerUseCase", () => {
     expect(cachedWrite?.value).not.toContain("shit")
   })
 
+  it("masks profanity the extractor echoes into reasonIfNotUnderstood before caching", async () => {
+    const longSystemPrompt = `Disconnected persona fragments only. ${"fragment ".repeat(700)}`
+    const cache = createMemoryCacheLayer()
+    const { layer: aiLayer } = createFakeAI({
+      generate: <T>() =>
+        Effect.succeed({
+          object: {
+            understood: false,
+            agentContext: "",
+            reasonIfNotUnderstood: 'Only persona fragments like "gets shit done" appear; no task is defined.',
+          } as T,
+          tokens: 20,
+          duration: 90_000_000,
+        }),
+    })
+
+    const result = await Effect.runPromise(
+      classifyTraceForFlaggerUseCase({
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        traceId: INPUT.traceId,
+        flaggerSlug: "laziness",
+        trace: makeTraceDetail(
+          [
+            { role: "user", parts: [{ type: "text", content: "Please do the work." }] },
+            { role: "assistant", parts: [{ type: "text", content: "Maybe later." }] },
+          ],
+          [],
+          [{ type: "text", content: longSystemPrompt }],
+        ),
+      }).pipe(Effect.provide(Layer.mergeAll(aiLayer, cache.layer))),
+    )
+
+    expect(result).toEqual({ matched: false })
+    const contentKey = buildContentKey(INPUT.organizationId, longSystemPrompt)
+    const cachedWrite = cache.writes.find((write) => write.key === contentKey)
+    expect(cachedWrite?.value).toContain("[redacted]")
+    expect(cachedWrite?.value).not.toContain("shit")
+  })
+
   it("falls back to prompt excerpts when the extractor returns understood=true without context", async () => {
     const longSystemPrompt = `
 <identity>

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -435,13 +435,58 @@ describe("runFlaggerUseCase", () => {
     expect(calls.generate).toHaveLength(2)
     expect(calls.generate[0]).toMatchObject(FLAGGER_DEFAULT_INSTRUCTION_EXTRACTOR_MODEL)
     expect(calls.generate[0].system).toContain("You extract agent context")
-    // Customer persona lines with profanity were copied verbatim into
-    // agentContext; the extractor must paraphrase crude wording professionally.
     expect(calls.generate[0].system).toContain("Never reproduce profanity")
     expect(calls.generate[0].system).toContain("neutral, professional wording")
     expect(calls.generate[1].prompt).toContain("EVALUATED AGENT CONTEXT")
     expect(calls.generate[1].prompt).toContain("dashboard design assistant")
     expect(calls.generate[1].prompt).not.toContain("Detailed rubric")
+  })
+
+  it("masks profanity the extractor echoes into agentContext before caching and classification", async () => {
+    const longSystemPrompt = `You are a recruiting assistant. ${"Detailed persona and tooling rules. ".repeat(200)}`
+    const cache = createMemoryCacheLayer()
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>(input: GenerateInput<T>) => {
+        if (input.system.includes("You extract agent context")) {
+          return Effect.succeed({
+            object: {
+              understood: true,
+              agentContext: "The agent is a recruiting assistant that is sharp, capable, and gets shit done.",
+            } as T,
+            tokens: 20,
+            duration: 90_000_000,
+          })
+        }
+
+        return Effect.succeed({ object: { matched: false } as T, tokens: 20, duration: 90_000_000 })
+      },
+    })
+
+    const result = await Effect.runPromise(
+      classifyTraceForFlaggerUseCase({
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        traceId: INPUT.traceId,
+        flaggerSlug: "laziness",
+        trace: makeTraceDetail(
+          [
+            { role: "user", parts: [{ type: "text", content: "Find candidates for this role." }] },
+            { role: "assistant", parts: [{ type: "text", content: "Here is a shortlist." }] },
+          ],
+          [],
+          [{ type: "text", content: longSystemPrompt }],
+        ),
+      }).pipe(Effect.provide(Layer.mergeAll(aiLayer, cache.layer))),
+    )
+
+    expect(result).toEqual({ matched: false })
+    expect(calls.generate[1].prompt).toContain("gets [redacted] done")
+    expect(calls.generate[1].prompt).not.toContain("shit")
+
+    const contentKey = buildContentKey(INPUT.organizationId, longSystemPrompt)
+    const cachedWrite = cache.writes.find((write) => write.key === contentKey)
+    expect(cachedWrite?.value).toContain("[redacted]")
+    expect(cachedWrite?.value).not.toContain("shit")
   })
 
   it("falls back to prompt excerpts when the extractor returns understood=true without context", async () => {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -252,15 +252,20 @@ const instructionExtractorOutputSchema = z
 type InstructionExtractorOutput = z.infer<typeof instructionExtractorOutputSchema>
 
 // Mask rather than reject a crude extraction: rejection would skip the flagger for the whole trace.
-const disallowedAgentContextWordingPattern = new RegExp(
+const disallowedExtractionWordingPattern = new RegExp(
   `${EXPLICIT_PROFANITY_PATTERN_SOURCE}|${SLUR_PATTERN_SOURCE}`,
   "gi",
 )
 
-const maskDisallowedAgentContextWording = (result: InstructionExtractorOutput): InstructionExtractorOutput =>
-  result.agentContext
-    ? { ...result, agentContext: result.agentContext.replace(disallowedAgentContextWordingPattern, "[redacted]") }
-    : result
+const maskDisallowedWording = (text: string): string => text.replace(disallowedExtractionWordingPattern, "[redacted]")
+
+const maskDisallowedExtractionWording = (result: InstructionExtractorOutput): InstructionExtractorOutput => ({
+  ...result,
+  agentContext: maskDisallowedWording(result.agentContext),
+  ...(result.reasonIfNotUnderstood === undefined
+    ? {}
+    : { reasonIfNotUnderstood: maskDisallowedWording(result.reasonIfNotUnderstood) }),
+})
 
 type InspectedAgentContext =
   | { readonly available: true; readonly text: string }
@@ -587,7 +592,7 @@ function runInstructionExtraction(input: {
                 }),
             }),
           ),
-          Effect.map(maskDisallowedAgentContextWording),
+          Effect.map(maskDisallowedExtractionWording),
           Effect.tap((result) => setCachedExtraction(input.cacheKey, result)),
           Effect.tap((result) =>
             result.understood

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -179,7 +179,7 @@ const annotationReviewOutputSchema = z.object({
 
 const INSPECTED_AGENT_EXTRACTED_TRUE_TTL_SECONDS = 30 * 24 * 60 * 60
 const INSPECTED_AGENT_EXTRACTED_FALSE_TTL_SECONDS = 24 * 60 * 60
-const INSPECTED_AGENT_CONTEXT_CACHE_VERSION = 2
+const INSPECTED_AGENT_CONTEXT_CACHE_VERSION = 3
 const INSPECTED_AGENT_CONTEXT_CACHE_BASE = `flaggers:inspected-agent-context:v${INSPECTED_AGENT_CONTEXT_CACHE_VERSION}`
 const INSPECTED_AGENT_CONTEXT_CACHE_PREFIX = `${INSPECTED_AGENT_CONTEXT_CACHE_BASE}:sha256:`
 const FALLBACK_SYSTEM_PROMPT_CHARS = 600
@@ -380,6 +380,8 @@ Return exactly one JSON object matching one of these shapes:
 Return understood=true only when you can infer what the agent is and what it should do. If understood=true, agentContext is required. Include expected output or response format in agentContext when it is present, but do not require one.
 
 Do not copy examples, taxonomies, policy lists, unsafe content, quoted user content, or category rubrics. Omit details that are not needed to understand the agent's role and task.
+
+Write agentContext in neutral, professional wording. Never reproduce profanity, slurs, or crude phrasing from the inspected prompt, even when it describes the agent's persona or tone; paraphrase such wording professionally.
 
 Return understood=false when the prompt does not define enough agent context. Never return understood=true without agentContext.
 `.trim()

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -23,7 +23,13 @@ import {
 } from "../constants.ts"
 import type { FlaggerConversation } from "../conversation.ts"
 import { getFlaggerStrategy, isLlmCapableStrategy } from "../flagger-strategies/index.ts"
-import { isRecord, iterMessageParts, truncateExcerpt } from "../flagger-strategies/shared.ts"
+import {
+  EXPLICIT_PROFANITY_PATTERN_SOURCE,
+  isRecord,
+  iterMessageParts,
+  SLUR_PATTERN_SOURCE,
+  truncateExcerpt,
+} from "../flagger-strategies/shared.ts"
 import type { FlaggerStrategy } from "../flagger-strategies/types.ts"
 import type { SessionHint } from "../hints/types.ts"
 import { reflagSuppressionTags } from "../reflag.ts"
@@ -244,6 +250,17 @@ const instructionExtractorOutputSchema = z
   })
 
 type InstructionExtractorOutput = z.infer<typeof instructionExtractorOutputSchema>
+
+// Mask rather than reject a crude extraction: rejection would skip the flagger for the whole trace.
+const disallowedAgentContextWordingPattern = new RegExp(
+  `${EXPLICIT_PROFANITY_PATTERN_SOURCE}|${SLUR_PATTERN_SOURCE}`,
+  "gi",
+)
+
+const maskDisallowedAgentContextWording = (result: InstructionExtractorOutput): InstructionExtractorOutput =>
+  result.agentContext
+    ? { ...result, agentContext: result.agentContext.replace(disallowedAgentContextWordingPattern, "[redacted]") }
+    : result
 
 type InspectedAgentContext =
   | { readonly available: true; readonly text: string }
@@ -570,6 +587,7 @@ function runInstructionExtraction(input: {
                 }),
             }),
           ),
+          Effect.map(maskDisallowedAgentContextWording),
           Effect.tap((result) => setCachedExtraction(input.cacheKey, result)),
           Effect.tap((result) =>
             result.understood


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Resolves LAT-JKIP

Signal: [Profanity in professional product outputs (flagger)](https://console.latitude.so/projects/latitude-flaggers/signals/LAT-JKIP), tag `flagger:extract-instructions`.

In trace `d6f314a3b892c24ea7348992b8d52f4e`, the flagger instruction extractor produced an `agentContext` containing "get shit done". The inspected customer system prompt (a recruiting assistant) contains the persona line "Sharp, capable, gets shit done", and the extractor copied it verbatim into its description. That description is Latitude product output: it lands in our own flagger telemetry (where the profanity flagger caught it), gets cached for up to 30 days, and is injected into every downstream classifier prompt for that agent.

The extractor system prompt forbade copying examples, taxonomies, and unsafe content, but said nothing about wording, so persona and tone lines were reproduced as-is. Three changes:

- `INSTRUCTION_EXTRACTOR_SYSTEM_PROMPT` now requires `agentContext` in neutral, professional wording and tells the model to paraphrase profanity or crude phrasing instead of reproducing it.
- A deterministic postcondition backs the prompt rule (review follow-up): extractor output is passed through `maskDisallowedAgentContextWording` before caching or rendering, masking profanity/slur matches as `[redacted]`. The lexicon is shared with the nsfw strategy via `flagger-strategies/shared.ts`. Masking, not rejection — rejecting the extraction would skip the flagger for the whole trace.
- `INSPECTED_AGENT_CONTEXT_CACHE_VERSION` bumped 2 → 3 so extractions cached under the old prompt (30-day TTL for `understood=true`) are not reused after deploy.

## Related issue (if applicable)

Latitude signal LAT-JKIP; no GitHub issue.

## How was this tested?

- Added assertions to the long-prompt extraction test verifying the extractor call carries the new paraphrase guidance.
- Added a regression test that the sanitizer masks echoed profanity in both the cached extraction and the downstream classifier prompt.
- Updated the cache-key test literals to the new `v3` prefix.
- `pnpm --filter @domain/flaggers test` (349 passed, 2 skipped) and `pnpm --filter @domain/flaggers typecheck` pass; Biome is clean on all changed files.

Note: `test-unit` and `test-integration` currently fail on data-pinned model-pricing tests (`@domain/models` `registry.test.ts`, `@platform/db-clickhouse` cost-archetype seeds) broken on trunk by the models.dev data refresh in #4315, whose `test` check was skipped. Unrelated to this PR's scope.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f1b0fec-5ee9-54b3-a71e-39d32ebff246?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f1b0fec-5ee9-54b3-a71e-39d32ebff246&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Inspected prompt content is now paraphrased using neutral, professional language.
  * Profanity, slurs, and crude wording are no longer reproduced in extracted instructions.
  * Detected offensive wording is redacted rather than blocking content extraction.
  * Improved consistency in detecting and handling offensive language across classification workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->