### PR TITLE
fix(models): stop models.dev refreshes from breaking PR unit/integration tests

### DIFF
--- a/.github/workflows/update-models-dev-data.yml
+++ b/.github/workflows/update-models-dev-data.yml
@@ -48,6 +48,8 @@ jobs:
         run: |
           cp -n .env.example .env.test || true
           pnpm --filter @domain/models exec vitest run --passWithNoTests src/registry.test.ts
+          pnpm --filter @platform/ai exec vitest run --passWithNoTests src/metering.test.ts
+          pnpm --filter @domain/evaluations exec vitest run --passWithNoTests src/runtime/evaluation-execution.test.ts
           pnpm --filter @platform/testkit chdb:build
           pnpm --filter @platform/db-clickhouse exec vitest run --passWithNoTests src/seeds/spans/cost-archetypes/archetypes.test.ts
 
@@ -63,7 +65,8 @@ jobs:
             Updates `packages/domain/models/src/data/models.dev.json`
             with the latest model information from the models.dev API.
 
-            Catalog-coupled unit and cost-archetype tests were run against the
+            Catalog-coupled unit tests (registry, AI metering, evaluation
+            execution) and the cost-archetype suite were run against the
             refreshed data before opening this PR.
           branch: chore/update-models-dev-data
           delete-branch: true

--- a/.github/workflows/update-models-dev-data.yml
+++ b/.github/workflows/update-models-dev-data.yml
@@ -41,6 +41,16 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Verify catalog-coupled tests
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          NODE_ENV: test
+        run: |
+          cp -n .env.example .env.test || true
+          pnpm --filter @domain/models exec vitest run --passWithNoTests src/registry.test.ts
+          pnpm --filter @platform/testkit chdb:build
+          pnpm --filter @platform/db-clickhouse exec vitest run --passWithNoTests src/seeds/spans/cost-archetypes/archetypes.test.ts
+
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
@@ -52,6 +62,9 @@ jobs:
 
             Updates `packages/domain/models/src/data/models.dev.json`
             with the latest model information from the models.dev API.
+
+            Catalog-coupled unit and cost-archetype tests were run against the
+            refreshed data before opening this PR.
           branch: chore/update-models-dev-data
           delete-branch: true
           labels: |

--- a/packages/domain/models/src/registry.test.ts
+++ b/packages/domain/models/src/registry.test.ts
@@ -455,6 +455,41 @@ describe("formatModel", () => {
   })
 })
 
+/**
+ * First provider in the bundled catalog that namespaces the same bare model id under two vendors,
+ * does not also list the bare id directly, and prices both vendors' entries. All three conditions
+ * matter: without the last one an unpriced bare id would prove nothing, since `getCostSpec` reports
+ * `costImplemented: false` for a model it cannot price as readily as for one it refuses to guess at.
+ * Sorted so a failure names the same pair on every run.
+ */
+function findAmbiguousBareId(): { provider: string; bareId: string; namespacedIds: string[] } | null {
+  const idsByProvider = new Map<string, string[]>()
+  for (const model of getAllModels()) {
+    idsByProvider.set(model.provider, [...(idsByProvider.get(model.provider) ?? []), model.id])
+  }
+
+  for (const provider of [...idsByProvider.keys()].sort()) {
+    const ids = idsByProvider.get(provider) ?? []
+    const direct = new Set(ids.map((id) => id.toLowerCase()))
+    const idsByBareId = new Map<string, string[]>()
+    for (const id of ids) {
+      if (!id.includes("/")) continue
+      const bareId = id.slice(id.lastIndexOf("/") + 1).toLowerCase()
+      idsByBareId.set(bareId, [...(idsByBareId.get(bareId) ?? []), id])
+    }
+
+    for (const bareId of [...idsByBareId.keys()].sort()) {
+      const namespacedIds = idsByBareId.get(bareId) ?? []
+      if (namespacedIds.length < 2 || direct.has(bareId)) continue
+      if (namespacedIds.every((id) => getCostSpec(provider, id).costImplemented)) {
+        return { provider, bareId, namespacedIds }
+      }
+    }
+  }
+
+  return null
+}
+
 describe("getCostSpec bare model ids on namespaced providers", () => {
   // OpenRouter's API takes `grok-4.5` while its catalog keys on `x-ai/grok-4.5`. The rate we
   // resolve is OpenRouter's own, so this borrows nothing from another host.
@@ -467,11 +502,23 @@ describe("getCostSpec bare model ids on namespaced providers", () => {
   })
 
   it("leaves a bare id unpriced when two vendors on that provider share the name", () => {
-    // nano-gpt lists `TEE/glm-5.1` and `zai-org/glm-5.1`: two vendors, two rates, so picking one
-    // would invent a number. Driven through getCostSpec because the fallback lives in
-    // `getModelForProvider` — `findModel` never reaches it, so asserting there proves nothing.
-    // The id has to be re-picked whenever a models.dev refresh drops one side of a pair.
-    expect(getCostSpec("nano-gpt", "glm-5.1").costImplemented).toBe(false)
+    // Two vendors on one provider means two rates, so picking one would invent a number. The pair
+    // is read out of the bundled catalog rather than hardcoded: this case needs both vendors to
+    // still list the same model, and a models.dev refresh dropping one of them (which is how
+    // `nano-gpt`/`glm-5` stopped being ambiguous) would otherwise look like a code regression.
+    // Driven through getCostSpec because the fallback lives in `getModelForProvider` — `findModel`
+    // never reaches it, so asserting there proves nothing.
+    const ambiguous = findAmbiguousBareId()
+    if (ambiguous === null) {
+      throw new Error("bundled catalog has no priced pair of vendors sharing a bare model id")
+    }
+
+    // Both vendors' own ids price, so the bare id going unpriced is the refusal to choose
+    // between their two rates rather than an absence of pricing.
+    for (const id of ambiguous.namespacedIds) {
+      expect(getCostSpec(ambiguous.provider, id).costImplemented).toBe(true)
+    }
+    expect(getCostSpec(ambiguous.provider, ambiguous.bareId).costImplemented).toBe(false)
   })
 
   it("does not reach into another provider's catalog for a model the reported one lacks", () => {

--- a/packages/domain/spans/src/redaction/validate-rule.ts
+++ b/packages/domain/spans/src/redaction/validate-rule.ts
@@ -60,6 +60,12 @@ const PROBE_LENGTHS = [12, 16, 20, 24] as const
 /** Timing is noisy at this scale, and noise only ever adds, so the fastest run is the honest one. */
 const PROBE_ATTEMPTS = 3
 
+/**
+ * Bail out of further attempts only once past the budget by a wide margin. A single attempt just
+ * over budget is usually CI scheduler noise; real catastrophic shapes land orders of magnitude over.
+ */
+const PROBE_ABORT_MS = PROBE_BUDGET_MS * 10
+
 const MAX_QUANTIFIER_BOUND = 1_000
 
 /**
@@ -461,9 +467,9 @@ function probeAlphabet(source: string): string[] {
 /**
  * Fastest of several runs: a scheduler hiccup or a cold JIT can only ever make a run look slower.
  *
- * Retrying stops once a run is over budget. Repetition is here to keep noise from condemning a rule
- * that was only marginally slow, and a pattern already past the budget by a wide margin is not
- * marginal — re-running it just pays its cost again, which is the opposite of what this is for.
+ * Retrying stops once a run is past the budget by a wide margin (`PROBE_ABORT_MS`). Repetition is
+ * here to keep noise from condemning a rule that was only marginally slow, and a pattern already
+ * past the budget by a wide margin is not marginal — re-running it just pays its cost again.
  */
 function timeAgainst(pattern: RegExp, run: string): number {
   const input = `${run}!`
@@ -475,7 +481,7 @@ function timeAgainst(pattern: RegExp, run: string): number {
     const started = performance.now()
     probe.test(input)
     fastest = Math.min(fastest, performance.now() - started)
-    if (fastest > PROBE_BUDGET_MS) return fastest
+    if (fastest > PROBE_ABORT_MS) return fastest
   }
 
   return fastest

--- a/packages/domain/spans/src/redaction/validate-rule.ts
+++ b/packages/domain/spans/src/redaction/validate-rule.ts
@@ -60,10 +60,7 @@ const PROBE_LENGTHS = [12, 16, 20, 24] as const
 /** Timing is noisy at this scale, and noise only ever adds, so the fastest run is the honest one. */
 const PROBE_ATTEMPTS = 3
 
-/**
- * Bail out of further attempts only once past the budget by a wide margin. A single attempt just
- * over budget is usually CI scheduler noise; real catastrophic shapes land orders of magnitude over.
- */
+// Abort retries only after the fastest measurement exceeds PROBE_ABORT_MS (wide margin over budget).
 const PROBE_ABORT_MS = PROBE_BUDGET_MS * 10
 
 const MAX_QUANTIFIER_BOUND = 1_000
@@ -467,9 +464,10 @@ function probeAlphabet(source: string): string[] {
 /**
  * Fastest of several runs: a scheduler hiccup or a cold JIT can only ever make a run look slower.
  *
- * Retrying stops once a run is past the budget by a wide margin (`PROBE_ABORT_MS`). Repetition is
- * here to keep noise from condemning a rule that was only marginally slow, and a pattern already
- * past the budget by a wide margin is not marginal — re-running it just pays its cost again.
+ * Retrying stops once the fastest measurement is past the budget by a wide margin
+ * (`PROBE_ABORT_MS`). Repetition is here to keep noise from condemning a rule that was only
+ * marginally slow, and a pattern already past the budget by a wide margin is not marginal —
+ * re-running it just pays its cost again.
  */
 function timeAgainst(pattern: RegExp, run: string): number {
   const input = `${run}!`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The last models.dev refresh (#4412) dropped catalog entries that two tests still hardcoded (`nano-gpt`/`glm-5` ambiguity and `claude-opus-4-1`). That PR was opened with `GITHUB_TOKEN`, so GitHub skipped `pull_request` workflows and the breakage only showed up on other PRs' merge commits.

## Changes

1. **`registry.test.ts`** — derive the ambiguous bare-id fixture from the bundled catalog instead of hardcoding `nano-gpt`/`glm-5.1`. The test still requires both vendors' namespaced ids to be priced, so it exercises the refusal-to-guess path rather than a missing price.

2. **`update-models-dev-data.yml`** — after refreshing the JSON, run catalog-coupled unit tests (registry, AI metering, evaluation execution) and the cost-archetype suite before opening the PR. If a future refresh drops a fixture those tests still name, the scheduled job fails closed instead of turning trunk red for every PR.

3. **`validate-rule.ts`** — the redaction probe's retry loop returned on the first attempt over the 8ms budget, so a CI scheduler hiccup (~10ms) condemned a linear pattern like `[A-Za-z]+` as catastrophic without giving later attempts a chance. Early abort now requires a wide margin over the budget (keyed off the fastest measurement).

`b-unknown` already points at `claude-opus-4-8` on `development` (via #4409); this PR does not change that fixture.

## Verification

- `pnpm --filter @domain/models exec vitest run src/registry.test.ts`
- `pnpm --filter @platform/ai exec vitest run src/metering.test.ts`
- `pnpm --filter @domain/evaluations exec vitest run src/runtime/evaluation-execution.test.ts`
- `pnpm --filter @platform/db-clickhouse exec vitest run src/seeds/spans/cost-archetypes/archetypes.test.ts`
- `pnpm --filter @domain/spans exec vitest run src/redaction/validate-rule.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6942615-653c-490b-a5d6-460bd00b0ea4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6942615-653c-490b-a5d6-460bd00b0ea4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timing validation reliability by allowing additional retries before aborting.
  * Strengthened model registry checks to correctly detect ambiguous model identifiers and pricing behavior.

* **Tests**
  * Added catalog-aware registry, metering, evaluation, and cost validation when model data changes.
  * Test runs now include the required environment setup and report coverage against refreshed model data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->