### PR TITLE
fix(web): drop stale flat 30-credit price from flagger settings copy

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -259,7 +259,7 @@ function ProjectFlaggersSettingsPage() {
                                   <Text.H5 className="w-10 tabular-nums">{row.viewSampling}%</Text.H5>
                                 </div>
                                 <Text.H6 color="foregroundMuted">
-                                  30 credits per scan · runs on {row.viewSampling}% of eligible sessions
+                                  Billed by AI usage · runs on {row.viewSampling}% of eligible sessions
                                 </Text.H6>
                               </div>
                             )}

--- a/dev-docs/flaggers.md
+++ b/dev-docs/flaggers.md
@@ -151,7 +151,7 @@ Context compaction mirrors the moments stance: the analyzed window is the last r
 ## Billing
 
 - Deterministic screening is free.
-- LLM scans bill `flagger-scan = 30 credits` in `draftSessionFlaggerAnnotation`, **only after a confirmed match** — classify-only misses consume Latitude's model spend but are not billed. The anchor dedup runs **before** billing authorization, and the idempotency key is `flagger-scan:{org}:{slug}:{sessionId}:{contentHash}` — one charge per distinct flagged anchor. Out of credits ⇒ the scan is skipped (`NoCreditsRemainingError`).
+- LLM scans bill by actual AI usage, not a flat price: each classification authorizes one `llm-call` then meters every LLM call under a `flagger-classify` activity scope, and the fallback annotator in `draftSessionFlaggerAnnotation` meters its calls under a `flagger:{slug}:{sessionId}:{contentHash}` scope — the anchor dedup runs **before** its authorization so a re-detected issue is never charged. Per-call credits come from `creditsForLlmGenerationCost` (estimated provider cost × 1.3 margin, 1-credit floor). Out of credits ⇒ the scan is skipped (`NoCreditsRemainingError` / non-retryable activity failure). See [`./billing.md`](./billing.md).
 - Spend governors on the LLM path: the sampling default (10%) and the three rate-limit buckets.
 
 ## Self-observability (reflag)
@@ -180,4 +180,3 @@ User/input-centric strategies (`classifiesAssistantResponseOnly: false` — toda
 | `FLAGGER_PROMPT_MAX_HINTS` / `FLAGGER_HINT_EVIDENCE_MAX_CHARS` | 20 / 256 | classifier hint block caps |
 | `FLAGGER_INSPECTED_AGENT_VERBATIM_MAX_CHARS` | 6,000 | verbatim vs extracted agent context |
 | `SESSION_END_DEBOUNCE_MS` (`spans`) | 5 min | session settle window upstream |
-| `flagger-scan` (`billing`) | 30 credits | LLM scan price |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The flaggers settings page still said LLM flaggers cost "30 credits per scan". That flat `flagger-scan` price no longer exists: flagger LLM scans are billed by actual AI usage through the AI metering scope (`flagger-classify` for classifications, the annotation scope for the fallback annotator), with per-call credits from `creditsForLlmGenerationCost` (estimated provider cost x 1.3 margin, 1-credit floor).

- Settings copy now reads "Billed by AI usage · runs on X% of eligible sessions"
- Rewrote the stale Billing section in `dev-docs/flaggers.md` to describe the metered model and removed the `flagger-scan = 30 credits` constants row

## Related issue (if applicable)

Reported in Slack.

## How was this tested?

Copy/docs-only change. `pnpm --filter web typecheck` and Biome pass; pre-commit hooks (format + knip) ran clean.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/D091ZVD96R0/p1785235788421049?thread_ts=1785235788.421049&cid=D091ZVD96R0)

<div><a href="https://cursor.com/agents/bc-96eb27bf-2e69-5e7e-9c76-cd7299b6ae6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96eb27bf-2e69-5e7e-9c76-cd7299b6ae6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated flagger scan billing information to explain that charges are based on actual AI usage.
  - Clarified estimated-cost credits, the 1-credit minimum, and when no charge applies.
  - Removed outdated references to the former flat-rate scan pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->