### PR TITLE
feat(taxonomy): near-duplicate name rate (LAT-861 Build 4)

### DIFF
--- a/apps/workflows/datadog/setup-datadog.sh
+++ b/apps/workflows/datadog/setup-datadog.sh
@@ -141,6 +141,7 @@ done <<'METRICS'
 taxonomy.quality.duplicate_name_rate|@taxonomy.quality.duplicateNameRate
 taxonomy.quality.cross_branch_duplicates|@taxonomy.quality.crossBranchDuplicateLeafCount
 taxonomy.quality.shared_sibling_word_share|@taxonomy.quality.sharedSiblingWordShare
+taxonomy.quality.near_duplicate_name_rate|@taxonomy.quality.nearDuplicateNameRate
 METRICS
 
 echo "== retired shadow-comparison metrics =="

--- a/apps/workflows/datadog/taxonomy-quality-dashboard.json
+++ b/apps/workflows/datadog/taxonomy-quality-dashboard.json
@@ -425,6 +425,36 @@
               ]
             },
             "layout": { "width": 4, "height": 3 }
+          },
+          {
+            "definition": {
+              "type": "toplist",
+              "title": "max nearDuplicateNameRate by project — share of leaf-name pairs sharing most of their words",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "near_dup_rate",
+                      "search": {
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.nameQuality $organization $project"
+                      },
+                      "compute": { "aggregation": "max", "metric": "@taxonomy.quality.nearDuplicateNameRate" },
+                      "group_by": [{ "facet": "@taxonomy.projectId", "limit": 15 }]
+                    }
+                  ],
+                  "formulas": [{ "formula": "near_dup_rate" }],
+                  "response_format": "scalar",
+                  "sort": { "order_by": [{ "type": "formula", "index": 0, "order": "desc" }], "count": 15 },
+                  "conditional_formats": [
+                    { "comparator": ">", "value": 0.2, "palette": "white_on_red" },
+                    { "comparator": ">", "value": 0.1, "palette": "white_on_yellow" },
+                    { "comparator": "<=", "value": 0.1, "palette": "white_on_green" }
+                  ]
+                }
+              ]
+            },
+            "layout": { "width": 4, "height": 3 }
           }
         ]
       },

--- a/apps/workflows/datadog/taxonomy-quality-datadog-setup.md
+++ b/apps/workflows/datadog/taxonomy-quality-datadog-setup.md
@@ -5,7 +5,7 @@ Every garden run emits two APM spans from the `workflows` service:
 | span (`resource_name`) | emitted by | carries |
 | --- | --- | --- |
 | `taxonomy.gardenTaxonomyWorkflow.buildQuality` | the planning activity, off the tree the run persists | `largestLeafShare`, `leafSizes`, `topLevelRowCount`, `largestTopLevelShare`, per-leaf `centeredCohesion` (p10/p50/p90 + min) |
-| `taxonomy.gardenTaxonomyWorkflow.nameQuality` | the assert-quality activity, after naming | `duplicateNameRate`, `crossBranchDuplicateLeafCount`, `sharedSiblingWordShare` |
+| `taxonomy.gardenTaxonomyWorkflow.nameQuality` | the assert-quality activity, after naming | `duplicateNameRate`, `crossBranchDuplicateLeafCount`, `sharedSiblingWordShare`, `nearDuplicateNameRate` |
 
 Unlike `taxonomy.gardenTaxonomyWorkflow.shadow`, **neither is flag-gated**: they
 fire for every project, every view, in every clustering mode, which is the point —
@@ -56,7 +56,8 @@ custom behavior and facet:
 
 `largest_leaf_share`, `largest_top_level_share`, `top_level_row_count`,
 `leaf_count`, `members_clustered`, `centered_cohesion_min`, `centered_cohesion_p50`,
-`duplicate_name_rate`, `cross_branch_duplicates`, `shared_sibling_word_share`.
+`duplicate_name_rate`, `cross_branch_duplicates`, `shared_sibling_word_share`,
+`near_duplicate_name_rate`.
 
 ## Interpreting the dashboard
 
@@ -70,6 +71,7 @@ custom behavior and facet:
 | `duplicateNameRate` | Leaves colliding with any other leaf **anywhere** in the tree | 0 | Non-zero. The shipped quality gate only compares siblings, so cross-branch collisions ship silently |
 | `crossBranchDuplicateLeafCount` | The subset the gate cannot see | 0 | Any. Observed twice in one tree |
 | `sharedSiblingWordShare` | Share of leaf-name words every sibling also uses | Below ~0.4 | Above ~0.6 — the namer described the shared domain instead of the split. On the best-separated partition available, 90% of leaf-name words came from vocabulary true of every session |
+| `nearDuplicateNameRate` | Share of leaf-name pairs, anywhere in the tree, scoring ≥ 0.5 Jaccard over segmented tokens | 0 | Any pair, and a rise after a naming change. This is the acceptance test for contrastive naming: exact collisions are its tail, and two names one word apart read as duplicates on the screen |
 
 ### The one pairing that matters
 

--- a/apps/workflows/src/activities/taxonomy-gardening-telemetry.test.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-telemetry.test.ts
@@ -163,10 +163,14 @@ describe("nameQualitySpanAttributes", () => {
       duplicateNameLeafCount: 4,
       crossBranchDuplicateLeafCount: 2,
       sharedSiblingWordShare: 0.9,
+      nearDuplicateNameRate: 0.2,
+      nearDuplicateNamePairCount: 9,
     })
 
     expect(attributes["taxonomy.quality.duplicateNameRate"]).toBeCloseTo(0.4)
     expect(attributes["taxonomy.quality.crossBranchDuplicateLeafCount"]).toBe(2)
     expect(attributes["taxonomy.quality.sharedSiblingWordShare"]).toBeCloseTo(0.9)
+    expect(attributes["taxonomy.quality.nearDuplicateNameRate"]).toBeCloseTo(0.2)
+    expect(attributes["taxonomy.quality.nearDuplicateNamePairCount"]).toBe(9)
   })
 })

--- a/apps/workflows/src/activities/taxonomy-gardening-telemetry.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-telemetry.ts
@@ -188,4 +188,6 @@ export const nameQualitySpanAttributes = (
   // The collisions the sibling-scoped quality gate lets through.
   "taxonomy.quality.crossBranchDuplicateLeafCount": metrics.crossBranchDuplicateLeafCount,
   "taxonomy.quality.sharedSiblingWordShare": metrics.sharedSiblingWordShare,
+  "taxonomy.quality.nearDuplicateNameRate": metrics.nearDuplicateNameRate,
+  "taxonomy.quality.nearDuplicateNamePairCount": metrics.nearDuplicateNamePairCount,
 })

--- a/packages/domain/taxonomy/src/name-quality.test.ts
+++ b/packages/domain/taxonomy/src/name-quality.test.ts
@@ -58,6 +58,64 @@ describe("taxonomyNameQualityMetrics", () => {
     expect(metrics.duplicateNameRate).toBe(0)
   })
 
+  it("catches siblings sharing most of their vocabulary without colliding exactly", () => {
+    const metrics = taxonomyNameQualityMetrics([
+      cluster("root", null, "Everything"),
+      cluster("a", "root", "Client report generation"),
+      cluster("b", "root", "Client report review"),
+      cluster("c", "root", "Refund disputes"),
+    ])
+
+    expect(metrics.duplicateNameRate).toBe(0)
+    expect(metrics.nearDuplicateNamePairCount).toBe(1)
+    expect(metrics.nearDuplicateNameRate).toBeCloseTo(1 / 3)
+  })
+
+  it("scores names across the whole tree, not only within a sibling set", () => {
+    const metrics = taxonomyNameQualityMetrics([
+      cluster("root", null, "Everything"),
+      cluster("a", "root", "Reporting"),
+      cluster("b", "root", "Onboarding"),
+      cluster("c", "a", "Weekly report export"),
+      cluster("d", "b", "Weekly report review"),
+    ])
+
+    expect(metrics.nearDuplicateNamePairCount).toBe(1)
+  })
+
+  it("scores unspaced names by segmented words rather than reading them as one token", () => {
+    const metrics = taxonomyNameQualityMetrics([
+      cluster("root", null, "全部"),
+      cluster("a", "root", "报告生成与导出"),
+      cluster("b", "root", "报告生成与查询"),
+    ])
+
+    expect(metrics.nearDuplicateNamePairCount).toBe(1)
+    expect(metrics.nearDuplicateNameRate).toBe(1)
+  })
+
+  it("compares composed and decomposed accents as the same name", () => {
+    const metrics = taxonomyNameQualityMetrics([
+      cluster("root", null, "Todo"),
+      cluster("a", "root", "Facturación de créditos".normalize("NFD")),
+      cluster("b", "root", "Facturación de créditos".normalize("NFC")),
+    ])
+
+    expect(metrics.nearDuplicateNameRate).toBe(1)
+  })
+
+  it("does not count leaves still waiting to be named as near-duplicates of each other", () => {
+    const metrics = taxonomyNameQualityMetrics([
+      cluster("root", null, "Everything"),
+      cluster("a", "root", "Pending"),
+      cluster("b", "root", "Pending"),
+      cluster("c", "root", "Refund requests"),
+    ])
+
+    expect(metrics.nearDuplicateNamePairCount).toBe(0)
+    expect(metrics.nearDuplicateNameRate).toBe(0)
+  })
+
   it("treats a lone root as the tree's only leaf", () => {
     const metrics = taxonomyNameQualityMetrics([cluster("root", null, "Ad campaign troubleshooting")])
 

--- a/packages/domain/taxonomy/src/name-quality.ts
+++ b/packages/domain/taxonomy/src/name-quality.ts
@@ -25,6 +25,12 @@ export interface TaxonomyNameQualityMetrics {
    * one measured project 90% of leaf-name words were true of every session.
    */
   readonly sharedSiblingWordShare: number
+  /**
+   * Leaf-name pairs anywhere in the tree that share most of their vocabulary, over every pair compared.
+   * Exact collisions are only this metric's tail: siblings usually collapse onto shared words, not one name.
+   */
+  readonly nearDuplicateNameRate: number
+  readonly nearDuplicateNamePairCount: number
 }
 
 /** Shared with `assertTaxonomyQuality` so the gate and the metric collide on exactly the same names. */
@@ -37,6 +43,42 @@ export const normalizedTaxonomyName = (name: string): string =>
     .trim()
 
 const isNamed = (normalized: string): boolean => normalized.length > 0 && normalized !== "pending"
+
+const wordSegmenter = new Intl.Segmenter(undefined, { granularity: "word" })
+
+/** The normalizer above empties Chinese, Japanese and Thai names, and whitespace leaves them one token. */
+const segmentedNameTokens = (name: string): readonly string[] =>
+  [...wordSegmenter.segment(name.normalize("NFC").toLowerCase())]
+    .filter((segment) => segment.isWordLike === true)
+    .map((segment) => segment.segment)
+
+// ICU knows no domain compounds and over-splits them into single characters, so CJK scores skew high against
+// English, and 0.5 is calibrated on English only. Same meaning with no shared surface is invisible here:
+// レポート生成 vs 報告書作成 scores 0.
+const NEAR_DUPLICATE_NAME_SIMILARITY = 0.5
+
+const jaccard = (a: ReadonlySet<string>, b: ReadonlySet<string>): number => {
+  const shared = [...a].filter((token) => b.has(token)).length
+  const union = a.size + b.size - shared
+  return union === 0 ? 0 : shared / union
+}
+
+/** Every pair in the tree, not just siblings: leaves under different parents render as adjacent rows. */
+const nearDuplicateNamePairs = (leafNames: readonly string[]): { pairs: number; nearDuplicates: number } => {
+  const tokenSets = leafNames
+    .map((name) => segmentedNameTokens(name))
+    .filter((tokens) => tokens.length > 0 && tokens.join(" ") !== "pending")
+    .map((tokens) => new Set(tokens))
+  let pairs = 0
+  let nearDuplicates = 0
+  tokenSets.forEach((tokens, index) => {
+    for (const other of tokenSets.slice(index + 1)) {
+      pairs += 1
+      if (jaccard(tokens, other) >= NEAR_DUPLICATE_NAME_SIMILARITY) nearDuplicates += 1
+    }
+  })
+  return { pairs, nearDuplicates }
+}
 
 interface NamedLeaf {
   readonly groupKey: string
@@ -89,6 +131,8 @@ export const taxonomyNameQualityMetrics = (
     if (new Set(collisions.map((leaf) => leaf.groupKey)).size > 1) crossBranchDuplicateLeafCount += collisions.length
   }
 
+  const nearDuplicates = nearDuplicateNamePairs(leafClusters.map((cluster) => cluster.name))
+
   return {
     leafCount: leafClusters.length,
     namedLeafCount: named.length,
@@ -96,5 +140,7 @@ export const taxonomyNameQualityMetrics = (
     duplicateNameLeafCount,
     crossBranchDuplicateLeafCount,
     sharedSiblingWordShare: sharedWordShare(named),
+    nearDuplicateNameRate: nearDuplicates.pairs === 0 ? 0 : nearDuplicates.nearDuplicates / nearDuplicates.pairs,
+    nearDuplicateNamePairCount: nearDuplicates.nearDuplicates,
   }
 }


### PR DESCRIPTION
## Why

Contrastive naming ([#4410](https://github.com/latitude-dev/latitude-llm/pull/4410), merged) exists to stop sibling labels collapsing onto shared vocabulary. The quality metrics from [#4409](https://github.com/latitude-dev/latitude-llm/pull/4409) only carry `duplicateNameRate`, which catches exact collisions — so the failure that build targets ("Client report generation" next to "Client report review") is currently unmeasurable, and the build has no acceptance test.

This adds one report-only number: the share of leaf-name pairs in the published tree that share most of their vocabulary.

## What it does

`taxonomyNameQualityMetrics` gains `nearDuplicateNameRate` (pairs at or above 0.5 similarity ÷ pairs compared) and `nearDuplicateNamePairCount`. Both ride the existing `taxonomy.gardenTaxonomyWorkflow.nameQuality` span and log line.

It is a number only. Nothing merges, renames, reassigns or hides a cluster — auto-merge (Build 2) stays cut.

## How two names are compared

1. `normalize("NFC")` + lowercase. Accented Spanish names are in production and NFC vs NFD compare unequal otherwise.
2. `Intl.Segmenter` at `word` granularity, keeping `isWordLike` segments — **not** whitespace splitting. Chinese, Japanese and Thai names are in production, have no spaces, and score 0.00 against everything under whitespace tokenization. Segmenter is built into Node with full ICU (verified on v25.7), so this needs no dependency.
3. Jaccard over the token sets.

Measured on real production names: two Chinese sibling names score 0.00 by whitespace, 0.40 by character bigrams, **0.56** segmented; two less-similar siblings from the same project score 0.44 and 0.36.

Comparison is across **every** leaf pair in the tree, not same-parent siblings only: leaves under different parents have shipped identical names, and de-nesting ([#4408](https://github.com/latitude-dev/latitude-llm/pull/4408)) now renders those as adjacent rows. Trees are ≤ ~30 nodes, so the pairwise cost is irrelevant.

## Where review should focus

- **The named-leaf set is deliberately not the one the other metrics use.** `normalizedTaxonomyName` strips everything outside `[a-z0-9]`, so CJK names normalize to the empty string and are already excluded from `namedLeafCount`/`duplicateNameRate` — a pre-existing gap this PR does not touch, to keep the existing metrics' denominators stable. The near-duplicate metric therefore tokenizes from the raw name and does its own "is it still Pending" check. Reusing the shared normalizer here would zero the metric for exactly the population that motivated it. Worth deciding whether the existing metrics should be fixed separately.
- **The 0.5 threshold**, and the three limitations commented next to it: ICU over-splits domain compounds so CJK scores skew high against English; the threshold was calibrated on English names only; and same-meaning names with no shared surface are invisible (レポート生成 vs 報告書作成 scores 0.00). The metric is a floor, not a ceiling.
- **Rate denominator is pairs, not leaves**, unlike `duplicateNameRate` (leaves). It reads differently on a dashboard: a 30-leaf tree has 435 pairs, so a single bad pair is 0.002. Pair count is emitted alongside for that reason.
- Whether the Datadog objects belong in this PR: it adds one span metric (`taxonomy.quality.near_duplicate_name_rate`) to `setup-datadog.sh`, one dashboard toplist, and the doc rows. Span metrics are not retroactive, so landing them late costs the before/after this build exists to provide — but the script must be re-run and the dashboard re-applied for the metric to exist.

## Not in this change

No Temporal activity was added — the metric is computed where the other name-quality metrics already are, so the workflow's Command sequence is unchanged and no `patched()` marker is needed. No LLM calls.

## Testing

- `packages/domain/taxonomy` suite: 309 pass, including new cases for near-duplicate siblings, cross-parent pairs, unspaced Chinese names, NFD-vs-NFC equality, and Pending leaves not counting as duplicates of each other.
- `apps/workflows` telemetry test: 8 pass.
- `typecheck` clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added taxonomy name-quality metrics for detecting near-duplicate names and counting affected name pairs.
  * Added dashboard reporting to highlight projects with elevated near-duplicate naming rates, with warning thresholds.
  * Added telemetry visibility for these naming-quality measurements.

* **Tests**
  * Added coverage for cross-branch comparisons, tokenization, accent normalization, and pending-name exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->