### PR TITLE
fix(taxonomy): clip a facet lens's time range to the coverage it has (LAT-862)

### DIFF
--- a/apps/web/src/components/time-filter-dropdown.test.ts
+++ b/apps/web/src/components/time-filter-dropdown.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { presetsWithinBounds, TIME_PRESETS } from "./time-filter-dropdown.tsx"
+
+const DAY = 24 * 60 * 60 * 1000
+const now = Date.UTC(2026, 7, 11, 12, 0, 0)
+const idsOf = (presets: readonly { readonly id: string }[]) => presets.map((preset) => preset.id)
+
+describe("presetsWithinBounds", () => {
+  it("offers every preset when there are no bounds", () => {
+    expect(presetsWithinBounds(TIME_PRESETS, {}, now)).toEqual(TIME_PRESETS)
+  })
+
+  it("drops presets that reach back before the bounds", () => {
+    const offered = presetsWithinBounds(TIME_PRESETS, { minDate: new Date(now - 2 * DAY) }, now)
+
+    expect(idsOf(offered)).toEqual(["last-30-seconds", "last-15-minutes", "last-30-minutes", "last-hour", "last-day"])
+  })
+
+  it("drops presets that land wholly past a stale upper bound", () => {
+    // Data stopped 4 days ago: "Last day" would be offered and answer nothing, so the
+    // only presets left are the ones long enough to still reach the covered band.
+    const bounds = { minDate: new Date(now - 30 * DAY), maxDate: new Date(now - 4 * DAY) }
+
+    expect(idsOf(presetsWithinBounds(TIME_PRESETS, bounds, now))).toEqual(["last-week", "last-2-weeks", "last-month"])
+  })
+
+  it("offers nothing when the bounds are narrower than the shortest preset", () => {
+    const bounds = { minDate: new Date(now - 10 * 1000), maxDate: new Date(now - 5 * 1000) }
+
+    expect(presetsWithinBounds(TIME_PRESETS, bounds, now)).toEqual([])
+  })
+})

--- a/apps/web/src/components/time-filter-dropdown.tsx
+++ b/apps/web/src/components/time-filter-dropdown.tsx
@@ -26,8 +26,8 @@ interface TimeFilterDropdownProps {
   readonly placeholder?: string
   /**
    * Selectable bounds, for a surface whose data only covers part of the timeline.
-   * Days outside are not offered, and a preset reaching past `minTime` is dropped —
-   * it would resolve to the same clipped answer under a label promising more.
+   * Days outside are not offered, and a preset whose window misses the bounds
+   * entirely is dropped — it would carry a label promising data it cannot answer.
    */
   readonly minTime?: string | undefined
   readonly maxTime?: string | undefined
@@ -89,6 +89,26 @@ function parseBound(iso?: string): Date | undefined {
   return Number.isFinite(date.getTime()) ? date : undefined
 }
 
+/**
+ * Presets worth offering inside selectable bounds. A preset is open-ended — it runs
+ * from its start to now — so it survives when its window overlaps the bounds at all:
+ * a start before `minDate` reaches for data that is not there, and a start after
+ * `maxDate` lands wholly past the data, which is the case that would otherwise offer
+ * "Last day" on a surface whose data stopped a week ago and answer it with nothing.
+ */
+export function presetsWithinBounds(
+  presets: readonly TimeFilterPreset[],
+  bounds: { readonly minDate?: Date; readonly maxDate?: Date },
+  nowMs: number,
+): readonly TimeFilterPreset[] {
+  const { minDate, maxDate } = bounds
+  if (!minDate && !maxDate) return presets
+  return presets.filter((preset) => {
+    const startMs = nowMs - preset.seconds * 1000
+    return (!minDate || startMs >= minDate.getTime()) && (!maxDate || startMs <= maxDate.getTime())
+  })
+}
+
 export function TimeFilterDropdown({
   startTimeFrom,
   startTimeTo,
@@ -100,9 +120,11 @@ export function TimeFilterDropdown({
 }: TimeFilterDropdownProps) {
   const minDate = parseBound(minTime)
   const maxDate = parseBound(maxTime)
-  const offeredPresets = minDate
-    ? presets.filter((preset) => Date.now() - preset.seconds * 1000 >= minDate.getTime())
-    : presets
+  const offeredPresets = presetsWithinBounds(
+    presets,
+    { ...(minDate ? { minDate } : {}), ...(maxDate ? { maxDate } : {}) },
+    Date.now(),
+  )
   const pickerPresets: readonly DateRangePickerPreset[] = offeredPresets.map((preset) => ({
     id: preset.id,
     label: preset.label,

--- a/apps/web/src/components/time-filter-dropdown.tsx
+++ b/apps/web/src/components/time-filter-dropdown.tsx
@@ -24,6 +24,13 @@ interface TimeFilterDropdownProps {
   /** Overrides the trace-filtering presets for surfaces with a coarser natural cadence. */
   readonly presets?: readonly TimeFilterPreset[]
   readonly placeholder?: string
+  /**
+   * Selectable bounds, for a surface whose data only covers part of the timeline.
+   * Days outside are not offered, and a preset reaching past `minTime` is dropped —
+   * it would resolve to the same clipped answer under a label promising more.
+   */
+  readonly minTime?: string | undefined
+  readonly maxTime?: string | undefined
 }
 
 function buildPresetRange(seconds: number): DateRange {
@@ -76,24 +83,39 @@ function getActivePresetId(
   return undefined
 }
 
+function parseBound(iso?: string): Date | undefined {
+  if (!iso) return undefined
+  const date = new Date(iso)
+  return Number.isFinite(date.getTime()) ? date : undefined
+}
+
 export function TimeFilterDropdown({
   startTimeFrom,
   startTimeTo,
   onChange,
   presets = TIME_PRESETS,
   placeholder = "All time",
+  minTime,
+  maxTime,
 }: TimeFilterDropdownProps) {
-  const pickerPresets: readonly DateRangePickerPreset[] = presets.map((preset) => ({
+  const minDate = parseBound(minTime)
+  const maxDate = parseBound(maxTime)
+  const offeredPresets = minDate
+    ? presets.filter((preset) => Date.now() - preset.seconds * 1000 >= minDate.getTime())
+    : presets
+  const pickerPresets: readonly DateRangePickerPreset[] = offeredPresets.map((preset) => ({
     id: preset.id,
     label: preset.label,
     range: buildPresetRange(preset.seconds),
   }))
   const pickerRange = buildPickerRange(startTimeFrom, startTimeTo)
-  const selectedPresetId = getActivePresetId(presets, startTimeFrom, startTimeTo)
+  const selectedPresetId = getActivePresetId(offeredPresets, startTimeFrom, startTimeTo)
 
   return (
     <DateRangePicker
       value={pickerRange}
+      {...(minDate ? { minDate } : {})}
+      {...(maxDate ? { maxDate } : {})}
       presets={pickerPresets}
       selectedPresetId={selectedPresetId}
       placeholder={placeholder}

--- a/apps/web/src/domains/projects/use-analytics-time-window.test.ts
+++ b/apps/web/src/domains/projects/use-analytics-time-window.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   applyAnalyticsBrushSelect,
   applyAnalyticsTimeChange,
+  clipRangeToCoverage,
   isAllTimeRead,
   resolveAnalyticsListRange,
   resolveAnalyticsTrendRange,
@@ -120,5 +121,45 @@ describe("applyAnalyticsBrushSelect", () => {
 
   it("clearing the brush returns to All time (empty params)", () => {
     expect(applyAnalyticsBrushSelect(null)).toEqual(["", ""])
+  })
+})
+
+describe("clipRangeToCoverage", () => {
+  const coverageFromIso = iso(now - 6 * DAY)
+  const coverageToIso = iso(now)
+
+  it("clips a selection wider than coverage down to it", () => {
+    const clipped = clipRangeToCoverage({
+      range: { fromIso: iso(now - 120 * DAY), toIso: iso(now) },
+      coverageFromIso,
+      coverageToIso,
+    })
+    expect(clipped).toEqual({ fromIso: coverageFromIso, toIso: coverageToIso })
+  })
+
+  it("resolves an unbounded All-time read to exactly the covered band", () => {
+    const clipped = clipRangeToCoverage({ range: { toIso: iso(now) }, coverageFromIso, coverageToIso })
+    expect(clipped).toEqual({ fromIso: coverageFromIso, toIso: coverageToIso })
+  })
+
+  it("leaves a selection already inside coverage alone", () => {
+    const range = { fromIso: iso(now - 3 * DAY), toIso: iso(now - 1 * DAY) }
+    expect(clipRangeToCoverage({ range, coverageFromIso, coverageToIso })).toEqual(range)
+  })
+
+  it("collapses a selection entirely before coverage instead of inverting it", () => {
+    const clipped = clipRangeToCoverage({
+      range: { fromIso: iso(now - 60 * DAY), toIso: iso(now - 40 * DAY) },
+      coverageFromIso,
+      coverageToIso,
+    })
+    expect(clipped).toEqual({ fromIso: coverageFromIso, toIso: coverageFromIso })
+  })
+
+  it("passes the range through when no coverage constraint is given", () => {
+    const range = { fromIso: iso(now - 120 * DAY), toIso: iso(now) }
+    expect(clipRangeToCoverage({ range })).toEqual(range)
+    expect(clipRangeToCoverage({ range, coverageFromIso })).toEqual(range)
+    expect(clipRangeToCoverage({ range, coverageFromIso: "not-a-date", coverageToIso })).toEqual(range)
   })
 })

--- a/apps/web/src/domains/projects/use-analytics-time-window.test.ts
+++ b/apps/web/src/domains/projects/use-analytics-time-window.test.ts
@@ -156,6 +156,18 @@ describe("clipRangeToCoverage", () => {
     expect(clipped).toEqual({ fromIso: coverageFromIso, toIso: coverageFromIso })
   })
 
+  it("pins a selection starting after a stale coverage end to that end", () => {
+    // Coverage ended 4 days ago (data stopped). "Last day" starts past it; the clipped
+    // window must stay inside the band the picker advertises rather than escape it.
+    const staleToIso = iso(now - 4 * DAY)
+    const clipped = clipRangeToCoverage({
+      range: { fromIso: iso(now - 1 * DAY), toIso: iso(now) },
+      coverageFromIso: iso(now - 10 * DAY),
+      coverageToIso: staleToIso,
+    })
+    expect(clipped).toEqual({ fromIso: staleToIso, toIso: staleToIso })
+  })
+
   it("passes the range through when no coverage constraint is given", () => {
     const range = { fromIso: iso(now - 120 * DAY), toIso: iso(now) }
     expect(clipRangeToCoverage({ range })).toEqual(range)

--- a/apps/web/src/domains/projects/use-analytics-time-window.ts
+++ b/apps/web/src/domains/projects/use-analytics-time-window.ts
@@ -73,7 +73,13 @@ export function clipRangeToCoverage(input: {
   if (!Number.isFinite(coverageFromMs) || !Number.isFinite(coverageToMs)) return range
   const requestedFromMs = range.fromIso ? Date.parse(range.fromIso) : Number.NaN
   const requestedToMs = Date.parse(range.toIso)
-  const fromMs = Number.isFinite(requestedFromMs) ? Math.max(requestedFromMs, coverageFromMs) : coverageFromMs
+  // Clamped at both ends: a coverage window that ends before now (data stopped) lets a
+  // recent selection start past it, and a start outside the band would report a window
+  // the picker says is unselectable.
+  const requestedOrFromMs = Number.isFinite(requestedFromMs)
+    ? Math.max(requestedFromMs, coverageFromMs)
+    : coverageFromMs
+  const fromMs = Math.min(requestedOrFromMs, coverageToMs)
   const toMs = Math.max(Math.min(Number.isFinite(requestedToMs) ? requestedToMs : coverageToMs, coverageToMs), fromMs)
   return { fromIso: new Date(fromMs).toISOString(), toIso: new Date(toMs).toISOString() }
 }

--- a/apps/web/src/domains/projects/use-analytics-time-window.ts
+++ b/apps/web/src/domains/projects/use-analytics-time-window.ts
@@ -57,6 +57,28 @@ export function resolveAnalyticsListRange(input: {
 }
 
 /**
+ * Clips a list range into the range the screen's data actually covers. Absent coverage bounds are
+ * open, so a screen without a coverage constraint keeps its range untouched, and an "All time" read
+ * on a screen with one comes back as exactly the covered band rather than an unbounded scan whose
+ * counts would be labelled with a wider range than the data spans.
+ */
+export function clipRangeToCoverage(input: {
+  readonly range: AnalyticsListRange
+  readonly coverageFromIso?: string | null | undefined
+  readonly coverageToIso?: string | null | undefined
+}): AnalyticsListRange {
+  const { range, coverageFromIso, coverageToIso } = input
+  const coverageFromMs = coverageFromIso ? Date.parse(coverageFromIso) : Number.NaN
+  const coverageToMs = coverageToIso ? Date.parse(coverageToIso) : Number.NaN
+  if (!Number.isFinite(coverageFromMs) || !Number.isFinite(coverageToMs)) return range
+  const requestedFromMs = range.fromIso ? Date.parse(range.fromIso) : Number.NaN
+  const requestedToMs = Date.parse(range.toIso)
+  const fromMs = Number.isFinite(requestedFromMs) ? Math.max(requestedFromMs, coverageFromMs) : coverageFromMs
+  const toMs = Math.max(Math.min(Number.isFinite(requestedToMs) ? requestedToMs : coverageToMs, coverageToMs), fromMs)
+  return { fromIso: new Date(fromMs).toISOString(), toIso: new Date(toMs).toISOString() }
+}
+
+/**
  * Clamps the trend/histogram window to `maxSpanSeconds`, anchored to the end. When All time, anchors
  * to `lastActivityIso` (latest data) so the chart isn't a blank "last N days from now".
  */
@@ -101,6 +123,13 @@ interface UseAnalyticsTimeWindowInput {
   /** Concrete lower bound for "All time" when the screen's endpoint needs one (e.g. `firstTraceAt`). */
   readonly allTimeLowerBoundIso?: string | null
   readonly trendMaxSpanSeconds?: number
+  /**
+   * The range the screen's data actually covers. Both bounds must be present to take effect; when
+   * they are, every range this hook reports is clipped into them so a wider selection can never be
+   * read as a wider answer.
+   */
+  readonly coverageFromIso?: string | null
+  readonly coverageToIso?: string | null
 }
 
 interface AnalyticsTimeWindow {
@@ -124,6 +153,8 @@ export function useAnalyticsTimeWindow({
   lastActivityIso,
   allTimeLowerBoundIso,
   trendMaxSpanSeconds,
+  coverageFromIso,
+  coverageToIso,
 }: UseAnalyticsTimeWindowInput): AnalyticsTimeWindow {
   const [timeFrom, setTimeFrom] = useParamState(fromKey, "")
   const [timeTo, setTimeTo] = useParamState(toKey, "")
@@ -137,12 +168,25 @@ export function useAnalyticsTimeWindow({
 
   const { listRange, trendRange } = useMemo(() => {
     const nowMs = Date.now()
-    const list = resolveAnalyticsListRange({ timeFrom, timeTo, nowMs, allTimeLowerBoundIso })
+    const list = clipRangeToCoverage({
+      range: resolveAnalyticsListRange({ timeFrom, timeTo, nowMs, allTimeLowerBoundIso }),
+      coverageFromIso,
+      coverageToIso,
+    })
     return {
       listRange: list,
       trendRange: resolveAnalyticsTrendRange({ listRange: list, isAllTime, lastActivityIso, maxSpanSeconds, nowMs }),
     }
-  }, [timeFrom, timeTo, isAllTime, lastActivityIso, allTimeLowerBoundIso, maxSpanSeconds])
+  }, [
+    timeFrom,
+    timeTo,
+    isAllTime,
+    lastActivityIso,
+    allTimeLowerBoundIso,
+    maxSpanSeconds,
+    coverageFromIso,
+    coverageToIso,
+  ])
 
   const onTimeChange = useCallback(
     (from?: string, to?: string) => {
@@ -169,8 +213,10 @@ export function useAnalyticsTimeWindow({
     hasExplicitRange: !isAllTime,
     listRange,
     trendRange,
-    pickerStartFrom: isAllTime ? undefined : timeFrom,
-    pickerStartTo: isAllTime ? undefined : timeTo || undefined,
+    // The clipped bounds, not the raw params: a selection reaching past coverage must
+    // read back as what was answered, not as what was asked for.
+    pickerStartFrom: isAllTime ? undefined : (listRange.fromIso ?? timeFrom),
+    pickerStartTo: isAllTime ? undefined : timeTo ? listRange.toIso : undefined,
     onTimeChange,
     onBrushSelect,
   }

--- a/apps/web/src/domains/projects/use-analytics-time-window.ts
+++ b/apps/web/src/domains/projects/use-analytics-time-window.ts
@@ -56,12 +56,7 @@ export function resolveAnalyticsListRange(input: {
   return allTimeLowerBoundIso ? { fromIso: allTimeLowerBoundIso, toIso } : { toIso }
 }
 
-/**
- * Clips a list range into the range the screen's data actually covers. Absent coverage bounds are
- * open, so a screen without a coverage constraint keeps its range untouched, and an "All time" read
- * on a screen with one comes back as exactly the covered band rather than an unbounded scan whose
- * counts would be labelled with a wider range than the data spans.
- */
+/** Clips a list range into the band the data covers. Without bounds it passes through; "All time" becomes the band. */
 export function clipRangeToCoverage(input: {
   readonly range: AnalyticsListRange
   readonly coverageFromIso?: string | null | undefined

--- a/apps/web/src/domains/taxonomy/taxonomy.collection.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.collection.ts
@@ -4,6 +4,7 @@ import {
   type BehaviourSessionFilter,
   type BehaviourTimeRangeRecord,
   type BehaviourTrajectoryAxis,
+  getBehaviourCoverage,
   getBehaviourSessions,
   getBehaviourTrajectory,
   getClusterProfile,
@@ -170,6 +171,7 @@ export function useProjectBehaviours({
   poll,
   customBehaviorId,
   facetId,
+  enabled = true,
 }: {
   readonly projectId: string
   readonly dimension: BehaviourDimension
@@ -182,6 +184,8 @@ export function useProjectBehaviours({
   readonly poll?: boolean
   readonly customBehaviorId?: string
   readonly facetId?: string
+  /** Hold the read until the caller's range is final — a first fetch under a range that is about to be clipped is wasted. */
+  readonly enabled?: boolean
 }) {
   return useQuery({
     queryKey: projectBehavioursQueryKey({ projectId, dimension, segment, sortBy, timeRange, customBehaviorId }),
@@ -198,11 +202,36 @@ export function useProjectBehaviours({
         },
       }),
     staleTime: 30_000,
-    enabled: projectId.length > 0,
+    enabled: projectId.length > 0 && enabled,
     refetchInterval: (query) => {
       if (poll) return 4_000
       return pollUntilTopics && (query.state.data?.topics.length ?? 0) === 0 ? 5_000 : false
     },
+  })
+}
+
+/**
+ * The band a facet lens has membership for, or null when it covers whole project
+ * history. Keyed without a time range: it bounds the range rather than answering
+ * one, so it must resolve before a range is applied.
+ */
+export function useBehaviourCoverage({
+  projectId,
+  customBehaviorId,
+  facetId,
+}: {
+  readonly projectId: string
+  readonly customBehaviorId?: string
+  readonly facetId?: string
+}) {
+  return useQuery({
+    queryKey: ["behaviourCoverage", projectId, customBehaviorId ?? "", facetId ?? ""] as const,
+    queryFn: () =>
+      getBehaviourCoverage({
+        data: { projectId, customBehaviorId: customBehaviorId ?? "", facetId: facetId ?? "" },
+      }),
+    staleTime: 60_000,
+    enabled: projectId.length > 0 && Boolean(customBehaviorId) && Boolean(facetId),
   })
 }
 

--- a/apps/web/src/domains/taxonomy/taxonomy.functions.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.functions.ts
@@ -2,8 +2,10 @@ import { MOMENT_KINDS, type MomentKind } from "@domain/conversation-intelligence
 import { CustomBehaviorId, FacetId, normalizeCentroid, ProjectId, TaxonomyClusterId } from "@domain/shared"
 import {
   type ClusterAnalysisAggregate,
+  clipRangeToLensCoverage,
   getBehaviourTrajectoryUseCase,
   getClusterSessionIntelligenceUseCase,
+  getLensCoverageUseCase,
   isDisplayableTaxonomyName,
   listBehaviourSessionsUseCase,
   listProjectBehavioursUseCase,
@@ -12,6 +14,7 @@ import {
   TaxonomyClusterIntelligenceRepository,
   TaxonomyClusterRepository,
   type TaxonomyClusterTrendSummary,
+  TaxonomyViewAssignmentRepository,
 } from "@domain/taxonomy"
 import {
   TaxonomyClusterIntelligenceRepositoryLive,
@@ -79,8 +82,15 @@ export interface BehaviourNodeRecord {
   readonly children: readonly BehaviourNodeRecord[]
 }
 
+/** The band a facet lens's counts were computed over; null when the tree covers whole project history. */
+export interface BehaviourCoverageRecord {
+  readonly fromIso: string
+  readonly toIso: string
+}
+
 interface ProjectBehavioursRecord {
   readonly topics: readonly BehaviourNodeRecord[]
+  readonly coverage: BehaviourCoverageRecord | null
 }
 
 export interface BehaviourTimeRangeRecord {
@@ -421,8 +431,11 @@ export const getProjectBehaviours = createServerFn({ method: "GET" })
         })
         const nodes = flattenNodes(result.topics)
         const intelligence = yield* TaxonomyClusterIntelligenceRepository
-        const sourceWindowEnd = timeRange.to ?? new Date()
-        const sourceWindowStart = timeRange.from ?? new Date(0)
+        // Same clip the tree's counts got, so the intelligence rollup is measured
+        // over the range the lens actually covers rather than the one requested.
+        const clipped = clipRangeToLensCoverage(timeRange, result.coverage)
+        const sourceWindowEnd = clipped.to ?? new Date()
+        const sourceWindowStart = clipped.from ?? new Date(0)
         const aggregateEntries = yield* Effect.forEach(
           nodes,
           (node) =>
@@ -451,7 +464,60 @@ export const getProjectBehaviours = createServerFn({ method: "GET" })
           toBehaviourNodeRecord(topic, aggregatesByClusterId, positionsByClusterId),
         )
         const displayTopics = data.segment === "high_escalation" ? pruneToHighEscalation(topics) : topics
-        return { topics: isOpenableBehaviourTree(displayTopics) ? displayTopics : [] }
+        return {
+          topics: isOpenableBehaviourTree(displayTopics) ? displayTopics : [],
+          coverage: result.coverage
+            ? { fromIso: result.coverage.from.toISOString(), toIso: result.coverage.to.toISOString() }
+            : null,
+        }
+      }).pipe(
+        withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId),
+        withScopedClickHouse(clickHouseTaxonomyIntelligenceLayer, getClickhouseClient(), orgId),
+        withTracing,
+      ),
+    )
+  })
+
+/**
+ * The band a facet lens has membership for, on its own key so the picker can be
+ * bounded before a range is applied — coverage is a property of the slice, not of
+ * the selected range, so folding it into the tree read would make the range
+ * depend on a response that depends on the range.
+ */
+export const getBehaviourCoverage = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      customBehaviorId: z.string(),
+      facetId: z.string(),
+    }),
+  )
+  .handler(async ({ data, context }): Promise<BehaviourCoverageRecord | null> => {
+    const orgId = await resolveOrgScope(context)
+    const projectId = ProjectId(data.projectId)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const clusters = yield* TaxonomyClusterRepository
+        const assignments = yield* TaxonomyViewAssignmentRepository
+        const customBehaviorId = CustomBehaviorId(data.customBehaviorId)
+        const facetId = FacetId(data.facetId)
+        const active = yield* clusters.listActiveByProject({
+          projectId,
+          dimension: "topic",
+          customBehaviorId,
+          facetId,
+        })
+        const coverage = yield* getLensCoverageUseCase({
+          organizationId: orgId,
+          projectId,
+          customBehaviorId,
+          facetId,
+          clusterIds: active.filter((cluster) => isDisplayableTaxonomyName(cluster.name)).map((cluster) => cluster.id),
+          assignments,
+          now: new Date(),
+        })
+        return coverage ? { fromIso: coverage.from.toISOString(), toIso: coverage.to.toISOString() } : null
       }).pipe(
         withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId),
         withScopedClickHouse(clickHouseTaxonomyIntelligenceLayer, getClickhouseClient(), orgId),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-page.tsx
@@ -14,8 +14,15 @@ import {
   useInvalidateBehaviorQueries,
   useStopBehavior,
 } from "../../../../../../domains/taxonomy/facets.collection.ts"
-import { type BehaviourSegment, useProjectBehaviours } from "../../../../../../domains/taxonomy/taxonomy.collection.ts"
-import type { BehaviourMomentRangeRecord } from "../../../../../../domains/taxonomy/taxonomy.functions.ts"
+import {
+  type BehaviourSegment,
+  useBehaviourCoverage,
+  useProjectBehaviours,
+} from "../../../../../../domains/taxonomy/taxonomy.collection.ts"
+import type {
+  BehaviourCoverageRecord,
+  BehaviourMomentRangeRecord,
+} from "../../../../../../domains/taxonomy/taxonomy.functions.ts"
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
@@ -355,6 +362,34 @@ function BehaviorColdStartProgress({
   )
 }
 
+const coverageDay = (iso: string) => new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" })
+
+/**
+ * Says out loud why the picker stops where it does. A facet lens groups sessions
+ * only inside the windows it has been gardened over, and the alternative to
+ * naming that band is a range control that silently answers a narrower question
+ * than the one it was asked.
+ */
+function CoverageNote({ coverage }: { readonly coverage: BehaviourCoverageRecord }) {
+  return (
+    <Tooltip
+      asChild
+      side="bottom"
+      trigger={
+        <span className="flex cursor-default flex-row items-center gap-1 text-muted-foreground">
+          <Icon icon={ClockIcon} size="sm" color="foregroundMuted" />
+          <Text.H6 color="foregroundMuted">{`Coverage: ${coverageDay(coverage.fromIso)} – ${coverageDay(coverage.toIso)}`}</Text.H6>
+        </span>
+      }
+    >
+      <span className="block max-w-xs">
+        This behavior only groups the sessions it has been analyzed over, so counts and trends outside this range would
+        be incomplete. The range grows as it keeps running.
+      </span>
+    </Tooltip>
+  )
+}
+
 /**
  * The single behaviours-tree page body, shared by the legacy global screen, the
  * topic behavior, every facet behavior, and every view. They differ only by
@@ -378,25 +413,41 @@ export function BehavioursTreeBody({
   })
   const [behaviourPathParam, setBehaviourPathParam] = useParamState("behaviourPath", "", { history: "push" })
   const [coldStartSessionId, setColdStartSessionId] = useState("")
-  const tw = useAnalyticsTimeWindow({ project, fromKey: "behaviourTimeFrom", toKey: "behaviourTimeTo" })
+  // A facet lens only has membership for the windows gardening wrote, so its
+  // picker, chart and counts are all bounded by that band rather than offering a
+  // range the slice cannot answer.
+  const coverageQuery = useBehaviourCoverage({
+    projectId: project.id,
+    ...(customBehaviour?.facetId ? { customBehaviorId: customBehaviour.id, facetId: customBehaviour.facetId } : {}),
+  })
+  const coverage = coverageQuery.data
+  const tw = useAnalyticsTimeWindow({
+    project,
+    fromKey: "behaviourTimeFrom",
+    toKey: "behaviourTimeTo",
+    ...(coverage ? { coverageFromIso: coverage.fromIso, coverageToIso: coverage.toIso } : {}),
+  })
   const [momentMetric, setMomentMetric] = useParamState("behaviourMomentMetric", "")
   const [momentTurnFrom, setMomentTurnFrom] = useParamState("behaviourMomentTurnFrom", "")
   const [momentTurnTo, setMomentTurnTo] = useParamState("behaviourMomentTurnTo", "")
   const [momentTurnMax, setMomentTurnMax] = useParamState("behaviourMomentTurnMax", "")
 
+  // All time on a covered lens is not unbounded — it is the covered band, and
+  // sending it explicitly is what keeps the trend chart off the coverage ramp.
   const timeRange = useMemo(
     () =>
-      tw.isAllTime
+      tw.isAllTime && !coverage
         ? undefined
         : {
             ...(tw.listRange.fromIso ? { fromIso: tw.listRange.fromIso } : {}),
             toIso: tw.listRange.toIso,
           },
-    [tw.isAllTime, tw.listRange],
+    [tw.isAllTime, tw.listRange, coverage],
   )
 
   const demoProject = isDemoProject(project)
-  const { data, isLoading } = useProjectBehaviours({
+  const { data, isLoading: treeLoading } = useProjectBehaviours({
+    enabled: !coverageQuery.isLoading,
     projectId: project.id,
     dimension: "topic",
     segment,
@@ -411,6 +462,9 @@ export function BehavioursTreeBody({
       : { pollUntilTopics: demoProject && segment === "all" && !timeRange }),
   })
   const topics = data?.topics ?? []
+  // Coverage bounds the range the tree is read over, so a tree read before it
+  // resolves is a read of the wrong range — that wait is loading, not emptiness.
+  const isLoading = treeLoading || coverageQuery.isLoading
 
   const momentRange = useMemo((): BehaviourMomentRangeRecord | undefined => {
     if (!isBehaviourTrajectoryMetric(momentMetric)) return undefined
@@ -473,11 +527,16 @@ export function BehavioursTreeBody({
             segment={segment}
             behaviourPath={behaviourPath}
             timeFilter={
-              <TimeFilterDropdown
-                {...(tw.pickerStartFrom ? { startTimeFrom: tw.pickerStartFrom } : {})}
-                {...(tw.pickerStartTo ? { startTimeTo: tw.pickerStartTo } : {})}
-                onChange={tw.onTimeChange}
-              />
+              <>
+                <TimeFilterDropdown
+                  {...(tw.pickerStartFrom ? { startTimeFrom: tw.pickerStartFrom } : {})}
+                  {...(tw.pickerStartTo ? { startTimeTo: tw.pickerStartTo } : {})}
+                  {...(coverage ? { minTime: coverage.fromIso, maxTime: coverage.toIso } : {})}
+                  placeholder={coverage ? "Covered range" : "All time"}
+                  onChange={tw.onTimeChange}
+                />
+                {coverage ? <CoverageNote coverage={coverage} /> : null}
+              </>
             }
             timeRange={timeRange}
             momentRange={momentRange}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -384,13 +384,13 @@ export function BehaviourDetailDrawer({
               {parentName ? <BehaviourBadge label={parentName} icon={TagIcon} /> : null}
               <BehaviourBadge label={`${formatCount(node.subtreeSessionCount)} sessions`} icon={TagIcon} />
               <BehaviourBadge label={trendLabel(node.trend.status)} icon={trendIcon(node.trend.status)} />
-              {node.firstSeenLabel === "older" ? null : (
+              {node.firstSeenLabel === "older" || node.firstSeenLabel === "unknown" ? null : (
                 <BehaviourBadge label={`First seen ${node.firstSeenLabel.replaceAll("_", " ")}`} icon={SparklesIcon} />
               )}
             </div>
             <Text.H6 color="foregroundMuted">
-              First seen {formatDate(cluster.firstObservedAt)} · Last seen{" "}
-              {relativeTime(new Date(cluster.lastObservedAt))}
+              First seen {node.firstSeenLabel === "unknown" ? "on or before " : ""}
+              {formatDate(cluster.firstObservedAt)} · Last seen {relativeTime(new Date(cluster.lastObservedAt))}
             </Text.H6>
             <div className="flex flex-col gap-2">
               <Text.H2>{cluster.name}</Text.H2>
@@ -1074,11 +1074,26 @@ export function BehavioursView({
       width: 170,
       render: (row) => {
         const firstObservedAt = row.node.cluster.firstObservedAt
+        // "unknown" means the earliest member sits at the edge of what this
+        // behavior has been analyzed over: it started then AT THE LATEST, and
+        // reporting that edge as a first sighting is what made every row read
+        // "First seen: <the day the lens was created>".
+        const bounded = row.node.firstSeenLabel === "unknown"
         return (
-          <Tooltip asChild trigger={<span>{relativeTime(new Date(firstObservedAt))}</span>}>
+          <Tooltip
+            asChild
+            trigger={
+              <span>{bounded ? `Before ${formatDate(firstObservedAt)}` : relativeTime(new Date(firstObservedAt))}</span>
+            }
+          >
             <div className="flex flex-col gap-1">
               <Text.H6 color="foregroundMuted">First seen</Text.H6>
-              <Text.H6B>{formatDate(firstObservedAt)}</Text.H6B>
+              <Text.H6B>
+                {bounded ? `On or before ${formatDate(firstObservedAt)}` : formatDate(firstObservedAt)}
+              </Text.H6B>
+              {bounded ? (
+                <Text.H6 color="foregroundMuted">Grouping does not reach further back, so it may be older.</Text.H6>
+              ) : null}
               <Text.H6 color="foregroundMuted">Last seen</Text.H6>
               <Text.H6B>{new Date(row.node.cluster.lastObservedAt).toLocaleString()}</Text.H6B>
             </div>

--- a/packages/domain/taxonomy/src/constants.ts
+++ b/packages/domain/taxonomy/src/constants.ts
@@ -302,6 +302,25 @@ export const TAXONOMY_FPS_SAMPLE_BUDGET_MAX = 12
 /** Same TTL horizon as semantic-search embeddings. */
 export const TAXONOMY_OBSERVATION_RETENTION_DAYS = 30
 
+// ---------------------------------------------------------------------------
+// Lens coverage
+// ---------------------------------------------------------------------------
+
+/**
+ * How far back a lens coverage scan looks: the `taxonomy_view_assignments` TTL
+ * horizon (retention plus the table's 30-day grace), past which no membership
+ * row survives to be covered.
+ */
+export const TAXONOMY_LENS_COVERAGE_HORIZON_DAYS = TAXONOMY_OBSERVATION_RETENTION_DAYS + 30
+
+/**
+ * A day counts as covered when its assigned share of clusterable observations
+ * reaches this fraction of the lens's current rate. The test is relative because
+ * the gardening sample is capped: a busy project's plateau sits well below 100%,
+ * and an absolute test would clip every such lens to nothing.
+ */
+export const TAXONOMY_LENS_COVERAGE_MIN_RATE_FRACTION = 0.75
+
 /**
  * Taxonomy observations are always ingested while retained. Gardening is the
  * bounded part: every pass operates on the newest live observations only.

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -357,6 +357,11 @@ export {
   getClusterDetailsUseCase,
 } from "./use-cases/get-details.ts"
 export {
+  clipRangeToLensCoverage,
+  getLensCoverageUseCase,
+  type TaxonomyLensCoverage,
+} from "./use-cases/lens-coverage.ts"
+export {
   type ListBehaviourSessionsInput,
   listBehaviourSessionsUseCase,
 } from "./use-cases/list-behaviour-sessions.ts"

--- a/packages/domain/taxonomy/src/ports/taxonomy-observation-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-observation-repository.ts
@@ -119,6 +119,12 @@ export interface TaxonomyObservationClusterAssignmentCount {
   readonly lastObservedAt: Date
 }
 
+/** Clusterable observations per UTC day, for the lens coverage scan. */
+export interface TaxonomyObservationDayCount {
+  readonly day: Date
+  readonly count: number
+}
+
 export interface TaxonomyObservationRepositoryShape {
   readonly upsert: (observation: TaxonomyMomentObservation) => Effect.Effect<void, RepositoryError, ChSqlClient>
   readonly upsertMany: (
@@ -297,6 +303,18 @@ export interface TaxonomyObservationRepositoryShape {
     readonly baselineSince: Date
     readonly baselineDays: number
   }) => Effect.Effect<readonly TaxonomyObservationClusterTrendCounts[], RepositoryError, ChSqlClient>
+  /**
+   * Observations a gardening pass could have clustered on each UTC day (same
+   * eligibility as the sampling reads: a valid id and a non-empty embedding) —
+   * the denominator of the lens coverage scan. Unscoped by design: coverage is
+   * judged against the lens's own rate, so a view's filter cancels out of the
+   * comparison and stays out of this query.
+   */
+  readonly getClusterableCountsByDay: (input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly since: Date
+  }) => Effect.Effect<readonly TaxonomyObservationDayCount[], RepositoryError, ChSqlClient>
 }
 
 export class TaxonomyObservationRepository extends Context.Service<

--- a/packages/domain/taxonomy/src/ports/taxonomy-view-assignment-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-view-assignment-repository.ts
@@ -41,6 +41,12 @@ export interface TaxonomyViewAssignmentClusterTrendCount {
   readonly baselineDays: number
 }
 
+/** Assigned rows per UTC day, for the lens coverage scan. */
+export interface TaxonomyViewAssignmentDayCount {
+  readonly day: Date
+  readonly count: number
+}
+
 /**
  * ClickHouse-backed `taxonomy_view_assignments` slice — the shared edges table
  * for every non-online tree. It never touches global
@@ -87,6 +93,21 @@ export interface TaxonomyViewAssignmentRepositoryShape {
     readonly baselineSince: Date
     readonly baselineDays: number
   }) => Effect.Effect<readonly TaxonomyViewAssignmentClusterTrendCount[], RepositoryError, ChSqlClient>
+  /**
+   * Rows per UTC day pointing at one of `clusterIds` — the numerator of the lens
+   * coverage scan. Only currently-active ids count: a row left behind by an
+   * earlier pass whose cluster the rebuild deprecated is orphaned, and the day it
+   * sits on is under-covered even though the slice has rows for it.
+   */
+  readonly getAssignedCountsByDay: (input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly customBehaviorId: CustomBehaviorId
+    /** Omit/null = topic slice (`facet_id = ''`); an id reads that facet's edges. */
+    readonly facetId?: FacetId | null
+    readonly clusterIds: readonly TaxonomyClusterId[]
+    readonly since: Date
+  }) => Effect.Effect<readonly TaxonomyViewAssignmentDayCount[], RepositoryError, ChSqlClient>
   /**
    * Member rows of one scoped cluster for the naming step, resolved by joining
    * the view's assignment slice back to the projection source: the topic path

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-observation-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-observation-repository.ts
@@ -481,6 +481,24 @@ export const createFakeTaxonomyObservationRepository = (
         }),
       ),
 
+    getClusterableCountsByDay: ({ organizationId, projectId, since }) =>
+      Effect.sync(() => {
+        const counts = new Map<number, number>()
+        for (const observation of rows.values()) {
+          if (observation.organizationId !== organizationId || observation.projectId !== projectId) continue
+          if (observation.embedding.length === 0 || observation.startTime < since) continue
+          const day = Date.UTC(
+            observation.startTime.getUTCFullYear(),
+            observation.startTime.getUTCMonth(),
+            observation.startTime.getUTCDate(),
+          )
+          counts.set(day, (counts.get(day) ?? 0) + 1)
+        }
+        return [...counts]
+          .sort(([left], [right]) => left - right)
+          .map(([day, count]) => ({ day: new Date(day), count }))
+      }),
+
     ...overrides,
   }
 

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-view-assignment-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-view-assignment-repository.ts
@@ -4,6 +4,8 @@ import type { TaxonomyMomentObservation } from "../entities/observation.ts"
 import type { TaxonomyViewAssignment } from "../entities/taxonomy-view-assignment.ts"
 import type { TaxonomyViewAssignmentRepositoryShape } from "../ports/taxonomy-view-assignment-repository.ts"
 
+const utcDayStart = (date: Date): number => Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+
 export const createFakeTaxonomyViewAssignmentRepository = (
   /** Member observation rows returned by `listClusterMemberObservations`, keyed by cluster id. */
   membersByClusterId: Readonly<Record<string, readonly TaxonomyMomentObservation[]>> = {},
@@ -62,6 +64,23 @@ export const createFakeTaxonomyViewAssignmentRepository = (
           baselineCount: baseline.get(clusterId as string) ?? 0,
           baselineDays,
         }))
+      }),
+
+    getAssignedCountsByDay: ({ customBehaviorId, facetId, clusterIds, since }) =>
+      Effect.sync(() => {
+        const wanted = new Set(clusterIds.map((id) => id as string))
+        const counts = new Map<number, number>()
+        for (const assignment of assignments) {
+          if (assignment.customBehaviorId !== customBehaviorId) continue
+          if ((assignment.facetId ?? "") !== (facetId ?? "")) continue
+          if (assignment.assignedClusterId == null || !wanted.has(assignment.assignedClusterId as string)) continue
+          if (assignment.startTime < since) continue
+          const day = utcDayStart(assignment.startTime)
+          counts.set(day, (counts.get(day) ?? 0) + 1)
+        }
+        return [...counts]
+          .sort(([left], [right]) => left - right)
+          .map(([day, count]) => ({ day: new Date(day), count }))
       }),
 
     listClusterMemberObservations: ({ clusterId, limit }) =>

--- a/packages/domain/taxonomy/src/use-cases/lens-coverage.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/lens-coverage.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest"
+import {
+  clipRangeToLensCoverage,
+  joinLensCoverageDays,
+  resolveLensCoverage,
+  type TaxonomyLensCoverageDay,
+} from "./lens-coverage.ts"
+
+const day = (iso: string) => new Date(`${iso}T00:00:00.000Z`)
+
+const covered = (iso: string, count: number): TaxonomyLensCoverageDay => ({
+  day: day(iso),
+  assignedCount: count,
+  clusterableCount: count,
+})
+
+describe("resolveLensCoverage", () => {
+  // The reporting project from LAT-862: 986 assignments over Aug 3 - Aug 11 with
+  // 39 of Aug 3's 74 rows orphaned by a rebuild, against real project volume.
+  const reportedLens: TaxonomyLensCoverageDay[] = [
+    { day: day("2026-08-01"), assignedCount: 0, clusterableCount: 26 },
+    { day: day("2026-08-02"), assignedCount: 0, clusterableCount: 48 },
+    { day: day("2026-08-03"), assignedCount: 35, clusterableCount: 155 },
+    covered("2026-08-05", 217),
+    covered("2026-08-06", 212),
+    covered("2026-08-07", 185),
+    covered("2026-08-08", 39),
+    covered("2026-08-09", 48),
+    covered("2026-08-10", 159),
+    { day: day("2026-08-11"), assignedCount: 52, clusterableCount: 72 },
+  ]
+
+  it("clips to the fully covered band, excluding the ramp", () => {
+    const coverage = resolveLensCoverage(reportedLens, { now: new Date("2026-08-11T18:00:00.000Z") })
+
+    expect(coverage).toEqual({ from: day("2026-08-05"), to: new Date("2026-08-11T18:00:00.000Z") })
+  })
+
+  it("keeps quiet-but-complete days inside the band", () => {
+    // Aug 8 and Aug 9 are 39 and 48 sessions against 217 the day before; low
+    // volume, full coverage. A count-based cut would break the band here.
+    const coverage = resolveLensCoverage(reportedLens, { now: new Date("2026-08-11T18:00:00.000Z") })
+
+    expect(coverage?.from).toEqual(day("2026-08-05"))
+  })
+
+  it("does not clip a lens whose plateau sits below full coverage", () => {
+    // The gardening sample is capped, so a busy project is covered uniformly at a
+    // fraction. That is a scaled trend, not a ramp, and must stay selectable.
+    const capped: TaxonomyLensCoverageDay[] = [
+      { day: day("2026-08-05"), assignedCount: 214, clusterableCount: 900 },
+      { day: day("2026-08-06"), assignedCount: 214, clusterableCount: 950 },
+      { day: day("2026-08-07"), assignedCount: 214, clusterableCount: 880 },
+      { day: day("2026-08-08"), assignedCount: 214, clusterableCount: 910 },
+    ]
+
+    const coverage = resolveLensCoverage(capped, { now: new Date("2026-08-08T12:00:00.000Z") })
+
+    expect(coverage?.from).toEqual(day("2026-08-05"))
+  })
+
+  it("treats a day with no traffic as neither covered nor missing", () => {
+    const withGap: TaxonomyLensCoverageDay[] = [
+      covered("2026-08-05", 100),
+      { day: day("2026-08-06"), assignedCount: 0, clusterableCount: 0 },
+      covered("2026-08-07", 100),
+    ]
+
+    const coverage = resolveLensCoverage(withGap, { now: new Date("2026-08-07T12:00:00.000Z") })
+
+    expect(coverage?.from).toEqual(day("2026-08-05"))
+  })
+
+  it("keeps the newest day even when it is still partial", () => {
+    const partialToday: TaxonomyLensCoverageDay[] = [
+      covered("2026-08-09", 100),
+      covered("2026-08-10", 100),
+      { day: day("2026-08-11"), assignedCount: 3, clusterableCount: 90 },
+    ]
+
+    const coverage = resolveLensCoverage(partialToday, { now: new Date("2026-08-11T02:00:00.000Z") })
+
+    expect(coverage).toEqual({ from: day("2026-08-09"), to: new Date("2026-08-11T02:00:00.000Z") })
+  })
+
+  it("ends at the last day with membership, not at now", () => {
+    const stale: TaxonomyLensCoverageDay[] = [covered("2026-08-05", 100), covered("2026-08-06", 100)]
+
+    const coverage = resolveLensCoverage(stale, { now: new Date("2026-08-11T12:00:00.000Z") })
+
+    expect(coverage?.to).toEqual(new Date("2026-08-07T00:00:00.000Z"))
+  })
+
+  it("is null when the slice has no membership at all", () => {
+    const empty: TaxonomyLensCoverageDay[] = [{ day: day("2026-08-05"), assignedCount: 0, clusterableCount: 40 }]
+
+    expect(resolveLensCoverage(empty, { now: new Date("2026-08-05T12:00:00.000Z") })).toBeNull()
+    expect(resolveLensCoverage([], { now: new Date("2026-08-05T12:00:00.000Z") })).toBeNull()
+  })
+
+  it("stops at a mid-band collapse rather than reaching past it", () => {
+    const eroded: TaxonomyLensCoverageDay[] = [
+      covered("2026-08-05", 100),
+      { day: day("2026-08-06"), assignedCount: 5, clusterableCount: 100 },
+      covered("2026-08-07", 100),
+      covered("2026-08-08", 100),
+    ]
+
+    const coverage = resolveLensCoverage(eroded, { now: new Date("2026-08-08T12:00:00.000Z") })
+
+    expect(coverage?.from).toEqual(day("2026-08-07"))
+  })
+})
+
+describe("joinLensCoverageDays", () => {
+  it("outer-joins both series into one ascending day series", () => {
+    const joined = joinLensCoverageDays(
+      [
+        { day: day("2026-08-06"), count: 12 },
+        { day: day("2026-08-05"), count: 7 },
+      ],
+      [
+        { day: day("2026-08-05"), count: 20 },
+        { day: day("2026-08-07"), count: 30 },
+      ],
+    )
+
+    expect(joined).toEqual([
+      { day: day("2026-08-05"), assignedCount: 7, clusterableCount: 20 },
+      { day: day("2026-08-06"), assignedCount: 12, clusterableCount: 0 },
+      { day: day("2026-08-07"), assignedCount: 0, clusterableCount: 30 },
+    ])
+  })
+
+  it("folds sub-day timestamps into their UTC day", () => {
+    const joined = joinLensCoverageDays(
+      [
+        { day: new Date("2026-08-05T04:00:00.000Z"), count: 2 },
+        { day: new Date("2026-08-05T22:00:00.000Z"), count: 3 },
+      ],
+      [],
+    )
+
+    expect(joined).toEqual([{ day: day("2026-08-05"), assignedCount: 5, clusterableCount: 0 }])
+  })
+})
+
+describe("clipRangeToLensCoverage", () => {
+  const coverage = { from: day("2026-08-05"), to: new Date("2026-08-11T18:00:00.000Z") }
+
+  it("intersects a wider selection down to the covered band", () => {
+    expect(clipRangeToLensCoverage({ from: day("2026-04-01"), to: day("2026-08-12") }, coverage)).toEqual({
+      from: coverage.from,
+      to: coverage.to,
+    })
+  })
+
+  it("resolves an unbounded read to exactly the covered band", () => {
+    expect(clipRangeToLensCoverage({}, coverage)).toEqual({ from: coverage.from, to: coverage.to })
+  })
+
+  it("leaves a narrower selection alone", () => {
+    const inside = { from: day("2026-08-07"), to: day("2026-08-09") }
+
+    expect(clipRangeToLensCoverage(inside, coverage)).toEqual(inside)
+  })
+
+  it("collapses a selection entirely outside coverage instead of inverting it", () => {
+    const clipped = clipRangeToLensCoverage({ from: day("2026-04-01"), to: day("2026-05-01") }, coverage)
+
+    expect(clipped).toEqual({ from: coverage.from, to: coverage.from })
+  })
+
+  it("passes the range through untouched when there is no coverage constraint", () => {
+    const range = { from: day("2026-04-01"), to: day("2026-08-12") }
+
+    expect(clipRangeToLensCoverage(range, null)).toEqual(range)
+  })
+})

--- a/packages/domain/taxonomy/src/use-cases/lens-coverage.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/lens-coverage.test.ts
@@ -165,10 +165,21 @@ describe("clipRangeToLensCoverage", () => {
     expect(clipRangeToLensCoverage(inside, coverage)).toEqual(inside)
   })
 
-  it("collapses a selection entirely outside coverage instead of inverting it", () => {
+  it("collapses a selection entirely before coverage instead of inverting it", () => {
     const clipped = clipRangeToLensCoverage({ from: day("2026-04-01"), to: day("2026-05-01") }, coverage)
 
     expect(clipped).toEqual({ from: coverage.from, to: coverage.from })
+  })
+
+  it("pins a selection starting after a stale band's end to that end, never outside it", () => {
+    // A lens whose last pass wrote nothing recent: coverage ends before now, so
+    // "the last day" starts past the band. The answer is zero either way, but the
+    // window it is answered over has to stay inside the range the UI offers.
+    const stale = { from: day("2026-08-01"), to: day("2026-08-07") }
+
+    const clipped = clipRangeToLensCoverage({ from: day("2026-08-10"), to: day("2026-08-11") }, stale)
+
+    expect(clipped).toEqual({ from: stale.to, to: stale.to })
   })
 
   it("passes the range through untouched when there is no coverage constraint", () => {

--- a/packages/domain/taxonomy/src/use-cases/lens-coverage.ts
+++ b/packages/domain/taxonomy/src/use-cases/lens-coverage.ts
@@ -129,7 +129,11 @@ export const clipRangeToLensCoverage = (
   coverage: TaxonomyLensCoverage | null,
 ): { readonly from?: Date; readonly to?: Date } => {
   if (coverage === null) return { ...(range.from ? { from: range.from } : {}), ...(range.to ? { to: range.to } : {}) }
-  const from = range.from && range.from > coverage.from ? range.from : coverage.from
+  const requestedFrom = range.from && range.from > coverage.from ? range.from : coverage.from
+  // A stale lens's band ends before now, so a recent selection can start past it.
+  // Pinning the start to the band's end keeps the reported window inside the range
+  // the UI says is selectable; it answers zero, which is the true count there.
+  const from = requestedFrom > coverage.to ? coverage.to : requestedFrom
   const to = range.to && range.to < coverage.to ? range.to : coverage.to
   return { from, to: to > from ? to : from }
 }

--- a/packages/domain/taxonomy/src/use-cases/lens-coverage.ts
+++ b/packages/domain/taxonomy/src/use-cases/lens-coverage.ts
@@ -1,0 +1,171 @@
+import type { CustomBehaviorId, FacetId, OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
+import { Effect } from "effect"
+import {
+  TAXONOMY_GARDENING_SAMPLE_LOOKBACK_DAYS,
+  TAXONOMY_LENS_COVERAGE_HORIZON_DAYS,
+  TAXONOMY_LENS_COVERAGE_MIN_RATE_FRACTION,
+} from "../constants.ts"
+import type { TaxonomyObservationDayCount } from "../ports/taxonomy-observation-repository.ts"
+import { TaxonomyObservationRepository } from "../ports/taxonomy-observation-repository.ts"
+import type {
+  TaxonomyViewAssignmentDayCount,
+  TaxonomyViewAssignmentRepositoryShape,
+} from "../ports/taxonomy-view-assignment-repository.ts"
+
+const MS_PER_DAY = 24 * 60 * 60_000
+
+/**
+ * The band a facet lens can honestly answer for. Facet plans are off-mode, so
+ * they never take the full-window reassignment path that keeps a cohort view's
+ * topic slice and the global tree covering whole project history: membership is
+ * whatever the gardening windows happened to write, accumulated from lens
+ * creation and eroding behind the latest pass. Reads clipped to this band report
+ * a real count for a real range; outside it they would report a sampling ramp.
+ */
+export interface TaxonomyLensCoverage {
+  /** Start of the oldest fully-covered UTC day. */
+  readonly from: Date
+  /** End of the newest day the lens has membership for, never past `now`. */
+  readonly to: Date
+}
+
+export interface TaxonomyLensCoverageDay {
+  /** Start of the UTC day. */
+  readonly day: Date
+  /** Rows pointing at a currently-active cluster. */
+  readonly assignedCount: number
+  /** Observations a pass could have clustered that day. */
+  readonly clusterableCount: number
+}
+
+const startOfUtcDay = (date: Date): Date =>
+  new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+
+const dayKey = (date: Date): number => startOfUtcDay(date).getTime()
+
+const lensCoverageScanStart = (now: Date): Date =>
+  startOfUtcDay(new Date(now.getTime() - TAXONOMY_LENS_COVERAGE_HORIZON_DAYS * MS_PER_DAY))
+
+/** Outer-join the two per-day counts into one ascending series. */
+export const joinLensCoverageDays = (
+  assigned: readonly TaxonomyViewAssignmentDayCount[],
+  clusterable: readonly TaxonomyObservationDayCount[],
+): readonly TaxonomyLensCoverageDay[] => {
+  const byDay = new Map<number, { assignedCount: number; clusterableCount: number }>()
+  const at = (day: Date) => {
+    const key = dayKey(day)
+    const existing = byDay.get(key)
+    if (existing) return existing
+    const created = { assignedCount: 0, clusterableCount: 0 }
+    byDay.set(key, created)
+    return created
+  }
+  for (const row of assigned) at(row.day).assignedCount += row.count
+  for (const row of clusterable) at(row.day).clusterableCount += row.count
+  return [...byDay.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([key, counts]) => ({ day: new Date(key), ...counts }))
+}
+
+/**
+ * Walk back from the newest day with membership while each day's assigned share
+ * holds at the lens's current rate, and return that contiguous band.
+ *
+ * The rate reference is the pooled share over the trailing gardening window
+ * rather than a fixed 100%: the sample is capped, so a busy lens plateaus well
+ * below full coverage and an absolute test would clip it to nothing. Days with
+ * no clusterable traffic are neither covered nor missing, so they extend the band
+ * without being judged, and the newest day is always included — it is partial by
+ * nature, exactly like the live edge of any other chart.
+ */
+export const resolveLensCoverage = (
+  days: readonly TaxonomyLensCoverageDay[],
+  input: { readonly now: Date },
+): TaxonomyLensCoverage | null => {
+  const ordered = [...days].sort((left, right) => left.day.getTime() - right.day.getTime())
+  let lastIndex = -1
+  for (let index = ordered.length - 1; index >= 0; index--) {
+    if ((ordered[index]?.assignedCount ?? 0) > 0) {
+      lastIndex = index
+      break
+    }
+  }
+  const last = ordered[lastIndex]
+  if (last === undefined) return null
+
+  // The latest sweep's own window, minus the partial newest day: the days the
+  // lens has certainly been written for, pooled so one thin day cannot set the bar.
+  const referenceFrom = last.day.getTime() - (TAXONOMY_GARDENING_SAMPLE_LOOKBACK_DAYS - 1) * MS_PER_DAY
+  const reference = ordered.filter(
+    (day) => day.day.getTime() >= referenceFrom && day.day.getTime() < last.day.getTime(),
+  )
+  const rated = reference.length > 0 ? reference : [last]
+  const referenceClusterable = rated.reduce((sum, day) => sum + day.clusterableCount, 0)
+  const referenceAssigned = rated.reduce((sum, day) => sum + day.assignedCount, 0)
+  const referenceRate = referenceClusterable > 0 ? referenceAssigned / referenceClusterable : 1
+  const minRate = referenceRate * TAXONOMY_LENS_COVERAGE_MIN_RATE_FRACTION
+
+  let startIndex = lastIndex
+  for (let index = lastIndex - 1; index >= 0; index--) {
+    const day = ordered[index]
+    if (day === undefined) break
+    if (day.clusterableCount > 0 && day.assignedCount / day.clusterableCount < minRate) break
+    startIndex = index
+  }
+
+  const from = ordered[startIndex]?.day ?? last.day
+  const endOfLastDay = last.day.getTime() + MS_PER_DAY
+  return { from, to: new Date(Math.min(input.now.getTime(), endOfLastDay)) }
+}
+
+/**
+ * Intersect a requested window with the covered band. Absent bounds are open, so
+ * an "All time" read comes back as exactly the covered band rather than the whole
+ * slice — which is what stops a four-month selection from reporting nine days of
+ * counts under a four-month label.
+ */
+export const clipRangeToLensCoverage = (
+  range: { readonly from?: Date | undefined; readonly to?: Date | undefined },
+  coverage: TaxonomyLensCoverage | null,
+): { readonly from?: Date; readonly to?: Date } => {
+  if (coverage === null) return { ...(range.from ? { from: range.from } : {}), ...(range.to ? { to: range.to } : {}) }
+  const from = range.from && range.from > coverage.from ? range.from : coverage.from
+  const to = range.to && range.to < coverage.to ? range.to : coverage.to
+  return { from, to: to > from ? to : from }
+}
+
+interface GetLensCoverageInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly customBehaviorId: CustomBehaviorId
+  readonly facetId: FacetId
+  readonly clusterIds: readonly TaxonomyClusterId[]
+  readonly assignments: TaxonomyViewAssignmentRepositoryShape
+  readonly now: Date
+}
+
+export const getLensCoverageUseCase = (input: GetLensCoverageInput) =>
+  Effect.gen(function* () {
+    if (input.clusterIds.length === 0) return null
+    const observations = yield* TaxonomyObservationRepository
+    const since = lensCoverageScanStart(input.now)
+    const [assigned, clusterable] = yield* Effect.all(
+      [
+        input.assignments.getAssignedCountsByDay({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          customBehaviorId: input.customBehaviorId,
+          facetId: input.facetId,
+          clusterIds: input.clusterIds,
+          since,
+        }),
+        observations.getClusterableCountsByDay({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          since,
+        }),
+      ],
+      { concurrency: 2 },
+    )
+    return resolveLensCoverage(joinLensCoverageDays(assigned, clusterable), { now: input.now })
+  })

--- a/packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts
+++ b/packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts
@@ -303,8 +303,13 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
     // stable cluster ids via the Hungarian lineage matcher, so the same
     // start_time-windowed born/continue/die trend the global tree derives is
     // computable over the taxonomy_view_assignments slice.
-    const currentSince = new Date(now.getTime() - TREND_CURRENT_DAYS * MS_PER_DAY)
-    const requestedBaselineSince = new Date(now.getTime() - trendWindowDays * MS_PER_DAY)
+    // Anchored at the covered band's end, not at now. A stale lens — one whose last
+    // pass wrote nothing for the newest days — would otherwise compare a current
+    // window it has no membership for against a covered baseline and report every row
+    // as fading: the same coverage-read-as-behaviour the clip exists to remove.
+    const trendAnchor = coverage !== null && coverage.to < now ? coverage.to : now
+    const currentSince = new Date(trendAnchor.getTime() - TREND_CURRENT_DAYS * MS_PER_DAY)
+    const requestedBaselineSince = new Date(trendAnchor.getTime() - trendWindowDays * MS_PER_DAY)
     // A baseline reaching past the covered band would average today's real counts
     // against days the lens has no membership for, which reads as a spike on every
     // row. Shorten the baseline to the covered part and divide by that.

--- a/packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts
+++ b/packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts
@@ -14,11 +14,13 @@ import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.
 import { TaxonomyObservationRepository } from "../ports/taxonomy-observation-repository.ts"
 import { TaxonomyViewAssignmentRepository } from "../ports/taxonomy-view-assignment-repository.ts"
 import { classifyClusterTrend, type TaxonomyClusterTrendSummary } from "./analytics.ts"
+import { clipRangeToLensCoverage, getLensCoverageUseCase, type TaxonomyLensCoverage } from "./lens-coverage.ts"
 
 export type BehaviourSegment = "all" | "new_this_week" | "spiking" | "high_escalation"
 export type BehaviourSortBy = "category" | "volume" | "trend" | "first_seen" | "last_seen" | "escalation_rate"
 export type BehaviourNovelty = "first_seen" | "spiking" | "resurfaced" | "unknown"
-export type BehaviourFirstSeenLabel = "today" | "this_week" | "older"
+/** `unknown`: membership does not reach far enough back to say when this started. */
+export type BehaviourFirstSeenLabel = "today" | "this_week" | "older" | "unknown"
 
 export interface ListProjectBehavioursInput {
   readonly organizationId: OrganizationId
@@ -69,6 +71,12 @@ export interface ListProjectBehavioursResult {
   readonly topics: readonly ProjectBehaviourNode[]
   /** Sessions the promoted-away nodes held, so they sit in no row; taken before `limit` truncates. */
   readonly residueObservationCount: number
+  /**
+   * The band every count above was actually computed over on a facet lens, whose
+   * membership only covers what gardening wrote. Null on trees that cover whole
+   * project history (the global tree, a cohort view's topic slice).
+   */
+  readonly coverage: TaxonomyLensCoverage | null
 }
 
 const MS_PER_DAY = 24 * 60 * 60_000
@@ -84,7 +92,17 @@ const startOfUtcDay = (date: Date): Date =>
 const daysWindowStart = (now: Date, days: number): Date =>
   startOfUtcDay(new Date(now.getTime() - (days - 1) * MS_PER_DAY))
 
-const firstSeenLabel = (firstObservedAt: Date, now: Date, firstSeenWindowDays: number): BehaviourFirstSeenLabel => {
+const firstSeenLabel = (
+  firstObservedAt: Date,
+  now: Date,
+  firstSeenWindowDays: number,
+  coverage: TaxonomyLensCoverage | null,
+): BehaviourFirstSeenLabel => {
+  // A cluster whose earliest member sits at the coverage floor started no later
+  // than the floor, and possibly long before it — the lens simply has no
+  // membership there. Reporting the floor as a first sighting is the customer's
+  // "First seen: August 3" on every row, where August 3 is when the lens began.
+  if (coverage !== null && firstObservedAt <= coverage.from) return "unknown"
   const todayStart = startOfUtcDay(now)
   if (firstObservedAt >= todayStart) return "today"
   if (firstObservedAt >= daysWindowStart(now, firstSeenWindowDays)) return "this_week"
@@ -96,8 +114,10 @@ const noveltyFor = (input: {
   readonly trend: TaxonomyClusterTrendSummary
   readonly firstSeenWindowStart: Date
   readonly minObservations: number
+  readonly coverage: TaxonomyLensCoverage | null
 }): BehaviourNovelty => {
-  if (input.cluster.firstObservedAt >= input.firstSeenWindowStart) return "first_seen"
+  const firstSeenUnknown = input.coverage !== null && input.cluster.firstObservedAt <= input.coverage.from
+  if (!firstSeenUnknown && input.cluster.firstObservedAt >= input.firstSeenWindowStart) return "first_seen"
   if (input.trend.status === "spike") return "spiking"
   if (input.trend.status === "new" && input.trend.currentCount >= input.minObservations) return "spiking"
   return "unknown"
@@ -237,6 +257,26 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
       childrenByParentId.set(cluster.parentClusterId, siblings)
     }
 
+    // A facet lens accumulates membership one gardening window at a time and
+    // never reaches the full-window reassignment a cohort view's topic slice
+    // takes, so the requested window is clipped to the band membership actually
+    // covers. Every count, trend and first-seen below is then computed over a
+    // range the data really spans, and the caller states that range instead of
+    // labelling nine days of counts with the four months someone picked.
+    const coverage =
+      scopedAssignmentRepository != null && customBehaviorId != null && input.facetId != null
+        ? yield* getLensCoverageUseCase({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            customBehaviorId,
+            facetId: input.facetId,
+            clusterIds: displayable.map((cluster) => cluster.id),
+            assignments: scopedAssignmentRepository,
+            now,
+          })
+        : null
+    const window = clipRangeToLensCoverage({ from: input.startTimeFrom, to: input.startTimeTo }, coverage)
+
     // Scoped trees read their per-cluster counts from the custom-behavior
     // assignment slice (never global observations); a global tree reads the
     // time-windowed global assignment counts.
@@ -247,15 +287,15 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
             projectId: input.projectId,
             customBehaviorId,
             ...(input.facetId != null ? { facetId: input.facetId } : {}),
-            ...(input.startTimeFrom ? { startTimeFrom: input.startTimeFrom } : {}),
-            ...(input.startTimeTo ? { startTimeTo: input.startTimeTo } : {}),
+            ...(window.from ? { startTimeFrom: window.from } : {}),
+            ...(window.to ? { startTimeTo: window.to } : {}),
           })
         : yield* observationRepository.getClusterAssignmentCounts({
             organizationId: input.organizationId,
             projectId: input.projectId,
             clusterIds: displayable.map((cluster) => cluster.id),
-            ...(input.startTimeFrom ? { startTimeFrom: input.startTimeFrom } : {}),
-            ...(input.startTimeTo ? { startTimeTo: input.startTimeTo } : {}),
+            ...(window.from ? { startTimeFrom: window.from } : {}),
+            ...(window.to ? { startTimeTo: window.to } : {}),
           })
     const directCountByClusterId = new Map(assignmentCounts.map((count) => [count.clusterId, count.count] as const))
 
@@ -264,8 +304,15 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
     // start_time-windowed born/continue/die trend the global tree derives is
     // computable over the taxonomy_view_assignments slice.
     const currentSince = new Date(now.getTime() - TREND_CURRENT_DAYS * MS_PER_DAY)
-    const baselineSince = new Date(now.getTime() - trendWindowDays * MS_PER_DAY)
-    const baselineDays = Math.max(trendWindowDays - TREND_CURRENT_DAYS, 1)
+    const requestedBaselineSince = new Date(now.getTime() - trendWindowDays * MS_PER_DAY)
+    // A baseline reaching past the covered band would average today's real counts
+    // against days the lens has no membership for, which reads as a spike on every
+    // row. Shorten the baseline to the covered part and divide by that.
+    const baselineSince =
+      coverage !== null && coverage.from > requestedBaselineSince
+        ? new Date(Math.min(coverage.from.getTime(), currentSince.getTime()))
+        : requestedBaselineSince
+    const baselineDays = Math.max(Math.round((currentSince.getTime() - baselineSince.getTime()) / MS_PER_DAY), 1)
     const trendCounts =
       scopedAssignmentRepository != null && customBehaviorId != null
         ? yield* scopedAssignmentRepository.getClusterTrendCounts({
@@ -308,9 +355,9 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
         classifyClusterTrend({
           currentCount: 0,
           baselineCount: 0,
-          baselineDays: Math.max(trendWindowDays - TREND_CURRENT_DAYS, 1),
+          baselineDays,
         })
-      const novelty = noveltyFor({ cluster, trend, firstSeenWindowStart, minObservations })
+      const novelty = noveltyFor({ cluster, trend, firstSeenWindowStart, minObservations, coverage })
       const directObservationCount = directCountByClusterId.get(cluster.id) ?? 0
       const subtreeObservationCount =
         directObservationCount + children.reduce((sum, child) => sum + child.subtreeObservationCount, 0)
@@ -322,7 +369,7 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
       if (!ownVisible && children.length === 0) return null
       return {
         cluster,
-        firstSeenLabel: firstSeenLabel(cluster.firstObservedAt, now, firstSeenWindowDays),
+        firstSeenLabel: firstSeenLabel(cluster.firstObservedAt, now, firstSeenWindowDays, coverage),
         trend,
         novelty,
         directObservationCount,
@@ -347,5 +394,6 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
     return {
       topics: truncateNodes(topics, limit),
       residueObservationCount,
+      coverage,
     } satisfies ListProjectBehavioursResult
   }).pipe(Effect.withSpan("taxonomy.listProjectBehaviours"))

--- a/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
@@ -2,6 +2,7 @@ import { AI, type AIShape, type GenerateResult } from "@domain/ai"
 import {
   ChSqlClient,
   CustomBehaviorId,
+  FacetId,
   OrganizationId,
   ProjectId,
   SessionId,
@@ -671,6 +672,99 @@ describe("listProjectBehavioursUseCase (custom behavior scope)", () => {
     const trendById = new Map(result.topics.map((topic) => [topic.cluster.id, topic.trend.status] as const))
     expect(trendById.get(scopedA)).toBe("spike")
     expect(trendById.get(scopedB)).toBe("cooling")
+  })
+
+  it("clips a wider selection to the band facet membership covers, and stops claiming a first sighting", async () => {
+    const facetId = FacetId("f".repeat(24))
+    const lensCluster = TaxonomyClusterId("3".repeat(24))
+    const coverageFrom = new Date("2026-05-19T00:00:00.000Z")
+    const clusters = createFakeTaxonomyClusterRepository([
+      makeCluster({
+        id: lensCluster,
+        name: "Lens group",
+        customBehaviorId: behaviorId,
+        facetId,
+        observationCount: 0,
+        // At the coverage floor: the lens has no membership before this, so the
+        // date is where grouping starts, not where the behaviour started.
+        firstObservedAt: coverageFrom,
+      }),
+    ])
+    // Uniform project traffic, but membership only from May 19 — the ramp before
+    // that is the coverage gap the picker must not offer.
+    const observations = createFakeTaxonomyObservationRepository(
+      Array.from({ length: 20 }, (_, index) => ({
+        ...makeObservation(index + 1, globalId),
+        startTime: new Date(now.getTime() - index * 24 * 60 * 60_000),
+      })),
+    )
+    const countWindows: { from?: Date; to?: Date }[] = []
+    const assignments = createFakeTaxonomyViewAssignmentRepository(
+      {},
+      {
+        getClusterAssignmentCounts: ({ startTimeFrom, startTimeTo }) => {
+          countWindows.push({
+            ...(startTimeFrom ? { from: startTimeFrom } : {}),
+            ...(startTimeTo ? { to: startTimeTo } : {}),
+          })
+          return Effect.succeed([{ clusterId: lensCluster, count: 9 }])
+        },
+        getAssignedCountsByDay: () =>
+          Effect.succeed(
+            [0, 1, 2, 3, 4, 5].map((back) => ({
+              day: new Date(Date.UTC(2026, 4, 24 - back)),
+              count: 1,
+            })),
+          ),
+      },
+    )
+
+    const result = await Effect.runPromise(
+      listProjectBehavioursUseCase({
+        organizationId,
+        projectId,
+        now,
+        customBehaviorId: behaviorId,
+        facetId,
+        startTimeFrom: new Date("2026-01-01T00:00:00.000Z"),
+      }).pipe(
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(TaxonomyObservationRepository, observations.repository)),
+        Effect.provide(Layer.succeed(TaxonomyViewAssignmentRepository, assignments.repository)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+        Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+      ),
+    )
+
+    expect(result.coverage).toEqual({ from: coverageFrom, to: now })
+    // The January selection was answered over the covered band, not over January.
+    expect(countWindows).toEqual([{ from: coverageFrom, to: now }])
+    expect(result.topics[0]?.firstSeenLabel).toBe("unknown")
+    expect(result.topics[0]?.novelty).not.toBe("first_seen")
+  })
+
+  it("does not clip a cohort view's topic slice, which reassigns the full window", async () => {
+    const clusters = seededClusters()
+    const observations = createFakeTaxonomyObservationRepository([])
+    const assignments = createFakeTaxonomyViewAssignmentRepository(
+      {},
+      {
+        getClusterAssignmentCounts: () => Effect.succeed([{ clusterId: scopedA, count: 4 }]),
+        getAssignedCountsByDay: () => Effect.fail(new Error("a cohort view must not run a coverage scan") as never),
+      },
+    )
+
+    const result = await Effect.runPromise(
+      listProjectBehavioursUseCase({ organizationId, projectId, now, customBehaviorId: behaviorId }).pipe(
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(TaxonomyObservationRepository, observations.repository)),
+        Effect.provide(Layer.succeed(TaxonomyViewAssignmentRepository, assignments.repository)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+        Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+      ),
+    )
+
+    expect(result.coverage).toBeNull()
   })
 
   it("the global read ignores custom-behavior clusters entirely", async () => {

--- a/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
@@ -743,6 +743,75 @@ describe("listProjectBehavioursUseCase (custom behavior scope)", () => {
     expect(result.topics[0]?.novelty).not.toBe("first_seen")
   })
 
+  it("anchors the trend at a stale band's end, so a lens that stopped gardening is not all fading", async () => {
+    const facetId = FacetId("f".repeat(24))
+    const lensCluster = TaxonomyClusterId("4".repeat(24))
+    // Membership stops 4 days before `now`: the last pass wrote nothing recent.
+    const lastCoveredDay = Date.UTC(2026, 4, 20)
+    const clusters = createFakeTaxonomyClusterRepository([
+      makeCluster({
+        id: lensCluster,
+        name: "Stale lens group",
+        customBehaviorId: behaviorId,
+        facetId,
+        observationCount: 0,
+        firstObservedAt: new Date(Date.UTC(2026, 4, 14)),
+      }),
+    ])
+    const observations = createFakeTaxonomyObservationRepository(
+      Array.from({ length: 12 }, (_, index) => ({
+        ...makeObservation(index + 1, globalId),
+        startTime: new Date(now.getTime() - index * 24 * 60 * 60_000),
+      })),
+    )
+    const coveredDays = [0, 1, 2, 3, 4, 5].map((back) => new Date(lastCoveredDay - back * 24 * 60 * 60_000))
+    const trendWindows: { currentSince: Date; baselineSince: Date; baselineDays: number }[] = []
+    const assignments = createFakeTaxonomyViewAssignmentRepository(
+      {},
+      {
+        getClusterAssignmentCounts: () => Effect.succeed([{ clusterId: lensCluster, count: 12 }]),
+        getAssignedCountsByDay: () => Effect.succeed(coveredDays.map((day) => ({ day, count: 1 }))),
+        // Counts derived from the window it is handed, one row per covered day, so an
+        // anchor sitting in the uncovered tail really does come back empty here.
+        getClusterTrendCounts: ({ clusterIds, currentSince, baselineSince, baselineDays }) => {
+          trendWindows.push({ currentSince, baselineSince, baselineDays })
+          const inWindow = (from: Date, to?: Date) =>
+            coveredDays.filter((day) => day >= from && (to === undefined || day < to)).length
+          return Effect.succeed(
+            clusterIds.map((clusterId) => ({
+              clusterId,
+              currentCount: inWindow(currentSince),
+              baselineCount: inWindow(baselineSince, currentSince),
+              baselineDays,
+            })),
+          )
+        },
+      },
+    )
+
+    const result = await Effect.runPromise(
+      listProjectBehavioursUseCase({ organizationId, projectId, now, customBehaviorId: behaviorId, facetId }).pipe(
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(TaxonomyObservationRepository, observations.repository)),
+        Effect.provide(Layer.succeed(TaxonomyViewAssignmentRepository, assignments.repository)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+        Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+      ),
+    )
+
+    // The band ends on the last covered day, and the current window sits inside it
+    // rather than in the 4 uncovered days before `now`.
+    const coverageTo = new Date(lastCoveredDay + 24 * 60 * 60_000)
+    expect(result.coverage?.to).toEqual(coverageTo)
+    expect(trendWindows).toHaveLength(1)
+    expect(trendWindows[0]?.currentSince).toEqual(new Date(coverageTo.getTime() - 24 * 60 * 60_000))
+    expect(trendWindows[0]?.baselineSince.getTime()).toBeLessThan(trendWindows[0]?.currentSince.getTime() ?? 0)
+    // Anchored at `now` this row reads `fading` (an empty current window against a
+    // covered baseline); anchored at the band's end it reads for what it is.
+    expect(result.topics[0]?.trend.currentCount).toBeGreaterThan(0)
+    expect(result.topics[0]?.trend.status).toBe("steady")
+  })
+
   it("does not clip a cohort view's topic slice, which reassigns the full window", async () => {
     const clusters = seededClusters()
     const observations = createFakeTaxonomyObservationRepository([])

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
@@ -722,4 +722,68 @@ describe("TaxonomyObservationRepositoryLive.listForFacetSample", () => {
     expect(sample[0]?.sessionObservationId).toBe("h".repeat(24))
     expect(sample[0]?.transcript).toBe("matched")
   })
+
+  it("counts clusterable observations per UTC day, skipping ones no pass could have used", async () => {
+    const dayProjectId = ProjectId("cov".padEnd(24, "0"))
+    await ch.client.insert({
+      table: "taxonomy_observations",
+      values: [
+        makeObservationRow(
+          makeObservation({
+            projectId: dayProjectId,
+            observationId: "d1".padEnd(24, "0"),
+            startTime: new Date("2026-05-24T01:00:00.000Z"),
+          }),
+        ),
+        makeObservationRow(
+          makeObservation({
+            projectId: dayProjectId,
+            observationId: "d2".padEnd(24, "0"),
+            startTime: new Date("2026-05-24T23:30:00.000Z"),
+          }),
+        ),
+        makeObservationRow(
+          makeObservation({
+            projectId: dayProjectId,
+            observationId: "d3".padEnd(24, "0"),
+            startTime: new Date("2026-05-25T02:00:00.000Z"),
+          }),
+        ),
+        // No embedding: never sampleable, so it is not coverage the lens is missing.
+        makeObservationRow(
+          makeObservation({
+            projectId: dayProjectId,
+            observationId: "d4".padEnd(24, "0"),
+            embedding: [],
+            startTime: new Date("2026-05-25T03:00:00.000Z"),
+          }),
+        ),
+        // Before the scan horizon.
+        makeObservationRow(
+          makeObservation({
+            projectId: dayProjectId,
+            observationId: "d5".padEnd(24, "0"),
+            startTime: new Date("2026-05-01T03:00:00.000Z"),
+          }),
+        ),
+      ],
+      format: "JSONEachRow",
+    })
+
+    const counts = await runWithRepository(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyObservationRepository
+        return yield* repo.getClusterableCountsByDay({
+          organizationId,
+          projectId: dayProjectId,
+          since: new Date("2026-05-20T00:00:00.000Z"),
+        })
+      }),
+    )
+
+    expect(counts).toEqual([
+      { day: new Date("2026-05-24T00:00:00.000Z"), count: 2 },
+      { day: new Date("2026-05-25T00:00:00.000Z"), count: 1 },
+    ])
+  })
 })

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
@@ -78,6 +78,9 @@ export const selectColumns = `
 
 export const validObservationIdClause = "length(observation_id) = 24"
 
+/** `toDate()` renders a bare `YYYY-MM-DD`, which `new Date()` would read as local time. */
+export const parseCHDay = (day: string): Date => new Date(`${day}T00:00:00.000Z`)
+
 const latestProjectWindow = `
   SELECT ${selectColumns}
   FROM taxonomy_observations FINAL
@@ -1186,6 +1189,42 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
             .pipe(
               Effect.mapError((error) =>
                 toRepositoryError(error, "TaxonomyObservationRepository.getClusterTrendCounts"),
+              ),
+            )
+        }),
+
+      // Coverage denominator: what a gardening pass could have clustered per day.
+      // Eligibility mirrors the sampling reads (valid id, non-empty embedding) and
+      // deliberately ignores `assigned_cluster_id` — an observation the global tree
+      // left unassigned is still one a lens could have covered.
+      getClusterableCountsByDay: ({ organizationId, projectId, since }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT toDate(start_time) AS day, count() AS count
+                        FROM taxonomy_observations FINAL
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND ${validObservationIdClause}
+                          AND length(embedding) > 0
+                          AND start_time >= {since:DateTime64(9, 'UTC')}
+                        GROUP BY day
+                        ORDER BY day ASC`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  since: formatCHDate(since),
+                },
+                format: "JSONEachRow",
+              })
+              const rows = await result.json<{ day: string; count: string | number }>()
+              return rows.map((row) => ({ day: parseCHDay(row.day), count: Number(row.count) }))
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                toRepositoryError(error, "TaxonomyObservationRepository.getClusterableCountsByDay"),
               ),
             )
         }),

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-view-assignment-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-view-assignment-repository.test.ts
@@ -294,4 +294,81 @@ describe("TaxonomyViewAssignmentRepositoryLive", () => {
     expect(members[0]?.projectionMetadata.summary).toBe("the user wants to cancel a subscription")
     expect(members[0]?.embedding).toEqual([0, 1, 0])
   })
+
+  it("counts assigned rows per UTC day, excluding rows a rebuild orphaned", async () => {
+    const cb = CustomBehaviorId("cov".padEnd(24, "0"))
+    const counts = await run(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyViewAssignmentRepository
+        yield* repo.upsertMany([
+          makeAssignment({
+            observationId: "c1".padEnd(24, "0"),
+            customBehaviorId: cb,
+            facetId,
+            startTime: new Date("2026-06-01T01:00:00.000Z"),
+          }),
+          makeAssignment({
+            observationId: "c2".padEnd(24, "0"),
+            customBehaviorId: cb,
+            facetId,
+            startTime: new Date("2026-06-01T23:30:00.000Z"),
+          }),
+          makeAssignment({
+            observationId: "c3".padEnd(24, "0"),
+            customBehaviorId: cb,
+            facetId,
+            startTime: new Date("2026-06-02T05:00:00.000Z"),
+          }),
+          // Orphaned by a rebuild: physically present, invisible to every other
+          // read, so it must not make 2026-06-03 look covered.
+          makeAssignment({
+            observationId: "c4".padEnd(24, "0"),
+            customBehaviorId: cb,
+            facetId,
+            assignedClusterId: clusterB,
+            startTime: new Date("2026-06-03T05:00:00.000Z"),
+          }),
+          // The same cohort's topic slice, and an older day outside the scan.
+          makeAssignment({ observationId: "c5".padEnd(24, "0"), customBehaviorId: cb, facetId: null }),
+          makeAssignment({
+            observationId: "c6".padEnd(24, "0"),
+            customBehaviorId: cb,
+            facetId,
+            startTime: new Date("2026-05-01T05:00:00.000Z"),
+          }),
+        ])
+        return yield* repo.getAssignedCountsByDay({
+          organizationId,
+          projectId,
+          customBehaviorId: cb,
+          facetId,
+          clusterIds: [clusterA],
+          since: new Date("2026-05-25T00:00:00.000Z"),
+        })
+      }),
+    )
+
+    expect(counts).toEqual([
+      { day: new Date("2026-06-01T00:00:00.000Z"), count: 2 },
+      { day: new Date("2026-06-02T00:00:00.000Z"), count: 1 },
+    ])
+  })
+
+  it("returns no coverage days when the tree has no active clusters", async () => {
+    const counts = await run(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyViewAssignmentRepository
+        return yield* repo.getAssignedCountsByDay({
+          organizationId,
+          projectId,
+          customBehaviorId,
+          facetId,
+          clusterIds: [],
+          since: new Date("2026-05-25T00:00:00.000Z"),
+        })
+      }),
+    )
+
+    expect(counts).toEqual([])
+  })
 })

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-view-assignment-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-view-assignment-repository.ts
@@ -19,6 +19,7 @@ import {
 import { formatCHDate, parseCHDate } from "@repo/utils"
 import { Effect, Layer } from "effect"
 import {
+  parseCHDay,
   type TaxonomyObservationRow,
   selectColumns as taxonomyObservationSelectColumns,
   toDomainObservation,
@@ -244,6 +245,47 @@ export const TaxonomyViewAssignmentRepositoryLive = Layer.effect(
             .pipe(
               Effect.mapError((error) =>
                 toRepositoryError(error, "TaxonomyViewAssignmentRepository.getClusterTrendCounts"),
+              ),
+            )
+        }),
+
+      // Coverage numerator: rows per UTC day that still point at a live cluster.
+      // `assigned_cluster_id IN clusterIds` is the whole point — rows a rebuild
+      // orphaned are physically present but invisible to every other read, so
+      // counting them would advertise coverage the tree cannot show.
+      getAssignedCountsByDay: ({ organizationId, projectId, customBehaviorId, facetId, clusterIds, since }) =>
+        Effect.gen(function* () {
+          if (clusterIds.length === 0) return []
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT toDate(start_time) AS day, count() AS count
+                        FROM taxonomy_view_assignments FINAL
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND custom_behavior_id = {customBehaviorId:String}
+                          AND facet_id = {facetId:String}
+                          AND assigned_cluster_id IN {clusterIds:Array(String)}
+                          AND start_time >= {since:DateTime64(9, 'UTC')}
+                        GROUP BY day
+                        ORDER BY day ASC`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  customBehaviorId: customBehaviorId as string,
+                  facetId: (facetId ?? "") as string,
+                  clusterIds: clusterIds as readonly string[],
+                  since: formatCHDate(since),
+                },
+                format: "JSONEachRow",
+              })
+              const rows = await result.json<{ day: string; count: string | number }>()
+              return rows.map((row) => ({ day: parseCHDay(row.day), count: Number(row.count) }))
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                toRepositoryError(error, "TaxonomyViewAssignmentRepository.getAssignedCountsByDay"),
               ),
             )
         }),

--- a/packages/ui/src/components/date-range-picker/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker/date-range-picker.tsx
@@ -34,6 +34,9 @@ interface DateRangePickerProps {
   readonly placeholder?: string
   readonly clearLabel?: string
   readonly disabled?: boolean
+  /** Selectable bounds. Days outside are disabled and month navigation stops at them. */
+  readonly minDate?: Date
+  readonly maxDate?: Date
   readonly align?: "start" | "center" | "end"
   readonly portalTarget?: "local" | "body"
   /** Fill the available width, pushing the chevron to the far end (defaults to sizing to content). */
@@ -145,16 +148,22 @@ function formatDraftSummary(range?: DateRange) {
 
 function RangeCalendar({
   value,
+  minDate,
+  maxDate,
   onChange,
 }: {
   readonly value: DateRange | undefined
+  readonly minDate?: Date
+  readonly maxDate?: Date
   readonly onChange: (next: DateRange | undefined) => void
 }) {
   return (
     <DayPicker
       mode="range"
       showOutsideDays
-      defaultMonth={value?.from ?? value?.to ?? new Date()}
+      defaultMonth={value?.from ?? value?.to ?? maxDate ?? new Date()}
+      {...(minDate ? { fromDate: minDate } : {})}
+      {...(maxDate ? { toDate: maxDate } : {})}
       selected={toDayPickerRange(value)}
       onSelect={(nextRange) => onChange(fromDayPickerRange(nextRange))}
       className="select-none"
@@ -212,6 +221,8 @@ export function DateRangePicker({
   placeholder = "Pick a date range",
   clearLabel = "Clear dates",
   disabled = false,
+  minDate,
+  maxDate,
   align = "start",
   portalTarget = "local",
   fullWidth = false,
@@ -322,7 +333,12 @@ export function DateRangePicker({
                 }}
               />
             ) : null}
-            <RangeCalendar value={draftRange} onChange={setDraftRange} />
+            <RangeCalendar
+              value={draftRange}
+              {...(minDate ? { minDate } : {})}
+              {...(maxDate ? { maxDate } : {})}
+              onChange={setDraftRange}
+            />
             <div className="flex items-center justify-between gap-3">
               <Text.H6 color="foregroundMuted" className="min-w-0 truncate">
                 {formatDraftSummary(draftRange)}


### PR DESCRIPTION
Closes part 1 of [LAT-862](https://linear.app/latitude/issue/LAT-862/facet-lens-session-counts-do-not-grow-with-the-selected-time-range).

<img width="590" height="529" alt="image" src="https://github.com/user-attachments/assets/42553c94-002e-484b-aa2a-b5e7f81e47a7" />


## The bug

A customer selected a four-month range on a lens view and the session counts did not move. They were right, and the picker was misleading rather than merely limited.

A facet lens's membership lives in `taxonomy_view_assignments` and only ever covers the windows gardening actually wrote. Facet plans are forced to `mode: "off"`, so they never take the full-window reassignment that keeps the global tree — and a cohort view's topic slice — covering whole project history. Widening the range filters a set that never contained the older sessions.

The worse consequence is the trend chart. On the reporting project, real volume across Aug 3 → Aug 5 goes 155 → 217 (1.4x) while the chart showed 35 → 217 (6x): the chart was plotting a coverage ramp as behavioural change. `First seen` read "August 3" on every row, which is when the lens was created.

This is **Part 1** — make the UI honest about what the data covers. Part 2 (projection-space reassignment, which grows coverage) is deliberately left for a separate PR; sequencing it after the `persistAdaptive` decoupling is a data-correctness requirement, not a preference.

## What this does

**Derives the covered band from the data, not from the assignment span.** Per UTC day, rows pointing at a currently-active cluster (`getAssignedCountsByDay`) are compared against the observations a pass could have clustered (`getClusterableCountsByDay`), then `resolveLensCoverage` walks back from the newest day with membership while that share holds at the lens's current rate.

Three deliberate choices there, all tested:
- **The rate test is relative, not absolute.** The gardening sample is capped at 1,500 per 7 days, so a project busier than ~214 sessions/day plateaus well below full coverage. A "must be 100%" test would clip every such lens to nothing.
- **Days with no traffic are neither covered nor missing**, so a quiet day does not break the band. Aug 8 and Aug 9 on the reporting project are 39 and 48 sessions at 100% coverage — a count-based cut would have severed the band there.
- **The newest day is always included.** It is partial by nature, like the live edge of any chart.

**The clip happens in the read, not only in the picker.** `listProjectBehavioursUseCase` intersects the requested window with the covered band before computing counts, and the intelligence rollup uses the same clipped window. So no range a client sends can label a short window's counts with a long range. The trend baseline is shortened to the covered part and divided by that, otherwise a baseline reaching past coverage averages real counts against days with no membership and reads as a spike on every row.

**`First seen` stops reporting the coverage floor as a sighting.** A cluster whose earliest member sits at the floor gets `firstSeenLabel: "unknown"`, renders as "Before <date>" with an explanation, and no longer counts as new — which also stops a fresh lens filling the *New this week* segment.

**The band is stated and enforced in the UI.** "Coverage: Aug 5 – Aug 11" sits next to the picker, the calendar disables days outside it (new `minDate`/`maxDate` on `DateRangePicker`), and presets reaching past it are dropped. Coverage is served on its own query key so it can bound the range before one is applied.

It degrades gracefully: when Part 2 lands, the band widens on its own and the clip stops binding, with no UI change.

## Not implemented on purpose

Both were raised in the issue and retracted there:
- **Clamping to `min(start_time)` of the assignment table** — advertises coverage that has already been orphaned by a rebuild. This is why `getAssignedCountsByDay` filters on the active cluster ids: an orphaned row is physically present but invisible to every other read, so counting it would claim coverage the tree cannot show.
- **Removing the temporal UI from lens views** — too aggressive; trends are valid inside the fully-covered band, which is exactly what this makes selectable.

## Where to focus review

- `resolveLensCoverage` in `packages/domain/taxonomy/src/use-cases/lens-coverage.ts` — the rate reference is the pooled assigned share over the trailing gardening window excluding the newest day. Pooling (rather than max or median) is what keeps a thin day from setting the bar; excluding the newest day is what keeps a big, barely-gardened "today" from collapsing the reference and falsely widening the band.
- **The denominator ignores a view's filter set on purpose.** A filtered view's eligible population is smaller, but the test is relative, so a uniform filter rate cancels out of the comparison. The trade-off: a filter whose match rate shifts mid-window (a model switched halfway through) skews the judgement. That buys a cheap query and no session-filter compilation on a page-load path — worth challenging if you disagree.
- **Cost**: two grouped ClickHouse counts per facet-lens page load, plus the same two inside the tree read. Both are partition-pruned day aggregates over the assignment TTL horizon (60 days). No LLM calls.
- `clipRangeToCoverage` in `use-analytics-time-window.ts` is a new generic capability on a shared hook; only the behaviours screen passes coverage today, and every other caller is unaffected (bounds absent ⇒ range untouched).
- The tree read now waits for coverage to resolve (`enabled`), and that wait counts as loading so the empty state cannot flash.

## Verification

- `pnpm typecheck` (workspace), `npx knip`, `biome check` clean.
- `@domain/taxonomy`: 266 tests pass, including new `lens-coverage.test.ts` — the reporting project's measured day-by-day numbers are a fixture, and it asserts the band comes out Aug 5 – Aug 11.
- `@platform/db-clickhouse`: the two touched repository test files pass, covering per-day grouping, orphaned-row exclusion, topic/facet slice isolation and the embedding-eligibility filter.
- `apps/web` (511 tests over `src/domains` + project routes) and `apps/workflows` (100) pass.
- Not exercised against live data — the clip's behaviour on a real lens is worth a look in staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added coverage-aware date filtering for behavior analytics.
  * Date pickers now restrict selections, presets, and navigation to available data.
  * Added coverage details and explanatory guidance for facet-scoped behavior views.
  * Added clearer handling for behaviors with unknown first-seen dates.

* **Bug Fixes**
  * Prevented analytics ranges from extending beyond available data.
  * Improved date-range handling for missing, incomplete, or unbounded coverage.
  * Adjusted first-seen and novelty displays to avoid unsupported date claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->