### PR TITLE
feat(taxonomy): de-nest the behaviour tree level-independently (LAT-861 Build 1)

### DIFF
--- a/packages/domain/taxonomy/src/build-quality.test.ts
+++ b/packages/domain/taxonomy/src/build-quality.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { promotedTopLevelRows, type ScaffoldingShape, taxonomyBuildQualityMetrics } from "./build-quality.ts"
+import {
+  promotedTopLevelRows,
+  type ScaffoldingRule,
+  type ScaffoldingShape,
+  taxonomyBuildQualityMetrics,
+} from "./build-quality.ts"
 import type { ClusteringTreeNode } from "./clustering.ts"
 
 /** `memberIndices` at a node covers its whole subtree, so a parent's list is the union of its children's. */
@@ -128,11 +133,14 @@ const row = (id: string, own: number, children: readonly Row[] = []): Row => ({ 
 
 const subtree = (node: Row): number => node.own + node.children.reduce((sum, child) => sum + subtree(child), 0)
 
-const rowShape = (node: Row): ScaffoldingShape<Row> => ({
-  ownMemberCount: node.own,
-  subtreeMemberCount: subtree(node),
-  children: node.children,
-})
+const rowRule: ScaffoldingRule<Row> = {
+  shapeOf: (node): ScaffoldingShape<Row> => ({
+    ownMemberCount: node.own,
+    subtreeMemberCount: subtree(node),
+    children: node.children,
+  }),
+  withChildren: (node, children) => ({ ...node, children }),
+}
 
 const ids = (rows: readonly Row[]): readonly string[] => rows.map((node) => node.id)
 
@@ -140,13 +148,13 @@ describe("promotedTopLevelRows", () => {
   it("leaves an already-flat tree untouched and in order", () => {
     const root = row("R", 0, [row("A", 30), row("B", 20), row("C", 10)])
 
-    expect(ids(promotedTopLevelRows(root, rowShape))).toEqual(["A", "B", "C"])
+    expect(ids(promotedTopLevelRows(root, rowRule))).toEqual(["A", "B", "C"])
   })
 
   it("collapses a whole chain of signposts in one pass, not one level per call", () => {
     const root = row("R", 0, [row("I1", 0, [row("I2", 0, [row("L1", 30), row("L2", 20)])])])
 
-    expect(ids(promotedTopLevelRows(root, rowShape))).toEqual(["L1", "L2"])
+    expect(ids(promotedTopLevelRows(root, rowRule))).toEqual(["L1", "L2"])
   })
 
   it("keeps a content-holding interior as a parent instead of flattening to its leaves", () => {
@@ -155,7 +163,7 @@ describe("promotedTopLevelRows", () => {
       row("B", 0, [row("B1", 10), row("B2", 10)]),
     ])
 
-    const rows = promotedTopLevelRows(root, rowShape)
+    const rows = promotedTopLevelRows(root, rowRule)
 
     expect(ids(rows)).toEqual(["A", "B1", "B2"])
     expect(ids(rows[0]?.children ?? [])).toEqual(["A1", "A2"])
@@ -164,12 +172,12 @@ describe("promotedTopLevelRows", () => {
   it("promotes an interior holding a single member — a strict-zero rule would silently keep it", () => {
     const root = row("R", 1, [row("I", 1, [row("L1", 99), row("L2", 55)]), row("L3", 494)])
 
-    expect(ids(promotedTopLevelRows(root, rowShape))).toEqual(["L1", "L2", "L3"])
+    expect(ids(promotedTopLevelRows(root, rowRule))).toEqual(["L1", "L2", "L3"])
   })
 
   it("unwraps a member-holding root positionally rather than on a content test", () => {
     const root = row("R", 9, [row("A", 40), row("B", 30)])
 
-    expect(ids(promotedTopLevelRows(root, rowShape))).toEqual(["A", "B"])
+    expect(ids(promotedTopLevelRows(root, rowRule))).toEqual(["A", "B"])
   })
 })

--- a/packages/domain/taxonomy/src/build-quality.ts
+++ b/packages/domain/taxonomy/src/build-quality.ts
@@ -43,16 +43,23 @@ export interface ScaffoldingShape<T> {
   readonly children: readonly T[]
 }
 
+export interface ScaffoldingRule<T> {
+  readonly shapeOf: (node: T) => ScaffoldingShape<T>
+  readonly withChildren: (node: T, children: readonly T[]) => T
+}
+
 /** Strict zero is not enough: a real signpost can hold one member of its own. */
 const isScaffolding = <T>(shape: ScaffoldingShape<T>): boolean =>
   shape.children.length > 0 &&
   shape.ownMemberCount <= Math.max(1, TAXONOMY_SCAFFOLDING_MAX_OWN_FRACTION * shape.subtreeMemberCount)
 
 /** Content-based, not "flatten everything": an interior holding real members survives as a parent. */
-export const promoteScaffolding = <T>(nodes: readonly T[], shapeOf: (node: T) => ScaffoldingShape<T>): readonly T[] =>
+export const promoteScaffolding = <T>(nodes: readonly T[], rule: ScaffoldingRule<T>): readonly T[] =>
   nodes.flatMap((node) => {
-    const shape = shapeOf(node)
-    return isScaffolding(shape) ? promoteScaffolding(shape.children, shapeOf) : [node]
+    const shape = rule.shapeOf(node)
+    if (isScaffolding(shape)) return promoteScaffolding(shape.children, rule)
+    if (shape.children.length === 0) return [node]
+    return [rule.withChildren(node, promoteScaffolding(shape.children, rule))]
   })
 
 /**
@@ -60,13 +67,13 @@ export const promoteScaffolding = <T>(nodes: readonly T[], shapeOf: (node: T) =>
  * node, and leaving it visible reinstates the single all-encompassing row. A childless
  * root is the exception: dropping it empties the screen of a project that has only one.
  */
-export const promotedTopLevelRows = <T>(root: T, shapeOf: (node: T) => ScaffoldingShape<T>): readonly T[] => {
-  const children = shapeOf(root).children
-  return children.length === 0 ? [root] : promoteScaffolding(children, shapeOf)
+export const promotedTopLevelRows = <T>(root: T, rule: ScaffoldingRule<T>): readonly T[] => {
+  const children = rule.shapeOf(root).children
+  return children.length === 0 ? [root] : promoteScaffolding(children, rule)
 }
 
 /** `memberIndices` carries every member at a node, so a node's own share is what its children do not hold. */
-const clusteringShape = (node: ClusteringTreeNode): ScaffoldingShape<ClusteringTreeNode> => {
+const clusteringShapeOf = (node: ClusteringTreeNode): ScaffoldingShape<ClusteringTreeNode> => {
   const subtreeMemberCount = node.memberIndices.length
   const inChildren = node.children.reduce((sum, child) => sum + child.memberIndices.length, 0)
   return {
@@ -74,6 +81,11 @@ const clusteringShape = (node: ClusteringTreeNode): ScaffoldingShape<ClusteringT
     subtreeMemberCount,
     children: node.children,
   }
+}
+
+const clusteringRule: ScaffoldingRule<ClusteringTreeNode> = {
+  shapeOf: clusteringShapeOf,
+  withChildren: (node, children) => ({ ...node, children }),
 }
 
 const collectLeaves = (node: ClusteringTreeNode): readonly ClusteringTreeNode[] =>
@@ -145,7 +157,7 @@ export const taxonomyBuildQualityMetrics = (input: {
       centeredCohesion: centeredCohesion(memberVectors(leaf.memberIndices, input.embeddings), corpusMean),
     }))
     .sort((a, b) => b.size - a.size)
-  const rows = promotedTopLevelRows(input.root, clusteringShape)
+  const rows = promotedTopLevelRows(input.root, clusteringRule)
   const largestRow = rows.reduce((max, row) => Math.max(max, row.memberIndices.length), 0)
   const inRows = rows.reduce((sum, row) => sum + row.memberIndices.length, 0)
   const cohesions = leaves.map((leaf) => leaf.centeredCohesion)

--- a/packages/domain/taxonomy/src/use-cases/behaviour-reads.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/behaviour-reads.test.ts
@@ -16,7 +16,7 @@ import { createFakeTaxonomyClusterIntelligenceRepository } from "../testing/fake
 import { createFakeTaxonomyClusterRepository } from "../testing/fake-taxonomy-cluster-repository.ts"
 import { getBehaviourTrajectoryUseCase } from "./get-behaviour-trajectory.ts"
 import { listBehaviourSessionsUseCase } from "./list-behaviour-sessions.ts"
-import { type ProjectBehaviourNode, promoteScaffolding, truncateNodes } from "./list-project-behaviours.ts"
+import { type ProjectBehaviourNode, promoteBehaviourScaffolding, truncateNodes } from "./list-project-behaviours.ts"
 
 const ORG_ID = OrganizationId("o".repeat(24))
 const PROJECT_ID = ProjectId("p".repeat(24))
@@ -250,9 +250,7 @@ describe("getBehaviourTrajectoryUseCase", () => {
   })
 })
 
-describe("promoteScaffolding", () => {
-  // The pilot project's real tree: 10 groups buried under 6 interiors that
-  // carry 2 sessions between them, 4 levels deep.
+describe("promoteBehaviourScaffolding", () => {
   const pilotTree = (rootOwn: number) =>
     behaviourNode("R", rootOwn, [
       behaviourNode("l494", 494),
@@ -271,26 +269,26 @@ describe("promoteScaffolding", () => {
     nodes.flatMap((node) => (node.children.length === 0 ? [String(node.cluster.id)] : leafIds(node.children)))
 
   it("leaves an already-flat tree alone and never reorders it", () => {
-    const flat = promoteScaffolding([
+    const flat = promoteBehaviourScaffolding([
       behaviourNode("R", 0, [behaviourNode("A", 30), behaviourNode("B", 20), behaviourNode("C", 10)]),
     ])
     expect(ids(flat.nodes)).toEqual(["A", "B", "C"])
 
-    // Ordering is the caller's job (`sortNodes` runs after promotion), so the
-    // rule must hand rows back in the order it received them.
-    const unsorted = promoteScaffolding([behaviourNode("R", 0, [behaviourNode("B", 20), behaviourNode("A", 30)])])
+    const unsorted = promoteBehaviourScaffolding([
+      behaviourNode("R", 0, [behaviourNode("B", 20), behaviourNode("A", 30)]),
+    ])
     expect(ids(unsorted.nodes)).toEqual(["B", "A"])
   })
 
   it("collapses the pilot tree's 6 signposts into its 10 real groups", () => {
-    const promoted = promoteScaffolding([pilotTree(1)])
+    const promoted = promoteBehaviourScaffolding([pilotTree(1)])
 
     expect(ids(promoted.nodes)).toEqual(PILOT_GROUPS)
     expect(promoted.nodes.every((node) => node.children.length === 0)).toBe(true)
   })
 
   it("keeps a childless root, which is the project's only group", () => {
-    const promoted = promoteScaffolding([behaviourNode("R", 1946)])
+    const promoted = promoteBehaviourScaffolding([behaviourNode("R", 1946)])
 
     expect(ids(promoted.nodes)).toEqual(["R"])
     expect(promoted.nodes[0]?.subtreeObservationCount).toBe(1946)
@@ -298,7 +296,7 @@ describe("promoteScaffolding", () => {
   })
 
   it("keeps a content-holding interior as a parent while promoting a signpost sibling", () => {
-    const promoted = promoteScaffolding([
+    const promoted = promoteBehaviourScaffolding([
       behaviourNode("R", 0, [
         behaviourNode("A", 40, [behaviourNode("A1", 30), behaviourNode("A2", 20)]),
         behaviourNode("B", 0, [behaviourNode("B1", 10), behaviourNode("B2", 10)]),
@@ -310,7 +308,7 @@ describe("promoteScaffolding", () => {
   })
 
   it("counts a surviving interior as its own members plus its visible descendants", () => {
-    const promoted = promoteScaffolding([
+    const promoted = promoteBehaviourScaffolding([
       behaviourNode("R", 0, [
         behaviourNode("A", 40, [behaviourNode("A1", 30), behaviourNode("A2", 20)]),
         behaviourNode("B", 0, [behaviourNode("B1", 10), behaviourNode("B2", 10)]),
@@ -321,7 +319,7 @@ describe("promoteScaffolding", () => {
   })
 
   it("collapses a whole signpost chain in one pass, not one level per call", () => {
-    const promoted = promoteScaffolding([
+    const promoted = promoteBehaviourScaffolding([
       behaviourNode("R", 0, [
         behaviourNode("I1", 0, [behaviourNode("I2", 0, [behaviourNode("L1", 30), behaviourNode("L2", 20)])]),
       ]),
@@ -332,7 +330,7 @@ describe("promoteScaffolding", () => {
 
   it("keeps the residue of every removed node so rows plus residue equal the project", () => {
     const root = pilotTree(9)
-    const promoted = promoteScaffolding([root])
+    const promoted = promoteBehaviourScaffolding([root])
 
     // The root's 9 plus the one session held by the promoted `i1`.
     expect(promoted.residueObservationCount).toBe(10)
@@ -340,8 +338,21 @@ describe("promoteScaffolding", () => {
     expect(rows + promoted.residueObservationCount).toBe(root.subtreeObservationCount)
   })
 
+  it("does not count a signpost's sessions as residue when a surviving parent still holds them", () => {
+    const root = behaviourNode("R", 0, [
+      behaviourNode("A", 40, [behaviourNode("B", 1, [behaviourNode("L1", 30), behaviourNode("L2", 20)])]),
+    ])
+    const promoted = promoteBehaviourScaffolding([root])
+
+    expect(ids(promoted.nodes)).toEqual(["A"])
+    expect(ids(promoted.nodes[0]?.children ?? [])).toEqual(["L1", "L2"])
+    expect(promoted.residueObservationCount).toBe(0)
+    const rows = promoted.nodes.reduce((sum, node) => sum + node.subtreeObservationCount, 0)
+    expect(rows + promoted.residueObservationCount).toBe(root.subtreeObservationCount)
+  })
+
   it("spends the node budget on real groups because promotion runs before truncation", () => {
-    expect(ids(truncateNodes(promoteScaffolding([pilotTree(1)]).nodes, 10))).toEqual(PILOT_GROUPS)
+    expect(ids(truncateNodes(promoteBehaviourScaffolding([pilotTree(1)]).nodes, 10))).toEqual(PILOT_GROUPS)
 
     // Truncating the raw tree instead spends most of the budget on scaffolding.
     const withoutPromotion = truncateNodes([pilotTree(1)], 10)
@@ -352,7 +363,9 @@ describe("promoteScaffolding", () => {
   it("collapses a degenerate chain to a single row", () => {
     // Deliberate: one row is below `isOpenableBehaviourTree`'s 2-node floor, so
     // such a project loses its entry point into the tree screen.
-    const promoted = promoteScaffolding([behaviourNode("R", 0, [behaviourNode("I", 0, [behaviourNode("L", 50)])])])
+    const promoted = promoteBehaviourScaffolding([
+      behaviourNode("R", 0, [behaviourNode("I", 0, [behaviourNode("L", 50)])]),
+    ])
 
     expect(ids(promoted.nodes)).toEqual(["L"])
   })

--- a/packages/domain/taxonomy/src/use-cases/behaviour-reads.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/behaviour-reads.test.ts
@@ -16,6 +16,7 @@ import { createFakeTaxonomyClusterIntelligenceRepository } from "../testing/fake
 import { createFakeTaxonomyClusterRepository } from "../testing/fake-taxonomy-cluster-repository.ts"
 import { getBehaviourTrajectoryUseCase } from "./get-behaviour-trajectory.ts"
 import { listBehaviourSessionsUseCase } from "./list-behaviour-sessions.ts"
+import { type ProjectBehaviourNode, promoteScaffolding, truncateNodes } from "./list-project-behaviours.ts"
 
 const ORG_ID = OrganizationId("o".repeat(24))
 const PROJECT_ID = ProjectId("p".repeat(24))
@@ -32,6 +33,23 @@ const cluster = (id: string, path: string, customBehaviorId: CustomBehaviorId | 
     customBehaviorId,
     facetId: null,
   }) as unknown as TaxonomyCluster
+
+const behaviourNode = (
+  id: string,
+  directObservationCount: number,
+  children: readonly ProjectBehaviourNode[] = [],
+): ProjectBehaviourNode => ({
+  cluster: cluster(id, ""),
+  firstSeenLabel: "older",
+  trend: { status: "steady", currentCount: 0, baselineCount: 0, baselineDailyAverage: 0, ratio: null },
+  novelty: "unknown",
+  directObservationCount,
+  subtreeObservationCount:
+    directObservationCount + children.reduce((sum, child) => sum + child.subtreeObservationCount, 0),
+  children,
+})
+
+const ids = (nodes: readonly ProjectBehaviourNode[]): readonly string[] => nodes.map((node) => String(node.cluster.id))
 
 const trajectoryRow = (bucket: string, frequency: number): ClusterTrajectoryRow => ({
   bucket,
@@ -229,5 +247,113 @@ describe("getBehaviourTrajectoryUseCase", () => {
     )
 
     expect(result.buckets).toEqual(["2026-05-02", "2026-05-10"])
+  })
+})
+
+describe("promoteScaffolding", () => {
+  // The pilot project's real tree: 10 groups buried under 6 interiors that
+  // carry 2 sessions between them, 4 levels deep.
+  const pilotTree = (rootOwn: number) =>
+    behaviourNode("R", rootOwn, [
+      behaviourNode("l494", 494),
+      behaviourNode("i1", 1, [
+        behaviourNode("l99", 99),
+        behaviourNode("ia", 0, [behaviourNode("l55", 55), behaviourNode("l35", 35)]),
+        behaviourNode("ib", 0, [behaviourNode("l23", 23), behaviourNode("l22", 22)]),
+        behaviourNode("ic", 0, [behaviourNode("l11", 11), behaviourNode("l10", 10)]),
+      ]),
+      behaviourNode("id", 0, [behaviourNode("l73", 73), behaviourNode("l14", 14)]),
+    ])
+
+  const PILOT_GROUPS = ["l494", "l99", "l55", "l35", "l23", "l22", "l11", "l10", "l73", "l14"]
+
+  const leafIds = (nodes: readonly ProjectBehaviourNode[]): readonly string[] =>
+    nodes.flatMap((node) => (node.children.length === 0 ? [String(node.cluster.id)] : leafIds(node.children)))
+
+  it("leaves an already-flat tree alone and never reorders it", () => {
+    const flat = promoteScaffolding([
+      behaviourNode("R", 0, [behaviourNode("A", 30), behaviourNode("B", 20), behaviourNode("C", 10)]),
+    ])
+    expect(ids(flat.nodes)).toEqual(["A", "B", "C"])
+
+    // Ordering is the caller's job (`sortNodes` runs after promotion), so the
+    // rule must hand rows back in the order it received them.
+    const unsorted = promoteScaffolding([behaviourNode("R", 0, [behaviourNode("B", 20), behaviourNode("A", 30)])])
+    expect(ids(unsorted.nodes)).toEqual(["B", "A"])
+  })
+
+  it("collapses the pilot tree's 6 signposts into its 10 real groups", () => {
+    const promoted = promoteScaffolding([pilotTree(1)])
+
+    expect(ids(promoted.nodes)).toEqual(PILOT_GROUPS)
+    expect(promoted.nodes.every((node) => node.children.length === 0)).toBe(true)
+  })
+
+  it("keeps a childless root, which is the project's only group", () => {
+    const promoted = promoteScaffolding([behaviourNode("R", 1946)])
+
+    expect(ids(promoted.nodes)).toEqual(["R"])
+    expect(promoted.nodes[0]?.subtreeObservationCount).toBe(1946)
+    expect(promoted.residueObservationCount).toBe(0)
+  })
+
+  it("keeps a content-holding interior as a parent while promoting a signpost sibling", () => {
+    const promoted = promoteScaffolding([
+      behaviourNode("R", 0, [
+        behaviourNode("A", 40, [behaviourNode("A1", 30), behaviourNode("A2", 20)]),
+        behaviourNode("B", 0, [behaviourNode("B1", 10), behaviourNode("B2", 10)]),
+      ]),
+    ])
+
+    expect(ids(promoted.nodes)).toEqual(["A", "B1", "B2"])
+    expect(ids(promoted.nodes[0]?.children ?? [])).toEqual(["A1", "A2"])
+  })
+
+  it("counts a surviving interior as its own members plus its visible descendants", () => {
+    const promoted = promoteScaffolding([
+      behaviourNode("R", 0, [
+        behaviourNode("A", 40, [behaviourNode("A1", 30), behaviourNode("A2", 20)]),
+        behaviourNode("B", 0, [behaviourNode("B1", 10), behaviourNode("B2", 10)]),
+      ]),
+    ])
+
+    expect(promoted.nodes[0]?.subtreeObservationCount).toBe(90)
+  })
+
+  it("collapses a whole signpost chain in one pass, not one level per call", () => {
+    const promoted = promoteScaffolding([
+      behaviourNode("R", 0, [
+        behaviourNode("I1", 0, [behaviourNode("I2", 0, [behaviourNode("L1", 30), behaviourNode("L2", 20)])]),
+      ]),
+    ])
+
+    expect(ids(promoted.nodes)).toEqual(["L1", "L2"])
+  })
+
+  it("keeps the residue of every removed node so rows plus residue equal the project", () => {
+    const root = pilotTree(9)
+    const promoted = promoteScaffolding([root])
+
+    // The root's 9 plus the one session held by the promoted `i1`.
+    expect(promoted.residueObservationCount).toBe(10)
+    const rows = promoted.nodes.reduce((sum, node) => sum + node.subtreeObservationCount, 0)
+    expect(rows + promoted.residueObservationCount).toBe(root.subtreeObservationCount)
+  })
+
+  it("spends the node budget on real groups because promotion runs before truncation", () => {
+    expect(ids(truncateNodes(promoteScaffolding([pilotTree(1)]).nodes, 10))).toEqual(PILOT_GROUPS)
+
+    // Truncating the raw tree instead spends most of the budget on scaffolding.
+    const withoutPromotion = truncateNodes([pilotTree(1)], 10)
+    expect(ids(withoutPromotion)).toEqual(["R"])
+    expect(leafIds(withoutPromotion).length).toBeLessThan(PILOT_GROUPS.length)
+  })
+
+  it("collapses a degenerate chain to a single row", () => {
+    // Deliberate: one row is below `isOpenableBehaviourTree`'s 2-node floor, so
+    // such a project loses its entry point into the tree screen.
+    const promoted = promoteScaffolding([behaviourNode("R", 0, [behaviourNode("I", 0, [behaviourNode("L", 50)])])])
+
+    expect(ids(promoted.nodes)).toEqual(["L"])
   })
 })

--- a/packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts
+++ b/packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts
@@ -57,6 +57,8 @@ export interface ProjectBehaviourNode {
   readonly firstSeenLabel: BehaviourFirstSeenLabel
   readonly trend: TaxonomyClusterTrendSummary
   readonly novelty: BehaviourNovelty
+  /** Sessions assigned to this node itself, excluding everything under it. */
+  readonly directObservationCount: number
   /** Sessions represented by this node's visible subtree; aggregate parents are not double-counted. */
   readonly subtreeObservationCount: number
   readonly children: readonly ProjectBehaviourNode[]
@@ -64,6 +66,12 @@ export interface ProjectBehaviourNode {
 
 export interface ListProjectBehavioursResult {
   readonly topics: readonly ProjectBehaviourNode[]
+  /**
+   * Sessions that reached a node the reader removed (the unwrapped root, or a
+   * promoted signpost) and no group below it, so rows plus residue still sum to
+   * the project total. Whether to render it as a row is a product decision.
+   */
+  readonly residueObservationCount: number
 }
 
 const MS_PER_DAY = 24 * 60 * 60_000
@@ -141,7 +149,10 @@ const sortNodes = (nodes: readonly ProjectBehaviourNode[], sortBy: BehaviourSort
 const countNodes = (nodes: readonly ProjectBehaviourNode[]): number =>
   nodes.reduce((sum, node) => sum + 1 + countNodes(node.children), 0)
 
-const truncateNodes = (nodes: readonly ProjectBehaviourNode[], budget: number): readonly ProjectBehaviourNode[] => {
+export const truncateNodes = (
+  nodes: readonly ProjectBehaviourNode[],
+  budget: number,
+): readonly ProjectBehaviourNode[] => {
   const out: ProjectBehaviourNode[] = []
   let remaining = budget
   for (const node of nodes) {
@@ -152,6 +163,56 @@ const truncateNodes = (nodes: readonly ProjectBehaviourNode[], budget: number): 
     out.push({ ...node, children })
   }
   return out
+}
+
+/**
+ * Above this share of its own subtree a node holds real content; at or below it
+ * the node is a signpost that exists only to bracket its children. `max(1, …)`
+ * is what carries the rule on today's trees (interiors hold 0-1 sessions of
+ * their own); the fraction keeps the same question meaningful on a large tree.
+ */
+const SCAFFOLDING_OWN_FRACTION = 0.02
+
+const isScaffolding = (node: ProjectBehaviourNode): boolean =>
+  node.directObservationCount <= Math.max(1, SCAFFOLDING_OWN_FRACTION * node.subtreeObservationCount)
+
+interface PromoteScaffoldingResult {
+  readonly nodes: readonly ProjectBehaviourNode[]
+  readonly residueObservationCount: number
+}
+
+/**
+ * Removes nodes that hold nothing — not nesting.
+ *
+ * The root goes positionally, whatever it holds: it englobes the project by
+ * construction, so a content test that kept it would reintroduce the single
+ * all-encompassing row this exists to prevent. A root with no children is the
+ * project's only group and stays. Every other node goes only when it holds no
+ * content of its own, at any depth, so an interior with real members survives
+ * as a parent with its children and its count intact.
+ *
+ * On every tree in the fleet today each non-root interior is a signpost, so the
+ * result comes out flat. That is a fact about the current builder's output, not
+ * the contract — collapsing this to a leaves-only walk would return nothing for
+ * a childless root, silently drop residue, and foreclose real hierarchy.
+ */
+export const promoteScaffolding = (rootNodes: readonly ProjectBehaviourNode[]): PromoteScaffoldingResult => {
+  let residueObservationCount = 0
+  const promote = (nodes: readonly ProjectBehaviourNode[]): readonly ProjectBehaviourNode[] =>
+    nodes.flatMap((node) => {
+      if (node.children.length === 0) return [node]
+      const children = promote(node.children)
+      if (!isScaffolding(node)) return [{ ...node, children }]
+      residueObservationCount += node.directObservationCount
+      return children
+    })
+
+  const nodes = rootNodes.flatMap((root) => {
+    if (root.children.length === 0) return [root]
+    residueObservationCount += root.directObservationCount
+    return promote(root.children)
+  })
+  return { nodes, residueObservationCount }
 }
 
 export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) =>
@@ -278,12 +339,10 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
         })
       const novelty = noveltyFor({ cluster, trend, firstSeenWindowStart, minObservations })
       const directObservationCount = directCountByClusterId.get(cluster.id) ?? 0
-      const ownObservationCount =
-        children.length > 0
-          ? children.reduce((sum, child) => sum + child.subtreeObservationCount, 0)
-          : directObservationCount
+      const subtreeObservationCount =
+        directObservationCount + children.reduce((sum, child) => sum + child.subtreeObservationCount, 0)
       const ownVisible =
-        ownObservationCount >= minObservations &&
+        subtreeObservationCount >= minObservations &&
         (segment === "all" ||
           (segment === "new_this_week" && novelty === "first_seen") ||
           (segment === "spiking" && novelty === "spiking"))
@@ -293,11 +352,12 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
         firstSeenLabel: firstSeenLabel(cluster.firstObservedAt, now, firstSeenWindowDays),
         trend,
         novelty,
+        directObservationCount,
         // UI session counts come from current observation assignments in the
         // selected time range. Interior nodes are aggregates, so their count is
-        // the sum of visible descendants rather than their stored all-time
-        // Postgres counter.
-        subtreeObservationCount: ownObservationCount,
+        // their own members plus their visible descendants rather than their
+        // stored all-time Postgres counter.
+        subtreeObservationCount,
         children,
       }
     }
@@ -309,16 +369,14 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
         return node === null ? [] : [node]
       })
 
-    // The divisive build always produces a single depth-0 root that englobes
-    // the entire project — it is the "everything" node, not a meaningful
-    // category. When it is the only root and it has children, surface its
-    // children (the real depth-1 categories) as the top-level rows so the
-    // behaviours table opens on several categories instead of one
-    // all-encompassing row. A tiny corpus that collapsed to a single childless
-    // root still shows that root.
-    const topLevel =
-      rootNodes.length === 1 && (rootNodes[0]?.children.length ?? 0) > 0 ? (rootNodes[0]?.children ?? []) : rootNodes
-    const topics = sortNodes(topLevel, sortBy)
+    // Promotion runs on the already-filtered tree so `ownVisible` decides which
+    // nodes exist first, and before truncation so the node budget is spent on
+    // real groups instead of scaffolding.
+    const { nodes: promoted, residueObservationCount } = promoteScaffolding(rootNodes)
+    const topics = sortNodes(promoted, sortBy)
 
-    return { topics: truncateNodes(topics, limit) } satisfies ListProjectBehavioursResult
+    return {
+      topics: truncateNodes(topics, limit),
+      residueObservationCount,
+    } satisfies ListProjectBehavioursResult
   }).pipe(Effect.withSpan("taxonomy.listProjectBehaviours"))

--- a/packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts
+++ b/packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts
@@ -6,6 +6,7 @@ import {
   RepositoryError,
 } from "@domain/shared"
 import { Effect, Option } from "effect"
+import { promotedTopLevelRows, type ScaffoldingRule } from "../build-quality.ts"
 import type { TaxonomyCluster } from "../entities/cluster.ts"
 import { TaxonomyDimension, type TaxonomyDimension as TaxonomyDimensionType } from "../entities/dimension.ts"
 import { isDisplayableTaxonomyName } from "../helpers.ts"
@@ -66,11 +67,7 @@ export interface ProjectBehaviourNode {
 
 export interface ListProjectBehavioursResult {
   readonly topics: readonly ProjectBehaviourNode[]
-  /**
-   * Sessions that reached a node the reader removed (the unwrapped root, or a
-   * promoted signpost) and no group below it, so rows plus residue still sum to
-   * the project total. Whether to render it as a row is a product decision.
-   */
+  /** Sessions the promoted-away nodes held, so they sit in no row; taken before `limit` truncates. */
   readonly residueObservationCount: number
 }
 
@@ -165,54 +162,30 @@ export const truncateNodes = (
   return out
 }
 
-/**
- * Above this share of its own subtree a node holds real content; at or below it
- * the node is a signpost that exists only to bracket its children. `max(1, …)`
- * is what carries the rule on today's trees (interiors hold 0-1 sessions of
- * their own); the fraction keeps the same question meaningful on a large tree.
- */
-const SCAFFOLDING_OWN_FRACTION = 0.02
+const behaviourScaffoldingRule: ScaffoldingRule<ProjectBehaviourNode> = {
+  shapeOf: (node) => ({
+    ownMemberCount: node.directObservationCount,
+    subtreeMemberCount: node.subtreeObservationCount,
+    children: node.children,
+  }),
+  withChildren: (node, children) => ({ ...node, children }),
+}
 
-const isScaffolding = (node: ProjectBehaviourNode): boolean =>
-  node.directObservationCount <= Math.max(1, SCAFFOLDING_OWN_FRACTION * node.subtreeObservationCount)
-
-interface PromoteScaffoldingResult {
+interface PromotedBehaviourRows {
   readonly nodes: readonly ProjectBehaviourNode[]
   readonly residueObservationCount: number
 }
 
 /**
- * Removes nodes that hold nothing — not nesting.
- *
- * The root goes positionally, whatever it holds: it englobes the project by
- * construction, so a content test that kept it would reintroduce the single
- * all-encompassing row this exists to prevent. A root with no children is the
- * project's only group and stays. Every other node goes only when it holds no
- * content of its own, at any depth, so an interior with real members survives
- * as a parent with its children and its count intact.
- *
- * On every tree in the fleet today each non-root interior is a signpost, so the
- * result comes out flat. That is a fact about the current builder's output, not
- * the contract — collapsing this to a leaves-only walk would return nothing for
- * a childless root, silently drop residue, and foreclose real hierarchy.
+ * Rows to show for a built tree, plus the sessions no row holds. Do not
+ * substitute a leaves-only walk: it looks equivalent on today's trees but
+ * returns nothing for a childless root and discards residue.
  */
-export const promoteScaffolding = (rootNodes: readonly ProjectBehaviourNode[]): PromoteScaffoldingResult => {
-  let residueObservationCount = 0
-  const promote = (nodes: readonly ProjectBehaviourNode[]): readonly ProjectBehaviourNode[] =>
-    nodes.flatMap((node) => {
-      if (node.children.length === 0) return [node]
-      const children = promote(node.children)
-      if (!isScaffolding(node)) return [{ ...node, children }]
-      residueObservationCount += node.directObservationCount
-      return children
-    })
-
-  const nodes = rootNodes.flatMap((root) => {
-    if (root.children.length === 0) return [root]
-    residueObservationCount += root.directObservationCount
-    return promote(root.children)
-  })
-  return { nodes, residueObservationCount }
+export const promoteBehaviourScaffolding = (rootNodes: readonly ProjectBehaviourNode[]): PromotedBehaviourRows => {
+  const nodes = rootNodes.flatMap((root) => promotedTopLevelRows(root, behaviourScaffoldingRule))
+  const total = rootNodes.reduce((sum, root) => sum + root.subtreeObservationCount, 0)
+  const inRows = nodes.reduce((sum, node) => sum + node.subtreeObservationCount, 0)
+  return { nodes, residueObservationCount: Math.max(0, total - inRows) }
 }
 
 export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) =>
@@ -353,10 +326,7 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
         trend,
         novelty,
         directObservationCount,
-        // UI session counts come from current observation assignments in the
-        // selected time range. Interior nodes are aggregates, so their count is
-        // their own members plus their visible descendants rather than their
-        // stored all-time Postgres counter.
+        // Counts come from assignments in the selected range, never the stored all-time Postgres counter.
         subtreeObservationCount,
         children,
       }
@@ -369,10 +339,9 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
         return node === null ? [] : [node]
       })
 
-    // Promotion runs on the already-filtered tree so `ownVisible` decides which
-    // nodes exist first, and before truncation so the node budget is spent on
-    // real groups instead of scaffolding.
-    const { nodes: promoted, residueObservationCount } = promoteScaffolding(rootNodes)
+    // Must stay between `ownVisible` filtering and truncation: it reads the filtered
+    // tree, and truncating first spends the node budget on scaffolding.
+    const { nodes: promoted, residueObservationCount } = promoteBehaviourScaffolding(rootNodes)
     const topics = sortNodes(promoted, sortBy)
 
     return {

--- a/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
@@ -311,16 +311,17 @@ describe("listProjectBehavioursUseCase", () => {
       ),
     )
 
-    // Topics sort by subtree volume; children nest under their parent node.
-    expect(result.topics.map((topic) => topic.cluster.id)).toEqual([rootId, leafRootId])
-    expect(result.topics[0]?.children.map((child) => child.cluster.id)).toEqual([childId])
+    // Roots are unwrapped, so the child surfaces as a row of its own; the
+    // childless root is the only group of its branch and stays.
+    expect(result.topics.map((topic) => topic.cluster.id)).toEqual([childId, leafRootId])
+    expect(result.topics.every((topic) => topic.children.length === 0)).toBe(true)
     // Parent counters are aggregate subtree counters, so the UI must not add
     // the parent value to its children and double-count the same sessions.
     expect(result.topics[0]?.subtreeObservationCount).toBe(3)
     expect(result.topics[1]?.subtreeObservationCount).toBe(3)
   })
 
-  it("unwraps the single englobing root and surfaces its depth-1 children as top-level rows", async () => {
+  it("unwraps the englobing root and surfaces its depth-1 children as top-level rows", async () => {
     const rootId = TaxonomyClusterId("a".repeat(24))
     const firstChildId = TaxonomyClusterId("b".repeat(24))
     const secondChildId = TaxonomyClusterId("c".repeat(24))

--- a/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
@@ -311,12 +311,8 @@ describe("listProjectBehavioursUseCase", () => {
       ),
     )
 
-    // Roots are unwrapped, so the child surfaces as a row of its own; the
-    // childless root is the only group of its branch and stays.
     expect(result.topics.map((topic) => topic.cluster.id)).toEqual([childId, leafRootId])
     expect(result.topics.every((topic) => topic.children.length === 0)).toBe(true)
-    // Parent counters are aggregate subtree counters, so the UI must not add
-    // the parent value to its children and double-count the same sessions.
     expect(result.topics[0]?.subtreeObservationCount).toBe(3)
     expect(result.topics[1]?.subtreeObservationCount).toBe(3)
   })


### PR DESCRIPTION
Build 1 of LAT-861 only. Builds 2 (merge), 3 (naming) and 4 (metrics) are being done separately.

## The problem

`list-project-behaviours.ts` unwrapped the tree with a one-level, positional special case:

```ts
rootNodes.length === 1 && (rootNodes[0]?.children.length ?? 0) > 0 ? rootNodes[0].children : rootNodes
```

It asks "is this the single root", not "does this node hold anything", so it stops after one level and leaves the real groups buried under interiors that hold nothing. On the pilot project a 16-node, 4-level tree contains 10 real groups and 6 nodes of scaffolding carrying 2 sessions between them.

Separately, `buildNode` computed a node's `directObservationCount` and then discarded it whenever the node had children. Combined with the root being dropped, a root's own members were counted nowhere and reachable from nowhere.

## The change

The ternary is gone, replaced by one mechanism — `promoteScaffolding`, a pure function over an already-built node list:

1. **Unwrap the root positionally**, whatever it holds. It englobes the project by construction, so a content test that kept a member-holding root visible would reintroduce the single all-encompassing row this logic exists to prevent.
2. **Recursively promote any node holding no content of its own** (`own <= max(1, 0.02 * subtree)`), replacing it with its children, at every depth. A whole chain collapses in one pass.
3. **Keep the residue** of every removed node in `residueObservationCount`, so rows plus residue still sum to the project total.

A childless root still renders as itself — the project with 1,946 members and no children is not an edge case to tidy away.

Counting fix in the same change: a node's count is its own direct members **plus** its visible descendants, at every level. These are the windowed ClickHouse counts; the Postgres `observation_count` counter is deliberately not read here (it is cumulative and will always disagree with a window).

## This is not "render the leaves"

A leaves-only walk produces byte-identical output to this rule on all 8 production trees, so it survives review and a screenshot comparison. It is still wrong: it returns nothing for the childless-root project, silently discards root and interior residue from both the rows and the totals, and permanently forecloses the hierarchy Builds 2/3 are meant to make meaningful. The rule here is **"remove nodes that hold nothing", not "remove nesting"** — that the two coincide on today's data is a fact about the current builder's output, not the contract.

## Tests

Nine fixture cases on the pure function in `behaviour-reads.test.ts` — no fakes, no Effect layers. Notably **case 4** (a content-holding interior survives as a parent with its children and its rolled-up count), which is the only case with no production instance and the one a "flatten everything" implementation gets wrong while passing everything else.

Also covered: already-flat input is unchanged and unreordered (sorting stays the caller's job), the real pilot shape collapsing 6 signposts into 10 groups, the childless root, chain collapse in one pass, residue arithmetic, and promotion-before-truncation (a budget of 10 on the raw tree yields 6 groups and 4 scaffolding rows; after promotion it yields all 10 groups).

## Seams handled

- `ProjectBehaviourNode` gains `directObservationCount` — the rule needs it and the count fix computes it anyway. Nothing outside this use-case constructs the node.
- Promotion runs **after** `ownVisible` filtering (so an interior whose children were all dropped still falls back to its own count) and **before** `truncateNodes` (so the node budget buys real groups).
- `truncateNodes` is exported so the ordering case can pin the real composition.

## Web consumers checked

- `isOpenableBehaviourTree` (≥ 2 nodes) — de-nesting raises node counts on 6 of 8 production trees and leaves the other 2 equal, and the only 1-row project is the childless root, which is already 1 node today. So no project loses its entry point. The boundary is real for a hypothetical `root → interior → single leaf` project, which now collapses to one row; fixture case 9 asserts that shape deliberately rather than leaving it implicit.
- `toGroupRecords` (behaviour catalog teaser) — indents by depth; on a flat tree every row is depth 0, which is an improvement over today, where the depth-0 rows are the scaffolding names and the real groups sit at depth 1. No code change needed.

## Review focus

- `promoteScaffolding` in `list-project-behaviours.ts` — specifically that the root is unwrapped positionally while every other node is judged on content.
- `SCAFFOLDING_OWN_FRACTION = 0.02`. The threshold sweep from `own = 0` through `own <= 10% of subtree` gave identical output on all 8 trees, so any value in that range is equally supported by the data; `max(1, …)` is what actually carries the rule today.
- Whether `residueObservationCount` should be surfaced as a row and folded into the existing `noise` bucket. This PR preserves and exposes the number but adds no UI — that is a product call, and the issue is explicit that it should be decided rather than settled by omission.

Closes part of LAT-861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Topic and behaviour views now promote meaningful nested items to the top level for easier browsing.
  - Structural-only groupings are removed while their observations remain accounted for.
  - Results distinguish direct observations from those inherited through visible descendants.
  - Empty or childless roots are preserved when appropriate.
  - Promoted items retain meaningful content and are sorted for clearer presentation.

- **Bug Fixes**
  - Improved node-limit truncation and observation counting across deep, nested, and degenerate trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->