### PR TITLE
feat(taxonomy): route a facet lens in projection space (LAT-862 Part 2b)

### DIFF
--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -5,6 +5,7 @@ import {
   type FilterSet,
   OrganizationId,
   ProjectId,
+  type SessionId,
   TaxonomyClusterId,
   TaxonomyRunId,
 } from "@domain/shared"
@@ -14,6 +15,7 @@ import {
   CustomBehaviorStatus,
   customBehaviorFilterSetHasConditions,
   emitLineageUseCase,
+  FacetProjectionRepository,
   type HierarchicalTaxonomyPlan,
   isDisplayableTaxonomyName,
   measureTaxonomyNameQualityUseCase,
@@ -426,13 +428,18 @@ const withCustomBehaviorClickHouse = <A, E, R>(effect: Effect.Effect<A, E, R>, o
     withClickHouse(TaxonomyViewAssignmentRepositoryLive, getClickhouseClient(), OrganizationId(organizationId)),
   )
 
-// Scoped full-window reassignment reads the global taxonomy window (filtered by
-// the behavior's sessions) and writes the scoped taxonomy_view_assignments
-// slice, so it needs both ClickHouse repositories.
+// Scoped full-window reassignment reads its window (the global taxonomy window
+// filtered by the behavior's sessions, or the facet's projection cache) and
+// writes the scoped taxonomy_view_assignments slice, so it needs all three
+// ClickHouse repositories.
 const withScopedReassignClickHouse = <A, E, R>(effect: Effect.Effect<A, E, R>, organizationId: string) =>
   effect.pipe(
     withClickHouse(
-      Layer.mergeAll(TaxonomyObservationRepositoryLive, TaxonomyViewAssignmentRepositoryLive),
+      Layer.mergeAll(
+        TaxonomyObservationRepositoryLive,
+        TaxonomyViewAssignmentRepositoryLive,
+        FacetProjectionRepositoryLive,
+      ),
       getClickhouseClient(),
       OrganizationId(organizationId),
     ),
@@ -821,6 +828,15 @@ const planLeaves = (plan: StoredGardenTaxonomyPlan): ReassignmentLeaf[] =>
 // those up after the swap). More than this means the bulk write did not land.
 const STAGING_SNAPSHOT_STRAGGLER_FRACTION = 0.05
 
+// What the write needs from a window row once routing is done, in either
+// embedding space — so the observation window and the projection window are
+// interchangeable to everything downstream of the router.
+interface ReassignmentWindowRow {
+  readonly observationId: string
+  readonly sessionId: SessionId
+  readonly startTime: Date
+}
+
 // Shared kernel of both full-window reassignment targets: read the bounded live
 // window (optionally scoped to the behavior's sessions) and route every row to
 // its nearest staging leaf. The caller maps the routed assignments onto its own
@@ -828,12 +844,47 @@ const STAGING_SNAPSHOT_STRAGGLER_FRACTION = 0.05
 const routeWindowToStagingLeaves = (input: GardenTaxonomyReassignObservationsInput, plan: StoredGardenTaxonomyPlan) =>
   Effect.gen(function* () {
     const observations = yield* TaxonomyObservationRepository
-    const window = yield* observations.listWindowForReassignment({
-      organizationId: OrganizationId(input.organizationId),
-      projectId: ProjectId(input.projectId),
-      limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
-      ...(input.filterSet ? { filterSet: input.filterSet } : {}),
-    })
+    const window: readonly (ReassignmentWindowRow & { readonly embedding: readonly number[] })[] =
+      yield* observations.listWindowForReassignment({
+        organizationId: OrganizationId(input.organizationId),
+        projectId: ProjectId(input.projectId),
+        limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
+        ...(input.filterSet ? { filterSet: input.filterSet } : {}),
+      })
+    const routed = routeObservationsToLeaves(
+      window.map((row) => ({ observationId: row.observationId, embedding: row.embedding })),
+      planLeaves(plan),
+    )
+    return { window, routed }
+  })
+
+/**
+ * The facet analogue: route the facet's cached PROJECTIONS, not the observation
+ * window. A facet's leaf centroids were built from projection embeddings, so
+ * comparing observation embeddings against them would be a cosine between two
+ * unrelated spaces. Both sides are normalized at write time
+ * (`extract-facet-projections` normalizes before persisting, exactly as the
+ * observation path does), which is what `cosineSimilarityNormalized` assumes.
+ *
+ * This is where the coverage win lands: extraction is cached per session and
+ * never invalidated, so the window is the union of every pass, not the 7-day
+ * sample. Cost is unchanged — nearest-centroid dot products, no LLM call.
+ */
+const routeProjectionWindowToStagingLeaves = (
+  input: GardenTaxonomyReassignObservationsInput,
+  plan: StoredGardenTaxonomyPlan,
+  facetId: FacetId,
+) =>
+  Effect.gen(function* () {
+    const projections = yield* FacetProjectionRepository
+    const window: readonly (ReassignmentWindowRow & { readonly embedding: readonly number[] })[] =
+      yield* projections.listWindowForReassignment({
+        organizationId: OrganizationId(input.organizationId),
+        projectId: ProjectId(input.projectId),
+        facetId,
+        limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
+        ...(input.filterSet ? { filterSet: input.filterSet } : {}),
+      })
     const routed = routeObservationsToLeaves(
       window.map((row) => ({ observationId: row.observationId, embedding: row.embedding })),
       planLeaves(plan),
@@ -879,10 +930,20 @@ const reassignFullWindowGlobal = (input: GardenTaxonomyReassignObservationsInput
     return { observationsReassigned: assignments.length, windowSize: window.length }
   }).pipe((effect) => withTaxonomyClickHouse(effect, input.organizationId))
 
-const reassignFullWindowScoped = (input: GardenTaxonomyReassignObservationsInput, plan: StoredGardenTaxonomyPlan) =>
+// The view slice's full-window writer. A cohort routes the observation window; a
+// facet routes its projection cache instead — the window source is the only thing
+// the two have that differs, and the leaf space follows it.
+const reassignFullWindowScoped = (
+  input: GardenTaxonomyReassignObservationsInput,
+  plan: StoredGardenTaxonomyPlan,
+  customBehaviorId: CustomBehaviorId,
+) =>
   Effect.gen(function* () {
     const assignmentsRepo = yield* TaxonomyViewAssignmentRepository
-    const { window, routed } = yield* routeWindowToStagingLeaves(input, plan)
+    const facetId = plan.facetId == null ? null : FacetId(plan.facetId)
+    const { window, routed } = yield* facetId === null
+      ? routeWindowToStagingLeaves(input, plan)
+      : routeProjectionWindowToStagingLeaves(input, plan, facetId)
     // Correlate routed results back to window rows for the slice's sessionId/startTime.
     const routedById = new Map(routed.map((assignment) => [assignment.observationId, assignment] as const))
     const now = new Date(input.now)
@@ -893,8 +954,8 @@ const reassignFullWindowScoped = (input: GardenTaxonomyReassignObservationsInput
         {
           organizationId: OrganizationId(input.organizationId),
           projectId: ProjectId(input.projectId),
-          customBehaviorId: CustomBehaviorId(plan.customBehaviorId as string),
-          facetId: null,
+          customBehaviorId,
+          facetId,
           observationId: row.observationId,
           sessionId: row.sessionId,
           assignedClusterId: routed.assignedClusterId,
@@ -913,28 +974,52 @@ const reassignFullWindowScoped = (input: GardenTaxonomyReassignObservationsInput
     return { observationsReassigned: assignments.length, windowSize: window.length }
   }).pipe((effect) => withScopedReassignClickHouse(effect, input.organizationId))
 
+/**
+ * Where this plan's assignments go, decided once and read by both the reassign
+ * and the catch-up pass.
+ *
+ * Being a view is asked BEFORE the staging-leaves question, and that ordering is
+ * load-bearing: only the whole-project topic tree may touch
+ * `taxonomy_observations.assigned_cluster_id`, and a view that fell through to a
+ * global branch would overwrite the shared topic tree's assignments with its own
+ * cluster ids. A view with no behavior has no slice row to write either (the
+ * slice is keyed by behavior), so it takes no full-window path at all rather than
+ * the global one.
+ */
+type ReassignmentTarget =
+  | { readonly kind: "fullWindowScoped"; readonly customBehaviorId: CustomBehaviorId }
+  | { readonly kind: "fullWindowGlobal" }
+  | { readonly kind: "sampleScoped" }
+  | { readonly kind: "sampleGlobal" }
+
+const reassignmentTarget = (plan: StoredGardenTaxonomyPlan): ReassignmentTarget => {
+  // A plan staged by the pre-unification code has no `customBehaviorId` key
+  // (undefined) — a nullish check keeps those, and every global run, on the
+  // observation-reassign branch; only a real behavior id routes to the slice.
+  const isView = plan.customBehaviorId != null || plan.facetId != null
+  if (!planHasStagingLeaves(plan)) return { kind: isView ? "sampleScoped" : "sampleGlobal" }
+  if (!isView) return { kind: "fullWindowGlobal" }
+  return plan.customBehaviorId == null
+    ? { kind: "sampleScoped" }
+    : { kind: "fullWindowScoped", customBehaviorId: CustomBehaviorId(plan.customBehaviorId) }
+}
+
 export const reassignGardenTaxonomyObservationsActivity = (input: GardenTaxonomyReassignObservationsInput) =>
   runGardenStep(
     "GardenTaxonomyWorkflow reassign observations",
     input,
-    // A plan staged by the pre-unification code has no `customBehaviorId` key
-    // (undefined) — a truthy check keeps those, and every global run, on the
-    // observation-reassign branch; only a real behavior id routes to the slice.
-    // Off does sample-only reassignment (byte-identical); adaptive routes the
-    // full bounded live window to the staging leaves.
+    // Sample-only reassignment writes what the plan already computed; the
+    // full-window paths route their whole window to the staging leaves.
     Effect.gen(function* () {
       const plan = yield* loadGardenTaxonomyPlan(input)
-      // Any view (a cohort OR a facet) writes the view-assignment slice; only
-      // the whole-project topic tree reassigns the inline column. Facet plans are
-      // always off-mode (no staging leaves), so they take the sample-only branch.
-      const isView = plan.customBehaviorId != null || plan.facetId != null
-      const reassigned = yield* planHasStagingLeaves(plan)
-        ? plan.customBehaviorId
-          ? reassignFullWindowScoped(input, plan)
-          : reassignFullWindowGlobal(input, plan)
-        : isView
-          ? reassignScopedAssignments(input, plan)
-          : reassignGlobalObservations(input, plan)
+      const target = reassignmentTarget(plan)
+      const reassigned = yield* target.kind === "fullWindowScoped"
+        ? reassignFullWindowScoped(input, plan, target.customBehaviorId)
+        : target.kind === "fullWindowGlobal"
+          ? reassignFullWindowGlobal(input, plan)
+          : target.kind === "sampleScoped"
+            ? reassignScopedAssignments(input, plan)
+            : reassignGlobalObservations(input, plan)
       // Publish here, not one activity later: the write above moved the counts the
       // Behaviours read drives visibility from onto the staged tree, so anything
       // between it and the swap is a window where neither tree is visible. The
@@ -1041,16 +1126,22 @@ const catchUpGlobal = (input: GardenTaxonomyDeprecateClustersInput, plan: Stored
     return assignments.length
   }).pipe((effect) => withTaxonomyClickHouse(effect, input.organizationId))
 
-// Adaptive: confirm publication (a no-op when the reassign activity already
-// swapped), then run one bounded catch-up pass for observations indexed during
-// reassignment.
+// Confirm publication (a no-op when the reassign activity already swapped), then
+// run one bounded catch-up pass for rows indexed during reassignment. The target
+// is resolved the same way as the reassign pass, so a facet catches up in
+// projection space too — skipping it here would leave coverage correct at
+// reassign time and stale the moment the swap landed.
 const swapAndCatchUp = (input: GardenTaxonomyDeprecateClustersInput, plan: StoredGardenTaxonomyPlan) =>
   Effect.gen(function* () {
     const published = yield* publishStagedTree(input, plan)
+    const target = reassignmentTarget(plan)
 
-    const caughtUp = plan.customBehaviorId
-      ? (yield* reassignFullWindowScoped(input, plan)).observationsReassigned
-      : yield* catchUpGlobal(input, plan)
+    const caughtUp =
+      target.kind === "fullWindowScoped"
+        ? (yield* reassignFullWindowScoped(input, plan, target.customBehaviorId)).observationsReassigned
+        : target.kind === "fullWindowGlobal"
+          ? yield* catchUpGlobal(input, plan)
+          : 0
 
     return { ...published, caughtUp }
   })

--- a/apps/workflows/src/activities/taxonomy-gardening-publish.test.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-publish.test.ts
@@ -1,11 +1,13 @@
-import { OrganizationId, ProjectId, SessionId, type TaxonomyClusterId } from "@domain/shared"
+import { FacetId, OrganizationId, ProjectId, SessionId, type TaxonomyClusterId } from "@domain/shared"
 import {
   type TaxonomyCluster,
+  type TaxonomyFacetProjection,
   type TaxonomyMomentObservation,
   type TaxonomyViewAssignment,
   taxonomyClusterSchema,
 } from "@domain/taxonomy"
 import {
+  createFakeFacetProjectionRepository,
   createFakeTaxonomyClusterRepository,
   createFakeTaxonomyObservationRepository,
   createFakeTaxonomyViewAssignmentRepository,
@@ -19,7 +21,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 // `evaluation-alignment-activities.test.ts`: domain fakes behind `withPostgres` /
 // `withClickHouse`, plus an in-memory stand-in for the Redis plan artifact.
 const { fakes, redis, calls } = vi.hoisted(() => ({
-  fakes: { clusters: null as unknown, observations: null as unknown, viewAssignments: null as unknown },
+  fakes: {
+    clusters: null as unknown,
+    observations: null as unknown,
+    viewAssignments: null as unknown,
+    facetProjections: null as unknown,
+  },
   redis: new Map<string, string>(),
   calls: [] as string[],
 }))
@@ -68,6 +75,7 @@ vi.mock("@platform/db-clickhouse", async (importOriginal) => {
         effect.pipe(
           E.provide(L.succeed(domain.TaxonomyObservationRepository, fakes.observations as never)),
           E.provide(L.succeed(domain.TaxonomyViewAssignmentRepository, fakes.viewAssignments as never)),
+          E.provide(L.succeed(domain.FacetProjectionRepository, fakes.facetProjections as never)),
           E.provide(L.succeed(shared.ChSqlClient, testing.createFakeChSqlClient())),
         ),
   }
@@ -93,6 +101,7 @@ const OLD_LEAF = "b".repeat(24)
 const NEW_ROOT = "c".repeat(24)
 const NEW_LEAF = "d".repeat(24)
 const BEHAVIOR = "e".repeat(24)
+const FACET = "f".repeat(24)
 
 const cluster = (input: {
   readonly id: string
@@ -212,7 +221,28 @@ const windowObservation = (index: number): TaxonomyMomentObservation => ({
   indexedAt: now,
 })
 
-const seedRepositories = (seed: readonly TaxonomyCluster[], window: readonly TaxonomyMomentObservation[] = []) => {
+// A cached facet projection: the row the projection-space window routes. Its
+// embedding is deliberately orthogonal to the observation embedding above, so a
+// test can tell which space a pass actually read.
+const windowProjection = (index: number): TaxonomyFacetProjection => ({
+  organizationId: OrganizationId(organizationId),
+  projectId: ProjectId(projectId),
+  facetId: FacetId(FACET),
+  sessionObservationId: String(index).padStart(24, "j").slice(0, 24),
+  sessionId: SessionId(`facet-session-${index}`),
+  extractedText: `Projection ${index}`,
+  analysisHash: String(index).repeat(64).slice(0, 64),
+  embedding: [0, 1],
+  startTime: new Date(now.getTime() - index * 60_000),
+  retentionDays: 90,
+  indexedAt: now,
+})
+
+const seedRepositories = (
+  seed: readonly TaxonomyCluster[],
+  window: readonly TaxonomyMomentObservation[] = [],
+  projections: readonly TaxonomyFacetProjection[] = [],
+) => {
   const clusters = createFakeTaxonomyClusterRepository(seed, {
     swapActiveTree: (input) => {
       calls.push("swap")
@@ -247,6 +277,7 @@ const seedRepositories = (seed: readonly TaxonomyCluster[], window: readonly Tax
   fakes.clusters = clusters.repository
   fakes.observations = observations.repository
   fakes.viewAssignments = viewAssignments.repository
+  fakes.facetProjections = createFakeFacetProjectionRepository(projections).repository
   return clusters
 }
 
@@ -423,6 +454,56 @@ describe("taxonomy gardening publish activities", () => {
     expect(stateOf(clusters, OLD_LEAF)).toBe("deprecated")
     expect(stateOf(clusters, OLD_ROOT)).toBe("active")
     expect(result).toEqual(expect.objectContaining({ clustersDeprecated: 1, clustersActivated: 0 }))
+  })
+
+  // LAT-862 Part 2b: a facet lens's coverage is the projection cache, not the
+  // 7-day sample, so its passes route `taxonomy_facet_projections`.
+  const facetPlan = (overrides: Partial<StoredPlan> = {}) => leavesWithoutAdaptiveTree({ facetId: FACET, ...overrides })
+
+  it("routes the facet's projection cache, not the observation window, and stamps the facet on every edge", async () => {
+    seedRepositories(
+      publishedTree(),
+      [windowObservation(1), windowObservation(2)],
+      [windowProjection(1), windowProjection(2), windowProjection(3)],
+    )
+    facetPlan()
+
+    await reassignGardenTaxonomyObservationsActivity({ ...stepInput, planKey })
+
+    // Three cached projections, two observations: reading the wrong table is
+    // visible in the count, and the sessions come from the projection rows.
+    expect(viewUpserts).toHaveLength(3)
+    expect(viewUpserts.every((row) => row.facetId === FACET)).toBe(true)
+    expect(viewUpserts.every((row) => (row.sessionId as string).startsWith("facet-session-"))).toBe(true)
+    // The inline column belongs to the global topic tree; a facet never writes it.
+    expect(calls).not.toContain("reassign")
+  })
+
+  it("catches the facet up in projection space after the swap", async () => {
+    seedRepositories(publishedTree(), [windowObservation(1)], [windowProjection(1), windowProjection(2)])
+    facetPlan()
+
+    await deprecateGardenTaxonomyClustersActivity({ ...stepInput, planKey })
+
+    // Without this the coverage is correct at reassign time and stale the moment
+    // the swap lands.
+    expect(viewUpserts).toHaveLength(2)
+    expect(viewUpserts.every((row) => row.facetId === FACET)).toBe(true)
+    expect(calls).not.toContain("reassign")
+  })
+
+  it("never reassigns the global column for a whole-project facet with no behavior", async () => {
+    // A facet plan that carries no cohort has no slice row to write (the slice is
+    // keyed by behavior). Falling through to the global branch would overwrite
+    // every project observation's `assigned_cluster_id` with facet cluster ids.
+    seedRepositories(publishedTree(), [windowObservation(1)], [windowProjection(1)])
+    facetPlan({ customBehaviorId: null })
+
+    await reassignGardenTaxonomyObservationsActivity({ ...stepInput, planKey })
+    await deprecateGardenTaxonomyClustersActivity({ ...stepInput, planKey })
+
+    expect(calls).not.toContain("reassign")
+    expect(viewUpserts).toHaveLength(0)
   })
 
   it("activates nothing on a pre-change-shaped plan with leaves but no adaptive tree", async () => {

--- a/packages/domain/taxonomy/src/ports/facet-projection-repository.ts
+++ b/packages/domain/taxonomy/src/ports/facet-projection-repository.ts
@@ -1,6 +1,29 @@
-import type { ChSqlClient, FacetId, OrganizationId, ProjectId, RepositoryError } from "@domain/shared"
+import type {
+  ChSqlClient,
+  FacetId,
+  FilterSet,
+  OrganizationId,
+  ProjectId,
+  RepositoryError,
+  SessionId,
+} from "@domain/shared"
 import { Context, type Effect } from "effect"
 import type { TaxonomyFacetProjection } from "../entities/facet-projection.ts"
+
+/**
+ * A cached projection ready to be routed to a staging leaf — the projection-space
+ * analogue of `TaxonomyReassignmentWindowObservation`, without the inline cluster
+ * assignment (a facet's membership lives in `taxonomy_view_assignments`).
+ *
+ * `observationId` is the row's `session_observation_id`, the same session handle
+ * the assignment slice keys on.
+ */
+export interface TaxonomyFacetProjectionWindowRow {
+  readonly observationId: string
+  readonly sessionId: SessionId
+  readonly embedding: readonly number[]
+  readonly startTime: Date
+}
 
 /**
  * ClickHouse-backed `taxonomy_facet_projections` slice — the facet-global
@@ -24,6 +47,23 @@ export interface FacetProjectionRepositoryShape {
     readonly facetId: FacetId
     readonly sessionObservationIds: readonly string[]
   }) => Effect.Effect<readonly TaxonomyFacetProjection[], RepositoryError, ChSqlClient>
+  /**
+   * The full-window routing source: every clear projection cached for this facet,
+   * newest first, optionally narrowed to a cohort's sessions with the same
+   * `FilterSet` the sample used. Unclear projections carry no embedding and are
+   * excluded — there is nothing to route them by.
+   *
+   * This is what lets a facet lens accumulate coverage: extraction is cached per
+   * session forever, so each pass re-routes the whole cache rather than only the
+   * window it just sampled.
+   */
+  readonly listWindowForReassignment: (input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly facetId: FacetId
+    readonly limit: number
+    readonly filterSet?: FilterSet
+  }) => Effect.Effect<readonly TaxonomyFacetProjectionWindowRow[], RepositoryError, ChSqlClient>
   /**
    * Cold-start health for a facet: how many sessions have been analyzed, how many
    * produced a usable answer (non-empty), and how many distinct answers there are.

--- a/packages/domain/taxonomy/src/testing/fake-facet-projection-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-facet-projection-repository.ts
@@ -36,6 +36,22 @@ export const createFakeFacetProjectionRepository = (
         return [...rows.values()].filter((row) => row.facetId === facetId && wanted.has(row.sessionObservationId))
       }),
 
+    // `filterSet` is compiled in ClickHouse against `sessions`, which this fake has
+    // no view of; a test that needs cohort narrowing overrides the method.
+    listWindowForReassignment: ({ facetId, limit }) =>
+      Effect.sync(() =>
+        [...rows.values()]
+          .filter((row) => row.facetId === facetId && row.embedding.length > 0)
+          .sort((a, b) => b.startTime.getTime() - a.startTime.getTime())
+          .slice(0, limit)
+          .map((row) => ({
+            observationId: row.sessionObservationId,
+            sessionId: row.sessionId,
+            embedding: row.embedding,
+            startTime: row.startTime,
+          })),
+      ),
+
     healthByFacet: ({ facetId }) =>
       Effect.sync(() => {
         const forFacet = [...rows.values()].filter((row) => row.facetId === facetId)

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.test.ts
@@ -472,17 +472,20 @@ describe("planHierarchicalTaxonomyUseCase facet-scoped (scope × facet)", () => 
     expect(plan.facetId).toBe(facetId)
     expect(plan.customBehaviorId).toBe(customBehaviorId)
     expect(plan.clustersBorn).toBe(1)
-    // Facet edges go to the view slice, never the inline global column.
+    // Facet edges go to the view slice, never the inline global column — and a
+    // facet defers them to the projection-space full-window pass, which needs the
+    // leaf centroids this plan stages.
     expect(plan.observationAssignments).toEqual([])
-    expect(plan.customAssignments).toHaveLength(20)
-    expect(plan.customAssignments.every((a) => a.customBehaviorId === customBehaviorId && a.facetId === facetId)).toBe(
-      true,
-    )
-    expect(plan.customAssignments.every((a) => (a.sessionId as string).startsWith("session-"))).toBe(true)
+    expect(plan.customAssignments).toEqual([])
+    expect(plan.leafClusters).toHaveLength(1)
+    expect(plan.leafClusters[0]?.centroid.length).toBeGreaterThan(0)
+    // Staging leaves is not the same fact as staging an adaptive tree; a facet has
+    // the first without the second, and publication reads the second.
+    expect(plan.persistsAdaptiveTree).toBe(false)
     expect(plan.clusters.every((c) => c.customBehaviorId === customBehaviorId && c.facetId === facetId)).toBe(true)
   })
 
-  it("whole-project facet (behavior, no filter): still writes facet-keyed view edges, never the global column", async () => {
+  it("whole-project facet (behavior, no filter): stages routing leaves, never the global column", async () => {
     const now = new Date("2026-05-24T12:00:00.000Z")
     const plan = await runFacetPlan({
       facetObservations: Array.from({ length: 20 }, (_, index) => makeProjection(index, E1, now)),
@@ -492,10 +495,8 @@ describe("planHierarchicalTaxonomyUseCase facet-scoped (scope × facet)", () => 
 
     expect(plan.facetId).toBe(facetId)
     expect(plan.observationAssignments).toEqual([])
-    expect(plan.customAssignments).toHaveLength(20)
-    expect(plan.customAssignments.every((a) => a.customBehaviorId === customBehaviorId && a.facetId === facetId)).toBe(
-      true,
-    )
+    expect(plan.customAssignments).toEqual([])
+    expect(plan.leafClusters).toHaveLength(1)
   })
 
   it("fails fast on a facet-scoped run with no wrapping behavior (facet edges have nowhere to write)", async () => {

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
@@ -271,14 +271,18 @@ export interface HierarchicalTaxonomyPlan extends BuildHierarchicalTaxonomyResul
   readonly observationAssignments: readonly ReassignTaxonomyObservationByIdInput[]
   /** Scoped write target: the `taxonomy_view_assignments` slice. Empty on the global/adaptive path. */
   readonly customAssignments: readonly TaxonomyViewAssignment[]
-  /** Leaf id + centroid for adaptive full-window routing. Empty on the off path. */
+  /**
+   * Leaf id + centroid for full-window routing, in whichever embedding space this
+   * pass clustered. Populated by the adaptive path and by every facet pass; empty
+   * on a sample-only pass, which wrote its assignments directly.
+   */
   readonly leafClusters: readonly StagingLeafCluster[]
   /**
    * Whether this pass persists a freshly-built ADAPTIVE tree: every node gets a
    * new id, so publication retires the whole prior tree rather than the ids no
-   * node continued. Distinct from having `leafClusters`, which says only that
-   * the assignment writes are deferred to a full-window routing pass — the two
-   * coincide today, and publication must keep reading this one.
+   * node continued. Distinct from having `leafClusters`, which says only that the
+   * assignment writes are deferred to a full-window routing pass — a facet has the
+   * second without the first, and publication must keep reading this one.
    */
   readonly persistsAdaptiveTree: boolean
   /**
@@ -864,11 +868,17 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       }),
     )
 
-    // Off writes the sample assignments here (sample-only reassignment). Adaptive
-    // reassigns the FULL bounded live window in a later activity, routing every
-    // window observation to these leaf centroids — so it publishes `leafClusters`
-    // instead and leaves both sample-assignment arrays empty.
-    const leafClusters: StagingLeafCluster[] = persistAdaptive
+    // Two write strategies, and `mode` is not what chooses between them.
+    // Sample-only writes the sampled assignments here; full-window publishes
+    // `leafClusters` instead, leaves both sample-assignment arrays empty, and a
+    // later activity routes the whole window to these centroids. Adaptive needs
+    // the second because it staged a whole new tree; a FACET needs it because its
+    // coverage would otherwise never outgrow the sample window, where routing the
+    // cumulative projection cache each pass makes it accumulate. A facet's
+    // centroids are already projection-space — this use-case was handed projection
+    // embeddings as its observations.
+    const routeFullWindow = persistAdaptive || scopedFacetId !== null
+    const leafClusters: StagingLeafCluster[] = routeFullWindow
       ? bornLeaves.map((leaf) => ({ clusterId: leaf.clusterId, centroid: [...leaf.centroid] }))
       : []
 
@@ -877,7 +887,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
     // view (cohort topic or facet) writes the `taxonomy_view_assignments` slice
     // (keyed by customBehaviorId × facetId, carrying sessionId), never the column.
     const observationAssignments: ReassignTaxonomyObservationByIdInput[] =
-      persistAdaptive || scopedBehaviorId
+      routeFullWindow || isView
         ? []
         : leafMembers.map(({ leaf, observation, confidence }) => ({
             observationId: observation.observationId,
@@ -888,7 +898,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
             indexedAt: now,
           }))
     const customAssignments: TaxonomyViewAssignment[] =
-      !persistAdaptive && scopedBehaviorId
+      !routeFullWindow && scopedBehaviorId
         ? leafMembers.flatMap(({ leaf, observation, confidence }) => {
             // Scoped/facet samples carry a sessionId; guard at runtime (via a
             // widening cast, not an unchecked one) so a whole-project topic

--- a/packages/domain/taxonomy/src/use-cases/plan-facet-garden.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/plan-facet-garden.test.ts
@@ -127,14 +127,15 @@ describe("planFacetGardenUseCase", () => {
     expect(plan.clustersBorn).toBeGreaterThanOrEqual(1)
     // All 20 clear projections were clustered (none dropped).
     expect(plan.observationsSampled).toBe(20)
-    // Facet edges go to the view slice, never the inline global column.
+    // Facet edges go to the view slice, never the inline global column — and they
+    // are written by the projection-space full-window pass, not from the sample,
+    // so the plan carries leaf centroids instead of assignments.
     expect(plan.observationAssignments).toEqual([])
-    expect(plan.customAssignments.length).toBeGreaterThan(0)
-    expect(plan.customAssignments.every((a) => a.customBehaviorId === customBehaviorId && a.facetId === facetId)).toBe(
-      true,
-    )
-    // sessionId is threaded from the extracted projections.
-    expect(plan.customAssignments.every((a) => (a.sessionId as string).startsWith("session-"))).toBe(true)
+    expect(plan.customAssignments).toEqual([])
+    expect(plan.leafClusters.length).toBeGreaterThan(0)
+    // Staging leaves without an adaptive tree: publication must keep upserting the
+    // view's continuations in place rather than retiring the whole prior tree.
+    expect(plan.persistsAdaptiveTree).toBe(false)
     expect(plan.clusters.every((c) => c.customBehaviorId === customBehaviorId && c.facetId === facetId)).toBe(true)
   })
 
@@ -148,8 +149,12 @@ describe("planFacetGardenUseCase", () => {
 
     // Only the 20 clear projections reach clustering; the 5 unclear are dropped.
     expect(plan.observationsSampled).toBe(20)
-    const unclearSessionIds = new Set(Array.from({ length: 5 }, (_, index) => `session-${100 + index}`))
-    expect(plan.customAssignments.some((a) => unclearSessionIds.has(a.sessionId as string))).toBe(false)
+    const unclearObservationIds = new Set(
+      Array.from({ length: 5 }, (_, index) => String(100 + index).padStart(24, "0")),
+    )
+    const clustered = plan.namingMembers.flatMap((members) => members.observationIds)
+    expect(clustered).toHaveLength(20)
+    expect(clustered.some((observationId) => unclearObservationIds.has(observationId))).toBe(false)
   })
 
   it("compiles the facet's instructions into the extraction prompt", async () => {

--- a/packages/domain/taxonomy/src/use-cases/plan-facet-garden.ts
+++ b/packages/domain/taxonomy/src/use-cases/plan-facet-garden.ts
@@ -34,9 +34,12 @@ const lookbackStart = (now: Date): Date =>
  * shared planner. The extraction side-effect (AI + projection cache) lives here,
  * not in `planHierarchicalTaxonomyUseCase`, so that planner stays a pure
  * embeddings→tree function; this use-case is the facet analogue of the topic
- * path's in-repo sampling. Always `mode: "off"` — facet clusters live in the
- * projection embedding space, where the adaptive full-window reassignment (which
- * routes the observation window) does not apply.
+ * path's in-repo sampling. Always `mode: "off"` — the adaptive builder's gates
+ * are tuned on observation embeddings, and adaptive doubles as "route the
+ * observation window later", which for a facet would compare observation vectors
+ * against projection-space centroids. The full-window reassignment a facet DOES
+ * get is the projection-space one, driven by the plan's staged leaves rather than
+ * by its mode.
  */
 export const planFacetGardenUseCase = (input: PlanFacetGardenInput) =>
   Effect.gen(function* () {

--- a/packages/platform/db-clickhouse/src/repositories/facet-projection-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/facet-projection-repository.test.ts
@@ -143,6 +143,30 @@ describe("FacetProjectionRepositoryLive", () => {
     expect(found[0]?.extractedText).toBe("facet A answer")
   })
 
+  it("lists the whole cached window for routing, newest first, skipping unclear rows and other facets", async () => {
+    const older = new Date("2026-05-01T00:00:00.000Z")
+    const window = await run(
+      Effect.gen(function* () {
+        const repo = yield* FacetProjectionRepository
+        yield* repo.upsertMany([
+          makeProjection({ sessionObservationId: "obs-new".padEnd(24, "0"), startTime: now }),
+          makeProjection({ sessionObservationId: "obs-old".padEnd(24, "0"), startTime: older }),
+          // Unclear: no embedding, so there is nothing to route it by.
+          makeProjection({ sessionObservationId: "obs-unclr".padEnd(24, "0"), extractedText: "", embedding: [] }),
+          makeProjection({ sessionObservationId: "obs-other".padEnd(24, "0"), facetId: otherFacetId }),
+        ])
+        return yield* repo.listWindowForReassignment({ organizationId, projectId, facetId, limit: 10 })
+      }),
+    )
+
+    // The window is the cumulative extraction cache — this is what makes a lens's
+    // coverage accumulate instead of tracking the latest sample window.
+    expect(window.map((row) => row.observationId)).toEqual(["obs-new".padEnd(24, "0"), "obs-old".padEnd(24, "0")])
+    expect(window[0]?.embedding).toEqual([1, 0, 0])
+    expect(window[1]?.startTime).toEqual(older)
+    expect(window[0]?.sessionId).toMatch(/^session-/)
+  })
+
   it("purges only the given facet's slice on deleteByFacet", async () => {
     const [mine, theirs] = await run(
       Effect.gen(function* () {

--- a/packages/platform/db-clickhouse/src/repositories/facet-projection-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/facet-projection-repository.ts
@@ -15,6 +15,7 @@ import {
 } from "@domain/taxonomy"
 import { formatCHDate, parseCHDate } from "@repo/utils"
 import { Effect, Layer } from "effect"
+import { buildSessionFilterClauses, LIST_SELECT, resolvePercentileFilters } from "./session-repository.ts"
 
 type TaxonomyFacetProjectionRow = {
   readonly organization_id: string
@@ -119,6 +120,77 @@ export const FacetProjectionRepositoryLive = Layer.effect(
             .pipe(
               Effect.mapError((error) =>
                 toRepositoryError(error, "FacetProjectionRepository.listBySessionObservationIds"),
+              ),
+            )
+        }),
+
+      listWindowForReassignment: ({ organizationId, projectId, facetId, limit, filterSet }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          // A cohort×facet view routes only the cohort's sessions, compiled by the
+          // same filter compiler the sample and the observation-space window use.
+          const resolvedFilterSet = filterSet
+            ? yield* resolvePercentileFilters(organizationId, projectId, filterSet)
+            : undefined
+          return yield* chSqlClient
+            .query(async (client) => {
+              let matchingSessionsClause = ""
+              let filterParams: Record<string, unknown> = {}
+              if (resolvedFilterSet) {
+                const { havingClauses, whereClauses, params } = buildSessionFilterClauses(resolvedFilterSet)
+                filterParams = params
+                const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
+                const havingClause = havingClauses.length > 0 ? `HAVING ${havingClauses.join(" AND ")}` : ""
+                matchingSessionsClause = `AND session_id IN (
+                        SELECT session_id
+                        FROM (
+                          SELECT ${LIST_SELECT}
+                          FROM sessions
+                          WHERE organization_id = {organizationId:String}
+                            AND project_id = {projectId:String}
+                            ${extraWhere}
+                          GROUP BY organization_id, project_id, session_id
+                          ${havingClause}
+                        )
+                      )`
+              }
+              const result = await client.query({
+                query: `SELECT
+                          session_observation_id,
+                          session_id,
+                          embedding,
+                          start_time
+                        FROM taxonomy_facet_projections FINAL
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND facet_id = {facetId:String}
+                          AND length(embedding) > 0
+                          ${matchingSessionsClause}
+                        ORDER BY start_time DESC, session_observation_id ASC
+                        LIMIT {limit:UInt32}`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  facetId: facetId as string,
+                  limit,
+                  ...filterParams,
+                },
+                format: "JSONEachRow",
+              })
+              const rows =
+                await result.json<
+                  Pick<TaxonomyFacetProjectionRow, "session_observation_id" | "session_id" | "embedding" | "start_time">
+                >()
+              return rows.map((row) => ({
+                observationId: row.session_observation_id,
+                sessionId: SessionId(row.session_id),
+                embedding: row.embedding,
+                startTime: parseCHDate(row.start_time),
+              }))
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                toRepositoryError(error, "FacetProjectionRepository.listWindowForReassignment"),
               ),
             )
         }),


### PR DESCRIPTION
## What

LAT-862 Part 2b. A facet lens's membership only ever covered the gardening window, so widening the date range added no sessions. [Part 1 (#4411)](https://github.com/latitude-dev/latitude-llm/pull/4411) made the UI honest about that by clipping the range to the coverage that exists. This removes the shortfall so coverage actually accumulates — Part 1's clip then widens on its own, with no UI change.

Stacked on [#4416](https://github.com/latitude-dev/latitude-llm/pull/4416) (Part 2a), which split "has staging leaves" from "is an adaptive tree". This fills that seam.

## The three changes

**1. Facet plans stage leaf centroids.** `leafClusters` is populated for a facet pass as well as an adaptive one, so the pass defers its assignment writes to a full-window routing pass instead of writing the sample's assignments. `persistsAdaptiveTree` stays `false`, so publication keeps upserting the view's continuations in place rather than retiring the whole prior tree — that is exactly the split Part 2a made.

The centroids need no conversion: `planFacetGardenUseCase` hands the planner facet projections as its observations, so `bornLeaves[].centroid` is already a projection-space centroid.

**2. Route the projection window, not the observation window.** New `FacetProjectionRepository.listWindowForReassignment` — every clear projection cached for the facet, newest first, narrowed to the cohort's sessions by the same filter compiler the sample and the observation-space window use. `routeObservationsToLeaves` is reused **unchanged**; it takes `{observationId, embedding}` plus leaf centroids and is indifferent to the space.

This is where the coverage win lands: extraction is cached per `(facet, session)` and never invalidated, so the routed window is the union of every pass, not the latest 7-day sample.

**3. `facetId` is no longer hard-coded to `null`, at both call sites.** `reassignFullWindowScoped` writes the plan's facet and picks its window source from it. The reassign target is now resolved once by `reassignmentTarget(plan)` and read by both the main reassign branch and the catch-up inside `swapAndCatchUp`. Missing the second would have left coverage correct at reassign time and stale the moment the swap landed.

## The corruption case this ordering exists to prevent

`reassignmentTarget` asks **"is this a view?" before "does it have staging leaves?"**, deliberately, rather than relying on the existing branch conditions:

| plan shape | before | now |
| --- | --- | --- |
| whole-project facet (`facetId` set, `customBehaviorId` null) | would reach `reassignFullWindowGlobal` → `observations.reassignManyById` overwrites `taxonomy_observations.assigned_cluster_id`, clobbering the **global topic tree** for every project | `sampleScoped`; never touches the inline column |
| cohort × facet | would write `facetId: null`, filing facet memberships as cohort memberships | `fullWindowScoped` with the facet stamped |

The whole-project-facet shape is unreachable from the workflow today (a facet only arrives via its behaviour, and the builder already fails fast without one), but it is pinned by a test rather than by trust.

`plan-facet-garden.ts` stays hard-coded to `mode: "off"`. Making it flag-driven is the separate follow-up that only becomes safe now that this has landed.

## Verified, not assumed

**Normalisation — confirmed.** `extract-facet-projections.ts` wraps the embedding in `normalizeTaxonomyEmbedding` before persisting (`use-cases/extract-facet-projections.ts`, the `answer.length === 0 ? [] : normalizeTaxonomyEmbedding(...)` branch), exactly as the observation path does. Both sides of `cosineSimilarityNormalized` are unit vectors, and `routeOne` re-normalises the source anyway, which is a no-op on an already-normalised vector.

**No confidence threshold — confirmed, and deliberately left alone.** `routeObservationsToLeaves` is pure nearest-centroid with no floor, and neither writer filters on confidence. `TAXONOMY_ASSIGN_ABSOLUTE_THRESHOLD = 0.65` is wired only into the online path and the builder, never into reassignment. So every clear projection lands in whichever leaf is nearest, however dissimilar — the same behaviour the observation-space path already has. **I did not add a gate.** I do think one is worth discussing: a facet's clusters answer a narrow question, so a projection that matches none of them is more likely than an off-topic observation is in the global tree. But adding it here would be a new product decision buried in a routing change, and it would add a third term to Part 1's coverage ratio. Separate issue if we want it.

**Cost — zero LLM calls per pass.** Extraction is cached per observation and already paid for; routing is dot products against ~10 centroids. Reaching sessions that were never sampled still costs one extraction each, but nothing on this path triggers that.

## Tests

- `taxonomy-gardening-publish.test.ts` — a facet pass routes the projection cache and not the observation window (distinct row counts and orthogonal embeddings make reading the wrong table visible); the facet is stamped on every edge; the catch-up after the swap routes in projection space too; a facet plan with no behaviour never reassigns the global column.
- `facet-projection-repository.test.ts` (chdb) — the window is the whole cache newest-first, skipping unclear rows and other facets.
- `build-hierarchical-taxonomy.test.ts` / `plan-facet-garden.test.ts` — a facet plan now stages leaves and empties both sample-assignment arrays, with `persistsAdaptiveTree` false.

`pnpm typecheck` (whole workspace), `pnpm knip`, `@domain/taxonomy` (304), `@app/workflows` (109), and the single chdb file all pass.

## Where to look

`reassignmentTarget` in `taxonomy-gardening-activities.ts` — it is the guard for the data-corruption case above, and both call sites read it.

Closes LAT-862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Facet-based taxonomy gardening now supports projection-space reassignment and catch-up processing.
  - Reassignment windows can apply optional filters and prioritize the most recent eligible projections.
  - Facet runs now stage leaf clusters for deferred full-window routing.

- **Bug Fixes**
  - Corrected facet and behavior identifiers during reassignment.
  - Prevented unnecessary global observation reassignment when no behavior slice exists.
  - Improved handling of unclear observations and projection eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## QA: measured on a live stack

Two real `gardenTaxonomyWorkflow` executions on Temporal — full pipeline (sample → Bedrock/minimax extraction → cluster → reassign → publish → naming → quality gate → lineage) against a local ClickHouse and Postgres. No activity was called directly.

The workflow reads `now` from the wall clock, so a two-pass scenario three weeks apart is not reachable by faking the clock. Elapsed time was simulated by moving the **fixture** instead: seed a batch inside the 7-day sample window → garden it → shift those rows 20 days into the past → seed a second batch → garden again. Pass 2 can then only *sample* the recent batch, and the question is whether the older, already-extracted sessions are still in the lens.

Pass 1 ran once. Its derived state was snapshotted and **pass 2 was replayed twice from that identical state** — once with a worker built from `bfc194d58` (this PR's parent), once with this branch. Same fixture, same databases, only the worker's code differs.

| | parent (`bfc194d58`) | this branch |
| --- | --- | --- |
| cached projections | 98 | 98 |
| **visible assignments** | **42** | **98** |
| **coverage span** | **Aug 7–12 (5 days)** | **Jul 18 – Aug 12 (25 days)** |
| older-batch sessions visible | 0 of 56 | 56 of 56 |
| orphaned rows left in `taxonomy_view_assignments` | 56 | 0 |
| rows with an empty `facet_id` | 0 | 0 |
| observations moved off the global topic cluster | 0 | 0 |

The parent reproduces the reported defect exactly: 98 sessions extracted and cached, 42 visible, and the other 56 still physically present in the slice but pointing at clusters the rebuild deprecated — the erosion term from LAT-862, measured.

**Routing sanity.** Per topic, the re-routed older sessions score the same as their in-window twins: 0.781 vs 0.783, 0.869 vs 0.871, 0.917 vs 0.917. They are pulled in because they match, not because nearest-centroid will accept anything.

**Coverage accumulates up to a ceiling, and it is not far away.** All three taxonomy tables are written with a hardcoded `TAXONOMY_OBSERVATION_RETENTION_DAYS = 30`, and the ClickHouse TTL is `start_time + retention_days + 30`, so embeddings and assignments survive roughly **60 days**. This PR moves a lens from ~7 days to *up to* ~60; it does not make coverage unbounded. Worth saying plainly because the original report asked about a four-month range, which is unreachable regardless of this change. Part 1 is already consistent with the ceiling — `TAXONOMY_LENS_COVERAGE_HORIZON_DAYS` is pinned to exactly that TTL horizon, so the picker can never advertise a band into deleted data.

**Part 1 composes as claimed.** With no UI change, the lens header moved from a 5-day band to `Coverage: 18 Jul – 13 Aug` — the clip widened on its own as coverage grew, which is the sequencing argument in LAT-862 confirmed end to end.

**Cost.** Pass 2's extraction was a 98/98 cache hit, so routing added no LLM calls. Naming still calls the model, exactly as before.

### The missing confidence floor, now measured rather than asserted

The fixture deliberately includes one topic present only in the older batch, so pass 2's tree has no counterpart for it. All 14 of those sessions were filed into **"Export Financial Data as CSV" at 0.567 confidence**, against 0.78–0.92 for every well-matched session.

This is not new behaviour — the observation-space path has no floor either — but it sharpens the trade-off. **Before this PR those sessions were silently invisible; after it they are visible and mislabelled.** Silent omission becomes visible misclassification, precisely for the topics that fade out of a tree as it rebuilds.

The gate is still deliberately left out of this PR, as scoped. But this is a stronger argument for adding one than the reasoning offered above, and it should get its own issue rather than being folded in here.

*The QA harness is not committed — it is fixture-specific, with hardcoded QA ids. Happy to add it under a scripts path if reviewers want the scenario reproducible in CI.*


### Production prevalence, measured before scoping the follow-up

Read-only aggregates, no customer text.

**Scale.** 743 projects have taxonomy observations. Exactly **one** has ever taken the full-window reassignment path, because on the topic tree it is gated on the adaptive flag; 612 are on sample-only assignment. This PR makes the facet path shape-driven rather than flag-driven, so on merge every existing lens (4 projects, 7 lenses) and every future one starts routing without a floor. Lenses become the dominant consumer of full-window reassignment immediately, which inverts where the risk sits.

**Prevalence.** On the one project running it, 113 of 3,725 re-routed observations (**3.03%**) sit below the online path's existing `TAXONOMY_ASSIGN_ABSOLUTE_THRESHOLD` of 0.65 — p01 0.537, p05 0.694, median 0.849. Across today's facet lenses (1,776 rows, all sample assignments) the below-0.65 share is **2.59%**, median 0.892. The lens figure is a floor, not a forecast: those rows are sample members matched against clusters they helped build, which is the best case by construction. The population this PR newly routes has no production analogue, because nothing has ever routed it.

**Mechanism.** Bucketed by session week, the below-gate share does not rise with age — it is a bump in two middle weeks (4.6% and 6.7%) with the oldest weeks among the cleanest, and a median that barely moves (0.843–0.857). So the exposure is not "old sessions" but "sessions from a period whose content the current tree no longer represents". My earlier age-based reasoning was wrong.

**A fixed threshold would not transfer.** Mean cosine between two *randomly chosen* sessions, sampled per project, ranges from 0.59 to 0.78 across the seven largest projects, and one project's median random pair is 0.985. So 0.65 sits far below the noise floor in some projects — where it could never fire — and at the median random pair in others. Any gate the follow-up adds should be relative to a per-project or per-cluster baseline rather than an absolute cosine. (Centroid similarity is systematically higher than pairwise, so these numbers are not directly comparable to assignment confidence; the point is the spread, not the level.)

Caveat throughout: confidence is not a correctness label. These are assignments the online path would have refused, not confirmed misfilings.

