### PR TITLE
fix(web): show experiment baseline filter dropdowns above the sticky column

### DIFF
--- a/apps/web/src/components/filters-builder/filter-builder.tsx
+++ b/apps/web/src/components/filters-builder/filter-builder.tsx
@@ -447,6 +447,7 @@ export function FilterBuilder({
         placeholderIcon={<Icon icon={PlusIcon} size="sm" color="foregroundMuted" />}
         value={undefined}
         options={availableFilters.map((descriptor) => ({ value: descriptor.field, label: descriptor.label }))}
+        portalTarget={portalContainer ? "local" : "body"}
         onChange={(field) => {
           const descriptor = availableFilters.find((d) => d.field === field)
           if (descriptor) addFilter(descriptor)

--- a/packages/ui/src/components/combobox/combobox.test.tsx
+++ b/packages/ui/src/components/combobox/combobox.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { Combobox, ComboboxContent, ComboboxItem, ComboboxList, ComboboxTrigger } from "./combobox.tsx"
+
+const mountedRoots: Array<{ root: ReturnType<typeof createRoot>; host: HTMLDivElement }> = []
+const extraNodes: HTMLDivElement[] = []
+
+async function renderOpenCombobox(container?: HTMLElement) {
+  const host = document.createElement("div")
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  mountedRoots.push({ root, host })
+
+  await act(async () => {
+    root.render(
+      <Combobox defaultOpen items={["status"]} itemToStringValue={(value: string) => value}>
+        <ComboboxTrigger>Open</ComboboxTrigger>
+        <ComboboxContent {...(container ? { container } : {})}>
+          <ComboboxList>
+            {(value: string) => (
+              <ComboboxItem key={value} value={value}>
+                {value}
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>,
+    )
+  })
+
+  const popover = document.querySelector("[data-slot='combobox-content']")
+  expect(popover).toBeInstanceOf(HTMLDivElement)
+
+  return { popover: popover as HTMLDivElement, host }
+}
+
+afterEach(async () => {
+  for (const { root, host } of mountedRoots.splice(0)) {
+    await act(async () => root.unmount())
+    host.remove()
+  }
+  for (const node of extraNodes.splice(0)) {
+    node.remove()
+  }
+})
+
+describe("ComboboxContent portal target", () => {
+  it("renders the popup under document.body by default", async () => {
+    const { popover, host } = await renderOpenCombobox()
+
+    expect(document.body.contains(popover)).toBe(true)
+    expect(host.contains(popover)).toBe(false)
+  })
+
+  it("renders the popup under an explicit container", async () => {
+    const local = document.createElement("div")
+    document.body.appendChild(local)
+    extraNodes.push(local)
+
+    const { popover } = await renderOpenCombobox(local)
+
+    expect(local.contains(popover)).toBe(true)
+  })
+})

--- a/packages/ui/src/components/combobox/combobox.tsx
+++ b/packages/ui/src/components/combobox/combobox.tsx
@@ -90,7 +90,8 @@ function ComboboxContent({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        positionMethod={positionMethod}
+        // Body portals use fixed so sticky/overflow ancestors of the trigger cannot trap the popup.
+        positionMethod={positionMethod ?? (container ? "absolute" : "fixed")}
         className="isolate z-[70]"
       >
         <ComboboxPrimitive.Popup

--- a/packages/ui/src/components/select/index.tsx
+++ b/packages/ui/src/components/select/index.tsx
@@ -113,6 +113,7 @@ export type SelectProps<V = unknown> = Omit<FormFieldProps, "children"> &
     open?: boolean
     onOpenChange?: (open: boolean) => void
     footerAction?: SelectFooterAction
+    portalTarget?: "local" | "body"
   }
 
 export function Select<V = unknown>(selectProps: SelectProps<V>) {
@@ -155,9 +156,11 @@ export function Select<V = unknown>(selectProps: SelectProps<V>) {
     open: controlledOpen,
     onOpenChange: controlledOnOpenChange,
     footerAction,
+    portalTarget = "local",
   } = selectProps
   const [internalSelected, setInternalSelected] = useState<V | undefined>(defaultValue)
   const [internalIsOpen, setInternalIsOpen] = useState(false)
+  // Local portals stay within modal interaction scopes; body portals escape ancestor stacking and overflow contexts.
   const [popoverContainer, setPopoverContainer] = useState<HTMLDivElement | null>(null)
 
   const selectedValue = isControlled ? value : internalSelected
@@ -265,7 +268,7 @@ export function Select<V = unknown>(selectProps: SelectProps<V>) {
             </PopoverTrigger>
             <PopoverContent
               data-slot="searchable-select-content"
-              container={popoverContainer ?? undefined}
+              container={portalTarget === "local" ? (popoverContainer ?? undefined) : undefined}
               align={align}
               side={side}
               {...(sideOffset !== undefined ? { sideOffset } : { sideOffset: 4 })}

--- a/packages/ui/src/components/select/select.test.tsx
+++ b/packages/ui/src/components/select/select.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { Select } from "./index.tsx"
+
+const mountedRoots: Array<{ root: ReturnType<typeof createRoot>; host: HTMLDivElement }> = []
+
+async function renderOpenSelect(portalTarget?: "local" | "body") {
+  const host = document.createElement("div")
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  mountedRoots.push({ root, host })
+
+  await act(async () => {
+    root.render(
+      <Select
+        name="add-filter"
+        searchable
+        value={undefined}
+        options={[
+          { value: "status", label: "Status" },
+          { value: "userId", label: "User" },
+        ]}
+        {...(portalTarget ? { portalTarget } : {})}
+        onChange={() => undefined}
+      />,
+    )
+  })
+
+  const trigger = host.querySelector("[aria-expanded]")
+  expect(trigger).toBeInstanceOf(HTMLElement)
+
+  await act(async () => {
+    trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+  })
+
+  const popover = document.querySelector("[data-slot='searchable-select-content']")
+  expect(popover).toBeInstanceOf(HTMLDivElement)
+
+  return { popover: popover as HTMLDivElement, host }
+}
+
+afterEach(async () => {
+  for (const { root, host } of mountedRoots.splice(0)) {
+    await act(async () => root.unmount())
+    host.remove()
+  }
+})
+
+describe("Select searchable portal target", () => {
+  it("renders the popover under the local wrapper by default", async () => {
+    const { popover, host } = await renderOpenSelect()
+
+    expect(host.contains(popover)).toBe(true)
+  })
+
+  it("renders the popover under document.body outside the local wrapper", async () => {
+    const { popover, host } = await renderOpenSelect("body")
+
+    expect(document.body.contains(popover)).toBe(true)
+    expect(host.contains(popover)).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The experiment comparison table pins the baseline column with `position: sticky` and a z-index so it stays on top while other variants scroll. Overlays that mount inside that cell get trapped in the baseline stacking context and paint behind the sticky header and the rows below. Variant columns are not sticky, which is why the same menus looked fine there.

[#4377](https://github.com/latitude-dev/latitude-llm/pull/4377) already portaled the period picker to `document.body`. This PR covers the rest of that view:

- Searchable `Select` (`portalTarget`) so the Add filter menu can opt into a body portal. The experiment `FilterBuilder` uses `body` unless a modal provides a local container.
- Filter value comboboxes already portal to `document.body`. They now use `position: fixed` when there is no explicit container, so sticky table stacking cannot trap them either.

Other overlays on the same page already escape that stacking context:

- Variant kebab `DropdownMenu` (Radix portal to body)
- Search syntax legend `Popover` (Radix portal to body)
- Tooltips (Radix portal to body)
- Import-from-search `Select` (local portal, inside a modal, which is the correct target)

Reported in Intercom conversation 215475471474580.

## How was this tested?

- Unit tests for searchable `Select` local vs body portal
- Unit tests for `ComboboxContent` default body portal vs explicit container
- `pnpm --filter @repo/ui check` and `typecheck`
- `pnpm --filter @app/web typecheck`

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows Conventional Commits
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C046WC7P2E5/p1786618974655879?thread_ts=1786618974.655879&cid=C046WC7P2E5)

<div><a href="https://cursor.com/agents/bc-44a727e4-fa98-5b5e-be90-2dbe3c728167?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44a727e4-fa98-5b5e-be90-2dbe3c728167&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select menus now support rendering within a local container or the document body.
  * Filter controls automatically use the appropriate local container when available.
  * Combobox popups now position correctly when rendered in custom containers.

* **Bug Fixes**
  * Improved searchable select behavior in contained layouts, helping menus display in the correct location.

* **Tests**
  * Added coverage for local and document-body menu rendering, custom containers, and popup positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->