### PR TITLE
fix(spans): dedupe multi-trace project queries by (trace_id, span_id)

### DIFF
--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -232,9 +232,9 @@ export interface SpanRepositoryShape {
   }): Effect.Effect<TraceId | null, RepositoryError, ChSqlClient>
 
   /**
-   * Settled-row window read: deduped spans (`LIMIT 1 BY span_id`, newest
-   * `ingested_at` wins) ordered by `(ingested_at, span_id)`, strictly after
-   * the compound cursor and up to `windowEnd` inclusive, capped at `limit`.
+   * Settled-row window read: deduped spans (`LIMIT 1 BY trace_id, span_id`,
+   * newest `ingested_at` wins) ordered by `(ingested_at, span_id)`, strictly
+   * after the compound cursor and up to `windowEnd` inclusive, capped at `limit`.
    * `nextCursor` is the last returned pair (null on an empty window) — resume
    * from it to continue a limit-truncated window without losing spans.
    */
@@ -248,8 +248,8 @@ export interface SpanRepositoryShape {
   }): Effect.Effect<SpanIngestedAtWindow, RepositoryError, ChSqlClient>
 
   /**
-   * The most recent settled spans for a project, deduped (`LIMIT 1 BY span_id`,
-   * newest `ingested_at` wins), newest first. A representative sample for
+   * The most recent settled spans for a project, deduped (`LIMIT 1 BY trace_id,
+   * span_id`, newest `ingested_at` wins), newest first. A representative sample for
    * previews — not a paged read; no cursor.
    */
   listRecentDetailsByProjectId(input: {

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -923,6 +923,40 @@ describe("SpanRepository", () => {
       })
     })
 
+    it("keeps colliding span ids from different traces while deduping each trace", async () => {
+      const traceA = TraceId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      const traceB = TraceId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+      const sharedSpanId = "abababababababab"
+
+      await runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({
+            trace_id: traceA,
+            span_id: sharedSpanId,
+            name: "trace-a-older",
+            ingested_at: "2026-01-01 00:10:00.000",
+          }),
+          makeSpanRow({
+            trace_id: traceA,
+            span_id: sharedSpanId,
+            name: "trace-a-newer",
+            ingested_at: "2026-01-01 00:20:00.000",
+          }),
+          makeSpanRow({
+            trace_id: traceB,
+            span_id: sharedSpanId,
+            name: "trace-b",
+            ingested_at: "2026-01-01 00:15:00.000",
+          }),
+        ]),
+      )
+
+      const window = await listWindow(startCursor, 10)
+
+      expect(window.spans.map((span) => span.name)).toEqual(["trace-b", "trace-a-newer"])
+      expect(window.spans.map((span) => span.traceId)).toEqual([traceB, traceA])
+    })
+
     it("pages multiple spans by latest ingested_at, surfacing a re-ingested span at its newest version", async () => {
       // Exercises late materialization end-to-end: the lean keyset picks the page's span_ids
       // (deduped to newest ingested_at, ordered, limited), then the detail re-dedups them.
@@ -1080,6 +1114,32 @@ describe("SpanRepository", () => {
       )
 
       expect(floor).toBeNull()
+    })
+
+    it("counts colliding span ids separately when finding the recent-limit floor", async () => {
+      const traceA = TraceId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      const traceB = TraceId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+      const traceC = TraceId("cccccccccccccccccccccccccccccccc")
+      const sharedSpanId = "abababababababab"
+
+      await runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({ trace_id: traceA, span_id: sharedSpanId, ingested_at: "2026-01-01 00:10:00.000" }),
+          makeSpanRow({ trace_id: traceB, span_id: sharedSpanId, ingested_at: "2026-01-01 00:20:00.000" }),
+          makeSpanRow({ trace_id: traceC, span_id: "cdcdcdcdcdcdcdcd", ingested_at: "2026-01-01 00:30:00.000" }),
+        ]),
+      )
+
+      const floor = await runCh(
+        repo.findIngestedAtFloorForRecentLimit({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          windowEnd: WINDOW_END,
+          limit: 2,
+        }),
+      )
+
+      expect(floor).toEqual(new Date("2026-01-01T00:10:00.000Z"))
     })
   })
 
@@ -1574,6 +1634,42 @@ describe("SpanRepository", () => {
       )
 
       expect(spans.map((span) => span.name)).toEqual(["span-4", "span-3"])
+    })
+
+    it("keeps colliding span ids from different traces in the recent sample", async () => {
+      const traceA = TraceId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      const traceB = TraceId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+      const sharedSpanId = "abababababababab"
+
+      await runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({
+            trace_id: traceA,
+            span_id: sharedSpanId,
+            name: "trace-a-older",
+            ingested_at: "2026-01-01 00:10:00.000",
+          }),
+          makeSpanRow({
+            trace_id: traceA,
+            span_id: sharedSpanId,
+            name: "trace-a-newer",
+            ingested_at: "2026-01-01 00:30:00.000",
+          }),
+          makeSpanRow({
+            trace_id: traceB,
+            span_id: sharedSpanId,
+            name: "trace-b",
+            ingested_at: "2026-01-01 00:20:00.000",
+          }),
+        ]),
+      )
+
+      const spans = await runCh(
+        repo.listRecentDetailsByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, limit: 2 }),
+      )
+
+      expect(spans.map((span) => span.name)).toEqual(["trace-a-newer", "trace-b"])
+      expect(spans.map((span) => span.traceId)).toEqual([traceA, traceB])
     })
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -868,25 +868,17 @@ export const SpanRepositoryLive = Layer.effect(
         return yield* chSqlClient
           .query(async (client) => {
             const result = await client.query({
-              // Late materialization: the inner `IN` subquery dedups the *whole* window
-              // (`ingested_at` isn't in the sort key, so the cursor can't prune — it scans
-              // every row for the org/project) but reads only `span_id`/`ingested_at`, so
-              // that sort stays in the low MiB. The outer query then reads the wide payload
-              // columns for just the ≤`limit` winning spans. Selecting the payloads inside
-              // the dedup instead made a single window peak multi-GiB and trip the per-query
-              // memory cap on payload-heavy projects (read bytes scaled with the window, not
-              // the page). Keep the two levels: the `IN` set must be deduped to latest-per-
-              // span before the page `LIMIT`, then the detail re-dedups the same rows.
+              // Late materialization: dedup latest-per-trace/span before LIMIT, then re-dedup those rows after loading details.
               query: `SELECT ${columns}
                     FROM (
                       SELECT ${columns}
                       FROM spans
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}
-                        AND span_id IN (
-                          SELECT span_id
+                        AND (trace_id, span_id) IN (
+                          SELECT trace_id, span_id
                           FROM (
-                            SELECT span_id, ingested_at
+                            SELECT trace_id, span_id, ingested_at
                             FROM spans
                             WHERE organization_id = {organizationId:String}
                               AND project_id = {projectId:String}
@@ -898,15 +890,15 @@ export const SpanRepositoryLive = Layer.effect(
                                 )
                               )
                               AND ingested_at <= {windowEnd:DateTime64(3, 'UTC')}
-                            ORDER BY span_id, ingested_at DESC
-                            LIMIT 1 BY span_id
+                            ORDER BY trace_id, span_id, ingested_at DESC
+                            LIMIT 1 BY trace_id, span_id
                           )
                           ORDER BY ingested_at ASC, span_id ASC
                           LIMIT {limit:UInt32}
                         )
                         AND ingested_at <= {windowEnd:DateTime64(3, 'UTC')}
-                      ORDER BY span_id, ingested_at DESC
-                      LIMIT 1 BY span_id
+                      ORDER BY trace_id, span_id, ingested_at DESC
+                      LIMIT 1 BY trace_id, span_id
                     )
                     ORDER BY ingested_at ASC, span_id ASC`,
               query_params: {
@@ -987,8 +979,8 @@ export const SpanRepositoryLive = Layer.effect(
                         FROM spans
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
-                        ORDER BY span_id, ingested_at DESC
-                        LIMIT 1 BY span_id
+                        ORDER BY trace_id, span_id, ingested_at DESC
+                        LIMIT 1 BY trace_id, span_id
                       )
                       ORDER BY ingested_at DESC, span_id DESC
                       LIMIT {limit:UInt32}`,
@@ -1020,13 +1012,13 @@ export const SpanRepositoryLive = Layer.effect(
               const result = await client.query({
                 query: `SELECT ingested_at
                       FROM (
-                        SELECT span_id, ingested_at
+                        SELECT trace_id, span_id, ingested_at
                         FROM spans
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
                           AND ingested_at <= {windowEnd:DateTime64(3, 'UTC')}
-                        ORDER BY span_id, ingested_at DESC
-                        LIMIT 1 BY span_id
+                        ORDER BY trace_id, span_id, ingested_at DESC
+                        LIMIT 1 BY trace_id, span_id
                       )
                       ORDER BY ingested_at DESC, span_id DESC
                       LIMIT 1 OFFSET {limit:UInt32}`,


### PR DESCRIPTION
## What does this PR do?

Closes #4082.

This PR is intentionally limited to the ClickHouse `SpanRepository` query layer and its direct regression tests.

- Deduplicates `listByIngestedAtWindow`, `listRecentDetailsByProjectId`, and `findIngestedAtFloorForRecentLimit` by `(trace_id, span_id)`.
- Preserves the two-level late-materialization window read so wide payloads are loaded only after the candidate page is selected.
- Keeps single-trace `LIMIT 1 BY span_id` queries unchanged.
- Leaves the complete destination cursor/state/sync/backfill/queue/worker chain to stacked PR [#4427](https://github.com/latitude-dev/latitude-llm/pull/4427).
- Leaves PostHog `sourceRecordId` qualification and tool analytics project-wide deduplication to the destination/follow-up work.

## Validation

- `pnpm --filter @platform/db-clickhouse check` — passed with 11 pre-existing warnings
- `pnpm --filter @platform/db-clickhouse typecheck` — passed after building the local telemetry dependency
- `pnpm --filter @platform/db-clickhouse test` — 42 files, 620 tests passed
- `git diff --check` — passed
