### PR TITLE
refactor(taxonomy): split "has staging leaves" from "is an adaptive tree" (LAT-862 Part 2a)

### DIFF
--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -195,12 +195,18 @@ interface StoredGardenTaxonomyPlan {
   /**
    * Non-null ⇒ enforced planning fell back to static (structural/non-finite
    * adaptive output), so this plan persists the static tree even though its mode
-   * is `enforced`. Drives `planPersistsAdaptive` so downstream never runs the
-   * staging path on a fallen-back plan.
+   * is `enforced`. Clears both `persistsAdaptiveTree` and `leafClusters` so
+   * downstream never runs the staging path on a fallen-back plan.
    */
   readonly fallbackReason?: TaxonomyAdaptiveFallbackReason | null
   /** Adaptive-only: leaf id + centroid for full-window routing. Empty/absent on off. */
   readonly leafClusters?: readonly StagingLeafCluster[]
+  /**
+   * Whether the plan staged a fresh adaptive tree (every id new, prior tree
+   * retired wholesale), as opposed to upserting continuations in place. Absent on
+   * plans staged by pre-change code, where `leafClusters` stood in for it.
+   */
+  readonly persistsAdaptiveTree?: boolean
   /** Adaptive-only: the full old active tree the atomic swap deprecates. Empty/absent on off. */
   readonly supersededClusterIds?: readonly string[]
   /**
@@ -223,19 +229,31 @@ interface StoredGardenTaxonomyPlan {
 }
 
 /**
- * Whether this plan actually stages an adaptive tree — the single gate every
- * publish step branches on. Keyed on the plan SHAPE (are there staging leaves?),
- * not the mode: a persisted adaptive tree is exactly one that produced staging
- * `leafClusters` for full-window routing. `off` and an enforced run that fell back
- * to static both leave `leafClusters` empty, so they take the off publish path;
- * only a genuinely-staged adaptive tree has them.
+ * Whether this plan defers its assignment writes to a full-window routing pass —
+ * it staged leaf centroids instead of sample assignments. Keyed on the plan
+ * SHAPE, which is exactly what routing needs: without leaves there is nothing to
+ * route against.
  *
  * Shape beats mode here because the plan artifact carries no code version: a
  * plan staged by one deploy can be published by the next (Temporal activities
  * run current code), and shape stays correct across that skew where a
  * mode+fallback check would misroute a differently-gated plan.
  */
-const planPersistsAdaptive = (plan: StoredGardenTaxonomyPlan): boolean => (plan.leafClusters ?? []).length > 0
+const planHasStagingLeaves = (plan: StoredGardenTaxonomyPlan): boolean => (plan.leafClusters ?? []).length > 0
+
+/**
+ * Whether this plan staged a fresh ADAPTIVE tree — every node a new id, so the
+ * swap retires the whole prior tree rather than the ids no node continued.
+ * Publication asks this, never the leaf question above: a statically-persisted
+ * tree upserts its continuations in place, and retiring the prior tree wholesale
+ * would deprecate those very rows while they are serving reads.
+ *
+ * `off` and an enforced run that fell back to static both answer false. Plans
+ * staged by pre-change code carry no flag, and there `leafClusters` was
+ * populated on the adaptive path alone, so their shape answers it.
+ */
+const planPersistsAdaptiveTree = (plan: StoredGardenTaxonomyPlan): boolean =>
+  plan.persistsAdaptiveTree ?? planHasStagingLeaves(plan)
 
 const chunk = <A>(items: readonly A[], size: number): A[][] => {
   const out: A[][] = []
@@ -650,6 +668,7 @@ const finalizeGardenPlan = (input: GardenTaxonomyStepInput, plan: HierarchicalTa
       mode: plan.mode,
       fallbackReason: plan.fallbackReason,
       leafClusters: plan.leafClusters,
+      persistsAdaptiveTree: plan.persistsAdaptiveTree,
       supersededClusterIds: plan.supersededClusterIds.map((clusterId) => clusterId as string),
       stagedClusterIds: plan.stagedClusterIds.map((clusterId) => clusterId as string),
       namingMembers: plan.namingMembers.map((members) => ({
@@ -902,7 +921,7 @@ export const reassignGardenTaxonomyObservationsActivity = (input: GardenTaxonomy
       // the whole-project topic tree reassigns the inline column. Facet plans are
       // always off-mode (no staging leaves), so they take the sample-only branch.
       const isView = plan.customBehaviorId != null || plan.facetId != null
-      const reassigned = yield* planPersistsAdaptive(plan)
+      const reassigned = yield* planHasStagingLeaves(plan)
         ? plan.customBehaviorId
           ? reassignFullWindowScoped(input, plan)
           : reassignFullWindowGlobal(input, plan)
@@ -922,14 +941,15 @@ export const reassignGardenTaxonomyObservationsActivity = (input: GardenTaxonomy
 // `stagedClusterIds`, so fall back to their whole cluster set (all staging).
 const publishClusterIds = (plan: StoredGardenTaxonomyPlan): TaxonomyClusterId[] =>
   (
-    plan.stagedClusterIds ?? (planPersistsAdaptive(plan) ? plan.clusters.map((cluster) => cluster.id as string) : [])
+    plan.stagedClusterIds ??
+    (planPersistsAdaptiveTree(plan) ? plan.clusters.map((cluster) => cluster.id as string) : [])
   ).map((clusterId) => TaxonomyClusterId(clusterId))
 
 // The old tree this publish retires: the whole previous tree on the adaptive
 // path, exactly the non-continued clusters when continuations were upserted in
 // place (static persist).
 const supersededByPublish = (plan: StoredGardenTaxonomyPlan): TaxonomyClusterId[] =>
-  (planPersistsAdaptive(plan) ? (plan.supersededClusterIds ?? []) : plan.deprecatedClusterIds).map((clusterId) =>
+  (planPersistsAdaptiveTree(plan) ? (plan.supersededClusterIds ?? []) : plan.deprecatedClusterIds).map((clusterId) =>
     TaxonomyClusterId(clusterId),
   )
 
@@ -1034,7 +1054,7 @@ export const deprecateGardenTaxonomyClustersActivity = (input: GardenTaxonomyDep
     input,
     Effect.gen(function* () {
       const plan = yield* loadGardenTaxonomyPlan(input)
-      return planPersistsAdaptive(plan) ? yield* swapAndCatchUp(input, plan) : yield* publishStagedTree(input, plan)
+      return planHasStagingLeaves(plan) ? yield* swapAndCatchUp(input, plan) : yield* publishStagedTree(input, plan)
     }),
   )
 

--- a/apps/workflows/src/activities/taxonomy-gardening-publish.test.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-publish.test.ts
@@ -1,6 +1,15 @@
-import type { TaxonomyClusterId } from "@domain/shared"
-import { type TaxonomyCluster, taxonomyClusterSchema } from "@domain/taxonomy"
-import { createFakeTaxonomyClusterRepository, createFakeTaxonomyObservationRepository } from "@domain/taxonomy/testing"
+import { OrganizationId, ProjectId, SessionId, type TaxonomyClusterId } from "@domain/shared"
+import {
+  type TaxonomyCluster,
+  type TaxonomyMomentObservation,
+  type TaxonomyViewAssignment,
+  taxonomyClusterSchema,
+} from "@domain/taxonomy"
+import {
+  createFakeTaxonomyClusterRepository,
+  createFakeTaxonomyObservationRepository,
+  createFakeTaxonomyViewAssignmentRepository,
+} from "@domain/taxonomy/testing"
 import { silenceLoggerInTests } from "@repo/vitest-config/silence-logger"
 import { Effect } from "effect"
 import { beforeEach, describe, expect, it, vi } from "vitest"
@@ -10,7 +19,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 // `evaluation-alignment-activities.test.ts`: domain fakes behind `withPostgres` /
 // `withClickHouse`, plus an in-memory stand-in for the Redis plan artifact.
 const { fakes, redis, calls } = vi.hoisted(() => ({
-  fakes: { clusters: null as unknown, observations: null as unknown },
+  fakes: { clusters: null as unknown, observations: null as unknown, viewAssignments: null as unknown },
   redis: new Map<string, string>(),
   calls: [] as string[],
 }))
@@ -58,7 +67,7 @@ vi.mock("@platform/db-clickhouse", async (importOriginal) => {
       <A, Err, R>(effect: Effect.Effect<A, Err, R>) =>
         effect.pipe(
           E.provide(L.succeed(domain.TaxonomyObservationRepository, fakes.observations as never)),
-          E.provide(L.succeed(domain.TaxonomyViewAssignmentRepository, {} as never)),
+          E.provide(L.succeed(domain.TaxonomyViewAssignmentRepository, fakes.viewAssignments as never)),
           E.provide(L.succeed(shared.ChSqlClient, testing.createFakeChSqlClient())),
         ),
   }
@@ -83,6 +92,7 @@ const OLD_ROOT = "a".repeat(24)
 const OLD_LEAF = "b".repeat(24)
 const NEW_ROOT = "c".repeat(24)
 const NEW_LEAF = "d".repeat(24)
+const BEHAVIOR = "e".repeat(24)
 
 const cluster = (input: {
   readonly id: string
@@ -134,6 +144,7 @@ type StoredPlan = {
   readonly mode: string
   readonly fallbackReason: null
   readonly leafClusters: readonly { readonly clusterId: string; readonly centroid: readonly number[] }[]
+  readonly persistsAdaptiveTree?: boolean | undefined
   readonly supersededClusterIds: readonly string[]
   readonly stagedClusterIds?: readonly string[] | undefined
   readonly namingMembers?:
@@ -165,6 +176,7 @@ const storePlan = (overrides: Partial<StoredPlan> = {}) => {
     mode: "off",
     fallbackReason: null,
     leafClusters: [],
+    persistsAdaptiveTree: false,
     supersededClusterIds: [],
     stagedClusterIds: [NEW_ROOT, NEW_LEAF],
     namingMembers: [{ clusterId: NEW_LEAF, observationIds: ["obs-1", "obs-2"] }],
@@ -175,7 +187,32 @@ const storePlan = (overrides: Partial<StoredPlan> = {}) => {
   return plan
 }
 
-const seedRepositories = (seed: readonly TaxonomyCluster[]) => {
+const viewUpserts: TaxonomyViewAssignment[] = []
+
+// A live-window row the full-window reassignment can route: the only fields that
+// path reads are the id, session, embedding and start time.
+const windowObservation = (index: number): TaxonomyMomentObservation => ({
+  organizationId: OrganizationId(organizationId),
+  projectId: ProjectId(projectId),
+  observationId: String(index).padStart(24, "w").slice(0, 24),
+  sessionId: SessionId(`session-${index}`),
+  analysisHash: String(index).repeat(64).slice(0, 64),
+  momentId: `moment-${index}`,
+  projectionMethod: "moment_text_embedding",
+  projectionHash: String(index).repeat(64).slice(0, 64),
+  projectionMetadata: { summary: `Observation ${index}` },
+  embedding: [1, 0],
+  startTime: new Date(now.getTime() - index * 60_000),
+  endTime: new Date(now.getTime() - index * 60_000 + 500),
+  assignedClusterId: null,
+  assignmentConfidence: 0,
+  assignmentMethod: "noise",
+  reassignmentRunId: null,
+  retentionDays: 90,
+  indexedAt: now,
+})
+
+const seedRepositories = (seed: readonly TaxonomyCluster[], window: readonly TaxonomyMomentObservation[] = []) => {
   const clusters = createFakeTaxonomyClusterRepository(seed, {
     swapActiveTree: (input) => {
       calls.push("swap")
@@ -191,14 +228,25 @@ const seedRepositories = (seed: readonly TaxonomyCluster[]) => {
       })
     },
   })
-  const observations = createFakeTaxonomyObservationRepository([], {
+  const observations = createFakeTaxonomyObservationRepository(window, {
     reassignManyById: () => {
       calls.push("reassign")
       return Effect.void
     },
   })
+  const viewAssignments = createFakeTaxonomyViewAssignmentRepository(
+    {},
+    {
+      upsertMany: (rows) =>
+        Effect.sync(() => {
+          calls.push("view-upsert")
+          viewUpserts.push(...rows)
+        }),
+    },
+  )
   fakes.clusters = clusters.repository
   fakes.observations = observations.repository
+  fakes.viewAssignments = viewAssignments.repository
   return clusters
 }
 
@@ -216,6 +264,7 @@ describe("taxonomy gardening publish activities", () => {
   beforeEach(() => {
     redis.clear()
     calls.length = 0
+    viewUpserts.length = 0
   })
 
   it("publishes in the same activity as the reassignment, reassign first", async () => {
@@ -328,6 +377,7 @@ describe("taxonomy gardening publish activities", () => {
       deprecatedClusterIds: [],
       supersededClusterIds: [OLD_ROOT, OLD_LEAF],
       leafClusters: [{ clusterId: NEW_LEAF, centroid: [1, 0] }],
+      persistsAdaptiveTree: true,
     })
     await deprecateGardenTaxonomyClustersActivity({ ...stepInput, planKey })
 
@@ -336,12 +386,66 @@ describe("taxonomy gardening publish activities", () => {
     expect(stateOf(adaptiveClusters, NEW_ROOT)).toBe("active")
   })
 
+  // Staging leaves and an adaptive tree are two different facts about a plan, and
+  // publication reads the second one. No plan carries the first without the second
+  // in production today — LAT-862 Part 2b gives facet lenses one — so the case is
+  // pinned by fixture rather than by trust. A cohort scope keeps it about the two
+  // predicates; the facet write target is Part 2b's problem.
+  const leavesWithoutAdaptiveTree = (overrides: Partial<StoredPlan> = {}) =>
+    storePlan({
+      customBehaviorId: BEHAVIOR,
+      mode: "off",
+      persistsAdaptiveTree: false,
+      leafClusters: [{ clusterId: NEW_LEAF, centroid: [1, 0] }],
+      // A statically-persisted view saves its tree active, so nothing is staged.
+      clusters: [
+        cluster({ id: NEW_ROOT, parentClusterId: null, name: "Rebuilt Umbrella", state: "active" }),
+        cluster({ id: NEW_LEAF, parentClusterId: NEW_ROOT, name: "Rebuilt Leaf", state: "active" }),
+      ],
+      stagedClusterIds: [],
+      deprecatedClusterIds: [OLD_LEAF],
+      supersededClusterIds: [],
+      ...overrides,
+    })
+
+  it("routes the full window but retires only the dead ids when a plan has leaves without an adaptive tree", async () => {
+    const clusters = seedRepositories(publishedTree(), [windowObservation(1), windowObservation(2)])
+    leavesWithoutAdaptiveTree()
+
+    const result = await deprecateGardenTaxonomyClustersActivity({ ...stepInput, planKey })
+
+    // Leaves ⇒ the catch-up pass runs: routing follows the plan's SHAPE.
+    expect(calls).toContain("view-upsert")
+    expect(viewUpserts).toHaveLength(2)
+    // Not an adaptive tree ⇒ the swap retires the ids no node continued, never the
+    // whole prior tree. Retiring it wholesale here would deprecate the live rows a
+    // static persist upserted its continuations onto.
+    expect(stateOf(clusters, OLD_LEAF)).toBe("deprecated")
+    expect(stateOf(clusters, OLD_ROOT)).toBe("active")
+    expect(result).toEqual(expect.objectContaining({ clustersDeprecated: 1, clustersActivated: 0 }))
+  })
+
+  it("activates nothing on a pre-change-shaped plan with leaves but no adaptive tree", async () => {
+    const clusters = seedRepositories(publishedTree(), [windowObservation(1)])
+    // Without `stagedClusterIds` the publish falls back to the whole cluster set,
+    // but only for an adaptive tree — a static view's rows are already active.
+    leavesWithoutAdaptiveTree({ stagedClusterIds: undefined, namingMembers: undefined })
+
+    const result = await deprecateGardenTaxonomyClustersActivity({ ...stepInput, planKey })
+
+    expect(result).toEqual(expect.objectContaining({ clustersActivated: 0 }))
+    expect(stateOf(clusters, NEW_ROOT)).toBe("staging")
+  })
+
   it("falls back to the plan's whole cluster set on a pre-change adaptive plan", async () => {
     const clusters = seedRepositories(publishedTree())
+    // Pre-change plans carry no `persistsAdaptiveTree`; their staging leaves are
+    // the only signal that this was an adaptive tree, and it still has to work.
     storePlan({
       mode: "enforced",
       supersededClusterIds: [OLD_ROOT, OLD_LEAF],
       leafClusters: [{ clusterId: NEW_LEAF, centroid: [1, 0] }],
+      persistsAdaptiveTree: undefined,
       stagedClusterIds: undefined,
       namingMembers: undefined,
     })
@@ -389,6 +493,7 @@ describe("planGardenTaxonomyNamingActivity", () => {
   beforeEach(() => {
     redis.clear()
     calls.length = 0
+    viewUpserts.length = 0
   })
 
   it("plans the STAGED tree deepest-first and carries its sample member ids", async () => {

--- a/packages/domain/taxonomy/src/use-cases/adaptive-gardening.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/adaptive-gardening.test.ts
@@ -175,6 +175,7 @@ describe("planHierarchicalTaxonomyUseCase off is a byte-identical no-op", () => 
     expect(plan.clusters.every((cluster) => cluster.state === "staging")).toBe(true)
     expect([...plan.stagedClusterIds].sort()).toEqual(plan.clusters.map((cluster) => cluster.id).sort())
     expect(plan.leafClusters).toEqual([])
+    expect(plan.persistsAdaptiveTree).toBe(false)
     expect(plan.supersededClusterIds).toEqual([])
     expect(plan.decisionMetadata).toBeNull()
     expect(plan.observationAssignments.length).toBeGreaterThan(0)
@@ -192,6 +193,7 @@ describe("planHierarchicalTaxonomyUseCase off is a byte-identical no-op", () => 
     expect(plan.customBehaviorId).toBe(customBehaviorId)
     expect(plan.clusters.every((cluster) => cluster.state === "active")).toBe(true)
     expect(plan.leafClusters).toEqual([])
+    expect(plan.persistsAdaptiveTree).toBe(false)
     expect(plan.supersededClusterIds).toEqual([])
     expect(plan.decisionMetadata).toBeNull()
     expect(plan.observationAssignments).toEqual([])
@@ -329,6 +331,9 @@ describe("planHierarchicalTaxonomyUseCase enforced falls back to static on unsaf
     expect(plan.clusters.length).toBeGreaterThan(0)
     expect(plan.clusters.every((cluster) => cluster.state === "staging")).toBe(true)
     expect(plan.leafClusters).toEqual([])
+    // The publish path reads this, not the mode: a fallen-back `enforced` run
+    // persists the static tree, so its swap must retire the dead ids only.
+    expect(plan.persistsAdaptiveTree).toBe(false)
     expect(plan.supersededClusterIds).toEqual([])
     expect(plan.observationAssignments.length).toBeGreaterThan(0)
   })
@@ -364,6 +369,7 @@ describe("planHierarchicalTaxonomyUseCase enforced falls back to static on unsaf
     expect(plan.fallbackReason).toBeNull()
     expect(plan.clusters.every((cluster) => cluster.state === "staging")).toBe(true)
     expect(plan.leafClusters.length).toBeGreaterThanOrEqual(2)
+    expect(plan.persistsAdaptiveTree).toBe(true)
   })
 })
 

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
@@ -274,6 +274,14 @@ export interface HierarchicalTaxonomyPlan extends BuildHierarchicalTaxonomyResul
   /** Leaf id + centroid for adaptive full-window routing. Empty on the off path. */
   readonly leafClusters: readonly StagingLeafCluster[]
   /**
+   * Whether this pass persists a freshly-built ADAPTIVE tree: every node gets a
+   * new id, so publication retires the whole prior tree rather than the ids no
+   * node continued. Distinct from having `leafClusters`, which says only that
+   * the assignment writes are deferred to a full-window routing pass — the two
+   * coincide today, and publication must keep reading this one.
+   */
+  readonly persistsAdaptiveTree: boolean
+  /**
    * The clusters this plan saves as `staging` — what the atomic swap activates
    * once they are named and ClickHouse points at them. Empty only when nothing
    * fresh was staged (a view's off path, which upserts active rows in place).
@@ -668,6 +676,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
         observationAssignments: [],
         customAssignments: [],
         leafClusters: [],
+        persistsAdaptiveTree: false,
         stagedClusterIds: [],
         namingMembers: [],
         continuedRestore: [],
@@ -940,6 +949,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       observationAssignments,
       customAssignments,
       leafClusters,
+      persistsAdaptiveTree: persistAdaptive,
       stagedClusterIds: bornClusters
         .filter((cluster) => cluster.state === "staging")
         .map((cluster) => cluster.id as TaxonomyClusterId),


### PR DESCRIPTION
Part 2a of LAT-862. **This PR changes no behaviour.** Facet-lens coverage is unchanged until Part 2b.

## The problem

`planPersistsAdaptive(plan)` was `(plan.leafClusters ?? []).length > 0`, and four call sites read it for two different questions:

| call site | what it actually asks |
| --- | --- |
| reassign branch | does this plan defer its assignment writes to a full-window routing pass? |
| `deprecateGardenTaxonomyClustersActivity` | same — is there a catch-up pass to run? |
| `publishClusterIds` | did this stage a fresh adaptive tree (legacy fallback for plans with no `stagedClusterIds`)? |
| `supersededByPublish` | did this stage a fresh adaptive tree, so the swap retires the whole prior tree? |

Today those coincide, because `leafClusters` is populated exactly when `persistAdaptive` is true. Part 2b needs facet plans to carry staging leaves without becoming adaptive trees, and under one boolean that flip lands on publication: `supersededByPublish` would return `supersededClusterIds ?? []` — empty on a static persist — so a facet rebuild would deprecate **nothing** and leave its old clusters active alongside the new ones.

## The change

`HierarchicalTaxonomyPlan` now carries `persistsAdaptiveTree` (set from the existing `persistAdaptive`, i.e. "the adaptive builder produced an accepted build" — not the org flag), and the plan artifact persists it. The predicate splits in two:

- `planHasStagingLeaves` — shape-keyed, as before. Reassign routing and the catch-up branch read it.
- `planPersistsAdaptiveTree` — `plan.persistsAdaptiveTree ?? planHasStagingLeaves(plan)`. Publication reads it.

The fallback keeps Temporal deploy skew safe: a plan staged by the current deploy and published by the next carries no flag, and there `leafClusters` answered the question correctly.

## Why it is byte-identical

The two predicates can only disagree when `persistAdaptive` is true and `leafClusters` is empty. `bornLeaves` gets one entry per descriptor with `children.length === 0`, and `collectNodes` emits the root itself as a descriptor — so a persisted tree always has at least one leaf, including a bare root. The divergence is unreachable by construction, not merely unlikely.

Per plan shape, `persistsAdaptiveTree` equals the old predicate's value everywhere:

| plan | old predicate | new `persistsAdaptiveTree` |
| --- | --- | --- |
| global topic, `off` | false | false |
| global topic, `enforced` accepted | true | true |
| global topic, `enforced` fallen back | false | false |
| cohort view, `off` | false | false |
| cohort view, `enforced` accepted | true | true |
| facet lens (forced `off`) | false | false |
| sample below the gardening minimum | false | false (explicit) |

## Tests

Publication is the risk here, not reassignment — #4305 published a tree before it was named and blanked Behaviours on every rebuild, #4347 let a degenerate bare-root rebuild wipe the live tree. So the case with no production instance gets a fixture rather than trust:

- A plan with staging leaves but **not** an adaptive tree still runs the full-window catch-up (shape), and its swap retires exactly `deprecatedClusterIds` while the prior root stays active (flag). Reverting `supersededByPublish` to the shape predicate fails this test, so it discriminates.
- The same plan in the pre-`stagedClusterIds` shape activates nothing, instead of falling back to the whole cluster set.
- The existing pre-change adaptive plan test now drops `persistsAdaptiveTree` entirely, pinning the shape fallback.
- Domain-side, `persistsAdaptiveTree` is asserted on off/global, off/scoped, adaptive-accepted and adaptive-fallen-back plans.

The fixture uses a cohort scope deliberately: a facet plan with leaves would also exercise `reassignFullWindowScoped`'s hard-coded `facetId: null`, which is Part 2b's to fix and should not be pinned as correct here.

## Explicitly not in this PR (all Part 2b)

`mode: "off"` in `plan-facet-garden.ts`, the hard-coded `facetId: null`, projection-space routing, and letting any facet plan gain leaves. No facet plan may gain leaves before the projection-space path and the routing guard land in the same change — `planPersistsAdaptive` flipping true for a whole-project facet routes it to `reassignFullWindowGlobal`, which overwrites `taxonomy_observations.assigned_cluster_id` and clobbers the global topic tree.

## Answered for Part 2b: projection embeddings are normalised

Verified in `extract-facet-projections.ts`: the extracted answer's embedding goes through `normalizeTaxonomyEmbedding` before it is persisted — the same helper the planner applies to observation embeddings. `routeOne` also re-normalises defensively before `cosineSimilarityNormalized`, so routing confidence is on the same footing in projection space as in observation space. Unclear projections carry an empty embedding and are dropped by `routeObservationsToLeaves`, which skips empty vectors.

## Verification

- `@domain/taxonomy` full suite: 296 passed
- `@app/workflows` taxonomy tests: 38 passed (11 in the publish file, up from 9)
- `@app/workers` taxonomy tests: 14 passed
- `typecheck` clean on `@domain/taxonomy` and `@app/workflows` (`@app/workers` has a pre-existing failure in `packages/platform/latitude-api/src/client.ts`, reproduced on the base commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)