### PR TITLE
fix(sessions): fall back to wall-clock duration when no root spans were ingested

### DIFF
--- a/packages/domain/spans/src/entities/session.ts
+++ b/packages/domain/spans/src/entities/session.ts
@@ -19,7 +19,10 @@ import { z } from "zod"
  * `durationNs` is **active execution time** (sum of root-span durations across
  * the session's traces), not wall-clock. Wall-clock is recoverable as
  * `endTime - startTime` when needed. See specs/session-problems/1-parity-traces-sessions.md
- * "On `duration_ns` semantics" for the rationale.
+ * "On `duration_ns` semantics" for the rationale. When the session has no
+ * spans with an empty parent (instrumentation nested under spans that are
+ * never exported), active execution is unknowable and `durationNs` falls
+ * back to the wall-clock window.
  */
 export const sessionSchema = z.object({
   organizationId: organizationIdSchema,

--- a/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
+++ b/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
@@ -146,7 +146,7 @@ const toOrphanSession = (row: SessionSearchRow): Session => {
     startTime,
     endTime,
     lastActivityTime: endTime,
-    durationNs: 0,
+    durationNs: Math.max(0, Number(row.duration_ns)),
     timeToFirstTokenNs: 0,
     tokensInput: 0,
     tokensOutput: 0,

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
@@ -316,8 +316,9 @@ describe("SessionRepository", () => {
       ])
 
       const session = nonNull(
-        (await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } })))
-          .items.find((s) => s.sessionId === sessionId),
+        (
+          await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } }))
+        ).items.find((s) => s.sessionId === sessionId),
       )
 
       // Wall-clock window: earliest start → latest end = 4s.
@@ -1490,9 +1491,7 @@ describe("SessionRepository", () => {
           name: "root",
         }),
       ])
-      await insertSearchDocs([
-        { traceId, text: "hydration miss needle", startTime: start, contentHashSuffix: "h1" },
-      ])
+      await insertSearchDocs([{ traceId, text: "hydration miss needle", startTime: start, contentHashSuffix: "h1" }])
       // Simulate a session row missing from `sessions` (legacy pre-00016 data
       // or an MV race): the search rollup still matches via `traces`, so the
       // synthesized fallback session must carry the rollup's duration.

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
@@ -286,6 +286,43 @@ describe("SessionRepository", () => {
       // Two roots × 3s each = 6_000_000_000 ns. Children are absent so no double counting.
       expect(session.durationNs).toBe(6_000_000_000)
     })
+
+    it("falls back to the wall-clock window when no span has an empty parent", async () => {
+      const sessionId = "orphan-root-session"
+      const start = new Date(Date.UTC(2026, 0, 1, 10, 0, 0))
+      // Instrumentation nested under a span that is never exported (e.g.
+      // Vercel AI SDK under the app's own HTTP span): every ingested span
+      // carries a parent_span_id pointing outside the ingested set, so
+      // sessions_mv materializes duration_ns = 0 for the whole session.
+      await insertSpans([
+        makeSpanRow({
+          traceId: "6".repeat(32),
+          spanId: "1".repeat(16),
+          parentSpanId: "f".repeat(16),
+          sessionId,
+          startTime: start,
+          durationMs: 4_000,
+          name: "local-root",
+        }),
+        makeSpanRow({
+          traceId: "6".repeat(32),
+          spanId: "2".repeat(16),
+          parentSpanId: "1".repeat(16),
+          sessionId,
+          startTime: new Date(start.getTime() + 500),
+          durationMs: 1_000,
+          name: "child",
+        }),
+      ])
+
+      const session = nonNull(
+        (await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } })))
+          .items[0],
+      )
+
+      // Wall-clock window: earliest start → latest end = 4s.
+      expect(session.durationNs).toBe(4_000_000_000)
+    })
   })
 
   describe("time_to_first_token_ns sentinel", () => {

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
@@ -290,10 +290,10 @@ describe("SessionRepository", () => {
     it("falls back to the wall-clock window when no span has an empty parent", async () => {
       const sessionId = "orphan-root-session"
       const start = new Date(Date.UTC(2026, 0, 1, 10, 0, 0))
-      // Instrumentation nested under a span that is never exported (e.g.
-      // Vercel AI SDK under the app's own HTTP span): every ingested span
-      // carries a parent_span_id pointing outside the ingested set, so
-      // sessions_mv materializes duration_ns = 0 for the whole session.
+      // The local root is nested under a span that is never exported (e.g.
+      // Vercel AI SDK under the app's own HTTP span). Its child is ingested,
+      // so no span has an empty parent and sessions_mv materializes
+      // duration_ns = 0 for the whole session.
       await insertSpans([
         makeSpanRow({
           traceId: "6".repeat(32),
@@ -317,7 +317,7 @@ describe("SessionRepository", () => {
 
       const session = nonNull(
         (await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } })))
-          .items[0],
+          .items.find((s) => s.sessionId === sessionId),
       )
 
       // Wall-clock window: earliest start → latest end = 4s.
@@ -1473,6 +1473,41 @@ describe("SessionRepository", () => {
       expect(match.matchingTraceCount).toBe(1)
       expect(match.matchingTraceIds).toEqual([orphanTrace])
       expect(match.bestTraceId).toBe(orphanTrace)
+    })
+
+    it("preserves the rollup duration when session hydration misses (toOrphanSession)", async () => {
+      const start = new Date(Date.UTC(2026, 0, 5, 12, 0, 0))
+      const traceId = padTrace("e2")
+      const sessionId = "hydration-miss-session"
+
+      await insertSpans([
+        makeSpanRow({
+          traceId,
+          spanId: padSpan("h1"),
+          sessionId,
+          startTime: start,
+          durationMs: 7_000,
+          name: "root",
+        }),
+      ])
+      await insertSearchDocs([
+        { traceId, text: "hydration miss needle", startTime: start, contentHashSuffix: "h1" },
+      ])
+      // Simulate a session row missing from `sessions` (legacy pre-00016 data
+      // or an MV race): the search rollup still matches via `traces`, so the
+      // synthesized fallback session must carry the rollup's duration.
+      await ch.client.command({ query: "TRUNCATE TABLE sessions" })
+
+      const page = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { searchQuery: '"hydration miss"', limit: 10 },
+        }),
+      )
+
+      const session = nonNull(page.items.find((s) => s.sessionId === sessionId))
+      expect(session.durationNs).toBe(7_000_000_000)
     })
 
     // 6) Multi-trace session: matching_trace_ids and matching_trace_scores

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.ts
@@ -65,7 +65,15 @@ export const LIST_SELECT = `
   if(max(max_start_time) >= min(min_start_time),
      max(max_start_time),
      max(max_end_time))         AS last_activity_time,
-  sum(duration_ns)             AS duration_ns,
+  -- sessions_mv only counts spans with an empty parent as active-execution
+  -- time, so instrumentation whose local roots reference a parent span that
+  -- is never exported (e.g. Vercel AI SDK spans nested under the app's own
+  -- HTTP span) materializes 0. Fall back to the session's wall-clock window
+  -- rather than showing no duration at all.
+  if(sum(duration_ns) > 0,
+     sum(duration_ns),
+     greatest(0, reinterpretAsInt64(max(max_end_time))
+                   - reinterpretAsInt64(min(min_start_time)))) AS duration_ns,
   if(
     min(time_of_first_token) < toDateTime64('2261-01-01', 9, 'UTC')
       AND min(time_of_first_token) > min(min_start_time),

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.ts
@@ -65,11 +65,7 @@ export const LIST_SELECT = `
   if(max(max_start_time) >= min(min_start_time),
      max(max_start_time),
      max(max_end_time))         AS last_activity_time,
-  -- sessions_mv only counts spans with an empty parent as active-execution
-  -- time, so instrumentation whose local roots reference a parent span that
-  -- is never exported (e.g. Vercel AI SDK spans nested under the app's own
-  -- HTTP span) materializes 0. Fall back to the session's wall-clock window
-  -- rather than showing no duration at all.
+  -- sessions_mv only sums empty-parent spans, so local roots nested under a never-exported parent (e.g. Vercel AI SDK under the app's HTTP span) store 0; fall back to wall-clock.
   if(sum(duration_ns) > 0,
      sum(duration_ns),
      greatest(0, reinterpretAsInt64(max(max_end_time))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Sessions showed no aggregate duration ("-" in the sessions list, 0µs in experiments comparisons, no duration-outlier flagger hints) while the individual traces inside them showed correct durations.

Root cause: `sessions_mv` materializes `duration_ns` as the sum of durations of spans with an empty `parent_span_id`. Instrumentation whose local root spans reference a parent that is never exported to Latitude (e.g. Vercel AI SDK spans nested under the app's own HTTP span) never produces such a span, so the whole session materializes `duration_ns = 0`. Trace duration is unaffected because it is computed at read time as wall-clock `max(end) − min(start)`.

Verified against production: in the reporting customer's project, 4,352 of 4,640 sessions (94%) stored zero duration despite valid span times; platform-wide ~8% of sessions in the last 24h were affected, including Latitude's own flagger sessions.

Fix: in the session rollup (`LIST_SELECT`), fall back to the session's wall-clock window when the stored active-execution sum is 0. Every session consumer builds on this rollup (sessions list/count/metrics/histogram, percentile filters, cohort baselines, analytics session stream, experiments variant metrics), so the read-time fallback fixes all surfaces at once, including historical data, with no migration.

The trade-off: for affected sessions the value is wall-clock rather than "active execution time", which can overstate duration for multi-trace sessions with idle gaps. That matches what users already see at the trace level and beats showing nothing. The `Session` entity docs note the fallback.

## Related issue (if applicable)

Linear project: [Investigate missing aggregate session duration](https://linear.app/latitude/project/investigate-missing-aggregate-session-duration-022e744b010e)

## How was this tested?

- New chdb integration test: a session whose spans all carry an orphan `parent_span_id` now reads its wall-clock window as `durationNs` instead of 0 (`session-repository.test.ts`).
- Validated the fallback expression read-only against production ClickHouse for the reporting org/project: previously-zero sessions now return sensible durations (0.6s–3.3min).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C0672DS68DD/p1786612456847799?thread_ts=1786612456.847799&cid=C0672DS68DD)

<div><a href="https://cursor.com/agents/bc-2dd947c4-845b-531c-a5ad-63ad99aaf015?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dd947c4-845b-531c-a5ad-63ad99aaf015&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Session durations now correctly fall back to elapsed wall-clock time when no active execution duration is available.
  - Session listings accurately report duration for spans linked to unexported parents.
  - Search results preserve rolled-up trace duration when session details are unavailable.

- **Documentation**
  - Clarified how session duration is calculated when exported root spans are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->