### PR TITLE
Promote ancestors of kept spans in telemetry smart filter

### DIFF
--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Smart filter now promotes ancestors of kept spans (including already-ended parents held briefly
+  after a drop) so exported traces stay connected when only a descendant independently passed the
+  filter — e.g. a stamped `tcp.connect` no longer ships without its parent.
+
 ## [3.7.0] - 2026-07-20
 
 ### Added

--- a/packages/telemetry/python/src/latitude_telemetry/telemetry/latitude_span_processor.py
+++ b/packages/telemetry/python/src/latitude_telemetry/telemetry/latitude_span_processor.py
@@ -137,7 +137,11 @@ class LatitudeSpanProcessor(SpanProcessor):
             blocked_instrumentation_scopes=options.blocked_instrumentation_scopes,
         )
         redact_then_export = RedactThenExportSpanProcessor(redact, batch_or_simple)
-        self._tail: SpanProcessor = ExportFilterSpanProcessor(should_export, redact_then_export)
+        self._tail: SpanProcessor = ExportFilterSpanProcessor(
+            should_export,
+            redact_then_export,
+            blocked_instrumentation_scopes=options.blocked_instrumentation_scopes,
+        )
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         # Read Latitude context from OTel context and stamp onto span

--- a/packages/telemetry/python/src/latitude_telemetry/telemetry/span_filter.py
+++ b/packages/telemetry/python/src/latitude_telemetry/telemetry/span_filter.py
@@ -9,12 +9,16 @@ from dataclasses import dataclass
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+from opentelemetry.trace import INVALID_SPAN_ID, format_span_id, get_current_span
 
 from latitude_telemetry.constants import SCOPE_LATITUDE
 
 GEN_AI_PREFIX = "gen_ai."
 LLM_PREFIX = "llm."
 OPENINFERENCE_KIND = "openinference.span.kind"
+
+# Cap for ended-but-dropped spans held so a later child can still promote them.
+_MAX_DROPPED_SPAN_BUFFER = 2048
 
 OTEL_LLM_INSTRUMENTATION_SCOPE_PREFIXES: tuple[str, ...] = (
     "opentelemetry.instrumentation.alephalpha",
@@ -54,6 +58,20 @@ def _instrumentation_scope_name(span: ReadableSpan) -> str:
     if scope is None:
         return ""
     return getattr(scope, "name", "") or ""
+
+
+def _span_id(span: ReadableSpan | Span) -> str:
+    return format_span_id(span.get_span_context().span_id)
+
+
+def _parent_span_id(span: ReadableSpan | Span) -> str | None:
+    parent = getattr(span, "parent", None)
+    if parent is None:
+        return None
+    span_id = getattr(parent, "span_id", None)
+    if span_id is None or span_id == INVALID_SPAN_ID:
+        return None
+    return format_span_id(span_id)
 
 
 def is_gen_ai_or_llm_attribute_span(span: ReadableSpan) -> bool:
@@ -130,7 +148,7 @@ def build_should_export_span(
 
 
 class ExportFilterSpanProcessor(SpanProcessor):
-    """Drops spans that fail the export predicate before passing them to the inner processor."""
+    """Drops filtered spans; when a span is kept, also exports its ancestors."""
 
     def __init__(
         self,
@@ -139,20 +157,69 @@ class ExportFilterSpanProcessor(SpanProcessor):
     ) -> None:
         self._should_export = should_export
         self._inner = inner
+        self._parent_by_span_id: dict[str, str | None] = {}
+        self._force_export_ids: set[str] = set()
+        self._dropped_by_span_id: dict[str, ReadableSpan] = {}
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
+        span_id = _span_id(span)
+        parent_id = _parent_span_id(span)
+        if parent_id is None and parent_context is not None:
+            parent_ctx = get_current_span(parent_context).get_span_context()
+            if parent_ctx.is_valid and parent_ctx.span_id != INVALID_SPAN_ID:
+                parent_id = format_span_id(parent_ctx.span_id)
+        self._parent_by_span_id[span_id] = parent_id
         self._inner.on_start(span, parent_context)
 
     def on_end(self, span: ReadableSpan) -> None:
-        if not self._should_export(span):
+        span_id = _span_id(span)
+        recorded_parent_id = self._parent_by_span_id.pop(span_id, None)
+        forced = span_id in self._force_export_ids
+        self._force_export_ids.discard(span_id)
+
+        if not forced and not self._should_export(span):
+            self._remember_dropped(span)
             return
+
+        self._dropped_by_span_id.pop(span_id, None)
+        self._promote_ancestors(span, recorded_parent_id)
         self._inner.on_end(span)
 
     def shutdown(self) -> None:
+        self._parent_by_span_id.clear()
+        self._force_export_ids.clear()
+        self._dropped_by_span_id.clear()
         self._inner.shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return self._inner.force_flush(timeout_millis)
+
+    def _remember_dropped(self, span: ReadableSpan) -> None:
+        if len(self._dropped_by_span_id) >= _MAX_DROPPED_SPAN_BUFFER:
+            oldest = next(iter(self._dropped_by_span_id))
+            del self._dropped_by_span_id[oldest]
+        self._dropped_by_span_id[_span_id(span)] = span
+
+    def _promote_ancestors(self, span: ReadableSpan, recorded_parent_id: str | None = None) -> None:
+        parent_id = _parent_span_id(span) or recorded_parent_id
+        seen: set[str] = set()
+
+        while parent_id and parent_id not in seen:
+            seen.add(parent_id)
+
+            dropped = self._dropped_by_span_id.pop(parent_id, None)
+            if dropped is not None:
+                self._promote_ancestors(dropped)
+                self._inner.on_end(dropped)
+                parent_id = _parent_span_id(dropped)
+                continue
+
+            if parent_id in self._parent_by_span_id:
+                self._force_export_ids.add(parent_id)
+                parent_id = self._parent_by_span_id.get(parent_id)
+                continue
+
+            break
 
 
 class RedactThenExportSpanProcessor(SpanProcessor):

--- a/packages/telemetry/python/src/latitude_telemetry/telemetry/span_filter.py
+++ b/packages/telemetry/python/src/latitude_telemetry/telemetry/span_filter.py
@@ -4,6 +4,7 @@ Smart export filter: only LLM-relevant spans are sent to Latitude by default.
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
@@ -17,8 +18,7 @@ GEN_AI_PREFIX = "gen_ai."
 LLM_PREFIX = "llm."
 OPENINFERENCE_KIND = "openinference.span.kind"
 
-# Cap for ended-but-dropped spans held so a later child can still promote them.
-_MAX_DROPPED_SPAN_BUFFER = 2048
+_MAX_TRACKED_SPANS = 2048
 
 OTEL_LLM_INSTRUMENTATION_SCOPE_PREFIXES: tuple[str, ...] = (
     "opentelemetry.instrumentation.alephalpha",
@@ -44,6 +44,12 @@ OTEL_LLM_INSTRUMENTATION_SCOPE_PREFIXES: tuple[str, ...] = (
 )
 
 LLM_SCOPE_SUBSTRINGS: tuple[str, ...] = ("openinference", "traceloop", "langsmith", "litellm")
+
+
+@dataclass(frozen=True)
+class _DroppedSpanEntry:
+    span: ReadableSpan
+    recorded_parent_id: str | None
 
 
 def _attribute_keys(span: ReadableSpan) -> list[str]:
@@ -157,12 +163,16 @@ class ExportFilterSpanProcessor(SpanProcessor):
         self,
         should_export: Callable[[ReadableSpan], bool],
         inner: SpanProcessor,
+        *,
+        blocked_instrumentation_scopes: Sequence[str] | None = None,
     ) -> None:
         self._should_export = should_export
         self._inner = inner
+        self._blocked_scopes = frozenset(blocked_instrumentation_scopes or ())
+        self._lock = threading.Lock()
         self._parent_by_span_id: dict[str, str | None] = {}
         self._force_export_ids: set[str] = set()
-        self._dropped_by_span_id: dict[str, ReadableSpan] = {}
+        self._dropped_by_span_id: dict[str, _DroppedSpanEntry] = {}
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         span_id = _span_id(span)
@@ -172,44 +182,65 @@ class ExportFilterSpanProcessor(SpanProcessor):
                 parent_ctx = get_current_span(parent_context).get_span_context()
                 if parent_ctx.is_valid and parent_ctx.span_id != INVALID_SPAN_ID:
                     parent_id = format_span_id(parent_ctx.span_id)
-            self._parent_by_span_id[span_id] = parent_id
+            with self._lock:
+                if len(self._parent_by_span_id) >= _MAX_TRACKED_SPANS:
+                    oldest = next(iter(self._parent_by_span_id))
+                    del self._parent_by_span_id[oldest]
+                self._parent_by_span_id[span_id] = parent_id
         self._inner.on_start(span, parent_context)
 
     def on_end(self, span: ReadableSpan) -> None:
-        span_id = _span_id(span)
-        recorded_parent_id = self._parent_by_span_id.pop(span_id, None) if span_id is not None else None
-        forced = span_id is not None and span_id in self._force_export_ids
-        if span_id is not None:
-            self._force_export_ids.discard(span_id)
+        to_export: list[ReadableSpan] = []
+        with self._lock:
+            span_id = _span_id(span)
+            recorded_parent_id = self._parent_by_span_id.pop(span_id, None) if span_id is not None else None
+            forced = span_id is not None and span_id in self._force_export_ids
+            if span_id is not None:
+                self._force_export_ids.discard(span_id)
 
-        if not forced and not self._should_export(span):
-            self._remember_dropped(span)
-            return
+            if self._is_blocked(span):
+                self._remember_dropped(span, recorded_parent_id)
+                if forced:
+                    to_export.extend(self._collect_promoted_ancestors(span, recorded_parent_id))
+            elif not forced and not self._should_export(span):
+                self._remember_dropped(span, recorded_parent_id)
+            else:
+                if span_id is not None:
+                    self._dropped_by_span_id.pop(span_id, None)
+                to_export.extend(self._collect_promoted_ancestors(span, recorded_parent_id))
+                to_export.append(span)
 
-        if span_id is not None:
-            self._dropped_by_span_id.pop(span_id, None)
-        self._promote_ancestors(span, recorded_parent_id)
-        self._inner.on_end(span)
+        for export_span in to_export:
+            self._inner.on_end(export_span)
 
     def shutdown(self) -> None:
-        self._parent_by_span_id.clear()
-        self._force_export_ids.clear()
-        self._dropped_by_span_id.clear()
+        with self._lock:
+            self._parent_by_span_id.clear()
+            self._force_export_ids.clear()
+            self._dropped_by_span_id.clear()
         self._inner.shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return self._inner.force_flush(timeout_millis)
 
-    def _remember_dropped(self, span: ReadableSpan) -> None:
+    def _is_blocked(self, span: ReadableSpan) -> bool:
+        return _instrumentation_scope_name(span) in self._blocked_scopes
+
+    def _remember_dropped(self, span: ReadableSpan, recorded_parent_id: str | None) -> None:
         span_id = _span_id(span)
         if span_id is None:
             return
-        if len(self._dropped_by_span_id) >= _MAX_DROPPED_SPAN_BUFFER:
+        if len(self._dropped_by_span_id) >= _MAX_TRACKED_SPANS:
             oldest = next(iter(self._dropped_by_span_id))
             del self._dropped_by_span_id[oldest]
-        self._dropped_by_span_id[span_id] = span
+        self._dropped_by_span_id[span_id] = _DroppedSpanEntry(span=span, recorded_parent_id=recorded_parent_id)
 
-    def _promote_ancestors(self, span: ReadableSpan, recorded_parent_id: str | None = None) -> None:
+    def _collect_promoted_ancestors(
+        self,
+        span: ReadableSpan,
+        recorded_parent_id: str | None,
+    ) -> list[ReadableSpan]:
+        to_export: list[ReadableSpan] = []
         parent_id = _parent_span_id(span) or recorded_parent_id
         seen: set[str] = set()
 
@@ -218,17 +249,24 @@ class ExportFilterSpanProcessor(SpanProcessor):
 
             dropped = self._dropped_by_span_id.pop(parent_id, None)
             if dropped is not None:
-                self._promote_ancestors(dropped)
-                self._inner.on_end(dropped)
-                parent_id = _parent_span_id(dropped)
+                to_export.extend(
+                    self._collect_promoted_ancestors(dropped.span, dropped.recorded_parent_id),
+                )
+                if not self._is_blocked(dropped.span):
+                    to_export.append(dropped.span)
+                parent_id = _parent_span_id(dropped.span) or dropped.recorded_parent_id
                 continue
 
             if parent_id in self._parent_by_span_id:
+                if len(self._force_export_ids) >= _MAX_TRACKED_SPANS:
+                    self._force_export_ids.pop()
                 self._force_export_ids.add(parent_id)
                 parent_id = self._parent_by_span_id.get(parent_id)
                 continue
 
             break
+
+        return to_export
 
 
 class RedactThenExportSpanProcessor(SpanProcessor):

--- a/packages/telemetry/python/src/latitude_telemetry/telemetry/span_filter.py
+++ b/packages/telemetry/python/src/latitude_telemetry/telemetry/span_filter.py
@@ -60,8 +60,11 @@ def _instrumentation_scope_name(span: ReadableSpan) -> str:
     return getattr(scope, "name", "") or ""
 
 
-def _span_id(span: ReadableSpan | Span) -> str:
-    return format_span_id(span.get_span_context().span_id)
+def _span_id(span: ReadableSpan | Span) -> str | None:
+    ctx = span.get_span_context()
+    if ctx is None or ctx.span_id == INVALID_SPAN_ID:
+        return None
+    return format_span_id(ctx.span_id)
 
 
 def _parent_span_id(span: ReadableSpan | Span) -> str | None:
@@ -163,25 +166,28 @@ class ExportFilterSpanProcessor(SpanProcessor):
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         span_id = _span_id(span)
-        parent_id = _parent_span_id(span)
-        if parent_id is None and parent_context is not None:
-            parent_ctx = get_current_span(parent_context).get_span_context()
-            if parent_ctx.is_valid and parent_ctx.span_id != INVALID_SPAN_ID:
-                parent_id = format_span_id(parent_ctx.span_id)
-        self._parent_by_span_id[span_id] = parent_id
+        if span_id is not None:
+            parent_id = _parent_span_id(span)
+            if parent_id is None and parent_context is not None:
+                parent_ctx = get_current_span(parent_context).get_span_context()
+                if parent_ctx.is_valid and parent_ctx.span_id != INVALID_SPAN_ID:
+                    parent_id = format_span_id(parent_ctx.span_id)
+            self._parent_by_span_id[span_id] = parent_id
         self._inner.on_start(span, parent_context)
 
     def on_end(self, span: ReadableSpan) -> None:
         span_id = _span_id(span)
-        recorded_parent_id = self._parent_by_span_id.pop(span_id, None)
-        forced = span_id in self._force_export_ids
-        self._force_export_ids.discard(span_id)
+        recorded_parent_id = self._parent_by_span_id.pop(span_id, None) if span_id is not None else None
+        forced = span_id is not None and span_id in self._force_export_ids
+        if span_id is not None:
+            self._force_export_ids.discard(span_id)
 
         if not forced and not self._should_export(span):
             self._remember_dropped(span)
             return
 
-        self._dropped_by_span_id.pop(span_id, None)
+        if span_id is not None:
+            self._dropped_by_span_id.pop(span_id, None)
         self._promote_ancestors(span, recorded_parent_id)
         self._inner.on_end(span)
 
@@ -195,10 +201,13 @@ class ExportFilterSpanProcessor(SpanProcessor):
         return self._inner.force_flush(timeout_millis)
 
     def _remember_dropped(self, span: ReadableSpan) -> None:
+        span_id = _span_id(span)
+        if span_id is None:
+            return
         if len(self._dropped_by_span_id) >= _MAX_DROPPED_SPAN_BUFFER:
             oldest = next(iter(self._dropped_by_span_id))
             del self._dropped_by_span_id[oldest]
-        self._dropped_by_span_id[_span_id(span)] = span
+        self._dropped_by_span_id[span_id] = span
 
     def _promote_ancestors(self, span: ReadableSpan, recorded_parent_id: str | None = None) -> None:
         parent_id = _parent_span_id(span) or recorded_parent_id

--- a/packages/telemetry/python/tests/telemetry/span_filter_test.py
+++ b/packages/telemetry/python/tests/telemetry/span_filter_test.py
@@ -164,3 +164,39 @@ class TestExportFilterParentChainPromotion:
 
         names = sorted(span.name for span in self.exporter.get_finished_spans())
         assert names == ["http.request", "tcp.connect", "tls.connect"]
+
+
+class TestExportFilterBlockedScopes:
+    def setup_method(self) -> None:
+        self.exporter = InMemorySpanExporter()
+        self.provider = TracerProvider()
+        blocked = ("opentelemetry.instrumentation.net",)
+        self.provider.add_span_processor(
+            ExportFilterSpanProcessor(
+                build_should_export_span(blocked_instrumentation_scopes=blocked),
+                SimpleSpanProcessor(self.exporter),
+                blocked_instrumentation_scopes=blocked,
+            )
+        )
+
+    def teardown_method(self) -> None:
+        self.provider.shutdown()
+        self.exporter.clear()
+
+    def test_does_not_export_blocked_ancestor_of_kept_child(self) -> None:
+        http = self.provider.get_tracer("opentelemetry.instrumentation.http")
+        net = self.provider.get_tracer("opentelemetry.instrumentation.net")
+        parent = http.start_span("http.request")
+        blocked = net.start_span("tcp.connect", context=trace.set_span_in_context(parent))
+        leaf = http.start_span(
+            "genai.child",
+            context=trace.set_span_in_context(blocked),
+            attributes={"gen_ai.request.model": "gpt-4"},
+        )
+        leaf.end()
+        blocked.end()
+        parent.end()
+        self.provider.force_flush()
+
+        names = sorted(span.name for span in self.exporter.get_finished_spans())
+        assert names == ["genai.child", "http.request"]

--- a/packages/telemetry/python/tests/telemetry/span_filter_test.py
+++ b/packages/telemetry/python/tests/telemetry/span_filter_test.py
@@ -2,8 +2,14 @@
 
 from unittest.mock import Mock
 
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
 from latitude_telemetry.constants import SCOPE_LATITUDE
 from latitude_telemetry.telemetry.span_filter import (
+    ExportFilterSpanProcessor,
     build_should_export_span,
     is_default_export_span,
     is_gen_ai_or_llm_attribute_span,
@@ -83,3 +89,78 @@ class TestBuildShouldExportSpan:
         )
         assert pred(_readable_span(scope_name="custom.scope"))
         assert not pred(_readable_span(scope_name="express"))
+
+
+class TestExportFilterParentChainPromotion:
+    def setup_method(self) -> None:
+        self.exporter = InMemorySpanExporter()
+        self.provider = TracerProvider()
+        self.provider.add_span_processor(
+            ExportFilterSpanProcessor(
+                build_should_export_span(),
+                SimpleSpanProcessor(self.exporter),
+            )
+        )
+
+    def teardown_method(self) -> None:
+        self.provider.shutdown()
+        self.exporter.clear()
+
+    def test_exports_unstamped_parent_when_kept_child_ends_first(self) -> None:
+        tracer = self.provider.get_tracer("opentelemetry.instrumentation.net")
+        parent = tracer.start_span("tcp.connect.parent")
+        child = tracer.start_span(
+            "tcp.connect",
+            context=trace.set_span_in_context(parent),
+            attributes={"latitude.tags": '["flagger"]'},
+        )
+        child.end()
+        parent.end()
+        self.provider.force_flush()
+
+        names = sorted(span.name for span in self.exporter.get_finished_spans())
+        assert names == ["tcp.connect", "tcp.connect.parent"]
+
+    def test_flushes_already_dropped_parent_when_child_kept(self) -> None:
+        tracer = self.provider.get_tracer("opentelemetry.instrumentation.net")
+        parent = tracer.start_span("http.request")
+        child_ctx = trace.set_span_in_context(parent)
+        parent.end()
+
+        child = tracer.start_span(
+            "tcp.connect",
+            context=child_ctx,
+            attributes={"latitude.capture.name": "flagger.draft"},
+        )
+        child.end()
+        self.provider.force_flush()
+
+        names = sorted(span.name for span in self.exporter.get_finished_spans())
+        assert names == ["http.request", "tcp.connect"]
+
+    def test_still_drops_spans_with_no_kept_descendant(self) -> None:
+        tracer = self.provider.get_tracer("opentelemetry.instrumentation.net")
+        parent = tracer.start_span("dns.lookup")
+        child = tracer.start_span("tcp.connect", context=trace.set_span_in_context(parent))
+        child.end()
+        parent.end()
+        self.provider.force_flush()
+
+        assert self.exporter.get_finished_spans() == ()
+
+    def test_promotes_multi_level_ancestor_chain(self) -> None:
+        tracer = self.provider.get_tracer("opentelemetry.instrumentation.net")
+        root = tracer.start_span("http.request")
+        mid = tracer.start_span("tls.connect", context=trace.set_span_in_context(root))
+        leaf = tracer.start_span(
+            "tcp.connect",
+            context=trace.set_span_in_context(mid),
+            attributes={"gen_ai.request.model": "gpt-4"},
+        )
+        leaf.end()
+        mid.end()
+        root.end()
+        self.provider.force_flush()
+
+        names = sorted(span.name for span in self.exporter.get_finished_spans())
+        assert names == ["http.request", "tcp.connect", "tls.connect"]

--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Smart filter now promotes ancestors of kept spans (including already-ended parents held briefly
+  after a drop) so exported traces stay connected when only a descendant independently passed the
+  filter — e.g. a stamped `tcp.connect` no longer ships without its parent.
+
 ## [4.0.0] - 2026-07-22
 
 ### Changed

--- a/packages/telemetry/typescript/src/sdk/processor.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.ts
@@ -100,7 +100,11 @@ export class LatitudeSpanProcessor implements SpanProcessor {
     })
 
     const redactThenExport = new RedactThenExportSpanProcessor(redact, batchOrSimple)
-    this.tail = new ExportFilterSpanProcessor(shouldExport, redactThenExport)
+    this.tail = new ExportFilterSpanProcessor(shouldExport, redactThenExport, {
+      ...(options?.blockedInstrumentationScopes !== undefined
+        ? { blockedInstrumentationScopes: options.blockedInstrumentationScopes }
+        : {}),
+    })
   }
 
   onStart(span: Span, parentContext: Context): void {

--- a/packages/telemetry/typescript/src/sdk/span-filter.test.ts
+++ b/packages/telemetry/typescript/src/sdk/span-filter.test.ts
@@ -1,8 +1,16 @@
-import type { ReadableSpan } from "@opentelemetry/sdk-trace-node"
-import { describe, expect, it } from "vitest"
+import { context, trace } from "@opentelemetry/api"
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks"
+import {
+  InMemorySpanExporter,
+  NodeTracerProvider,
+  type ReadableSpan,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { SCOPE_LATITUDE } from "../constants/scope.ts"
 import {
   buildShouldExportSpan,
+  ExportFilterSpanProcessor,
   isDefaultExportSpan,
   isGenAiOrLlmAttributeSpan,
   isLatitudeInstrumentationSpan,
@@ -110,5 +118,101 @@ describe("buildShouldExportSpan", () => {
     })
     expect(pred(mockSpan({ scopeName: "my.custom.scope" }))).toBe(true)
     expect(pred(mockSpan({ scopeName: "express" }))).toBe(false)
+  })
+})
+
+describe("ExportFilterSpanProcessor parent-chain promotion", () => {
+  const exporter = new InMemorySpanExporter()
+  let provider: NodeTracerProvider
+  let previousProvider: ReturnType<typeof trace.getTracerProvider>
+
+  beforeAll(() => {
+    context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+    previousProvider = trace.getTracerProvider()
+    provider = new NodeTracerProvider({
+      spanProcessors: [new ExportFilterSpanProcessor(buildShouldExportSpan({}), new SimpleSpanProcessor(exporter))],
+    })
+    trace.setGlobalTracerProvider(provider)
+  })
+
+  beforeEach(() => {
+    exporter.reset()
+  })
+
+  afterAll(async () => {
+    trace.setGlobalTracerProvider(previousProvider)
+    await provider.shutdown()
+  })
+
+  it("exports an unstamped parent when a kept child ends first", async () => {
+    const net = trace.getTracer("opentelemetry.instrumentation.net")
+    const parent = net.startSpan("tcp.connect.parent")
+    const child = net.startSpan(
+      "tcp.connect",
+      { attributes: { "latitude.tags": '["flagger"]' } },
+      trace.setSpan(context.active(), parent),
+    )
+    child.end()
+    parent.end()
+    await provider.forceFlush()
+
+    const names = exporter
+      .getFinishedSpans()
+      .map((s) => s.name)
+      .sort()
+    expect(names).toEqual(["tcp.connect", "tcp.connect.parent"])
+    const exportedChild = exporter.getFinishedSpans().find((s) => s.name === "tcp.connect")
+    const exportedParent = exporter.getFinishedSpans().find((s) => s.name === "tcp.connect.parent")
+    expect(exportedChild?.parentSpanContext?.spanId).toBe(exportedParent?.spanContext().spanId)
+  })
+
+  it("flushes an already-dropped parent when a later child is kept", async () => {
+    const net = trace.getTracer("opentelemetry.instrumentation.net")
+    const parent = net.startSpan("http.request")
+    const childCtx = trace.setSpan(context.active(), parent)
+    // End parent before the kept child — unusual but possible with async instrumentation.
+    parent.end()
+
+    const child = net.startSpan("tcp.connect", { attributes: { "latitude.capture.name": "flagger.draft" } }, childCtx)
+    child.end()
+    await provider.forceFlush()
+
+    const names = exporter
+      .getFinishedSpans()
+      .map((s) => s.name)
+      .sort()
+    expect(names).toEqual(["http.request", "tcp.connect"])
+  })
+
+  it("still drops spans with no kept descendant", async () => {
+    const net = trace.getTracer("opentelemetry.instrumentation.net")
+    const parent = net.startSpan("dns.lookup")
+    const child = net.startSpan("tcp.connect", undefined, trace.setSpan(context.active(), parent))
+    child.end()
+    parent.end()
+    await provider.forceFlush()
+
+    expect(exporter.getFinishedSpans()).toHaveLength(0)
+  })
+
+  it("promotes a multi-level ancestor chain", async () => {
+    const net = trace.getTracer("opentelemetry.instrumentation.net")
+    const root = net.startSpan("http.request")
+    const mid = net.startSpan("tls.connect", undefined, trace.setSpan(context.active(), root))
+    const leaf = net.startSpan(
+      "tcp.connect",
+      { attributes: { "gen_ai.request.model": "gpt-4" } },
+      trace.setSpan(context.active(), mid),
+    )
+    leaf.end()
+    mid.end()
+    root.end()
+    await provider.forceFlush()
+
+    const names = exporter
+      .getFinishedSpans()
+      .map((s) => s.name)
+      .sort()
+    expect(names).toEqual(["http.request", "tcp.connect", "tls.connect"])
   })
 })

--- a/packages/telemetry/typescript/src/sdk/span-filter.test.ts
+++ b/packages/telemetry/typescript/src/sdk/span-filter.test.ts
@@ -216,3 +216,41 @@ describe("ExportFilterSpanProcessor parent-chain promotion", () => {
     expect(names).toEqual(["http.request", "tcp.connect", "tls.connect"])
   })
 })
+
+describe("ExportFilterSpanProcessor blocked scopes", () => {
+  it("does not export a blocked ancestor even when a kept child promotes the chain", async () => {
+    const exporter = new InMemorySpanExporter()
+    const provider = new NodeTracerProvider({
+      spanProcessors: [
+        new ExportFilterSpanProcessor(
+          buildShouldExportSpan({
+            blockedInstrumentationScopes: ["opentelemetry.instrumentation.net"],
+          }),
+          new SimpleSpanProcessor(exporter),
+          { blockedInstrumentationScopes: ["opentelemetry.instrumentation.net"] },
+        ),
+      ],
+    })
+
+    const http = provider.getTracer("opentelemetry.instrumentation.http")
+    const net = provider.getTracer("opentelemetry.instrumentation.net")
+    const parent = http.startSpan("http.request")
+    const blocked = net.startSpan("tcp.connect", undefined, trace.setSpan(context.active(), parent))
+    const leaf = http.startSpan(
+      "genai.child",
+      { attributes: { "gen_ai.request.model": "gpt-4" } },
+      trace.setSpan(context.active(), blocked),
+    )
+    leaf.end()
+    blocked.end()
+    parent.end()
+    await provider.forceFlush()
+
+    const names = exporter
+      .getFinishedSpans()
+      .map((s) => s.name)
+      .sort()
+    expect(names).toEqual(["genai.child", "http.request"])
+    await provider.shutdown()
+  })
+})

--- a/packages/telemetry/typescript/src/sdk/span-filter.ts
+++ b/packages/telemetry/typescript/src/sdk/span-filter.ts
@@ -1,6 +1,24 @@
-import type { Context } from "@opentelemetry/api"
+import { type Context, isValidSpanId, trace } from "@opentelemetry/api"
 import type { ReadableSpan, Span, SpanProcessor } from "@opentelemetry/sdk-trace-node"
 import { SCOPE_LATITUDE } from "../constants/scope.ts"
+
+/** Cap for ended-but-dropped spans held so a later child can still promote them. */
+const MAX_DROPPED_SPAN_BUFFER = 2048
+
+function parentSpanIdOf(span: ReadableSpan | Span): string | undefined {
+  const fromContext = (span as ReadableSpan).parentSpanContext?.spanId
+  if (fromContext && isValidSpanId(fromContext)) return fromContext
+  const legacy = (span as { parentSpanId?: string }).parentSpanId
+  if (legacy && isValidSpanId(legacy)) return legacy
+  return undefined
+}
+
+function spanIdOf(span: ReadableSpan | Span): string | undefined {
+  const spanContext = span.spanContext?.()
+  const spanId = spanContext?.spanId
+  if (spanId && isValidSpanId(spanId)) return spanId
+  return undefined
+}
 
 /** OpenTelemetry GenAI semantic convention attribute prefix. */
 const GEN_AI_PREFIX = "gen_ai."
@@ -141,12 +159,18 @@ export function buildShouldExportSpan(options: SmartFilterOptions): (span: Reada
 }
 
 /**
- * Drops spans that fail the export predicate before passing them to the inner processor.
- * Inner processor should perform redaction and export.
+ * Drops spans that fail the export predicate; when a span is kept, also exports its ancestors
+ * so Latitude receives a connected tree.
  */
 export class ExportFilterSpanProcessor implements SpanProcessor {
   private readonly shouldExport: (span: ReadableSpan) => boolean
   private readonly inner: SpanProcessor
+  /** In-flight span id → parent span id (when valid). */
+  private readonly parentBySpanId = new Map<string, string | undefined>()
+  /** Span ids that must export even if they fail {@link shouldExport}. */
+  private readonly forceExportIds = new Set<string>()
+  /** Recently dropped ended spans, keyed by span id, for late ancestor promotion. */
+  private readonly droppedBySpanId = new Map<string, ReadableSpan>()
 
   constructor(shouldExport: (span: ReadableSpan) => boolean, inner: SpanProcessor) {
     this.shouldExport = shouldExport
@@ -154,11 +178,34 @@ export class ExportFilterSpanProcessor implements SpanProcessor {
   }
 
   onStart(span: Span, parentContext: Context): void {
+    const spanId = spanIdOf(span)
+    if (spanId) {
+      let parentId = parentSpanIdOf(span)
+      if (!parentId) {
+        const fromCtx = trace.getSpanContext(parentContext)?.spanId
+        if (fromCtx && isValidSpanId(fromCtx)) parentId = fromCtx
+      }
+      this.parentBySpanId.set(spanId, parentId)
+    }
     this.inner.onStart(span, parentContext)
   }
 
   onEnd(span: ReadableSpan): void {
-    if (!this.shouldExport(span)) return
+    const spanId = spanIdOf(span)
+    const recordedParentId = spanId ? this.parentBySpanId.get(spanId) : undefined
+    const forced = spanId !== undefined && this.forceExportIds.has(spanId)
+    if (spanId) {
+      this.forceExportIds.delete(spanId)
+      this.parentBySpanId.delete(spanId)
+    }
+
+    if (!forced && !this.shouldExport(span)) {
+      this.rememberDropped(span)
+      return
+    }
+
+    if (spanId) this.droppedBySpanId.delete(spanId)
+    this.promoteAncestors(span, recordedParentId)
     this.inner.onEnd(span)
   }
 
@@ -167,7 +214,46 @@ export class ExportFilterSpanProcessor implements SpanProcessor {
   }
 
   shutdown(): Promise<void> {
+    this.parentBySpanId.clear()
+    this.forceExportIds.clear()
+    this.droppedBySpanId.clear()
     return this.inner.shutdown()
+  }
+
+  private rememberDropped(span: ReadableSpan): void {
+    const spanId = spanIdOf(span)
+    if (!spanId) return
+    if (this.droppedBySpanId.size >= MAX_DROPPED_SPAN_BUFFER) {
+      const oldest = this.droppedBySpanId.keys().next().value
+      if (oldest !== undefined) this.droppedBySpanId.delete(oldest)
+    }
+    this.droppedBySpanId.set(spanId, span)
+  }
+
+  private promoteAncestors(span: ReadableSpan, recordedParentId?: string): void {
+    let parentId = parentSpanIdOf(span) ?? recordedParentId
+    const seen = new Set<string>()
+
+    while (parentId && !seen.has(parentId)) {
+      seen.add(parentId)
+
+      const dropped = this.droppedBySpanId.get(parentId)
+      if (dropped) {
+        this.droppedBySpanId.delete(parentId)
+        this.promoteAncestors(dropped)
+        this.inner.onEnd(dropped)
+        parentId = parentSpanIdOf(dropped)
+        continue
+      }
+
+      if (this.parentBySpanId.has(parentId)) {
+        this.forceExportIds.add(parentId)
+        parentId = this.parentBySpanId.get(parentId)
+        continue
+      }
+
+      break
+    }
   }
 }
 

--- a/packages/telemetry/typescript/src/sdk/span-filter.ts
+++ b/packages/telemetry/typescript/src/sdk/span-filter.ts
@@ -2,8 +2,16 @@ import { type Context, isValidSpanId, trace } from "@opentelemetry/api"
 import type { ReadableSpan, Span, SpanProcessor } from "@opentelemetry/sdk-trace-node"
 import { SCOPE_LATITUDE } from "../constants/scope.ts"
 
-/** Cap for ended-but-dropped spans held so a later child can still promote them. */
-const MAX_DROPPED_SPAN_BUFFER = 2048
+const MAX_TRACKED_SPANS = 2048
+
+type DroppedSpanEntry = {
+  span: ReadableSpan
+  recordedParentId: string | undefined
+}
+
+type ExportFilterSpanProcessorOptions = {
+  blockedInstrumentationScopes?: readonly string[]
+}
 
 function parentSpanIdOf(span: ReadableSpan | Span): string | undefined {
   const fromContext = (span as ReadableSpan).parentSpanContext?.spanId
@@ -18,6 +26,11 @@ function spanIdOf(span: ReadableSpan | Span): string | undefined {
   const spanId = spanContext?.spanId
   if (spanId && isValidSpanId(spanId)) return spanId
   return undefined
+}
+
+function evictOldestKey(map: Map<string, unknown>): void {
+  const oldest = map.keys().next().value
+  if (oldest !== undefined) map.delete(oldest)
 }
 
 /** OpenTelemetry GenAI semantic convention attribute prefix. */
@@ -165,16 +178,19 @@ export function buildShouldExportSpan(options: SmartFilterOptions): (span: Reada
 export class ExportFilterSpanProcessor implements SpanProcessor {
   private readonly shouldExport: (span: ReadableSpan) => boolean
   private readonly inner: SpanProcessor
-  /** In-flight span id → parent span id (when valid). */
+  private readonly blockedScopes: ReadonlySet<string>
   private readonly parentBySpanId = new Map<string, string | undefined>()
-  /** Span ids that must export even if they fail {@link shouldExport}. */
   private readonly forceExportIds = new Set<string>()
-  /** Recently dropped ended spans, keyed by span id, for late ancestor promotion. */
-  private readonly droppedBySpanId = new Map<string, ReadableSpan>()
+  private readonly droppedBySpanId = new Map<string, DroppedSpanEntry>()
 
-  constructor(shouldExport: (span: ReadableSpan) => boolean, inner: SpanProcessor) {
+  constructor(
+    shouldExport: (span: ReadableSpan) => boolean,
+    inner: SpanProcessor,
+    options?: ExportFilterSpanProcessorOptions,
+  ) {
     this.shouldExport = shouldExport
     this.inner = inner
+    this.blockedScopes = new Set(options?.blockedInstrumentationScopes ?? [])
   }
 
   onStart(span: Span, parentContext: Context): void {
@@ -185,6 +201,7 @@ export class ExportFilterSpanProcessor implements SpanProcessor {
         const fromCtx = trace.getSpanContext(parentContext)?.spanId
         if (fromCtx && isValidSpanId(fromCtx)) parentId = fromCtx
       }
+      if (this.parentBySpanId.size >= MAX_TRACKED_SPANS) evictOldestKey(this.parentBySpanId)
       this.parentBySpanId.set(spanId, parentId)
     }
     this.inner.onStart(span, parentContext)
@@ -199,13 +216,19 @@ export class ExportFilterSpanProcessor implements SpanProcessor {
       this.parentBySpanId.delete(spanId)
     }
 
+    if (this.isBlocked(span)) {
+      this.rememberDropped(span, recordedParentId)
+      if (forced) this.flushPromotedAncestors(span, recordedParentId)
+      return
+    }
+
     if (!forced && !this.shouldExport(span)) {
-      this.rememberDropped(span)
+      this.rememberDropped(span, recordedParentId)
       return
     }
 
     if (spanId) this.droppedBySpanId.delete(spanId)
-    this.promoteAncestors(span, recordedParentId)
+    this.flushPromotedAncestors(span, recordedParentId)
     this.inner.onEnd(span)
   }
 
@@ -220,17 +243,25 @@ export class ExportFilterSpanProcessor implements SpanProcessor {
     return this.inner.shutdown()
   }
 
-  private rememberDropped(span: ReadableSpan): void {
-    const spanId = spanIdOf(span)
-    if (!spanId) return
-    if (this.droppedBySpanId.size >= MAX_DROPPED_SPAN_BUFFER) {
-      const oldest = this.droppedBySpanId.keys().next().value
-      if (oldest !== undefined) this.droppedBySpanId.delete(oldest)
-    }
-    this.droppedBySpanId.set(spanId, span)
+  private isBlocked(span: ReadableSpan): boolean {
+    return this.blockedScopes.has(instrumentationScopeName(span))
   }
 
-  private promoteAncestors(span: ReadableSpan, recordedParentId?: string): void {
+  private rememberDropped(span: ReadableSpan, recordedParentId: string | undefined): void {
+    const spanId = spanIdOf(span)
+    if (!spanId) return
+    if (this.droppedBySpanId.size >= MAX_TRACKED_SPANS) evictOldestKey(this.droppedBySpanId)
+    this.droppedBySpanId.set(spanId, { span, recordedParentId })
+  }
+
+  private flushPromotedAncestors(span: ReadableSpan, recordedParentId: string | undefined): void {
+    for (const ancestor of this.collectPromotedAncestors(span, recordedParentId)) {
+      this.inner.onEnd(ancestor)
+    }
+  }
+
+  private collectPromotedAncestors(span: ReadableSpan, recordedParentId: string | undefined): ReadableSpan[] {
+    const toExport: ReadableSpan[] = []
     let parentId = parentSpanIdOf(span) ?? recordedParentId
     const seen = new Set<string>()
 
@@ -240,13 +271,17 @@ export class ExportFilterSpanProcessor implements SpanProcessor {
       const dropped = this.droppedBySpanId.get(parentId)
       if (dropped) {
         this.droppedBySpanId.delete(parentId)
-        this.promoteAncestors(dropped)
-        this.inner.onEnd(dropped)
-        parentId = parentSpanIdOf(dropped)
+        toExport.push(...this.collectPromotedAncestors(dropped.span, dropped.recordedParentId))
+        if (!this.isBlocked(dropped.span)) toExport.push(dropped.span)
+        parentId = parentSpanIdOf(dropped.span) ?? dropped.recordedParentId
         continue
       }
 
       if (this.parentBySpanId.has(parentId)) {
+        if (this.forceExportIds.size >= MAX_TRACKED_SPANS) {
+          const oldest = this.forceExportIds.values().next().value
+          if (oldest !== undefined) this.forceExportIds.delete(oldest)
+        }
         this.forceExportIds.add(parentId)
         parentId = this.parentBySpanId.get(parentId)
         continue
@@ -254,6 +289,8 @@ export class ExportFilterSpanProcessor implements SpanProcessor {
 
       break
     }
+
+    return toExport
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The smart filter decides keep/drop per span in isolation. Under `capture()`, `LatitudeSpanProcessor` stamps `latitude.*` onto auto-instrumentation children (e.g. `tcp.connect`). Those children pass the filter; their parents — often started slightly earlier and unstamped — fail it and are dropped. Latitude then stores a subtree with a dangling `parentSpanId`.

That shows up in dogfood (flaggers) as lone `tcp.connect` rows.

## Fix

When a span is kept, `ExportFilterSpanProcessor` also exports its ancestors:

- Still-open parents are marked for forced export on end
- Already-ended dropped parents are held briefly (with their recorded parent id) and flushed if a descendant is later kept
- `blockedInstrumentationScopes` still win over forced promotion
- Python processor state is locked for concurrent `on_start`/`on_end`
- In-flight parent/force maps are capped like the dropped buffer

Same behavior in the TypeScript and Python SDKs. Non-LLM plumbing can still appear when it sits on the path to a kept span; product UI can filter those out of the tree view.

## Tests

- TS/Python: child kept → parent promoted (child-ends-first and parent-already-dropped); multi-level chain; unrelated noise still dropped
- TS/Python: blocked ancestor is not exported while promotion continues above it

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c63aa69c-4d69-40db-9c99-20db969b1a6f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c63aa69c-4d69-40db-9c99-20db969b1a6f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart filtering to preserve connected traces by exporting necessary ancestors when descendant spans are retained.
  * Supports ancestor promotion across multiple levels, including spans that finish before or after their descendants.
  * Retains briefly completed parent spans when needed to keep exported traces connected.
  * Prevents blocked instrumentation scopes from triggering unwanted ancestor exports.
  * Continues dropping complete traces with no retained descendants.
* **Documentation**
  * Added unreleased changelog entries describing the smart-filter improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->