### PR TITLE
Seed immutable chdb fixtures once per file

### DIFF
--- a/packages/platform/db-clickhouse/src/repositories/analytics-query-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/analytics-query-repository.test.ts
@@ -2,7 +2,7 @@ import { type ChSqlClient, OrganizationId, ProjectId } from "@domain/shared"
 import { type AnalyticsQueryInput, AnalyticsQueryReader, type AnalyticsQueryReaderShape } from "@domain/spans"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
-import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { ChSqlClientLive } from "../ch-sql-client.ts"
 import type { SpanRow } from "../seeds/spans/span-builders.ts"
 import { insertJsonEachRow } from "../sql.ts"
@@ -177,7 +177,7 @@ const score = (
   created_at: toCh3(new Date("2026-06-05T10:00:00.000Z")),
 })
 
-const ch = setupTestClickHouse()
+const ch = setupTestClickHouse({ truncateBetweenTests: false })
 const baseInput = {
   organizationId: ORG_ID,
   projectId: PROJECT_ID,
@@ -204,7 +204,8 @@ describe("AnalyticsQueryReaderLive (traces)", () => {
 
   const run = (input: AnalyticsQueryInput) => runCh(reader.query(input))
 
-  beforeEach(async () => {
+  // Every test only reads, so the fixture is seeded once for the file.
+  beforeAll(async () => {
     await Effect.runPromise(
       insertJsonEachRow(ch.client, "spans", [
         span(1, DAY1, { model: "gpt-4o-mini" }),

--- a/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/cost-analytics-repository.test.ts
@@ -3,7 +3,7 @@ import type { CacheCadenceRow, CostAnalyticsRepositoryShape } from "@domain/span
 import { CACHE_CEILING_LIFETIME_SECONDS, CostAnalyticsRepository } from "@domain/spans"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
-import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { ChSqlClientLive } from "../ch-sql-client.ts"
 import type { SpanRow } from "../seeds/spans/span-builders.ts"
 import { insertJsonEachRow } from "../sql.ts"
@@ -111,7 +111,7 @@ const span = (n: number, startTime: Date, opts: SpanOpts = {}): CostSpanRow =>
     scope_version: "",
   }) satisfies CostSpanRow
 
-const ch = setupTestClickHouse()
+const ch = setupTestClickHouse({ truncateBetweenTests: false })
 
 const runCh = <A, E>(effect: Effect.Effect<A, E, ChSqlClient>) =>
   Effect.runPromise(effect.pipe(Effect.provide(ChSqlClientLive(ch.client, ORG_ID))))
@@ -167,7 +167,8 @@ describe("CostAnalyticsRepositoryLive", () => {
     )
   })
 
-  beforeEach(async () => {
+  // Every test only reads, so the fixture is seeded once for the file.
+  beforeAll(async () => {
     await Effect.runPromise(
       insertJsonEachRow(ch.client, "spans", [
         // Trace 1: two billable spans, plus a tool span that must not count.

--- a/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-cost-factors.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@domain/spans"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
-import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { ChSqlClientLive } from "../ch-sql-client.ts"
 import { buildCohortsSpans, type CostCohort } from "../seeds/spans/cost-archetypes/cohorts.ts"
 import { GPT_5_MINI } from "../seeds/spans/cost-archetypes/models.ts"
@@ -76,7 +76,7 @@ const PARITY_COHORTS: readonly CostCohort[] = [
   },
 ]
 
-const ch = setupTestClickHouse()
+const ch = setupTestClickHouse({ truncateBetweenTests: false })
 
 const runCh = <A, E>(effect: Effect.Effect<A, E, ChSqlClient>) =>
   Effect.runPromise(effect.pipe(Effect.provide(ChSqlClientLive(ch.client, ORG_ID))))
@@ -102,16 +102,13 @@ const decompositionFor = async (projectId: ProjectId) =>
 
 let repo: CostAnalyticsRepositoryShape
 
+// Every test only reads, so the fixture is seeded once for the file.
 beforeAll(async () => {
   repo = await Effect.runPromise(
     Effect.gen(function* () {
       return yield* CostAnalyticsRepository
     }).pipe(Effect.provide(CostAnalyticsRepositoryLive)),
   )
-})
-
-// The testkit truncates between tests, so the fixtures are re-inserted per test.
-beforeEach(async () => {
   await Effect.runPromise(
     insertJsonEachRow(ch.client, "spans", [
       ...spansOf(REGRESSION_COHORTS, BLENDED_PROJECT_ID),

--- a/packages/platform/db-clickhouse/src/repositories/user-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/user-analytics-repository.test.ts
@@ -3,7 +3,7 @@ import { ExternalUserId, OrganizationId, ProjectId } from "@domain/shared"
 import { UserAnalyticsRepository, type UserAnalyticsRepositoryShape } from "@domain/spans"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
-import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { ChSqlClientLive } from "../ch-sql-client.ts"
 import { insertJsonEachRow } from "../sql.ts"
 import { withClickHouse } from "../with-clickhouse.ts"
@@ -178,7 +178,7 @@ const SPANS = [
   }),
 ]
 
-const ch = setupTestClickHouse()
+const ch = setupTestClickHouse({ truncateBetweenTests: false })
 
 const runCh = <A, E>(effect: Effect.Effect<A, E, ChSqlClient>) =>
   Effect.runPromise(effect.pipe(Effect.provide(ChSqlClientLive(ch.client, ORG_ID))))
@@ -194,7 +194,8 @@ describe("UserAnalyticsRepository", () => {
     )
   })
 
-  beforeEach(async () => {
+  // Every test only reads, so the fixture is seeded once for the file.
+  beforeAll(async () => {
     await Effect.runPromise(insertJsonEachRow(ch.client, "spans", SPANS))
   })
 

--- a/packages/platform/db-clickhouse/src/seeds/spans/custom-behavior-qa.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/custom-behavior-qa.test.ts
@@ -12,17 +12,19 @@ import {
 } from "@domain/taxonomy"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { TaxonomyObservationRepositoryLive } from "../../repositories/taxonomy-observation-repository.ts"
 import { withClickHouse } from "../../with-clickhouse.ts"
 import { buildCustomBehaviorQaFixture } from "./custom-behavior-qa.ts"
 
-const ch = setupTestClickHouse()
+const ch = setupTestClickHouse({ truncateBetweenTests: false })
 
 const organizationId = bootstrapSeedScope.organizationId as OrganizationId
 const projectId = bootstrapSeedScope.projectId as ProjectId
 const NOW_MS = Date.parse("2026-07-14T12:00:00.000Z")
 const SINCE = new Date(NOW_MS - TAXONOMY_GARDENING_SAMPLE_LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
+
+const { spans, observations, analyses, momentLabels } = buildCustomBehaviorQaFixture(bootstrapSeedScope, NOW_MS)
 
 const cohortSize = (cohort: (typeof CUSTOM_BEHAVIOR_QA_COHORTS)["a"]) =>
   cohort.subTopics.reduce((sum, topic) => sum + topic.sessionCount, 0)
@@ -31,15 +33,12 @@ const runWithRepository = <A, E>(effect: Effect.Effect<A, E, TaxonomyObservation
   Effect.runPromise(effect.pipe(withClickHouse(TaxonomyObservationRepositoryLive, ch.client, organizationId)))
 
 describe("customBehaviorQa fixture", () => {
-  beforeEach(async () => {
-    // Runs after the testkit's truncate-all beforeEach, so it re-seeds each test.
-    const { spans, observations } = buildCustomBehaviorQaFixture(bootstrapSeedScope, NOW_MS)
+  beforeAll(async () => {
     await ch.client.insert({ table: "spans", values: spans, format: "JSONEachRow" })
     await ch.client.insert({ table: "taxonomy_observations", values: observations, format: "JSONEachRow" })
   })
 
   it("builds clustered observations with non-empty embeddings and global cluster ids", () => {
-    const { observations } = buildCustomBehaviorQaFixture(bootstrapSeedScope, NOW_MS)
     const totalObservations = CUSTOM_BEHAVIOR_QA_COHORT_LIST.reduce((sum, cohort) => sum + cohortSize(cohort), 0)
     const totalSubTopics = CUSTOM_BEHAVIOR_QA_COHORT_LIST.reduce((sum, cohort) => sum + cohort.subTopics.length, 0)
     expect(observations).toHaveLength(totalObservations)
@@ -55,7 +54,6 @@ describe("customBehaviorQa fixture", () => {
   })
 
   it("emits an analysis and moment labels per session, joined by a shared analysis_hash", () => {
-    const { observations, analyses, momentLabels } = buildCustomBehaviorQaFixture(bootstrapSeedScope, NOW_MS)
     const totalSessions = CUSTOM_BEHAVIOR_QA_COHORT_LIST.reduce((sum, cohort) => sum + cohortSize(cohort), 0)
 
     expect(analyses).toHaveLength(totalSessions)

--- a/packages/platform/testkit/src/clickhouse/test-clickhouse.ts
+++ b/packages/platform/testkit/src/clickhouse/test-clickhouse.ts
@@ -147,15 +147,25 @@ interface TestClickHouseContext {
   readonly client: ClickHouseClient
 }
 
+interface SetupTestClickHouseOptions {
+  /**
+   * Truncate every table before each test. Pass `false` when the whole file reads one
+   * immutable fixture, so it can seed once in its own `beforeAll` instead.
+   */
+  readonly truncateBetweenTests?: boolean
+}
+
 /**
  * Registers beforeAll / beforeEach / afterAll hooks for a chdb-backed test file.
  * - beforeAll: creates session + loads schema
- * - beforeEach: truncates all tables
+ * - beforeEach: truncates all tables, unless `truncateBetweenTests: false`
  * - afterAll: destroys the session
  *
  * Returns an object whose `client` property resolves lazily after beforeAll.
  */
-export function setupTestClickHouse(): TestClickHouseContext {
+export function setupTestClickHouse({
+  truncateBetweenTests = true,
+}: SetupTestClickHouseOptions = {}): TestClickHouseContext {
   let ch: TestClickHouse | undefined
 
   beforeAll(() => {
@@ -163,10 +173,12 @@ export function setupTestClickHouse(): TestClickHouseContext {
     loadClickHouseSchema(ch)
   })
 
-  beforeEach(() => {
-    if (!ch) return
-    truncateClickHouseTables(ch)
-  })
+  if (truncateBetweenTests) {
+    beforeEach(() => {
+      if (!ch) return
+      truncateClickHouseTables(ch)
+    })
+  }
 
   afterAll(() => {
     if (!ch) return


### PR DESCRIPTION
## what

`setupTestClickHouse()` truncates every table before each test, so a file that seeds a fixture in `beforeEach` re-inserts it once per test. For the five heaviest read-only fixtures in `@platform/db-clickhouse` that is pure waste: no test in those files writes, so one seed per file is enough.

Adds a `truncateBetweenTests` option to the testkit helper. Passing `false` skips the truncate hook, which lets the file seed once in its own `beforeAll` (registered after the testkit's schema-loading `beforeAll`, so ordering is unchanged).

Converted: `session-cost-factors`, `cost-analytics-repository`, `user-analytics-repository`, `analytics-query-repository`, `custom-behavior-qa`. Together they went from 78 fixture inserts per run to 5. `custom-behavior-qa` also built its fixture six times (once per `beforeEach`, plus again inside two tests) and now builds it once at module scope.

## measured

Local, per file, `tests` time from the vitest summary:

| file | before | after |
| --- | --- | --- |
| `session-cost-factors` (10 tests) | 9.36s | 1.84s |
| `cost-analytics` + `user-analytics` + `analytics-query` (64 tests) | 8.47s | 2.93s |
| `custom-behavior-qa` (4 tests) | 1.49s | 1.08s |

`session-cost-factors` is the slowest file in the whole `test-integration` job (15.5s in CI). Full `@platform/db-clickhouse` suite still green: 42 files, 619 tests.

## why now

Today's release run for `v0.3.79` failed the `test-integration` job with every test passing — the vitest fork running `session-cost-factors.test.ts` died on its tenth and last test, and the pool reported `Worker exited unexpectedly` (run [31696859144](https://github.com/latitude-dev/latitude-llm/actions/runs/31696859144)). The same file with the same signature killed the job on an unrelated branch three hours earlier (run [31682335100](https://github.com/latitude-dev/latitude-llm/actions/runs/31682335100)), which then passed on retry.

This PR does not claim to fix that. The obvious explanation — the fixture growing the chdb session until the fork is OOM-killed — did not hold up locally: peak RSS for that file is ~1.5GB before the change and ~1.5GB after, dominated by chdb's own baseline rather than the fixture. What the change does do is cut the file's work by 5x, which shrinks the window the fork spends in heavy native calls. If the flake returns, the next thing to look at is chdb thread oversubscription on a 4-core runner with three concurrent sessions.

## left alone

`facet-projection-repository` and the other files whose tests write between assertions still need the per-test truncate. `metric-series-reader`, `trace-repository`, and `score-analytics-repository` seed per-test data inside the tests themselves, so there is no single file-level fixture to hoist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved ClickHouse test setup efficiency by sharing fixture data across tests.
  * Added support for preserving test data between test cases when needed.
  * Maintained existing isolation behavior by default for other test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->