### PR TITLE
feat(taxonomy): per-build quality metrics (LAT-861 Build 4)

### DIFF
--- a/apps/workflows/datadog/setup-datadog.sh
+++ b/apps/workflows/datadog/setup-datadog.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 #
-# Datadog APM setup for the taxonomy adaptive clustering rollout.
-# Creates the retention filter (100% keep of the garden-run spans, which Datadog's
-# default intelligent retention would otherwise only sample) and the span-based
-# metrics (15-month durable history) over the taxonomy.gardenTaxonomyWorkflow.shadow
-# span. Run this BEFORE enabling the flag for an organization — neither is
-# retroactive. The span keeps its shadow-era name on purpose: both objects below
-# key on it, so renaming the span orphans them.
+# Datadog APM setup for the taxonomy garden telemetry — two independent feature
+# sets, converged together because they share credentials and both are missed
+# just as easily:
+#
+#   1. Adaptive clustering rollout — the taxonomy.gardenTaxonomyWorkflow.shadow
+#      span, emitted only for organizations the adaptiveTaxonomyClustering flag
+#      has enabled. Run this BEFORE enabling the flag for an organization.
+#   2. Tree quality (LAT-861 Build 4) — the .buildQuality and .nameQuality spans,
+#      emitted for EVERY garden run of every project regardless of mode. Run this
+#      BEFORE the Build 4 deploy, and before Builds 1-3 land, or their before/after
+#      has no "before".
+#
+# Neither retention filters nor span metrics are retroactive, which is why the
+# ordering above matters. Each span name is load-bearing: the retention filter,
+# the span metrics, and the dashboard widgets all key on it, so renaming a span
+# orphans three objects at once and silently empties a dashboard.
 #
 # Requires a Datadog API key and Application key (read/write APM config). They are
 # read from the environment and never printed; do not paste them into shared logs.
@@ -23,9 +32,12 @@ set -euo pipefail
 
 DD=https://api.datadoghq.eu/api/v2/apm/config
 Q='service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow'
-# Also the key this script converges on, so renaming it would leave the deployed
+BUILD_Q='service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality'
+NAME_Q='service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.nameQuality'
+# Also the keys this script converges on, so renaming one would leave the deployed
 # filter behind and create a duplicate.
 RETENTION_FILTER_NAME='Taxonomy adaptive shadow spans'
+QUALITY_RETENTION_FILTER_NAME='Taxonomy quality spans'
 HDR=(-H "DD-API-KEY: ${DD_API_KEY}" -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" -H 'Content-Type: application/json')
 
 FAILED=0
@@ -50,21 +62,33 @@ del() { # <url>  — delete; 2xx or 404 (nothing to delete) ok, else records a f
   esac
 }
 
-echo "== retention filter =="
-# Retention filters have no client-supplied id, so converge by deleting every
-# filter that carries our name before recreating (avoids duplicates on rerun).
-existing="$(curl -sS "${DD}/retention-filters" "${HDR[@]}" | python3 -c '
+retention_filter() { # <name> <query>  — 100%-keep filter, converged by name
+  # Retention filters have no client-supplied id, so converge by deleting every
+  # filter that carries our name before recreating (avoids duplicates on rerun).
+  local existing fid
+  existing="$(curl -sS "${DD}/retention-filters" "${HDR[@]}" | python3 -c '
 import sys, json
 name = sys.argv[1]
 for f in json.load(sys.stdin).get("data", []):
     if f.get("attributes", {}).get("name") == name:
         print(f["id"])
-' "${RETENTION_FILTER_NAME}")"
-for fid in ${existing}; do
-  echo "-- deleting existing ${fid}"
-  del "${DD}/retention-filters/${fid}"
-done
-post "${DD}/retention-filters" '{"data":{"type":"apm_retention_filter","attributes":{"name":"'"${RETENTION_FILTER_NAME}"'","filter_type":"spans-sampling-processor","filter":{"query":"'"${Q}"'"},"rate":1.0,"enabled":true}}}'
+' "$1")"
+  for fid in ${existing}; do
+    echo "-- deleting existing ${fid}"
+    del "${DD}/retention-filters/${fid}"
+  done
+  post "${DD}/retention-filters" '{"data":{"type":"apm_retention_filter","attributes":{"name":"'"$1"'","filter_type":"spans-sampling-processor","filter":{"query":"'"$2"'"},"rate":1.0,"enabled":true}}}'
+}
+
+echo "== retention filter (adaptive) =="
+retention_filter "${RETENTION_FILTER_NAME}" "${Q}"
+
+echo "== retention filter (quality) =="
+# One filter over both quality spans: they are read together and a single object
+# is one ordering problem instead of two (filters are evaluated top-down and the
+# first match decides, so a broad catch-all above this one would sample it out).
+retention_filter "${QUALITY_RETENTION_FILTER_NAME}" \
+  'service:workflows resource_name:(taxonomy.gardenTaxonomyWorkflow.buildQuality OR taxonomy.gardenTaxonomyWorkflow.nameQuality)'
 
 GRP='[{"path":"@taxonomy.projectId","tag_name":"project_id"},{"path":"@taxonomy.organizationId","tag_name":"organization_id"},{"path":"@taxonomy.customBehaviorId","tag_name":"custom_behavior_id"}]'
 
@@ -84,6 +108,40 @@ METRICS
 echo "== fallback count metric =="
 del "${DD}/metrics/taxonomy.adaptive.fallback"
 post "${DD}/metrics" '{"data":{"type":"spans_metrics","id":"taxonomy.adaptive.fallback","attributes":{"compute":{"aggregation_type":"count"},"filter":{"query":"'"${Q}"' -@taxonomy.adaptive.fallbackReason:none"},"group_by":[{"path":"@taxonomy.projectId","tag_name":"project_id"},{"path":"@taxonomy.adaptive.fallbackReason","tag_name":"fallback_reason"}]}}}'
+
+# Quality spans carry the facet too, so views are separable from the topic tree.
+QUALITY_GRP='[{"path":"@taxonomy.projectId","tag_name":"project_id"},{"path":"@taxonomy.organizationId","tag_name":"organization_id"},{"path":"@taxonomy.customBehaviorId","tag_name":"custom_behavior_id"},{"path":"@taxonomy.facetId","tag_name":"facet_id"}]'
+
+# Span metrics are computed at ingestion, so these keep accruing regardless of what
+# the retention filter above indexes — they are the channel that outlives the
+# 15-day span window and carries the before/after for Builds 1-3.
+echo "== build quality span metrics =="
+while IFS='|' read -r id path; do
+  [ -z "${id}" ] && continue
+  echo "-- ${id}"
+  del "${DD}/metrics/${id}"
+  post "${DD}/metrics" '{"data":{"type":"spans_metrics","id":"'"${id}"'","attributes":{"compute":{"aggregation_type":"distribution","include_percentiles":true,"path":"'"${path}"'"},"filter":{"query":"'"${BUILD_Q}"'"},"group_by":'"${QUALITY_GRP}"'}}}'
+done <<'METRICS'
+taxonomy.quality.largest_leaf_share|@taxonomy.quality.largestLeafShare
+taxonomy.quality.largest_top_level_share|@taxonomy.quality.largestTopLevelShare
+taxonomy.quality.top_level_row_count|@taxonomy.quality.topLevelRowCount
+taxonomy.quality.leaf_count|@taxonomy.quality.leafCount
+taxonomy.quality.members_clustered|@taxonomy.quality.membersClustered
+taxonomy.quality.centered_cohesion_min|@taxonomy.quality.centeredCohesion.min
+taxonomy.quality.centered_cohesion_p50|@taxonomy.quality.centeredCohesion.p50
+METRICS
+
+echo "== name quality span metrics =="
+while IFS='|' read -r id path; do
+  [ -z "${id}" ] && continue
+  echo "-- ${id}"
+  del "${DD}/metrics/${id}"
+  post "${DD}/metrics" '{"data":{"type":"spans_metrics","id":"'"${id}"'","attributes":{"compute":{"aggregation_type":"distribution","include_percentiles":true,"path":"'"${path}"'"},"filter":{"query":"'"${NAME_Q}"'"},"group_by":'"${QUALITY_GRP}"'}}}'
+done <<'METRICS'
+taxonomy.quality.duplicate_name_rate|@taxonomy.quality.duplicateNameRate
+taxonomy.quality.cross_branch_duplicates|@taxonomy.quality.crossBranchDuplicateLeafCount
+taxonomy.quality.shared_sibling_word_share|@taxonomy.quality.sharedSiblingWordShare
+METRICS
 
 echo "== retired shadow-comparison metrics =="
 # The paired static-vs-adaptive attributes are no longer emitted (LAT-774), so these

--- a/apps/workflows/datadog/taxonomy-adaptive-datadog-setup.md
+++ b/apps/workflows/datadog/taxonomy-adaptive-datadog-setup.md
@@ -18,6 +18,11 @@ and the keys' role must carry the RBAC permissions for each write: the retention
 filter needs `apm_retention_filter_write`, the span metrics need
 `apm_generate_metrics`. A key without them returns 403.
 
+`setup-datadog.sh` also converges the tree-quality objects (the `.buildQuality` /
+`.nameQuality` spans, which are **not** flag-gated) — see
+[taxonomy-quality-datadog-setup.md](./taxonomy-quality-datadog-setup.md). One run
+of the script sets up both.
+
 ## Gate 1 — ingestion (mostly handled in code)
 
 The OTel SDK samples AlwaysOn, so the app exports 100% of spans to the DD agent.

--- a/apps/workflows/datadog/taxonomy-quality-dashboard.json
+++ b/apps/workflows/datadog/taxonomy-quality-dashboard.json
@@ -1,0 +1,509 @@
+{
+  "title": "Taxonomy tree quality (LAT-861)",
+  "description": "Reads the APM spans `taxonomy.gardenTaxonomyWorkflow.buildQuality` and `.nameQuality` emitted by the workflows service: one pair per garden run, for every project and every view, in every clustering mode. Unlike the adaptive rollout dashboard this is not flag-gated. Every share is measured on the partition that one build produced — never on live assigned_cluster_id across a window, which mixes in deprecated clusters and biases the number down badly. The app ships logs to CloudWatch only, so this uses the APM spans channel. Requires the 'Taxonomy quality spans' retention filter and the taxonomy.quality.* span metrics from apps/workflows/datadog/setup-datadog.sh. Apply with the Datadog MCP upsert_datadog_dashboard (title/description/template_variables/widgets).",
+  "layout_type": "ordered",
+  "template_variables": [
+    { "name": "organization", "prefix": "@taxonomy.organizationId", "available_values": [], "default": "*" },
+    { "name": "project", "prefix": "@taxonomy.projectId", "available_values": [], "default": "*" }
+  ],
+  "widgets": [
+    {
+      "definition": {
+        "type": "note",
+        "content": "## Taxonomy tree quality\n\nOne `buildQuality` span per garden run (the partition the build persisted) and one `nameQuality` span per run (the names it published), for **every** project and view in **every** mode — this is not gated on the adaptive flag.\n\n**Watch first:** `largestLeafShare`. A project whose biggest leaf holds a majority of its window has a tree that is technically fine and useless to read.\n\n**Read the two shares together.** A change that improves `largestLeafShare` while cutting `topLevelRowCount` has buried the good groups deeper — better on the tracked metric, worse for the user. That is a measured regression, not a hypothetical, which is why they share a chart.\n\n**`topLevelRowCount` is the promoted row list**, not the root's child count. Until the de-nesting read ships it describes a screen the customer does not see yet.\n\n**`leafSizes` is a string tag, not a metric** — read it per run in Trace Explorer: `service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality`. The vector is what makes a regression legible at a glance.\n\n**Centered cohesion below ~0.35 means residue** — a leaf holding unrelated traffic that raw cohesion cannot distinguish from a real cluster. It is emitted per leaf; the minimum is the one to rank on, because residue is not confined to the biggest leaf.\n\n> Spans are indexed for 15 days. Anything longer — the before/after for de-nesting, merging and naming — reads the `taxonomy.quality.*` span metrics in the last group.",
+        "background_color": "yellow",
+        "font_size": "14",
+        "text_align": "left",
+        "vertical_align": "top",
+        "has_padding": true,
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      },
+      "layout": { "width": 12, "height": 4 }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "layout_type": "ordered",
+        "title": "Fleet triage — which projects have an unreadable tree",
+        "show_title": true,
+        "widgets": [
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Projects whose biggest leaf holds > 50% of the build",
+              "autoscale": true,
+              "precision": 0,
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "concentrated",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality @taxonomy.quality.largestLeafShare:>0.5 $organization $project"
+                      },
+                      "compute": { "aggregation": "cardinality", "metric": "@taxonomy.projectId" }
+                    }
+                  ],
+                  "formulas": [{ "formula": "concentrated" }],
+                  "response_format": "scalar",
+                  "aggregator": "max",
+                  "conditional_formats": [
+                    { "comparator": ">", "value": 0, "palette": "white_on_yellow" },
+                    { "comparator": "<=", "value": 0, "palette": "white_on_green" }
+                  ]
+                }
+              ]
+            },
+            "layout": { "width": 4, "height": 3 }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Projects reporting a build",
+              "autoscale": true,
+              "precision": 0,
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "projects",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "cardinality", "metric": "@taxonomy.projectId" }
+                    }
+                  ],
+                  "formulas": [{ "formula": "projects" }],
+                  "response_format": "scalar",
+                  "aggregator": "max"
+                }
+              ]
+            },
+            "layout": { "width": 4, "height": 3 }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Widest tree (max topLevelRowCount) — the row-count guard",
+              "autoscale": true,
+              "precision": 0,
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "widest",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "max", "metric": "@taxonomy.quality.topLevelRowCount" }
+                    }
+                  ],
+                  "formulas": [{ "formula": "widest" }],
+                  "response_format": "scalar",
+                  "aggregator": "max",
+                  "conditional_formats": [
+                    { "comparator": ">", "value": 30, "palette": "white_on_red" },
+                    { "comparator": ">", "value": 20, "palette": "white_on_yellow" },
+                    { "comparator": "<=", "value": 20, "palette": "white_on_green" }
+                  ]
+                }
+              ]
+            },
+            "layout": { "width": 4, "height": 3 }
+          },
+          {
+            "definition": {
+              "type": "query_table",
+              "title": "Per-project tree shape — concentration, rows, worst leaf",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "largest_leaf",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "max", "metric": "@taxonomy.quality.largestLeafShare" },
+                      "group_by": [{ "facet": "@taxonomy.projectId", "limit": 40 }]
+                    },
+                    {
+                      "data_source": "spans",
+                      "name": "largest_top_level",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "max", "metric": "@taxonomy.quality.largestTopLevelShare" },
+                      "group_by": [{ "facet": "@taxonomy.projectId", "limit": 40 }]
+                    },
+                    {
+                      "data_source": "spans",
+                      "name": "rows",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "max", "metric": "@taxonomy.quality.topLevelRowCount" },
+                      "group_by": [{ "facet": "@taxonomy.projectId", "limit": 40 }]
+                    },
+                    {
+                      "data_source": "spans",
+                      "name": "worst_leaf_cohesion",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "min", "metric": "@taxonomy.quality.centeredCohesion.min" },
+                      "group_by": [{ "facet": "@taxonomy.projectId", "limit": 40 }]
+                    },
+                    {
+                      "data_source": "spans",
+                      "name": "members",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "max", "metric": "@taxonomy.quality.membersClustered" },
+                      "group_by": [{ "facet": "@taxonomy.projectId", "limit": 40 }]
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "formula": "largest_leaf",
+                      "alias": "largestLeafShare",
+                      "conditional_formats": [
+                        { "comparator": ">", "value": 0.7, "palette": "white_on_red" },
+                        { "comparator": ">", "value": 0.5, "palette": "white_on_yellow" },
+                        { "comparator": "<=", "value": 0.5, "palette": "white_on_green" }
+                      ]
+                    },
+                    { "formula": "largest_top_level", "alias": "largestTopLevelShare" },
+                    {
+                      "formula": "rows",
+                      "alias": "topLevelRowCount",
+                      "conditional_formats": [
+                        { "comparator": "<=", "value": 2, "palette": "white_on_yellow" },
+                        { "comparator": ">", "value": 2, "palette": "white_on_green" }
+                      ]
+                    },
+                    {
+                      "formula": "worst_leaf_cohesion",
+                      "alias": "worst leaf centeredCohesion",
+                      "conditional_formats": [
+                        { "comparator": "<", "value": 0.35, "palette": "white_on_red" },
+                        { "comparator": "<", "value": 0.45, "palette": "white_on_yellow" },
+                        { "comparator": ">=", "value": 0.45, "palette": "white_on_green" }
+                      ]
+                    },
+                    { "formula": "members", "alias": "membersClustered" }
+                  ],
+                  "response_format": "scalar",
+                  "sort": { "order_by": [{ "type": "formula", "index": 0, "order": "desc" }], "count": 40 }
+                }
+              ]
+            },
+            "layout": { "width": 12, "height": 6 }
+          }
+        ]
+      },
+      "layout": { "width": 12, "height": 14 }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "layout_type": "ordered",
+        "title": "Concentration vs shape — the pair that catches a false win",
+        "show_title": true,
+        "widgets": [
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "avg largestLeafShare and largestTopLevelShare — a drop in one with a drop in rows is a regression",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "leaf_share",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "avg", "metric": "@taxonomy.quality.largestLeafShare" }
+                    },
+                    {
+                      "data_source": "spans",
+                      "name": "top_share",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "avg", "metric": "@taxonomy.quality.largestTopLevelShare" }
+                    }
+                  ],
+                  "formulas": [
+                    { "formula": "leaf_share", "alias": "avg largestLeafShare" },
+                    { "formula": "top_share", "alias": "avg largestTopLevelShare" }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ]
+            },
+            "layout": { "width": 6, "height": 4 }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "avg topLevelRowCount and leafCount — rows must never fall when de-nesting lands",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "rows",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "avg", "metric": "@taxonomy.quality.topLevelRowCount" }
+                    },
+                    {
+                      "data_source": "spans",
+                      "name": "leaves",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "avg", "metric": "@taxonomy.quality.leafCount" }
+                    }
+                  ],
+                  "formulas": [
+                    { "formula": "rows", "alias": "avg topLevelRowCount" },
+                    { "formula": "leaves", "alias": "avg leafCount" }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ]
+            },
+            "layout": { "width": 6, "height": 4 }
+          },
+          {
+            "definition": {
+              "type": "toplist",
+              "title": "min centeredCohesion by project — worst leaf first, below 0.35 is residue",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "cohesion",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "min", "metric": "@taxonomy.quality.centeredCohesion.min" },
+                      "group_by": [{ "facet": "@taxonomy.projectId", "limit": 20 }]
+                    }
+                  ],
+                  "formulas": [{ "formula": "cohesion" }],
+                  "response_format": "scalar",
+                  "sort": { "order_by": [{ "type": "formula", "index": 0, "order": "asc" }], "count": 20 },
+                  "conditional_formats": [
+                    { "comparator": "<", "value": 0.35, "palette": "white_on_red" },
+                    { "comparator": "<", "value": 0.45, "palette": "white_on_yellow" },
+                    { "comparator": ">=", "value": 0.45, "palette": "white_on_green" }
+                  ]
+                }
+              ]
+            },
+            "layout": { "width": 12, "height": 4 }
+          }
+        ]
+      },
+      "layout": { "width": 12, "height": 13 }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "layout_type": "ordered",
+        "title": "Naming — collisions and shared-domain labels",
+        "show_title": true,
+        "widgets": [
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Cross-branch duplicate leaf names — the collisions the quality gate cannot see (target 0)",
+              "autoscale": true,
+              "precision": 0,
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "cross_branch",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.nameQuality $organization $project"
+                      },
+                      "compute": {
+                        "aggregation": "max",
+                        "metric": "@taxonomy.quality.crossBranchDuplicateLeafCount"
+                      }
+                    }
+                  ],
+                  "formulas": [{ "formula": "cross_branch" }],
+                  "response_format": "scalar",
+                  "aggregator": "max",
+                  "conditional_formats": [
+                    { "comparator": ">", "value": 0, "palette": "white_on_red" },
+                    { "comparator": "<=", "value": 0, "palette": "white_on_green" }
+                  ]
+                }
+              ]
+            },
+            "layout": { "width": 4, "height": 3 }
+          },
+          {
+            "definition": {
+              "type": "toplist",
+              "title": "max duplicateNameRate by project",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "dup_rate",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.nameQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "max", "metric": "@taxonomy.quality.duplicateNameRate" },
+                      "group_by": [{ "facet": "@taxonomy.projectId", "limit": 15 }]
+                    }
+                  ],
+                  "formulas": [{ "formula": "dup_rate" }],
+                  "response_format": "scalar",
+                  "sort": { "order_by": [{ "type": "formula", "index": 0, "order": "desc" }], "count": 15 },
+                  "conditional_formats": [
+                    { "comparator": ">", "value": 0, "palette": "white_on_yellow" },
+                    { "comparator": "<=", "value": 0, "palette": "white_on_green" }
+                  ]
+                }
+              ]
+            },
+            "layout": { "width": 4, "height": 3 }
+          },
+          {
+            "definition": {
+              "type": "toplist",
+              "title": "max sharedSiblingWordShare by project — high means the namer described the domain, not the split",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "shared_words",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.nameQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "max", "metric": "@taxonomy.quality.sharedSiblingWordShare" },
+                      "group_by": [{ "facet": "@taxonomy.projectId", "limit": 15 }]
+                    }
+                  ],
+                  "formulas": [{ "formula": "shared_words" }],
+                  "response_format": "scalar",
+                  "sort": { "order_by": [{ "type": "formula", "index": 0, "order": "desc" }], "count": 15 },
+                  "conditional_formats": [
+                    { "comparator": ">", "value": 0.6, "palette": "white_on_red" },
+                    { "comparator": ">", "value": 0.4, "palette": "white_on_yellow" },
+                    { "comparator": "<=", "value": 0.4, "palette": "white_on_green" }
+                  ]
+                }
+              ]
+            },
+            "layout": { "width": 4, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "width": 12, "height": 5 }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "layout_type": "ordered",
+        "title": "Durable history — span metrics, 15 months, for the before/after across builds",
+        "show_title": true,
+        "widgets": [
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "taxonomy.quality.largest_leaf_share p50 and p90 — spans expire at 15 days, this does not",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "p50",
+                      "query": "p50:taxonomy.quality.largest_leaf_share{$organization,$project}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "p90",
+                      "query": "p90:taxonomy.quality.largest_leaf_share{$organization,$project}"
+                    }
+                  ],
+                  "formulas": [
+                    { "formula": "p50", "alias": "p50 largestLeafShare" },
+                    { "formula": "p90", "alias": "p90 largestLeafShare" }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ]
+            },
+            "layout": { "width": 6, "height": 4 }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "taxonomy.quality.top_level_row_count avg and p90",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "rows_avg",
+                      "query": "avg:taxonomy.quality.top_level_row_count{$organization,$project}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "rows_p90",
+                      "query": "p90:taxonomy.quality.top_level_row_count{$organization,$project}"
+                    }
+                  ],
+                  "formulas": [
+                    { "formula": "rows_avg", "alias": "avg topLevelRowCount" },
+                    { "formula": "rows_p90", "alias": "p90 topLevelRowCount" }
+                  ],
+                  "response_format": "timeseries",
+                  "display_type": "line",
+                  "style": { "palette": "dog_classic", "line_type": "solid", "line_width": "normal" }
+                }
+              ]
+            },
+            "layout": { "width": 6, "height": 4 }
+          }
+        ]
+      },
+      "layout": { "width": 12, "height": 5 }
+    }
+  ]
+}

--- a/apps/workflows/datadog/taxonomy-quality-dashboard.json
+++ b/apps/workflows/datadog/taxonomy-quality-dashboard.json
@@ -449,12 +449,12 @@
                     {
                       "data_source": "metrics",
                       "name": "p50",
-                      "query": "p50:taxonomy.quality.largest_leaf_share{$organization,$project}"
+                      "query": "p50:taxonomy.quality.largest_leaf_share{organization_id:$organization.value,project_id:$project.value}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "p90",
-                      "query": "p90:taxonomy.quality.largest_leaf_share{$organization,$project}"
+                      "query": "p90:taxonomy.quality.largest_leaf_share{organization_id:$organization.value,project_id:$project.value}"
                     }
                   ],
                   "formulas": [
@@ -481,12 +481,12 @@
                     {
                       "data_source": "metrics",
                       "name": "rows_avg",
-                      "query": "avg:taxonomy.quality.top_level_row_count{$organization,$project}"
+                      "query": "avg:taxonomy.quality.top_level_row_count{organization_id:$organization.value,project_id:$project.value}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "rows_p90",
-                      "query": "p90:taxonomy.quality.top_level_row_count{$organization,$project}"
+                      "query": "p90:taxonomy.quality.top_level_row_count{organization_id:$organization.value,project_id:$project.value}"
                     }
                   ],
                   "formulas": [

--- a/apps/workflows/datadog/taxonomy-quality-datadog-setup.md
+++ b/apps/workflows/datadog/taxonomy-quality-datadog-setup.md
@@ -1,0 +1,112 @@
+# Taxonomy tree quality — Datadog setup
+
+Every garden run emits two APM spans from the `workflows` service:
+
+| span (`resource_name`) | emitted by | carries |
+| --- | --- | --- |
+| `taxonomy.gardenTaxonomyWorkflow.buildQuality` | the planning activity, off the tree the run persists | `largestLeafShare`, `leafSizes`, `topLevelRowCount`, `largestTopLevelShare`, per-leaf `centeredCohesion` (p10/p50/p90 + min) |
+| `taxonomy.gardenTaxonomyWorkflow.nameQuality` | the assert-quality activity, after naming | `duplicateNameRate`, `crossBranchDuplicateLeafCount`, `sharedSiblingWordShare` |
+
+Unlike `taxonomy.gardenTaxonomyWorkflow.shadow`, **neither is flag-gated**: they
+fire for every project, every view, in every clustering mode, which is the point —
+a baseline that excluded the projects running `off` would be a baseline for nobody.
+Budget for roughly two spans per garden run; the flag-gated shadow span alone runs
+~5k/week, so expect these to land somewhat above that each.
+
+Application logs go to CloudWatch, not Datadog, so spans are the read path.
+
+## Do this before the Build 4 deploy, and before Builds 1–3 land
+
+Retention filters and span metrics are **not retroactive**. Build 4 exists so that
+de-nesting, sibling merging and contrastive naming have a measured before/after; if
+these objects are created after those builds ship, there is no "before" and the
+whole enabler is wasted. Order:
+
+1. `DD_APP_KEY=xxx DD_API_KEY=yyy ./apps/workflows/datadog/setup-datadog.sh` —
+   creates the `Taxonomy quality spans` retention filter and the `taxonomy.quality.*`
+   span metrics (alongside the adaptive-rollout objects it already managed).
+   Idempotent: every object is deleted and recreated, so re-running repairs drift.
+2. Move the new filter **above** any broad `service:workflows` or catch-all filter
+   (APM → Retention Filters). Filters are evaluated top-down and the first match
+   decides, so a broad filter above this one samples the quality spans out before it
+   runs. The script cannot set ordering.
+3. Apply `taxonomy-quality-dashboard.json` with the Datadog MCP
+   `upsert_datadog_dashboard`.
+4. Deploy Build 4, then confirm in Trace Explorer:
+   `service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.buildQuality`.
+   Gardening runs ~6-hourly per project, so the first spans land within hours.
+5. Let it accrue **before** merging Builds 1–3.
+
+The keys' role needs `apm_retention_filter_write` and `apm_generate_metrics`; a key
+without them returns 403.
+
+## The two channels, and why both exist
+
+**Retention filter (15 days).** Keeps 100% of the quality spans so a single run is
+readable per project in Trace Explorer. This is the only way to read `leafSizes` —
+it is a comma-joined string tag, not a number, so it cannot become a metric, and
+the sorted vector (`1302,52,43,38,18,16,16,15`) is what makes a regression legible
+at a glance.
+
+**Span metrics (15 months).** Generated at ingestion, so they accrue independently
+of what the retention filter indexes and outlive the 15-day span window. This is
+the channel that carries the before/after across builds that land weeks apart. The
+script generates distributions (with percentiles) grouped by project, organization,
+custom behavior and facet:
+
+`largest_leaf_share`, `largest_top_level_share`, `top_level_row_count`,
+`leaf_count`, `members_clustered`, `centered_cohesion_min`, `centered_cohesion_p50`,
+`duplicate_name_rate`, `cross_branch_duplicates`, `shared_sibling_word_share`.
+
+## Interpreting the dashboard
+
+| Metric | What it is | Good | Bad / watch |
+| --- | --- | --- | --- |
+| `largestLeafShare` | Biggest leaf ÷ members in the build's own partition | Below ~0.4 | Above 0.5 — one group swallows the project and the tree is unreadable. Measured on the fleet: 16 of 29 projects had a single cluster holding a majority, 3 resolved to a single cluster |
+| `largestTopLevelShare` | Same, over the promoted top-level rows | Tracks `largestLeafShare` | Diverging from it means the concentration is in a parent, not a leaf |
+| `topLevelRowCount` | Rows after content-free interiors are promoted away | 4–17 | **Falling** after a change is the failure mode to catch (see below). Above ~30 is the width case the row cap exists for; the widest tree measured in production yields 17 |
+| `leafSizes` | Sorted leaf-size vector (span tag, Trace Explorer only) | A gradual profile | A long head and a flat tail — `[1302, 52, 43, …]` is one residue plus noise |
+| `centeredCohesion` min / p50 | Per-leaf cohesion on corpus-mean-centered vectors | Above ~0.45 | Below ~0.35 is residue. **Raw cohesion cannot see this** — it spans 0.85–0.94 for residue and genuine leaves alike, because the corpus-wide shared component inflates both. Rank on the minimum: an 88-session leaf measured ~58% one job plus a 42% unrelated tail, and mid-range cohesion did not certify it |
+| `duplicateNameRate` | Leaves colliding with any other leaf **anywhere** in the tree | 0 | Non-zero. The shipped quality gate only compares siblings, so cross-branch collisions ship silently |
+| `crossBranchDuplicateLeafCount` | The subset the gate cannot see | 0 | Any. Observed twice in one tree |
+| `sharedSiblingWordShare` | Share of leaf-name words every sibling also uses | Below ~0.4 | Above ~0.6 — the namer described the shared domain instead of the split. On the best-separated partition available, 90% of leaf-name words came from vocabulary true of every session |
+
+### The one pairing that matters
+
+`largestLeafShare` and `topLevelRowCount` share a chart because reading either
+alone has already produced a wrong conclusion. One tested change improved
+`largestLeafShare` 62% → 49% while cutting top-level rows 3 → 2 and burying the
+newly-coherent groups two levels down: better on the tracked metric, worse for the
+customer. Treat a fall in row count as a regression even when concentration
+improves.
+
+### `topLevelRowCount` is not correct until de-nesting ships
+
+It is computed against the **promoted** row list — root unwrapped, content-free
+interiors replaced by their children — which is what the Behaviours screen will
+render once the de-nesting read lands. Until then the screen still shows the root's
+literal children (`topLevelClustersBuilt`, on the adaptive span), so the two
+disagree by design.
+
+A second consequence: the divisive builder routes every member to a leaf, so no
+freshly-built interior holds anything and `topLevelRowCount` currently always
+equals `leafCount`. That is a fact about today's builder, not the definition —
+interior residue is a display-path phenomenon, from online routing stopping at an
+interior between rebuilds.
+
+### Reading a trend needs ~2 weeks
+
+Same caveat as the adaptive dashboard: gardening runs every ~6h but each run
+clusters a sample from the trailing 7-day window, so consecutive runs share nearly
+all their input. One week for the window to turn over, two to confirm a shape holds
+across more than one turnover. Cross-branch duplicates are the exception — a single
+run is enough to see one.
+
+### Not on this dashboard
+
+`leafSizes` (string tag — Trace Explorer), and any query over live
+`assigned_cluster_id`. Deriving these shares from a window of assignments mixes the
+current tree with historical `centroid_online` assignments to deprecated clusters
+and biases them badly: two projects measured both ways came out 0.22 vs **0.54**
+and 0.45 vs **0.87**. Anything added later must scope to a single
+`reassignment_run_id`.

--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -16,6 +16,7 @@ import {
   emitLineageUseCase,
   type HierarchicalTaxonomyPlan,
   isDisplayableTaxonomyName,
+  measureTaxonomyNameQualityUseCase,
   planFacetGardenUseCase,
   planHierarchicalTaxonomyUseCase,
   type ReassignmentLeaf,
@@ -34,6 +35,7 @@ import {
   type TaxonomyClusterLineage,
   TaxonomyClusterRepository,
   type TaxonomyDimension,
+  type TaxonomyNameQualityMetrics,
   TaxonomyObservationRepository,
   type TaxonomyRun,
   TaxonomyRunRepository,
@@ -62,7 +64,14 @@ import { Data, Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
 import { billingMeteringRepositoriesLive, withActivityAIMetering } from "./ai-metering.ts"
 import { buildHierarchicalClustersInWorker } from "./taxonomy-clustering-worker.ts"
-import { adaptiveGardenRunFields, adaptiveSpanAttributes } from "./taxonomy-gardening-telemetry.ts"
+import {
+  adaptiveGardenRunFields,
+  adaptiveSpanAttributes,
+  buildQualityFields,
+  buildQualitySpanAttributes,
+  nameQualityFields,
+  nameQualitySpanAttributes,
+} from "./taxonomy-gardening-telemetry.ts"
 
 /**
  * Resolve which builder this garden run persists, from the per-organization
@@ -599,6 +608,29 @@ const emitDegenerateRebuildTelemetry = (input: GardenTaxonomyStepInput, plan: Hi
   })
 }
 
+// Quality is emitted for every mode — `off` is what most projects run, and a
+// baseline that excluded them would be a baseline for nobody.
+const emitBuildQualityTelemetry = (input: GardenTaxonomyStepInput, plan: HierarchicalTaxonomyPlan): void => {
+  const metrics = plan.qualityMetrics
+  if (!metrics) return
+  logger.info("Taxonomy build quality", {
+    metric: "taxonomy.gardenTaxonomyWorkflow.buildQuality",
+    ...buildQualityFields(input, plan, metrics),
+  })
+}
+
+const annotateBuildQualitySpan = (input: GardenTaxonomyStepInput, plan: HierarchicalTaxonomyPlan) => {
+  const metrics = plan.qualityMetrics
+  if (!metrics) return Effect.void
+  return Effect.gen(function* () {
+    // Same reason as the adaptive span: APM sampling drops these low-volume traces otherwise.
+    yield* Effect.annotateCurrentSpan("manual.keep", true)
+    for (const [key, value] of Object.entries(buildQualitySpanAttributes(input, plan, metrics))) {
+      yield* Effect.annotateCurrentSpan(key, value)
+    }
+  }).pipe(Effect.withSpan("taxonomy.gardenTaxonomyWorkflow.buildQuality"))
+}
+
 // Telemetry + persist the staged plan artifact + shape the activity result. No
 // repository requirements (Redis + sync only), so both the topic and facet
 // planning paths reuse it after computing the plan under their own layers.
@@ -606,7 +638,9 @@ const finalizeGardenPlan = (input: GardenTaxonomyStepInput, plan: HierarchicalTa
   Effect.gen(function* () {
     yield* Effect.sync(() => emitAdaptivePlanTelemetry(input, plan))
     yield* Effect.sync(() => emitDegenerateRebuildTelemetry(input, plan))
+    yield* Effect.sync(() => emitBuildQualityTelemetry(input, plan))
     yield* annotateAdaptiveTelemetrySpan(input, plan)
+    yield* annotateBuildQualitySpan(input, plan)
     const planKey = yield* storeGardenTaxonomyPlan(input, {
       clusters: plan.clusters,
       observationAssignments: plan.observationAssignments,
@@ -1005,21 +1039,41 @@ export const deprecateGardenTaxonomyClustersActivity = (input: GardenTaxonomyDep
     }),
   )
 
-export const assertGardenTaxonomyQualityActivity = (input: GardenTaxonomyStepInput) =>
-  runGardenStep(
+// Measured before the gate runs, so a tree that trips the gate still reports how
+// its names came out — that is exactly the run worth measuring.
+const emitNameQualityTelemetry = (input: GardenTaxonomyStepInput, metrics: TaxonomyNameQualityMetrics) =>
+  Effect.gen(function* () {
+    yield* Effect.sync(() =>
+      logger.info("Taxonomy name quality", {
+        metric: "taxonomy.gardenTaxonomyWorkflow.nameQuality",
+        ...nameQualityFields(input, metrics),
+      }),
+    )
+    yield* Effect.annotateCurrentSpan("manual.keep", true)
+    for (const [key, value] of Object.entries(nameQualitySpanAttributes(input, metrics))) {
+      yield* Effect.annotateCurrentSpan(key, value)
+    }
+  }).pipe(Effect.withSpan("taxonomy.gardenTaxonomyWorkflow.nameQuality"))
+
+export const assertGardenTaxonomyQualityActivity = (input: GardenTaxonomyStepInput) => {
+  const scope = {
+    projectId: ProjectId(input.projectId),
+    dimension: input.dimension,
+    ...(input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}),
+    ...(input.facetId ? { facetId: FacetId(input.facetId) } : {}),
+  }
+  return runGardenStep(
     "GardenTaxonomyWorkflow assert quality",
     input,
-    assertTaxonomyQualityUseCase({
-      organizationId: OrganizationId(input.organizationId),
-      projectId: ProjectId(input.projectId),
-      dimension: input.dimension,
-      ...(input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}),
-      ...(input.facetId ? { facetId: FacetId(input.facetId) } : {}),
+    Effect.gen(function* () {
+      yield* emitNameQualityTelemetry(input, yield* measureTaxonomyNameQualityUseCase(scope))
+      return yield* assertTaxonomyQualityUseCase({ organizationId: OrganizationId(input.organizationId), ...scope })
     }).pipe(
       (effect) => withTaxonomyPostgres(effect, input.organizationId),
       (effect) => withTaxonomyClickHouse(effect, input.organizationId),
     ),
   )
+}
 
 export const planGardenTaxonomyNamingActivity = (
   input: GardenTaxonomyStepInput & GardenTaxonomyLineageResult & { readonly planKey?: string },

--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -608,8 +608,7 @@ const emitDegenerateRebuildTelemetry = (input: GardenTaxonomyStepInput, plan: Hi
   })
 }
 
-// Quality is emitted for every mode — `off` is what most projects run, and a
-// baseline that excluded them would be a baseline for nobody.
+// Emitted for every mode, unlike the adaptive telemetry above; `off` is what most projects run.
 const emitBuildQualityTelemetry = (input: GardenTaxonomyStepInput, plan: HierarchicalTaxonomyPlan): void => {
   const metrics = plan.qualityMetrics
   if (!metrics) return
@@ -1039,8 +1038,7 @@ export const deprecateGardenTaxonomyClustersActivity = (input: GardenTaxonomyDep
     }),
   )
 
-// Measured before the gate runs, so a tree that trips the gate still reports how
-// its names came out — that is exactly the run worth measuring.
+// Measured before the gate runs, so a tree that trips it still reports how its names came out.
 const emitNameQualityTelemetry = (input: GardenTaxonomyStepInput, metrics: TaxonomyNameQualityMetrics) =>
   Effect.gen(function* () {
     yield* Effect.sync(() =>

--- a/apps/workflows/src/activities/taxonomy-gardening-telemetry.test.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-telemetry.test.ts
@@ -1,6 +1,12 @@
-import type { HierarchicalTaxonomyPlan } from "@domain/taxonomy"
+import type { HierarchicalTaxonomyPlan, TaxonomyBuildQualityMetrics } from "@domain/taxonomy"
 import { describe, expect, it } from "vitest"
-import { adaptiveGardenRunFields, adaptiveSpanAttributes } from "./taxonomy-gardening-telemetry.ts"
+import {
+  adaptiveGardenRunFields,
+  adaptiveSpanAttributes,
+  buildQualityFields,
+  buildQualitySpanAttributes,
+  nameQualitySpanAttributes,
+} from "./taxonomy-gardening-telemetry.ts"
 
 const scope = { organizationId: "o".repeat(24), projectId: "p".repeat(24) }
 
@@ -101,5 +107,63 @@ describe("adaptiveGardenRunFields", () => {
     expect(fields.nodeCount).toBe(9)
     expect(fields.peakRssBytes).toBeGreaterThan(0)
     expect(JSON.stringify(fields)).not.toContain("acceptedRelativeSeparations")
+  })
+})
+
+const qualityMetrics: TaxonomyBuildQualityMetrics = {
+  membersClustered: 1_500,
+  leafCount: 8,
+  largestLeafShare: 0.868,
+  topLevelRowCount: 8,
+  largestTopLevelShare: 0.868,
+  leaves: [
+    { size: 1_302, centeredCohesion: 0.249 },
+    { size: 52, centeredCohesion: 0.684 },
+    { size: 43, centeredCohesion: 0.862 },
+  ],
+}
+
+describe("buildQualitySpanAttributes", () => {
+  it("carries the shares, the leaf-size vector, and the worst leaf's centered cohesion", () => {
+    const attributes = buildQualitySpanAttributes(scope, plan({ mode: "off" }), qualityMetrics)
+
+    expect(attributes["taxonomy.quality.largestLeafShare"]).toBeCloseTo(0.868)
+    expect(attributes["taxonomy.quality.leafSizes"]).toBe("1302,52,43")
+    expect(attributes["taxonomy.quality.centeredCohesion.min"]).toBeCloseTo(0.249)
+    // Emitted for every mode, unlike the adaptive attributes.
+    expect(attributes["taxonomy.quality.mode"]).toBe("off")
+  })
+
+  it("reports how many leaves the profile bound dropped rather than truncating silently", () => {
+    const attributes = buildQualitySpanAttributes(scope, plan(), qualityMetrics)
+
+    expect(attributes["taxonomy.quality.leavesOmitted"]).toBe(5)
+  })
+})
+
+describe("buildQualityFields", () => {
+  it("logs the sorted leaf vector and the per-leaf cohesions alongside it", () => {
+    const fields = buildQualityFields(scope, plan(), qualityMetrics)
+
+    expect(fields.leafSizes).toEqual([1_302, 52, 43])
+    expect(fields.centeredCohesionByLeaf).toEqual([0.249, 0.684, 0.862])
+    expect(fields.topLevelRowCount).toBe(8)
+  })
+})
+
+describe("nameQualitySpanAttributes", () => {
+  it("separates cross-branch collisions from the sibling ones the gate already blocks", () => {
+    const attributes = nameQualitySpanAttributes(scope, {
+      leafCount: 10,
+      namedLeafCount: 10,
+      duplicateNameRate: 0.4,
+      duplicateNameLeafCount: 4,
+      crossBranchDuplicateLeafCount: 2,
+      sharedSiblingWordShare: 0.9,
+    })
+
+    expect(attributes["taxonomy.quality.duplicateNameRate"]).toBeCloseTo(0.4)
+    expect(attributes["taxonomy.quality.crossBranchDuplicateLeafCount"]).toBe(2)
+    expect(attributes["taxonomy.quality.sharedSiblingWordShare"]).toBeCloseTo(0.9)
   })
 })

--- a/apps/workflows/src/activities/taxonomy-gardening-telemetry.test.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-telemetry.test.ts
@@ -116,6 +116,8 @@ const qualityMetrics: TaxonomyBuildQualityMetrics = {
   largestLeafShare: 0.868,
   topLevelRowCount: 8,
   largestTopLevelShare: 0.868,
+  promotedResidue: 0,
+  centeredCohesion: { p10: 0.249, p50: 0.684, p90: 0.862, min: 0.11 },
   leaves: [
     { size: 1_302, centeredCohesion: 0.249 },
     { size: 52, centeredCohesion: 0.684 },
@@ -129,7 +131,8 @@ describe("buildQualitySpanAttributes", () => {
 
     expect(attributes["taxonomy.quality.largestLeafShare"]).toBeCloseTo(0.868)
     expect(attributes["taxonomy.quality.leafSizes"]).toBe("1302,52,43")
-    expect(attributes["taxonomy.quality.centeredCohesion.min"]).toBeCloseTo(0.249)
+    // Taken over every leaf, so a low-cohesion leaf outside the bounded profile still shows here.
+    expect(attributes["taxonomy.quality.centeredCohesion.min"]).toBeCloseTo(0.11)
     // Emitted for every mode, unlike the adaptive attributes.
     expect(attributes["taxonomy.quality.mode"]).toBe("off")
   })

--- a/apps/workflows/src/activities/taxonomy-gardening-telemetry.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-telemetry.ts
@@ -130,21 +130,20 @@ export const buildQualityFields = (
   largestLeafShare: metrics.largestLeafShare,
   topLevelRowCount: metrics.topLevelRowCount,
   largestTopLevelShare: metrics.largestTopLevelShare,
+  promotedResidue: metrics.promotedResidue,
   // The sorted vector is the point: [1302, 52, 43, 38] reads as a regression at a glance.
   leafSizes: metrics.leaves.map((leaf) => leaf.size),
   centeredCohesionByLeaf: metrics.leaves.map((leaf) => leaf.centeredCohesion),
+  centeredCohesion: metrics.centeredCohesion,
   leavesOmitted: metrics.leafCount - metrics.leaves.length,
 })
-
-const cohesions = (metrics: TaxonomyBuildQualityMetrics): readonly number[] =>
-  metrics.leaves.map((leaf) => leaf.centeredCohesion)
 
 export const buildQualitySpanAttributes = (
   scope: QualityTelemetryScope,
   plan: HierarchicalTaxonomyPlan,
   metrics: TaxonomyBuildQualityMetrics,
 ): Record<string, string | number> => {
-  const centeredCohesion = boundedPercentiles(cohesions(metrics))
+  const centeredCohesion = metrics.centeredCohesion
   return {
     "taxonomy.organizationId": scope.organizationId,
     "taxonomy.projectId": scope.projectId,
@@ -157,6 +156,8 @@ export const buildQualitySpanAttributes = (
     // Rows AFTER content-free interiors are promoted away — not the root's literal child count.
     "taxonomy.quality.topLevelRowCount": metrics.topLevelRowCount,
     "taxonomy.quality.largestTopLevelShare": metrics.largestTopLevelShare,
+    // Non-zero means rows do not sum to the partition, so the shares above have a wider denominator than the rows.
+    "taxonomy.quality.promotedResidue": metrics.promotedResidue,
     // Span tags are flat scalars, so the vector travels as a string.
     "taxonomy.quality.leafSizes": metrics.leaves.map((leaf) => leaf.size).join(","),
     "taxonomy.quality.leavesOmitted": metrics.leafCount - metrics.leaves.length,
@@ -164,7 +165,7 @@ export const buildQualitySpanAttributes = (
     "taxonomy.quality.centeredCohesion.p50": centeredCohesion.p50,
     "taxonomy.quality.centeredCohesion.p90": centeredCohesion.p90,
     // Residue shows up as the worst leaf, which percentiles over a 5-leaf tree can hide.
-    "taxonomy.quality.centeredCohesion.min": Math.min(...cohesions(metrics), 1),
+    "taxonomy.quality.centeredCohesion.min": centeredCohesion.min,
   }
 }
 

--- a/apps/workflows/src/activities/taxonomy-gardening-telemetry.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-telemetry.ts
@@ -109,11 +109,7 @@ export const adaptiveSpanAttributes = (
   return attributes
 }
 
-/**
- * Build-quality payload — emitted for EVERY mode, unlike the adaptive events
- * above, because the baseline these metrics exist to establish has to cover the
- * projects running `off` (which is most of them).
- */
+/** Build-quality payload — emitted for EVERY mode, unlike the adaptive events above. */
 export const buildQualityFields = (
   scope: QualityTelemetryScope,
   plan: HierarchicalTaxonomyPlan,

--- a/apps/workflows/src/activities/taxonomy-gardening-telemetry.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-telemetry.ts
@@ -6,7 +6,11 @@
  * percentile summaries, never a raw per-split array, member id, or embedding.
  */
 
-import type { HierarchicalTaxonomyPlan } from "@domain/taxonomy"
+import type {
+  HierarchicalTaxonomyPlan,
+  TaxonomyBuildQualityMetrics,
+  TaxonomyNameQualityMetrics,
+} from "@domain/taxonomy"
 import { boundedPercentiles, TAXONOMY_ADAPTIVE_POLICY_VERSION } from "@domain/taxonomy"
 
 /** The scope fields the events carry; a structural subset of `GardenTaxonomyStepInput`. */
@@ -14,6 +18,11 @@ export interface AdaptiveTelemetryScope {
   readonly organizationId: string
   readonly projectId: string
   readonly customBehaviorId?: string | undefined
+}
+
+/** Quality is emitted for every tree, so unlike the adaptive events it names the facet too. */
+export interface QualityTelemetryScope extends AdaptiveTelemetryScope {
+  readonly facetId?: string | undefined
 }
 
 /** Log payload for one adaptive garden run — CloudWatch only, so un-sampled unlike the span mirror below. */
@@ -99,3 +108,87 @@ export const adaptiveSpanAttributes = (
   }
   return attributes
 }
+
+/**
+ * Build-quality payload — emitted for EVERY mode, unlike the adaptive events
+ * above, because the baseline these metrics exist to establish has to cover the
+ * projects running `off` (which is most of them).
+ */
+export const buildQualityFields = (
+  scope: QualityTelemetryScope,
+  plan: HierarchicalTaxonomyPlan,
+  metrics: TaxonomyBuildQualityMetrics,
+) => ({
+  mode: plan.mode,
+  organizationId: scope.organizationId,
+  projectId: scope.projectId,
+  customBehaviorId: scope.customBehaviorId,
+  facetId: scope.facetId,
+  fallbackReason: plan.fallbackReason,
+  membersClustered: metrics.membersClustered,
+  leafCount: metrics.leafCount,
+  largestLeafShare: metrics.largestLeafShare,
+  topLevelRowCount: metrics.topLevelRowCount,
+  largestTopLevelShare: metrics.largestTopLevelShare,
+  // The sorted vector is the point: [1302, 52, 43, 38] reads as a regression at a glance.
+  leafSizes: metrics.leaves.map((leaf) => leaf.size),
+  centeredCohesionByLeaf: metrics.leaves.map((leaf) => leaf.centeredCohesion),
+  leavesOmitted: metrics.leafCount - metrics.leaves.length,
+})
+
+const cohesions = (metrics: TaxonomyBuildQualityMetrics): readonly number[] =>
+  metrics.leaves.map((leaf) => leaf.centeredCohesion)
+
+export const buildQualitySpanAttributes = (
+  scope: QualityTelemetryScope,
+  plan: HierarchicalTaxonomyPlan,
+  metrics: TaxonomyBuildQualityMetrics,
+): Record<string, string | number> => {
+  const centeredCohesion = boundedPercentiles(cohesions(metrics))
+  return {
+    "taxonomy.organizationId": scope.organizationId,
+    "taxonomy.projectId": scope.projectId,
+    "taxonomy.customBehaviorId": scope.customBehaviorId ?? "none",
+    "taxonomy.facetId": scope.facetId ?? "none",
+    "taxonomy.quality.mode": plan.mode,
+    "taxonomy.quality.membersClustered": metrics.membersClustered,
+    "taxonomy.quality.leafCount": metrics.leafCount,
+    "taxonomy.quality.largestLeafShare": metrics.largestLeafShare,
+    // Rows AFTER content-free interiors are promoted away — not the root's literal child count.
+    "taxonomy.quality.topLevelRowCount": metrics.topLevelRowCount,
+    "taxonomy.quality.largestTopLevelShare": metrics.largestTopLevelShare,
+    // Span tags are flat scalars, so the vector travels as a string.
+    "taxonomy.quality.leafSizes": metrics.leaves.map((leaf) => leaf.size).join(","),
+    "taxonomy.quality.leavesOmitted": metrics.leafCount - metrics.leaves.length,
+    "taxonomy.quality.centeredCohesion.p10": centeredCohesion.p10,
+    "taxonomy.quality.centeredCohesion.p50": centeredCohesion.p50,
+    "taxonomy.quality.centeredCohesion.p90": centeredCohesion.p90,
+    // Residue shows up as the worst leaf, which percentiles over a 5-leaf tree can hide.
+    "taxonomy.quality.centeredCohesion.min": Math.min(...cohesions(metrics), 1),
+  }
+}
+
+export const nameQualityFields = (scope: QualityTelemetryScope, metrics: TaxonomyNameQualityMetrics) => ({
+  organizationId: scope.organizationId,
+  projectId: scope.projectId,
+  customBehaviorId: scope.customBehaviorId,
+  facetId: scope.facetId,
+  ...metrics,
+})
+
+export const nameQualitySpanAttributes = (
+  scope: QualityTelemetryScope,
+  metrics: TaxonomyNameQualityMetrics,
+): Record<string, string | number> => ({
+  "taxonomy.organizationId": scope.organizationId,
+  "taxonomy.projectId": scope.projectId,
+  "taxonomy.customBehaviorId": scope.customBehaviorId ?? "none",
+  "taxonomy.facetId": scope.facetId ?? "none",
+  "taxonomy.quality.leafCount": metrics.leafCount,
+  "taxonomy.quality.namedLeafCount": metrics.namedLeafCount,
+  "taxonomy.quality.duplicateNameRate": metrics.duplicateNameRate,
+  "taxonomy.quality.duplicateNameLeafCount": metrics.duplicateNameLeafCount,
+  // The collisions the sibling-scoped quality gate lets through.
+  "taxonomy.quality.crossBranchDuplicateLeafCount": metrics.crossBranchDuplicateLeafCount,
+  "taxonomy.quality.sharedSiblingWordShare": metrics.sharedSiblingWordShare,
+})

--- a/packages/domain/models/src/registry.test.ts
+++ b/packages/domain/models/src/registry.test.ts
@@ -467,10 +467,11 @@ describe("getCostSpec bare model ids on namespaced providers", () => {
   })
 
   it("leaves a bare id unpriced when two vendors on that provider share the name", () => {
-    // nano-gpt lists `TEE/glm-5` and `zai-org/glm-5`: two vendors, two rates, so picking one would
-    // invent a number. Driven through getCostSpec because the fallback lives in
+    // nano-gpt lists `TEE/glm-5.1` and `zai-org/glm-5.1`: two vendors, two rates, so picking one
+    // would invent a number. Driven through getCostSpec because the fallback lives in
     // `getModelForProvider` — `findModel` never reaches it, so asserting there proves nothing.
-    expect(getCostSpec("nano-gpt", "glm-5").costImplemented).toBe(false)
+    // The id has to be re-picked whenever a models.dev refresh drops one side of a pair.
+    expect(getCostSpec("nano-gpt", "glm-5.1").costImplemented).toBe(false)
   })
 
   it("does not reach into another provider's catalog for a model the reported one lacks", () => {

--- a/packages/domain/taxonomy/src/build-quality.test.ts
+++ b/packages/domain/taxonomy/src/build-quality.test.ts
@@ -71,6 +71,45 @@ describe("taxonomyBuildQualityMetrics", () => {
     expect(metrics.largestLeafShare).toBeCloseTo(1)
   })
 
+  it("summarizes cohesion over every leaf, including ones the profile bound drops", () => {
+    // 60 leaves, so the bound drops 10. The smallest leaf is the least cohesive, and sorting by
+    // size puts it last — exactly where a summary taken after truncation would stop looking.
+    const residue = range(0, 24).map((index) => embedding((index / 24) * 2 * Math.PI, 3))
+    const tight = range(0, 60).map(() => embedding(0.5, 3))
+    const embeddings = [...tight, ...residue]
+    const leaves = range(0, 60).map((index) => node([index]))
+    const tree = node(range(0, 84), [...leaves, node(range(60, 84))])
+
+    const metrics = taxonomyBuildQualityMetrics({ root: tree, embeddings })
+
+    expect(metrics.leafCount).toBe(61)
+    expect(metrics.leaves.length).toBe(50)
+    expect(metrics.leaves.some((leaf) => leaf.size === 24)).toBe(true)
+    expect(metrics.centeredCohesion.min).toBeLessThan(0.5)
+  })
+
+  it("reports members left in no row when a signpost is promoted away", () => {
+    // The interior holds 1 member of its own, so promoting it leaves that member in no row.
+    const tree = node(range(0, 100), [
+      node(range(0, 60), [node(range(0, 30)), node(range(30, 59))]),
+      node(range(60, 100)),
+    ])
+
+    const metrics = taxonomyBuildQualityMetrics({ root: tree, embeddings: [] })
+
+    expect(metrics.topLevelRowCount).toBe(3)
+    expect(metrics.promotedResidue).toBe(1)
+    expect(metrics.promotedResidue + 30 + 29 + 40).toBe(metrics.membersClustered)
+  })
+
+  it("counts a member-holding root's residue too, since the root is always unwrapped", () => {
+    const tree = node(range(0, 100), [node(range(0, 55)), node(range(55, 91))])
+
+    const metrics = taxonomyBuildQualityMetrics({ root: tree, embeddings: [] })
+
+    expect(metrics.promotedResidue).toBe(9)
+  })
+
   it("has no leaves and no shares when nothing was clustered", () => {
     const metrics = taxonomyBuildQualityMetrics({ root: node([]), embeddings: [] })
 

--- a/packages/domain/taxonomy/src/build-quality.test.ts
+++ b/packages/domain/taxonomy/src/build-quality.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest"
+import { promotedTopLevelRows, type ScaffoldingShape, taxonomyBuildQualityMetrics } from "./build-quality.ts"
+import type { ClusteringTreeNode } from "./clustering.ts"
+
+/** `memberIndices` at a node covers its whole subtree, so a parent's list is the union of its children's. */
+const node = (memberIndices: readonly number[], children: readonly ClusteringTreeNode[] = []): ClusteringTreeNode => ({
+  memberIndices,
+  centroid: [],
+  children,
+  depth: 0,
+})
+
+const range = (from: number, to: number): number[] => Array.from({ length: to - from }, (_, index) => from + index)
+
+/** Unit vectors that share a strong common component, so raw cohesion is high for everything. */
+const embedding = (angle: number, shared: number): readonly number[] => {
+  const x = shared
+  const y = Math.cos(angle)
+  const z = Math.sin(angle)
+  const norm = Math.sqrt(x * x + y * y + z * z)
+  return [x / norm, y / norm, z / norm]
+}
+
+describe("taxonomyBuildQualityMetrics", () => {
+  it("reports the leaf-size vector and the largest leaf's share of one build's partition", () => {
+    const tree = node(range(0, 100), [node(range(0, 70)), node(range(70, 90)), node(range(90, 100))])
+
+    const metrics = taxonomyBuildQualityMetrics({ root: tree, embeddings: [] })
+
+    expect(metrics.leaves.map((leaf) => leaf.size)).toEqual([70, 20, 10])
+    expect(metrics.largestLeafShare).toBeCloseTo(0.7)
+    expect(metrics.membersClustered).toBe(100)
+    expect(metrics.leafCount).toBe(3)
+  })
+
+  it("separates a residue leaf from a genuine one on centered cohesion where raw cohesion cannot", () => {
+    // Leaf A spans the whole angular range (a residue); leaf B is a tight arc.
+    const residue = range(0, 24).map((index) => embedding((index / 24) * 2 * Math.PI, 3))
+    const genuine = range(0, 24).map((index) => embedding(0.9 + (index / 24) * 0.2, 3))
+    const embeddings = [...residue, ...genuine]
+    const tree = node(range(0, 48), [node(range(0, 24)), node(range(24, 48))])
+
+    const metrics = taxonomyBuildQualityMetrics({ root: tree, embeddings })
+    const [first, second] = metrics.leaves
+
+    // Equal sizes, so order is stable on input order: residue first.
+    expect(first?.centeredCohesion).toBeLessThan(0.5)
+    expect(second?.centeredCohesion).toBeGreaterThan(0.9)
+  })
+
+  it("counts top-level rows after content-free interiors are promoted, not the root's children", () => {
+    const tree = node(range(0, 100), [
+      node(range(0, 60), [node(range(0, 35)), node(range(35, 60))]),
+      node(range(60, 100), [node(range(60, 80)), node(range(80, 100))]),
+    ])
+
+    const metrics = taxonomyBuildQualityMetrics({ root: tree, embeddings: [] })
+
+    // The two interiors hold nothing of their own, so the user sees four rows, not two.
+    expect(metrics.topLevelRowCount).toBe(4)
+    expect(metrics.largestTopLevelShare).toBeCloseTo(0.35)
+  })
+
+  it("keeps a childless root as its own row instead of reporting an empty screen", () => {
+    const tree = node(range(0, 1946))
+
+    const metrics = taxonomyBuildQualityMetrics({ root: tree, embeddings: [] })
+
+    expect(metrics.topLevelRowCount).toBe(1)
+    expect(metrics.largestTopLevelShare).toBeCloseTo(1)
+    expect(metrics.largestLeafShare).toBeCloseTo(1)
+  })
+
+  it("has no leaves and no shares when nothing was clustered", () => {
+    const metrics = taxonomyBuildQualityMetrics({ root: node([]), embeddings: [] })
+
+    expect(metrics.largestLeafShare).toBe(0)
+    expect(metrics.largestTopLevelShare).toBe(0)
+  })
+})
+
+interface Row {
+  readonly id: string
+  readonly own: number
+  readonly children: readonly Row[]
+}
+
+const row = (id: string, own: number, children: readonly Row[] = []): Row => ({ id, own, children })
+
+const subtree = (node: Row): number => node.own + node.children.reduce((sum, child) => sum + subtree(child), 0)
+
+const rowShape = (node: Row): ScaffoldingShape<Row> => ({
+  ownMemberCount: node.own,
+  subtreeMemberCount: subtree(node),
+  children: node.children,
+})
+
+const ids = (rows: readonly Row[]): readonly string[] => rows.map((node) => node.id)
+
+describe("promotedTopLevelRows", () => {
+  it("leaves an already-flat tree untouched and in order", () => {
+    const root = row("R", 0, [row("A", 30), row("B", 20), row("C", 10)])
+
+    expect(ids(promotedTopLevelRows(root, rowShape))).toEqual(["A", "B", "C"])
+  })
+
+  it("collapses a whole chain of signposts in one pass, not one level per call", () => {
+    const root = row("R", 0, [row("I1", 0, [row("I2", 0, [row("L1", 30), row("L2", 20)])])])
+
+    expect(ids(promotedTopLevelRows(root, rowShape))).toEqual(["L1", "L2"])
+  })
+
+  it("keeps a content-holding interior as a parent instead of flattening to its leaves", () => {
+    const root = row("R", 0, [
+      row("A", 40, [row("A1", 30), row("A2", 20)]),
+      row("B", 0, [row("B1", 10), row("B2", 10)]),
+    ])
+
+    const rows = promotedTopLevelRows(root, rowShape)
+
+    expect(ids(rows)).toEqual(["A", "B1", "B2"])
+    expect(ids(rows[0]?.children ?? [])).toEqual(["A1", "A2"])
+  })
+
+  it("promotes an interior holding a single member — a strict-zero rule would silently keep it", () => {
+    const root = row("R", 1, [row("I", 1, [row("L1", 99), row("L2", 55)]), row("L3", 494)])
+
+    expect(ids(promotedTopLevelRows(root, rowShape))).toEqual(["L1", "L2", "L3"])
+  })
+
+  it("unwraps a member-holding root positionally rather than on a content test", () => {
+    const root = row("R", 9, [row("A", 40), row("B", 30)])
+
+    expect(ids(promotedTopLevelRows(root, rowShape))).toEqual(["A", "B"])
+  })
+})

--- a/packages/domain/taxonomy/src/build-quality.ts
+++ b/packages/domain/taxonomy/src/build-quality.ts
@@ -1,0 +1,181 @@
+/**
+ * Quality metrics for one build's partition — pure arithmetic over the tree the
+ * build produced and the sample it was built from. No LLM, no repository, no
+ * effect on what gets clustered or persisted.
+ *
+ * Two traps this module exists to encode:
+ *
+ * 1. Every share here is computed from a SINGLE build's partition. Deriving the
+ *    same numbers from live `assigned_cluster_id` over a time window mixes the
+ *    current tree with historical online assignments to deprecated clusters and
+ *    biases them badly (two projects measured both ways came out 0.22 vs 0.54
+ *    and 0.45 vs 0.87). A dashboard query must scope to one `reassignment_run_id`.
+ * 2. Cohesion is mean-centered to MEASURE only. Raw cohesion spans 0.85-0.94
+ *    across residue and genuine leaves alike because the corpus-wide shared
+ *    component inflates both; centering separates them around 0.35-0.45. Feeding
+ *    centered vectors to the builder is a separately measured regression, so
+ *    nothing computed here is ever read back into clustering.
+ */
+
+import type { ClusteringTreeNode } from "./clustering.ts"
+import { TAXONOMY_QUALITY_LEAF_PROFILE_MAX, TAXONOMY_SCAFFOLDING_MAX_OWN_FRACTION } from "./constants.ts"
+
+export interface TaxonomyLeafQuality {
+  readonly size: number
+  /** Mean cosine of the leaf's corpus-mean-centered members to their centered centroid. */
+  readonly centeredCohesion: number
+}
+
+export interface TaxonomyBuildQualityMetrics {
+  /** Denominator for every share below: members the build actually partitioned. */
+  readonly membersClustered: number
+  readonly leafCount: number
+  readonly largestLeafShare: number
+  /**
+   * Rows the Behaviours screen renders once content-free scaffolding is promoted
+   * away — distinct from `topLevelClustersBuilt`, which is the root's literal
+   * child count, and the number the user actually sees only once the de-nesting
+   * read lands. The divisive builder routes every member to a leaf, so today's
+   * interiors all hold nothing and this equals `leafCount`; that is a fact about
+   * the current builder, not the definition.
+   */
+  readonly topLevelRowCount: number
+  readonly largestTopLevelShare: number
+  /** Size-descending and bounded; `leafCount - leaves.length` were dropped by the bound. */
+  readonly leaves: readonly TaxonomyLeafQuality[]
+}
+
+/** What the promotion rule reads off a node, whatever the node's own type is. */
+export interface ScaffoldingShape<T> {
+  readonly ownMemberCount: number
+  readonly subtreeMemberCount: number
+  readonly children: readonly T[]
+}
+
+/**
+ * A node holds nothing of its own: it exists only to bracket its children, so
+ * the rows below it are what the user should see. The threshold is not a free
+ * parameter — swept from `own = 0` through `own <= 10% of subtree` across 8
+ * production trees it produced identical output at every setting — but strict
+ * zero is not enough either, since one project's depth-1 signpost holds exactly
+ * one member.
+ */
+const isScaffolding = <T>(shape: ScaffoldingShape<T>): boolean =>
+  shape.children.length > 0 &&
+  shape.ownMemberCount <= Math.max(1, TAXONOMY_SCAFFOLDING_MAX_OWN_FRACTION * shape.subtreeMemberCount)
+
+/**
+ * Replace every content-free interior with its children, recursively and at any
+ * depth. Content-based, not "flatten everything": an interior that holds real
+ * members of its own survives as a parent even though no tree in the current
+ * fleet has one.
+ */
+export const promoteScaffolding = <T>(nodes: readonly T[], shapeOf: (node: T) => ScaffoldingShape<T>): readonly T[] =>
+  nodes.flatMap((node) => {
+    const shape = shapeOf(node)
+    return isScaffolding(shape) ? promoteScaffolding(shape.children, shapeOf) : [node]
+  })
+
+/**
+ * The root is the "everything" node by construction, so it is unwrapped
+ * positionally rather than on a content test — a member-holding root left
+ * visible would be the single all-encompassing row this rule exists to remove.
+ * A childless root is the exception and stays: one project is a lone root with
+ * ~1,900 members, and returning nothing there empties its whole screen.
+ */
+export const promotedTopLevelRows = <T>(root: T, shapeOf: (node: T) => ScaffoldingShape<T>): readonly T[] => {
+  const children = shapeOf(root).children
+  return children.length === 0 ? [root] : promoteScaffolding(children, shapeOf)
+}
+
+/** `memberIndices` carries every member at a node, so a node's own share is what its children do not hold. */
+const clusteringShape = (node: ClusteringTreeNode): ScaffoldingShape<ClusteringTreeNode> => {
+  const subtreeMemberCount = node.memberIndices.length
+  const inChildren = node.children.reduce((sum, child) => sum + child.memberIndices.length, 0)
+  return {
+    ownMemberCount: Math.max(0, subtreeMemberCount - inChildren),
+    subtreeMemberCount,
+    children: node.children,
+  }
+}
+
+const collectLeaves = (node: ClusteringTreeNode): readonly ClusteringTreeNode[] =>
+  node.children.length === 0 ? [node] : node.children.flatMap(collectLeaves)
+
+const unitVector = (vector: readonly number[]): readonly number[] | null => {
+  let squared = 0
+  for (const value of vector) squared += value * value
+  if (!Number.isFinite(squared) || squared === 0) return null
+  const norm = Math.sqrt(squared)
+  return vector.map((value) => value / norm)
+}
+
+const meanVector = (vectors: readonly (readonly number[])[]): readonly number[] => {
+  const dimensions = vectors[0]?.length ?? 0
+  if (dimensions === 0) return []
+  const sums = new Array<number>(dimensions).fill(0)
+  let counted = 0
+  for (const vector of vectors) {
+    if (vector.length !== dimensions) continue
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      sums[dimension] = (sums[dimension] ?? 0) + (vector[dimension] ?? 0)
+    }
+    counted++
+  }
+  return counted === 0 ? [] : sums.map((sum) => sum / counted)
+}
+
+const memberVectors = (
+  memberIndices: readonly number[],
+  embeddings: readonly (readonly number[])[],
+): readonly (readonly number[])[] =>
+  memberIndices.flatMap((index) => {
+    const embedding = embeddings[index]
+    return embedding && embedding.length > 0 ? [embedding] : []
+  })
+
+const dot = (a: readonly number[], b: readonly number[]): number => {
+  let total = 0
+  for (let dimension = 0; dimension < a.length; dimension++) total += (a[dimension] ?? 0) * (b[dimension] ?? 0)
+  return total
+}
+
+const centeredCohesion = (members: readonly (readonly number[])[], corpusMean: readonly number[]): number => {
+  if (corpusMean.length === 0) return 0
+  const centered = members.flatMap((embedding) => {
+    if (embedding.length !== corpusMean.length) return []
+    const vector = unitVector(embedding.map((value, dimension) => value - (corpusMean[dimension] ?? 0)))
+    return vector ? [vector] : []
+  })
+  if (centered.length === 0) return 0
+  const centroid = unitVector(meanVector(centered))
+  if (!centroid) return 0
+  return centered.reduce((sum, vector) => sum + dot(vector, centroid), 0) / centered.length
+}
+
+const share = (part: number, whole: number): number => (whole === 0 ? 0 : part / whole)
+
+export const taxonomyBuildQualityMetrics = (input: {
+  readonly root: ClusteringTreeNode
+  /** The normalized sample the build partitioned, indexed by `memberIndices`. */
+  readonly embeddings: readonly (readonly number[])[]
+}): TaxonomyBuildQualityMetrics => {
+  const membersClustered = input.root.memberIndices.length
+  const corpusMean = meanVector(memberVectors(input.root.memberIndices, input.embeddings))
+  const leaves = collectLeaves(input.root)
+    .map((leaf) => ({
+      size: leaf.memberIndices.length,
+      centeredCohesion: centeredCohesion(memberVectors(leaf.memberIndices, input.embeddings), corpusMean),
+    }))
+    .sort((a, b) => b.size - a.size)
+  const rows = promotedTopLevelRows(input.root, clusteringShape)
+  const largestRow = rows.reduce((max, row) => Math.max(max, row.memberIndices.length), 0)
+  return {
+    membersClustered,
+    leafCount: leaves.length,
+    largestLeafShare: share(leaves[0]?.size ?? 0, membersClustered),
+    topLevelRowCount: rows.length,
+    largestTopLevelShare: share(largestRow, membersClustered),
+    leaves: leaves.slice(0, TAXONOMY_QUALITY_LEAF_PROFILE_MAX),
+  }
+}

--- a/packages/domain/taxonomy/src/build-quality.ts
+++ b/packages/domain/taxonomy/src/build-quality.ts
@@ -1,24 +1,15 @@
 /**
- * Quality metrics for one build's partition — pure arithmetic over the tree the
- * build produced and the sample it was built from. No LLM, no repository, no
- * effect on what gets clustered or persisted.
+ * Quality metrics for one build's partition.
  *
- * Two traps this module exists to encode:
- *
- * 1. Every share here is computed from a SINGLE build's partition. Deriving the
- *    same numbers from live `assigned_cluster_id` over a time window mixes the
- *    current tree with historical online assignments to deprecated clusters and
- *    biases them badly (two projects measured both ways came out 0.22 vs 0.54
- *    and 0.45 vs 0.87). A dashboard query must scope to one `reassignment_run_id`.
- * 2. Cohesion is mean-centered to MEASURE only. Raw cohesion spans 0.85-0.94
- *    across residue and genuine leaves alike because the corpus-wide shared
- *    component inflates both; centering separates them around 0.35-0.45. Feeding
- *    centered vectors to the builder is a separately measured regression, so
- *    nothing computed here is ever read back into clustering.
+ * Measured on a SINGLE build's tree: the same shares taken from live
+ * `assigned_cluster_id` over a window mix in deprecated clusters and read far
+ * too low. Cohesion is mean-centered for measurement only — centering the
+ * vectors the builder sees is a measured regression.
  */
 
 import type { ClusteringTreeNode } from "./clustering.ts"
 import { TAXONOMY_QUALITY_LEAF_PROFILE_MAX, TAXONOMY_SCAFFOLDING_MAX_OWN_FRACTION } from "./constants.ts"
+import { type BoundedPercentiles, boundedPercentiles } from "./telemetry-percentiles.ts"
 
 export interface TaxonomyLeafQuality {
   readonly size: number
@@ -32,15 +23,15 @@ export interface TaxonomyBuildQualityMetrics {
   readonly leafCount: number
   readonly largestLeafShare: number
   /**
-   * Rows the Behaviours screen renders once content-free scaffolding is promoted
-   * away — distinct from `topLevelClustersBuilt`, which is the root's literal
-   * child count, and the number the user actually sees only once the de-nesting
-   * read lands. The divisive builder routes every member to a leaf, so today's
-   * interiors all hold nothing and this equals `leafCount`; that is a fact about
-   * the current builder, not the definition.
+   * Rows left after scaffolding is promoted away, not the root's child count
+   * (`topLevelClustersBuilt`); it matches the screen only once the de-nesting read ships.
    */
   readonly topLevelRowCount: number
   readonly largestTopLevelShare: number
+  /** Members promoted-away nodes held, so they sit in no row: rows + this = `membersClustered`. */
+  readonly promotedResidue: number
+  /** Over EVERY leaf, so a residue leaf outside the bounded profile below still moves them. */
+  readonly centeredCohesion: BoundedPercentiles & { readonly min: number }
   /** Size-descending and bounded; `leafCount - leaves.length` were dropped by the bound. */
   readonly leaves: readonly TaxonomyLeafQuality[]
 }
@@ -52,24 +43,12 @@ export interface ScaffoldingShape<T> {
   readonly children: readonly T[]
 }
 
-/**
- * A node holds nothing of its own: it exists only to bracket its children, so
- * the rows below it are what the user should see. The threshold is not a free
- * parameter — swept from `own = 0` through `own <= 10% of subtree` across 8
- * production trees it produced identical output at every setting — but strict
- * zero is not enough either, since one project's depth-1 signpost holds exactly
- * one member.
- */
+/** Strict zero is not enough: a real signpost can hold one member of its own. */
 const isScaffolding = <T>(shape: ScaffoldingShape<T>): boolean =>
   shape.children.length > 0 &&
   shape.ownMemberCount <= Math.max(1, TAXONOMY_SCAFFOLDING_MAX_OWN_FRACTION * shape.subtreeMemberCount)
 
-/**
- * Replace every content-free interior with its children, recursively and at any
- * depth. Content-based, not "flatten everything": an interior that holds real
- * members of its own survives as a parent even though no tree in the current
- * fleet has one.
- */
+/** Content-based, not "flatten everything": an interior holding real members survives as a parent. */
 export const promoteScaffolding = <T>(nodes: readonly T[], shapeOf: (node: T) => ScaffoldingShape<T>): readonly T[] =>
   nodes.flatMap((node) => {
     const shape = shapeOf(node)
@@ -77,11 +56,9 @@ export const promoteScaffolding = <T>(nodes: readonly T[], shapeOf: (node: T) =>
   })
 
 /**
- * The root is the "everything" node by construction, so it is unwrapped
- * positionally rather than on a content test — a member-holding root left
- * visible would be the single all-encompassing row this rule exists to remove.
- * A childless root is the exception and stays: one project is a lone root with
- * ~1,900 members, and returning nothing there empties its whole screen.
+ * The root is unwrapped positionally, never on a content test — it is the "everything"
+ * node, and leaving it visible reinstates the single all-encompassing row. A childless
+ * root is the exception: dropping it empties the screen of a project that has only one.
  */
 export const promotedTopLevelRows = <T>(root: T, shapeOf: (node: T) => ScaffoldingShape<T>): readonly T[] => {
   const children = shapeOf(root).children
@@ -170,12 +147,17 @@ export const taxonomyBuildQualityMetrics = (input: {
     .sort((a, b) => b.size - a.size)
   const rows = promotedTopLevelRows(input.root, clusteringShape)
   const largestRow = rows.reduce((max, row) => Math.max(max, row.memberIndices.length), 0)
+  const inRows = rows.reduce((sum, row) => sum + row.memberIndices.length, 0)
+  const cohesions = leaves.map((leaf) => leaf.centeredCohesion)
   return {
     membersClustered,
     leafCount: leaves.length,
     largestLeafShare: share(leaves[0]?.size ?? 0, membersClustered),
     topLevelRowCount: rows.length,
     largestTopLevelShare: share(largestRow, membersClustered),
+    promotedResidue: Math.max(0, membersClustered - inRows),
+    // Computed before the profile is truncated, so the worst leaf cannot hide past the bound.
+    centeredCohesion: { ...boundedPercentiles(cohesions), min: cohesions.length === 0 ? 0 : Math.min(...cohesions) },
     leaves: leaves.slice(0, TAXONOMY_QUALITY_LEAF_PROFILE_MAX),
   }
 }

--- a/packages/domain/taxonomy/src/constants.ts
+++ b/packages/domain/taxonomy/src/constants.ts
@@ -528,22 +528,15 @@ export const TAXONOMY_ADAPTIVE_ESCALATION_MAX_WORK =
 // ---------------------------------------------------------------------------
 
 /**
- * A node holding at most this share of its own subtree (floored at 1 member) is
- * scaffolding: it brackets its children without holding conversations, so the
- * rows beneath it are what a reader should see.
- *
- * Not a tuning knob. Swept from 0 through 0.10 across 8 production trees the
- * promoted row list was identical at every setting, because interiors are never
- * ambiguous — they hold 0-1 members or real content. Strict zero is still wrong:
- * one project's depth-1 signpost holds exactly 1 member, which is what the
- * `max(1, ...)` floor at the call site covers.
+ * A node holding at most this share of its own subtree (floored at 1 member at the
+ * call site) is scaffolding. Not a tuning knob: swept 0 through 0.10 across 8
+ * production trees the promoted row list was identical at every setting.
  */
 export const TAXONOMY_SCAFFOLDING_MAX_OWN_FRACTION = 0.05
 
 /**
- * Cap on the per-leaf quality profile carried in telemetry. The structural worst
- * case is 10 * 8 * 6 leaves, and a log line is not the place for 480 records; the
- * widest tree in the fleet yields 17, so this never truncates in practice and the
- * emitter reports how many it dropped when it does.
+ * Cap on the per-leaf quality profile carried in telemetry; the structural worst case
+ * is 10 * 8 * 6 leaves. Cohesion summaries are taken before this truncates, and the
+ * emitter reports how many leaves it dropped.
  */
 export const TAXONOMY_QUALITY_LEAF_PROFILE_MAX = 50

--- a/packages/domain/taxonomy/src/constants.ts
+++ b/packages/domain/taxonomy/src/constants.ts
@@ -522,3 +522,28 @@ const CLUSTERING_ROOT_SWEEP_OPS_PER_BUILD_MS = 80_000
  */
 export const TAXONOMY_ADAPTIVE_ESCALATION_MAX_WORK =
   TAXONOMY_CLUSTERING_WORKER_TIMEOUT_MS * CLUSTERING_ROOT_SWEEP_OPS_PER_BUILD_MS
+
+// ---------------------------------------------------------------------------
+// Build quality metrics
+// ---------------------------------------------------------------------------
+
+/**
+ * A node holding at most this share of its own subtree (floored at 1 member) is
+ * scaffolding: it brackets its children without holding conversations, so the
+ * rows beneath it are what a reader should see.
+ *
+ * Not a tuning knob. Swept from 0 through 0.10 across 8 production trees the
+ * promoted row list was identical at every setting, because interiors are never
+ * ambiguous — they hold 0-1 members or real content. Strict zero is still wrong:
+ * one project's depth-1 signpost holds exactly 1 member, which is what the
+ * `max(1, ...)` floor at the call site covers.
+ */
+export const TAXONOMY_SCAFFOLDING_MAX_OWN_FRACTION = 0.05
+
+/**
+ * Cap on the per-leaf quality profile carried in telemetry. The structural worst
+ * case is 10 * 8 * 6 leaves, and a log line is not the place for 480 records; the
+ * widest tree in the fleet yields 17, so this never truncates in practice and the
+ * emitter reports how many it dropped when it does.
+ */
+export const TAXONOMY_QUALITY_LEAF_PROFILE_MAX = 50

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -5,6 +5,14 @@ export {
   type TaxonomyAdaptiveClusteringMode,
 } from "./adaptive-mode.ts"
 export {
+  promotedTopLevelRows,
+  promoteScaffolding,
+  type ScaffoldingShape,
+  type TaxonomyBuildQualityMetrics,
+  type TaxonomyLeafQuality,
+  taxonomyBuildQualityMetrics,
+} from "./build-quality.ts"
+export {
   type BuildRelativeHierarchicalClustersInput,
   type BuildRelativeHierarchicalClustersResult,
   type BuildStaticHierarchicalClustersInput,
@@ -79,9 +87,11 @@ export {
   TAXONOMY_OBSERVATION_WEIGHT_SCHEME,
   TAXONOMY_PENDING_DISPLAY_NAME,
   TAXONOMY_PROJECTION_METHODS,
+  TAXONOMY_QUALITY_LEAF_PROFILE_MAX,
   TAXONOMY_REASSIGNMENT_BATCH_SIZE,
   TAXONOMY_RUN_STATUSES,
   TAXONOMY_RUN_TRIGGERS,
+  TAXONOMY_SCAFFOLDING_MAX_OWN_FRACTION,
   TAXONOMY_SEARCH_MIN_SCORE,
   TAXONOMY_SEARCH_MIN_VECTOR_SIMILARITY,
   TAXONOMY_TREE_RELATIVE_DEPTH_SCHEDULE,
@@ -192,6 +202,12 @@ export {
   type TaxonomyLineageMatch,
 } from "./lineage.ts"
 export { taxonomyClusterLockKey, withTaxonomyClusterLock } from "./locks.ts"
+export {
+  normalizedTaxonomyName,
+  type TaxonomyNameQualityCluster,
+  type TaxonomyNameQualityMetrics,
+  taxonomyNameQualityMetrics,
+} from "./name-quality.ts"
 export {
   CustomBehaviorRepository,
   type CustomBehaviorRepositoryShape,
@@ -374,6 +390,10 @@ export {
   listUserBehavioursUseCase,
   type UserBehaviourItem,
 } from "./use-cases/list-user-behaviours.ts"
+export {
+  type MeasureTaxonomyNameQualityInput,
+  measureTaxonomyNameQualityUseCase,
+} from "./use-cases/measure-taxonomy-name-quality.ts"
 export {
   type NameCustomBehaviorClusterInput,
   nameCustomBehaviorClusterUseCase,

--- a/packages/domain/taxonomy/src/name-quality.test.ts
+++ b/packages/domain/taxonomy/src/name-quality.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import { type TaxonomyNameQualityCluster, taxonomyNameQualityMetrics } from "./name-quality.ts"
+
+const cluster = (id: string, parentClusterId: string | null, name: string): TaxonomyNameQualityCluster => ({
+  id,
+  parentClusterId,
+  name,
+})
+
+describe("taxonomyNameQualityMetrics", () => {
+  it("counts collisions across branches, which the sibling-scoped quality gate cannot see", () => {
+    const metrics = taxonomyNameQualityMetrics([
+      cluster("root", null, "Everything"),
+      cluster("a", "root", "Reporting"),
+      cluster("b", "root", "Onboarding"),
+      cluster("c", "a", "Client reporting"),
+      cluster("d", "b", "Client Reporting"),
+    ])
+
+    expect(metrics.leafCount).toBe(2)
+    expect(metrics.duplicateNameLeafCount).toBe(2)
+    expect(metrics.crossBranchDuplicateLeafCount).toBe(2)
+    expect(metrics.duplicateNameRate).toBeCloseTo(1)
+  })
+
+  it("reports no duplicates when every leaf name is distinct", () => {
+    const metrics = taxonomyNameQualityMetrics([
+      cluster("root", null, "Everything"),
+      cluster("a", "root", "Invoice disputes"),
+      cluster("b", "root", "Refund requests"),
+    ])
+
+    expect(metrics.duplicateNameRate).toBe(0)
+    expect(metrics.crossBranchDuplicateLeafCount).toBe(0)
+  })
+
+  it("measures how much of a sibling set's naming is the shared domain rather than the split", () => {
+    const metrics = taxonomyNameQualityMetrics([
+      cluster("root", null, "Everything"),
+      cluster("a", "root", "Client report generation"),
+      cluster("b", "root", "Client report review"),
+    ])
+
+    // Two of every three words ("client", "report") are true of both siblings.
+    expect(metrics.sharedSiblingWordShare).toBeCloseTo(2 / 3)
+  })
+
+  it("ignores leaves still waiting to be named", () => {
+    const metrics = taxonomyNameQualityMetrics([
+      cluster("root", null, "Everything"),
+      cluster("a", "root", "Pending"),
+      cluster("b", "root", "Pending"),
+      cluster("c", "root", "Refund requests"),
+    ])
+
+    expect(metrics.leafCount).toBe(3)
+    expect(metrics.namedLeafCount).toBe(1)
+    expect(metrics.duplicateNameRate).toBe(0)
+  })
+
+  it("treats a lone root as the tree's only leaf", () => {
+    const metrics = taxonomyNameQualityMetrics([cluster("root", null, "Ad campaign troubleshooting")])
+
+    expect(metrics.leafCount).toBe(1)
+    expect(metrics.namedLeafCount).toBe(1)
+    expect(metrics.sharedSiblingWordShare).toBe(0)
+  })
+})

--- a/packages/domain/taxonomy/src/name-quality.ts
+++ b/packages/domain/taxonomy/src/name-quality.ts
@@ -1,11 +1,7 @@
 /**
- * Naming quality for a published tree — pure arithmetic over the final names,
- * no LLM and no second naming pass.
- *
- * The duplicate rate here is deliberately wider than the `assertTaxonomyQuality`
- * gate, which only compares a cluster against its own sibling group: two leaves
- * under different parents can ship the same name today and nothing reports it.
- * This measures that, it does not block on it.
+ * Naming quality for a published tree. Wider than the `assertTaxonomyQuality` gate,
+ * which only compares a cluster against its own sibling group: this measures the
+ * cross-branch collisions that gate lets through, and never blocks on them.
  */
 
 export interface TaxonomyNameQualityCluster {

--- a/packages/domain/taxonomy/src/name-quality.ts
+++ b/packages/domain/taxonomy/src/name-quality.ts
@@ -1,0 +1,104 @@
+/**
+ * Naming quality for a published tree — pure arithmetic over the final names,
+ * no LLM and no second naming pass.
+ *
+ * The duplicate rate here is deliberately wider than the `assertTaxonomyQuality`
+ * gate, which only compares a cluster against its own sibling group: two leaves
+ * under different parents can ship the same name today and nothing reports it.
+ * This measures that, it does not block on it.
+ */
+
+export interface TaxonomyNameQualityCluster {
+  readonly id: string
+  readonly parentClusterId: string | null
+  readonly name: string
+}
+
+export interface TaxonomyNameQualityMetrics {
+  readonly leafCount: number
+  /** Leaves with a real name; a still-"Pending" leaf is not a naming outcome yet. */
+  readonly namedLeafCount: number
+  /** Named leaves colliding with any other leaf anywhere in the tree, over named leaves. */
+  readonly duplicateNameRate: number
+  readonly duplicateNameLeafCount: number
+  /** The subset the sibling-only gate cannot see. */
+  readonly crossBranchDuplicateLeafCount: number
+  /**
+   * Share of leaf-name words that every one of that leaf's siblings also uses.
+   * High means the namer described the shared domain instead of the split: on
+   * one measured project 90% of leaf-name words were true of every session.
+   */
+  readonly sharedSiblingWordShare: number
+}
+
+/** Shared with `assertTaxonomyQuality` so the gate and the metric collide on exactly the same names. */
+export const normalizedTaxonomyName = (name: string): string =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+
+const isNamed = (normalized: string): boolean => normalized.length > 0 && normalized !== "pending"
+
+interface NamedLeaf {
+  readonly groupKey: string
+  readonly normalized: string
+  readonly words: readonly string[]
+}
+
+const sharedWordShare = (leaves: readonly NamedLeaf[]): number => {
+  const byGroup = new Map<string, NamedLeaf[]>()
+  for (const leaf of leaves) byGroup.set(leaf.groupKey, [...(byGroup.get(leaf.groupKey) ?? []), leaf])
+  let sharedWords = 0
+  let totalWords = 0
+  for (const group of byGroup.values()) {
+    if (group.length < 2) continue
+    const wordSets = group.map((leaf) => new Set(leaf.words))
+    const common = [...(wordSets[0] ?? new Set<string>())].filter((word) => wordSets.every((words) => words.has(word)))
+    const commonSet = new Set(common)
+    for (const leaf of group) {
+      totalWords += leaf.words.length
+      sharedWords += leaf.words.filter((word) => commonSet.has(word)).length
+    }
+  }
+  return totalWords === 0 ? 0 : sharedWords / totalWords
+}
+
+export const taxonomyNameQualityMetrics = (
+  clusters: readonly TaxonomyNameQualityCluster[],
+): TaxonomyNameQualityMetrics => {
+  const parents = new Set(clusters.flatMap((cluster) => (cluster.parentClusterId ? [cluster.parentClusterId] : [])))
+  const leafClusters = clusters.filter((cluster) => !parents.has(cluster.id))
+  const named: NamedLeaf[] = leafClusters.flatMap((cluster) => {
+    const normalized = normalizedTaxonomyName(cluster.name)
+    if (!isNamed(normalized)) return []
+    return [
+      {
+        groupKey: cluster.parentClusterId ?? "__root__",
+        normalized,
+        words: normalized.split(" ").filter((word) => word.length > 0),
+      },
+    ]
+  })
+
+  const byName = new Map<string, NamedLeaf[]>()
+  for (const leaf of named) byName.set(leaf.normalized, [...(byName.get(leaf.normalized) ?? []), leaf])
+  let duplicateNameLeafCount = 0
+  let crossBranchDuplicateLeafCount = 0
+  for (const collisions of byName.values()) {
+    if (collisions.length < 2) continue
+    duplicateNameLeafCount += collisions.length
+    if (new Set(collisions.map((leaf) => leaf.groupKey)).size > 1) crossBranchDuplicateLeafCount += collisions.length
+  }
+
+  return {
+    leafCount: leafClusters.length,
+    namedLeafCount: named.length,
+    duplicateNameRate: named.length === 0 ? 0 : duplicateNameLeafCount / named.length,
+    duplicateNameLeafCount,
+    crossBranchDuplicateLeafCount,
+    sharedSiblingWordShare: sharedWordShare(named),
+  }
+}

--- a/packages/domain/taxonomy/src/use-cases/assert-taxonomy-quality.ts
+++ b/packages/domain/taxonomy/src/use-cases/assert-taxonomy-quality.ts
@@ -2,6 +2,7 @@ import type { CustomBehaviorId, FacetId, OrganizationId, ProjectId } from "@doma
 import { Effect } from "effect"
 import { TaxonomyDimension, type TaxonomyDimension as TaxonomyDimensionType } from "../entities/dimension.ts"
 import { TaxonomyQualityGateError } from "../errors.ts"
+import { normalizedTaxonomyName } from "../name-quality.ts"
 import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
 
 export interface AssertTaxonomyQualityInput {
@@ -18,14 +19,6 @@ export interface AssertTaxonomyQualityResult {
   readonly clustersScanned: number
   readonly findings: readonly string[]
 }
-
-const normalizedName = (name: string): string =>
-  name
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
 
 /**
  * Hard gates for taxonomy graph invariants that should never be presented to
@@ -58,7 +51,7 @@ export const assertTaxonomyQualityUseCase = (input: AssertTaxonomyQualityInput) 
     const namesBySiblingGroup = new Map<string, Map<string, string[]>>()
     for (const cluster of active) {
       const groupKey = cluster.parentClusterId ?? "__root__"
-      const name = normalizedName(cluster.name)
+      const name = normalizedTaxonomyName(cluster.name)
       if (name.length === 0 || name === "pending") continue
       const group = namesBySiblingGroup.get(groupKey) ?? new Map<string, string[]>()
       const ids = group.get(name) ?? []

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
@@ -66,6 +66,7 @@ import {
   TAXONOMY_ADAPTIVE_CLUSTERING_MODE_DEFAULT,
   type TaxonomyAdaptiveClusteringMode,
 } from "../adaptive-mode.ts"
+import { type TaxonomyBuildQualityMetrics, taxonomyBuildQualityMetrics } from "../build-quality.ts"
 import {
   buildRelativeHierarchicalClusters,
   buildStaticHierarchicalClusters,
@@ -332,6 +333,12 @@ export interface HierarchicalTaxonomyPlan extends BuildHierarchicalTaxonomyResul
    * carries WHY — `Effect.logError` does not reach Datadog from here.
    */
   readonly adaptiveBuildError: string | null
+  /**
+   * Quality of the partition this pass actually persists — measured off the
+   * build's own tree, never off a window of live assignments. Null when the
+   * sample fell below the gardening minimum and no tree was built.
+   */
+  readonly qualityMetrics: TaxonomyBuildQualityMetrics | null
 }
 
 const lookbackStart = (now: Date): Date =>
@@ -674,6 +681,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
         adaptiveDurationMs: 0,
         staticDurationMs: 0,
         adaptiveBuildError: null,
+        qualityMetrics: null,
       } satisfies HierarchicalTaxonomyPlan
     }
 
@@ -966,5 +974,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       adaptiveDurationMs,
       staticDurationMs,
       adaptiveBuildError,
+      // Measured on the tree this pass persists, which on a rejected adaptive run is the static fallback.
+      qualityMetrics: taxonomyBuildQualityMetrics({ root: tree, embeddings: normalizedEmbeddings }),
     } satisfies HierarchicalTaxonomyPlan
   }).pipe(Effect.withSpan("taxonomy.planHierarchicalTaxonomy"))

--- a/packages/domain/taxonomy/src/use-cases/measure-taxonomy-name-quality.ts
+++ b/packages/domain/taxonomy/src/use-cases/measure-taxonomy-name-quality.ts
@@ -1,0 +1,31 @@
+import type { CustomBehaviorId, FacetId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import { TaxonomyDimension, type TaxonomyDimension as TaxonomyDimensionType } from "../entities/dimension.ts"
+import { taxonomyNameQualityMetrics } from "../name-quality.ts"
+import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
+
+export interface MeasureTaxonomyNameQualityInput {
+  readonly projectId: ProjectId
+  readonly dimension?: TaxonomyDimensionType
+  /** Omit/null measures the whole-project tree; an id measures that cohort's scoped tree. */
+  readonly customBehaviorId?: CustomBehaviorId | null
+  /** Omit/null = topic; an id measures that facet's tree. */
+  readonly facetId?: FacetId | null
+}
+
+/**
+ * Report-only counterpart to `assertTaxonomyQuality`: same active tree, but it
+ * never fails a run, so a build that names badly is measurable instead of just
+ * blocked or silently shipped.
+ */
+export const measureTaxonomyNameQualityUseCase = (input: MeasureTaxonomyNameQualityInput) =>
+  Effect.gen(function* () {
+    const clusters = yield* TaxonomyClusterRepository
+    const active = yield* clusters.listActiveByProject({
+      projectId: input.projectId,
+      dimension: input.dimension ?? TaxonomyDimension.Topic,
+      customBehaviorId: input.customBehaviorId ?? null,
+      facetId: input.facetId ?? null,
+    })
+    return taxonomyNameQualityMetrics(active)
+  }).pipe(Effect.withSpan("taxonomy.measureNameQuality"))

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/findings-fire.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/findings-fire.ts
@@ -1,10 +1,10 @@
 import type { CostCohort } from "./cohorts.ts"
 import {
   CLAUDE_HAIKU_4_5,
-  CLAUDE_OPUS_4_1,
   CLAUDE_OPUS_4_5,
   CLAUDE_OPUS_4_6,
   CLAUDE_OPUS_4_7,
+  CLAUDE_OPUS_4_8,
   COST_LONG_TAIL_MODELS,
   GEMINI_2_5_FLASH_LITE,
   GPT_5_4_MINI,
@@ -182,7 +182,7 @@ const MISSING_COST_COHORTS: readonly CostCohort[] = [
   {
     key: "b-unknown",
     serviceName: "legacy-worker",
-    modelConfig: CLAUDE_OPUS_4_1,
+    modelConfig: CLAUDE_OPUS_4_8,
     cadence: { endDaysAgo: 0, clusters: 26, clusterSpacingHours: 5, callsPerCluster: 1, gapWithinClusterSeconds: 0 },
     cache: { kind: "off" },
     promptTokens: 900,

--- a/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/models.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/cost-archetypes/models.ts
@@ -22,7 +22,7 @@ const model = (
 /** Anthropic's 1.25x write / 0.1x read premium, so break-even lands at 21.7%. */
 export const CLAUDE_OPUS_4_5 = model({ provider: "anthropic", model: "claude-opus-4-5" })
 export const CLAUDE_HAIKU_4_5 = model({ provider: "anthropic", model: "claude-haiku-4-5" })
-export const CLAUDE_OPUS_4_1 = model({ provider: "anthropic", model: "claude-opus-4-1" })
+export const CLAUDE_OPUS_4_8 = model({ provider: "anthropic", model: "claude-opus-4-8" })
 export const CLAUDE_OPUS_4_6 = model({ provider: "anthropic", model: "claude-opus-4-6" })
 /**
  * The only family still on a five-minute cache by default, which is what a `Stop caching`


### PR DESCRIPTION
Build 4 of [LAT-861](https://linear.app/latitude/issue/LAT-861) and nothing else. Builds 1 (de-nesting), 2 (merge) and 3 (naming) are landing separately.

Pure measurement: no LLM call anywhere, no change to what gets clustered, named or persisted. The point is that without these numbers the other three builds are not judgeable — this whole class of defect stayed invisible until a customer reported it by hand, because the shadow comparison tracked agreement between builders and nothing about whether a tree is usable.

## What is emitted

**Per build** (`taxonomy.gardenTaxonomyWorkflow.buildQuality`, log + span), computed in `planHierarchicalTaxonomyUseCase` off the tree the pass actually persists:

- `largestLeafShare`, `leafSizes` (sorted descending — `[1302, 52, 43, 38]` tells the story at a glance)
- `topLevelRowCount`, `largestTopLevelShare`
- `centeredCohesion` **per leaf**, plus p10/p50/p90 and the minimum on the span

**After naming** (`taxonomy.gardenTaxonomyWorkflow.nameQuality`, log + span), from the assert-quality activity:

- `duplicateNameRate` and `duplicateNameLeafCount`
- `crossBranchDuplicateLeafCount` — the collisions the sibling-scoped gate cannot see today
- `sharedSiblingWordShare` — how much of a sibling set's naming is the shared domain rather than the split

Both events fire for **every** mode, unlike the adaptive telemetry which returns early on `off`. `off` is what most projects run, so a baseline excluding them is a baseline for nobody.

## The two traps, encoded

**Single build partition, never a window.** Every share comes from one build's own tree and its own sample. Deriving the same numbers from live `assigned_cluster_id` across a time window mixes the current tree with historical `centroid_online` assignments to deprecated clusters and biases them badly — 0.22 vs **0.54** on one project, 0.45 vs **0.87** on another. Any dashboard query added later must scope to a single `reassignment_run_id`.

**Centering measures, it never feeds the builder.** Raw cohesion spans 0.85–0.94 across residue and genuine leaves alike because the corpus-wide shared component inflates both; centered separates cleanly around 0.35–0.45. Centering the vectors the *builder* sees is a separately measured regression with its own resolved issue, and nothing computed here is read back into clustering.

## Coupling with Build 1 — read this before merging

`topLevelRowCount` is defined against the **promoted** row list, not the root's literal child count (`topLevelClustersBuilt` already reports that). The rule is content-based, matching what Build 1 will do to the display tree: always unwrap the root, recursively promote any interior holding `<= max(1, 5% of its subtree)` of its own, keep a childless root as its own row.

**The number is only correct once Build 1 lands.** Until then the UI still shows the root's children, so the metric describes the screen a user does not yet see. That is deliberate — the issue asks for this metric to land *before* de-nesting so the row-count distribution is watchable rather than re-measured by hand.

Two follow-ups for whoever merges these two branches:

- `promotedTopLevelRows` / `promoteScaffolding` in `build-quality.ts` are generic over a `ScaffoldingShape` accessor precisely so Build 1's display-tree rule can consume them instead of writing a second copy. If Build 1 landed its own, collapse them to one.
- `TAXONOMY_SCAFFOLDING_MAX_OWN_FRACTION` is the shared threshold. If Build 1 introduced a separate constant, keep one.

Also worth knowing: because the divisive builder routes every member to a leaf, no interior in a *freshly built* tree holds anything, so `topLevelRowCount` currently always equals `leafCount`. That is a fact about today's builder, not the definition — the rule stays content-based so it degrades gracefully if the builder ever produces genuine intermediate categories. Interior residue is a display-path phenomenon (online routing stopping at an interior), which is Build 1's territory.

## Notes for review

- **Where to look hardest:** `centeredCohesion` in `build-quality.ts` (corpus mean → per-member centering → renormalize → cosine to the centered centroid), and `sharedSiblingWordShare` in `name-quality.ts`, which is the metric with the most room for a defensible-but-different definition.
- The naming metric reads the active tree a second time via a new report-only `measureTaxonomyNameQualityUseCase`, so it is emitted **before** the gate and survives a run the gate then fails. That run is exactly the one worth measuring. Cost is one small query per garden pass.
- `normalizedTaxonomyName` moved out of `assert-taxonomy-quality.ts` into `name-quality.ts` so the gate and the metric collide on exactly the same names.
- **No workflow change.** The Temporal activity sequence is untouched, so no `patched()` marker is needed; both emissions live inside activities that already ran.
- **Datadog:** set up in the second commit — see the section below.
- `qualityMetrics` rides on the in-memory plan only; it is not written into the Redis plan artifact.

## How it is consumed (second commit)

Emitting the spans is not enough on its own: retention filters and span metrics are **not retroactive**, so if they are created after Builds 1–3 ship there is no "before" and the enabler is wasted. `apps/workflows/datadog/setup-datadog.sh` now converges both feature sets — the existing adaptive-rollout objects and, new here:

- **One 100%-keep retention filter** over both quality spans (`Taxonomy quality spans`). One object rather than two, so it is one ordering problem: retention filters are evaluated top-down and the first match decides, so it has to sit above any broad `service:workflows` filter. The script can't set ordering; that step is in the doc.
- **Ten `taxonomy.quality.*` distribution metrics** grouped by project, organization, custom behavior and facet.

The two channels do different jobs, and both are needed. The filter indexes spans for 15 days and is the only way to read `leafSizes` — it is a joined string tag, cannot become a metric, and the sorted vector is what makes a regression legible at a glance. The span metrics are generated at ingestion, so they accrue regardless of what the filter indexes and last 15 months: that is what carries the comparison across builds landing weeks apart.

**Dashboard:** `apps/workflows/datadog/taxonomy-quality-dashboard.json`, applied with the Datadog MCP `upsert_datadog_dashboard`. It leads with a per-project triage table (concentration, rows, worst-leaf cohesion, sample size, ranked worst-first) and deliberately charts `largestLeafShare` against `topLevelRowCount` **on one axis** — a change that improves the first while cutting the second has buried the good groups deeper, which is the measured regression this metric set exists to catch, not a hypothetical.

`apps/workflows/datadog/taxonomy-quality-datadog-setup.md` carries the ordering, the RBAC permissions, a threshold table for reading each number, and the two caveats that bite: `topLevelRowCount` is only the user-visible number once Build 1 lands, and no query here may ever be rewritten against live `assigned_cluster_id`.

**Volume note:** unlike the adaptive span these are not flag-gated — two spans per garden run for every project and view, in every mode. The flag-gated shadow span alone runs ~5k/week today, so expect these to land somewhat above that each. 100% keep is still cheap at that scale, and the durable metrics do not depend on it.

Running the script needs `DD_API_KEY` / `DD_APP_KEY` with `apm_retention_filter_write` and `apm_generate_metrics`, which I don't have here — so the filter and metrics are authored but **not yet created in Datadog**. Run it before this deploys.

## One commit here is unrelated — say the word and I'll split it

`fix(models): repoint two catalog-coupled tests at models that still exist` fixes CI breakage that was **already on `development`**, not caused by this PR (the diff touches no file in either failing package). The last bundled models.dev refresh retired `claude-opus-4-1` and dropped `TEE/glm-5`, so a cost-archetype seed cohort and a registry test both named models the catalog no longer has. The test workflow runs on PRs only, so nothing reported it against trunk.

While deriving the ambiguous-id case instead of hardcoding one, I found a **real mispricing bug** and filed it separately rather than widening this PR: bare ids can resolve to a neighbouring model's rate through `findModel`'s prefix fallback — `glm-4.7` prices as `glm-4`, `minimax-m2.5` as `MiniMax-M2` — and come back `costImplemented: true`, so nothing downstream can tell the number is borrowed. See #4415.

## Review feedback addressed

Four threads, all resolved. Two were real bugs in this PR:

- **Cohesion summaries were computed after truncation.** The percentiles and minimum were taken from the leaf profile after it was capped to the 50 largest, so a low-cohesion residue leaf ranked past the bound could not move them — blind to exactly the leaf the metric exists to surface. Now computed over every leaf in the domain layer.
- **Durable-history widgets filtered on the wrong tags.** The metric queries used the dashboard's APM-prefixed template variables instead of the `organization_id` / `project_id` tags the span metrics actually carry, so all four would have returned no data.

One was a real defect with a fix I declined and replaced: promotion dropped a node's own direct members from the row partition, so `largestTopLevelShare` divided by a total the rows did not sum to. The suggested fix — promote only zero-own nodes — is the one option LAT-861 explicitly rules out, since a real signpost can hold one member and a strict-zero rule leaves it standing. Fixed instead by reporting the gap as `promotedResidue`, so rows plus residue reconcile to the partition exactly.

The fourth was the comment convention; the narrative blocks are down to one-line invariants, keeping only the two traps AGENTS.md exempts.

## Verification

- `pnpm --filter @domain/taxonomy typecheck`, `pnpm --filter @app/workflows typecheck` — clean
- `pnpm --filter @domain/taxonomy test` — 264 passed (29 files), including 15 new
- `pnpm --filter @app/workflows test` — 104 passed (16 files)
- `pnpm knip`, `biome check` — clean
- Full CI green on `888aaaf87` (Tests, Typecheck, Knip, Check, API Manifests, Web Bundle Size)

New test coverage pins the parts that are easy to get subtly wrong: that centered cohesion separates a wide residue leaf from a tight one where raw cohesion would not; that a content-holding interior survives promotion as a parent (the branch with no production instance today); that a chain of signposts collapses in one pass; that an interior holding exactly one member is still promoted, which a strict-zero rule would miss; that a childless root stays a row rather than reporting an empty screen; and that cross-branch name collisions are counted separately from sibling ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added taxonomy build-quality metrics covering leaf sizes, cohesion, row shares, and structure.
  - Added naming-quality metrics for duplicates, cross-branch collisions, and sibling naming patterns.
  - Added report-only quality measurement by project, dimension, behavior, or facet.
  - Included quality metrics in taxonomy builds and telemetry.
  - Added a dashboard for monitoring taxonomy quality over time.

- **Bug Fixes**
  - Improved handling of empty, invalid, or incomplete taxonomy data.

- **Tests**
  - Expanded coverage for build quality, naming quality, and telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

