### PR TITLE
Settings update | Managing up integrations per project/organization

### DIFF
--- a/apps/web/src/domains/projects/project-sections.ts
+++ b/apps/web/src/domains/projects/project-sections.ts
@@ -240,6 +240,12 @@ const PROJECT_SETTINGS_GROUPS: readonly ProjectSettingsGroup[] = [
         path: (slug) => `/projects/${slug}/settings/defaults`,
       },
       {
+        key: "global-integrations",
+        label: "Global integrations",
+        icon: Plug,
+        path: (slug) => `/projects/${slug}/settings/global-integrations`,
+      },
+      {
         key: "sso",
         label: "Single sign-on",
         icon: Fingerprint,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -79,7 +79,6 @@ import { Route as AuthenticatedProjectsProjectSlugSettingsMembersRouteImport } f
 import { Route as AuthenticatedProjectsProjectSlugSettingsKeysRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/keys'
 import { Route as AuthenticatedProjectsProjectSlugSettingsGeneralRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/general'
 import { Route as AuthenticatedProjectsProjectSlugSettingsFlaggersRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/flaggers'
-import { Route as AuthenticatedProjectsProjectSlugSettingsDefaultsRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/defaults'
 import { Route as AuthenticatedProjectsProjectSlugSettingsBillingRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/billing'
 import { Route as AuthenticatedProjectsProjectSlugSettingsAccountRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/account'
 import { Route as AuthenticatedProjectsProjectSlugMonitorsSignalsRouteImport } from './routes/_authenticated/projects/$projectSlug/monitors/signals'
@@ -91,6 +90,8 @@ import { Route as AuthenticatedProjectsProjectSlugToolsToolNameIndexRouteImport 
 import { Route as AuthenticatedProjectsProjectSlugSignalsSignalSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/signals/$signalSlug/index'
 import { Route as AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/integrations/index'
 import { Route as AuthenticatedProjectsProjectSlugSettingsImportsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/imports/index'
+import { Route as AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/global-integrations/index'
+import { Route as AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/defaults/index'
 import { Route as AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/data-destinations/index'
 import { Route as AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index'
 import { Route as AuthenticatedProjectsProjectSlugMemoryStoreIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/memory/$store/index'
@@ -100,6 +101,7 @@ import { Route as AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRo
 import { Route as AuthenticatedProjectsProjectSlugSettingsIntegrationsSlackRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/integrations/slack'
 import { Route as AuthenticatedProjectsProjectSlugSettingsIntegrationsGithubRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/integrations/github'
 import { Route as AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind'
+import { Route as AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/global-integrations/$integrationKind'
 import { Route as AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId'
 import { Route as AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugViewsNewRouteImport } from './routes/_authenticated/projects/$projectSlug/behaviours/$behaviourSlug/views/new'
 import { Route as AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugViewsViewSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/behaviours/$behaviourSlug/views/$viewSlug/index'
@@ -500,12 +502,6 @@ const AuthenticatedProjectsProjectSlugSettingsFlaggersRoute =
     path: '/flaggers',
     getParentRoute: () => AuthenticatedProjectsProjectSlugSettingsRoute,
   } as any)
-const AuthenticatedProjectsProjectSlugSettingsDefaultsRoute =
-  AuthenticatedProjectsProjectSlugSettingsDefaultsRouteImport.update({
-    id: '/defaults',
-    path: '/defaults',
-    getParentRoute: () => AuthenticatedProjectsProjectSlugSettingsRoute,
-  } as any)
 const AuthenticatedProjectsProjectSlugSettingsBillingRoute =
   AuthenticatedProjectsProjectSlugSettingsBillingRouteImport.update({
     id: '/billing',
@@ -572,6 +568,20 @@ const AuthenticatedProjectsProjectSlugSettingsImportsIndexRoute =
     path: '/imports/',
     getParentRoute: () => AuthenticatedProjectsProjectSlugSettingsRoute,
   } as any)
+const AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRoute =
+  AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRouteImport.update(
+    {
+      id: '/global-integrations/',
+      path: '/global-integrations/',
+      getParentRoute: () => AuthenticatedProjectsProjectSlugSettingsRoute,
+    } as any,
+  )
+const AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRoute =
+  AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRouteImport.update({
+    id: '/defaults/',
+    path: '/defaults/',
+    getParentRoute: () => AuthenticatedProjectsProjectSlugSettingsRoute,
+  } as any)
 const AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute =
   AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRouteImport.update(
     {
@@ -633,6 +643,14 @@ const AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute =
     {
       id: '/integrations/$integrationKind',
       path: '/integrations/$integrationKind',
+      getParentRoute: () => AuthenticatedProjectsProjectSlugSettingsRoute,
+    } as any,
+  )
+const AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRoute =
+  AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRouteImport.update(
+    {
+      id: '/global-integrations/$integrationKind',
+      path: '/global-integrations/$integrationKind',
       getParentRoute: () => AuthenticatedProjectsProjectSlugSettingsRoute,
     } as any,
   )
@@ -725,7 +743,6 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/monitors/signals': typeof AuthenticatedProjectsProjectSlugMonitorsSignalsRoute
   '/projects/$projectSlug/settings/account': typeof AuthenticatedProjectsProjectSlugSettingsAccountRoute
   '/projects/$projectSlug/settings/billing': typeof AuthenticatedProjectsProjectSlugSettingsBillingRoute
-  '/projects/$projectSlug/settings/defaults': typeof AuthenticatedProjectsProjectSlugSettingsDefaultsRoute
   '/projects/$projectSlug/settings/flaggers': typeof AuthenticatedProjectsProjectSlugSettingsFlaggersRoute
   '/projects/$projectSlug/settings/general': typeof AuthenticatedProjectsProjectSlugSettingsGeneralRoute
   '/projects/$projectSlug/settings/keys': typeof AuthenticatedProjectsProjectSlugSettingsKeysRoute
@@ -747,6 +764,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/tools/': typeof AuthenticatedProjectsProjectSlugToolsIndexRoute
   '/projects/$projectSlug/users/': typeof AuthenticatedProjectsProjectSlugUsersIndexRoute
   '/projects/$projectSlug/settings/data-destinations/$destinationId': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute
+  '/projects/$projectSlug/settings/global-integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRoute
   '/projects/$projectSlug/settings/integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute
   '/projects/$projectSlug/settings/integrations/github': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsGithubRoute
   '/projects/$projectSlug/settings/integrations/slack': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsSlackRoute
@@ -756,6 +774,8 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/memory/$store/': typeof AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute
   '/projects/$projectSlug/monitors/$monitorSlug/': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
   '/projects/$projectSlug/settings/data-destinations/': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute
+  '/projects/$projectSlug/settings/defaults/': typeof AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRoute
+  '/projects/$projectSlug/settings/global-integrations/': typeof AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRoute
   '/projects/$projectSlug/settings/imports/': typeof AuthenticatedProjectsProjectSlugSettingsImportsIndexRoute
   '/projects/$projectSlug/settings/integrations/': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRoute
   '/projects/$projectSlug/signals/$signalSlug/': typeof AuthenticatedProjectsProjectSlugSignalsSignalSlugIndexRoute
@@ -817,7 +837,6 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/monitors/signals': typeof AuthenticatedProjectsProjectSlugMonitorsSignalsRoute
   '/projects/$projectSlug/settings/account': typeof AuthenticatedProjectsProjectSlugSettingsAccountRoute
   '/projects/$projectSlug/settings/billing': typeof AuthenticatedProjectsProjectSlugSettingsBillingRoute
-  '/projects/$projectSlug/settings/defaults': typeof AuthenticatedProjectsProjectSlugSettingsDefaultsRoute
   '/projects/$projectSlug/settings/flaggers': typeof AuthenticatedProjectsProjectSlugSettingsFlaggersRoute
   '/projects/$projectSlug/settings/general': typeof AuthenticatedProjectsProjectSlugSettingsGeneralRoute
   '/projects/$projectSlug/settings/keys': typeof AuthenticatedProjectsProjectSlugSettingsKeysRoute
@@ -839,6 +858,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/tools': typeof AuthenticatedProjectsProjectSlugToolsIndexRoute
   '/projects/$projectSlug/users': typeof AuthenticatedProjectsProjectSlugUsersIndexRoute
   '/projects/$projectSlug/settings/data-destinations/$destinationId': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute
+  '/projects/$projectSlug/settings/global-integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRoute
   '/projects/$projectSlug/settings/integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute
   '/projects/$projectSlug/settings/integrations/github': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsGithubRoute
   '/projects/$projectSlug/settings/integrations/slack': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsSlackRoute
@@ -848,6 +868,8 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/memory/$store': typeof AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute
   '/projects/$projectSlug/monitors/$monitorSlug': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
   '/projects/$projectSlug/settings/data-destinations': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute
+  '/projects/$projectSlug/settings/defaults': typeof AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRoute
+  '/projects/$projectSlug/settings/global-integrations': typeof AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRoute
   '/projects/$projectSlug/settings/imports': typeof AuthenticatedProjectsProjectSlugSettingsImportsIndexRoute
   '/projects/$projectSlug/settings/integrations': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRoute
   '/projects/$projectSlug/signals/$signalSlug': typeof AuthenticatedProjectsProjectSlugSignalsSignalSlugIndexRoute
@@ -915,7 +937,6 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectSlug/monitors/signals': typeof AuthenticatedProjectsProjectSlugMonitorsSignalsRoute
   '/_authenticated/projects/$projectSlug/settings/account': typeof AuthenticatedProjectsProjectSlugSettingsAccountRoute
   '/_authenticated/projects/$projectSlug/settings/billing': typeof AuthenticatedProjectsProjectSlugSettingsBillingRoute
-  '/_authenticated/projects/$projectSlug/settings/defaults': typeof AuthenticatedProjectsProjectSlugSettingsDefaultsRoute
   '/_authenticated/projects/$projectSlug/settings/flaggers': typeof AuthenticatedProjectsProjectSlugSettingsFlaggersRoute
   '/_authenticated/projects/$projectSlug/settings/general': typeof AuthenticatedProjectsProjectSlugSettingsGeneralRoute
   '/_authenticated/projects/$projectSlug/settings/keys': typeof AuthenticatedProjectsProjectSlugSettingsKeysRoute
@@ -937,6 +958,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectSlug/tools/': typeof AuthenticatedProjectsProjectSlugToolsIndexRoute
   '/_authenticated/projects/$projectSlug/users/': typeof AuthenticatedProjectsProjectSlugUsersIndexRoute
   '/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute
+  '/_authenticated/projects/$projectSlug/settings/global-integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRoute
   '/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute
   '/_authenticated/projects/$projectSlug/settings/integrations/github': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsGithubRoute
   '/_authenticated/projects/$projectSlug/settings/integrations/slack': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsSlackRoute
@@ -946,6 +968,8 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectSlug/memory/$store/': typeof AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute
   '/_authenticated/projects/$projectSlug/monitors/$monitorSlug/': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
   '/_authenticated/projects/$projectSlug/settings/data-destinations/': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute
+  '/_authenticated/projects/$projectSlug/settings/defaults/': typeof AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRoute
+  '/_authenticated/projects/$projectSlug/settings/global-integrations/': typeof AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRoute
   '/_authenticated/projects/$projectSlug/settings/imports/': typeof AuthenticatedProjectsProjectSlugSettingsImportsIndexRoute
   '/_authenticated/projects/$projectSlug/settings/integrations/': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRoute
   '/_authenticated/projects/$projectSlug/signals/$signalSlug/': typeof AuthenticatedProjectsProjectSlugSignalsSignalSlugIndexRoute
@@ -1013,7 +1037,6 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/monitors/signals'
     | '/projects/$projectSlug/settings/account'
     | '/projects/$projectSlug/settings/billing'
-    | '/projects/$projectSlug/settings/defaults'
     | '/projects/$projectSlug/settings/flaggers'
     | '/projects/$projectSlug/settings/general'
     | '/projects/$projectSlug/settings/keys'
@@ -1035,6 +1058,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/tools/'
     | '/projects/$projectSlug/users/'
     | '/projects/$projectSlug/settings/data-destinations/$destinationId'
+    | '/projects/$projectSlug/settings/global-integrations/$integrationKind'
     | '/projects/$projectSlug/settings/integrations/$integrationKind'
     | '/projects/$projectSlug/settings/integrations/github'
     | '/projects/$projectSlug/settings/integrations/slack'
@@ -1044,6 +1068,8 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/memory/$store/'
     | '/projects/$projectSlug/monitors/$monitorSlug/'
     | '/projects/$projectSlug/settings/data-destinations/'
+    | '/projects/$projectSlug/settings/defaults/'
+    | '/projects/$projectSlug/settings/global-integrations/'
     | '/projects/$projectSlug/settings/imports/'
     | '/projects/$projectSlug/settings/integrations/'
     | '/projects/$projectSlug/signals/$signalSlug/'
@@ -1105,7 +1131,6 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/monitors/signals'
     | '/projects/$projectSlug/settings/account'
     | '/projects/$projectSlug/settings/billing'
-    | '/projects/$projectSlug/settings/defaults'
     | '/projects/$projectSlug/settings/flaggers'
     | '/projects/$projectSlug/settings/general'
     | '/projects/$projectSlug/settings/keys'
@@ -1127,6 +1152,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/tools'
     | '/projects/$projectSlug/users'
     | '/projects/$projectSlug/settings/data-destinations/$destinationId'
+    | '/projects/$projectSlug/settings/global-integrations/$integrationKind'
     | '/projects/$projectSlug/settings/integrations/$integrationKind'
     | '/projects/$projectSlug/settings/integrations/github'
     | '/projects/$projectSlug/settings/integrations/slack'
@@ -1136,6 +1162,8 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/memory/$store'
     | '/projects/$projectSlug/monitors/$monitorSlug'
     | '/projects/$projectSlug/settings/data-destinations'
+    | '/projects/$projectSlug/settings/defaults'
+    | '/projects/$projectSlug/settings/global-integrations'
     | '/projects/$projectSlug/settings/imports'
     | '/projects/$projectSlug/settings/integrations'
     | '/projects/$projectSlug/signals/$signalSlug'
@@ -1202,7 +1230,6 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectSlug/monitors/signals'
     | '/_authenticated/projects/$projectSlug/settings/account'
     | '/_authenticated/projects/$projectSlug/settings/billing'
-    | '/_authenticated/projects/$projectSlug/settings/defaults'
     | '/_authenticated/projects/$projectSlug/settings/flaggers'
     | '/_authenticated/projects/$projectSlug/settings/general'
     | '/_authenticated/projects/$projectSlug/settings/keys'
@@ -1224,6 +1251,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectSlug/tools/'
     | '/_authenticated/projects/$projectSlug/users/'
     | '/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId'
+    | '/_authenticated/projects/$projectSlug/settings/global-integrations/$integrationKind'
     | '/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind'
     | '/_authenticated/projects/$projectSlug/settings/integrations/github'
     | '/_authenticated/projects/$projectSlug/settings/integrations/slack'
@@ -1233,6 +1261,8 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectSlug/memory/$store/'
     | '/_authenticated/projects/$projectSlug/monitors/$monitorSlug/'
     | '/_authenticated/projects/$projectSlug/settings/data-destinations/'
+    | '/_authenticated/projects/$projectSlug/settings/defaults/'
+    | '/_authenticated/projects/$projectSlug/settings/global-integrations/'
     | '/_authenticated/projects/$projectSlug/settings/imports/'
     | '/_authenticated/projects/$projectSlug/settings/integrations/'
     | '/_authenticated/projects/$projectSlug/signals/$signalSlug/'
@@ -1764,13 +1794,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSettingsFlaggersRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugSettingsRoute
     }
-    '/_authenticated/projects/$projectSlug/settings/defaults': {
-      id: '/_authenticated/projects/$projectSlug/settings/defaults'
-      path: '/defaults'
-      fullPath: '/projects/$projectSlug/settings/defaults'
-      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSettingsDefaultsRouteImport
-      parentRoute: typeof AuthenticatedProjectsProjectSlugSettingsRoute
-    }
     '/_authenticated/projects/$projectSlug/settings/billing': {
       id: '/_authenticated/projects/$projectSlug/settings/billing'
       path: '/billing'
@@ -1848,6 +1871,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSettingsImportsIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugSettingsRoute
     }
+    '/_authenticated/projects/$projectSlug/settings/global-integrations/': {
+      id: '/_authenticated/projects/$projectSlug/settings/global-integrations/'
+      path: '/global-integrations'
+      fullPath: '/projects/$projectSlug/settings/global-integrations/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectSlugSettingsRoute
+    }
+    '/_authenticated/projects/$projectSlug/settings/defaults/': {
+      id: '/_authenticated/projects/$projectSlug/settings/defaults/'
+      path: '/defaults'
+      fullPath: '/projects/$projectSlug/settings/defaults/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectSlugSettingsRoute
+    }
     '/_authenticated/projects/$projectSlug/settings/data-destinations/': {
       id: '/_authenticated/projects/$projectSlug/settings/data-destinations/'
       path: '/data-destinations'
@@ -1909,6 +1946,13 @@ declare module '@tanstack/react-router' {
       path: '/integrations/$integrationKind'
       fullPath: '/projects/$projectSlug/settings/integrations/$integrationKind'
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectSlugSettingsRoute
+    }
+    '/_authenticated/projects/$projectSlug/settings/global-integrations/$integrationKind': {
+      id: '/_authenticated/projects/$projectSlug/settings/global-integrations/$integrationKind'
+      path: '/global-integrations/$integrationKind'
+      fullPath: '/projects/$projectSlug/settings/global-integrations/$integrationKind'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugSettingsRoute
     }
     '/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId': {
@@ -1976,7 +2020,6 @@ const BackofficeRouteRouteWithChildren = BackofficeRouteRoute._addFileChildren(
 interface AuthenticatedProjectsProjectSlugSettingsRouteChildren {
   AuthenticatedProjectsProjectSlugSettingsAccountRoute: typeof AuthenticatedProjectsProjectSlugSettingsAccountRoute
   AuthenticatedProjectsProjectSlugSettingsBillingRoute: typeof AuthenticatedProjectsProjectSlugSettingsBillingRoute
-  AuthenticatedProjectsProjectSlugSettingsDefaultsRoute: typeof AuthenticatedProjectsProjectSlugSettingsDefaultsRoute
   AuthenticatedProjectsProjectSlugSettingsFlaggersRoute: typeof AuthenticatedProjectsProjectSlugSettingsFlaggersRoute
   AuthenticatedProjectsProjectSlugSettingsGeneralRoute: typeof AuthenticatedProjectsProjectSlugSettingsGeneralRoute
   AuthenticatedProjectsProjectSlugSettingsKeysRoute: typeof AuthenticatedProjectsProjectSlugSettingsKeysRoute
@@ -1987,10 +2030,13 @@ interface AuthenticatedProjectsProjectSlugSettingsRouteChildren {
   AuthenticatedProjectsProjectSlugSettingsSsoRoute: typeof AuthenticatedProjectsProjectSlugSettingsSsoRoute
   AuthenticatedProjectsProjectSlugSettingsIndexRoute: typeof AuthenticatedProjectsProjectSlugSettingsIndexRoute
   AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute: typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute
+  AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRoute: typeof AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRoute
   AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute: typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute
   AuthenticatedProjectsProjectSlugSettingsIntegrationsGithubRoute: typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsGithubRoute
   AuthenticatedProjectsProjectSlugSettingsIntegrationsSlackRoute: typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsSlackRoute
   AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute: typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute
+  AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRoute: typeof AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRoute
+  AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRoute: typeof AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRoute
   AuthenticatedProjectsProjectSlugSettingsImportsIndexRoute: typeof AuthenticatedProjectsProjectSlugSettingsImportsIndexRoute
   AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRoute: typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRoute
 }
@@ -2001,8 +2047,6 @@ const AuthenticatedProjectsProjectSlugSettingsRouteChildren: AuthenticatedProjec
       AuthenticatedProjectsProjectSlugSettingsAccountRoute,
     AuthenticatedProjectsProjectSlugSettingsBillingRoute:
       AuthenticatedProjectsProjectSlugSettingsBillingRoute,
-    AuthenticatedProjectsProjectSlugSettingsDefaultsRoute:
-      AuthenticatedProjectsProjectSlugSettingsDefaultsRoute,
     AuthenticatedProjectsProjectSlugSettingsFlaggersRoute:
       AuthenticatedProjectsProjectSlugSettingsFlaggersRoute,
     AuthenticatedProjectsProjectSlugSettingsGeneralRoute:
@@ -2023,6 +2067,8 @@ const AuthenticatedProjectsProjectSlugSettingsRouteChildren: AuthenticatedProjec
       AuthenticatedProjectsProjectSlugSettingsIndexRoute,
     AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute:
       AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute,
+    AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRoute:
+      AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIntegrationKindRoute,
     AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute:
       AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute,
     AuthenticatedProjectsProjectSlugSettingsIntegrationsGithubRoute:
@@ -2031,6 +2077,10 @@ const AuthenticatedProjectsProjectSlugSettingsRouteChildren: AuthenticatedProjec
       AuthenticatedProjectsProjectSlugSettingsIntegrationsSlackRoute,
     AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute:
       AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute,
+    AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRoute:
+      AuthenticatedProjectsProjectSlugSettingsDefaultsIndexRoute,
+    AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRoute:
+      AuthenticatedProjectsProjectSlugSettingsGlobalIntegrationsIndexRoute,
     AuthenticatedProjectsProjectSlugSettingsImportsIndexRoute:
       AuthenticatedProjectsProjectSlugSettingsImportsIndexRoute,
     AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRoute:

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings.tsx
@@ -1,5 +1,5 @@
 import { isShowcaseProjectSlug } from "@domain/shared"
-import { Container, cn } from "@repo/ui"
+import { cn } from "@repo/ui"
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
 import { useHasMatchStaticData } from "../../../../lib/hooks/use-router-selectors.ts"
 import { BreadcrumbText } from "../../-components/breadcrumb-ui.tsx"
@@ -28,13 +28,13 @@ function SettingsLayout() {
     <div className="flex h-full min-w-0">
       <SettingsSubNav projectSlug={projectSlug} />
       <main className={cn("flex-1 min-w-0 flex flex-col", fillHeight ? "overflow-hidden" : "overflow-y-auto")}>
-        <Container
-          className={cn("@container flex flex-col gap-8 px-6 pt-6", {
+        <div
+          className={cn("@container mx-auto flex w-full max-w-4xl flex-col gap-8 px-6 py-6", {
             "flex-1 min-h-0 overflow-hidden": fillHeight,
           })}
         >
           <Outlet />
-        </Container>
+        </div>
       </main>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
@@ -25,7 +25,7 @@ import {
 import { relativeTime } from "@repo/utils"
 import { useForm } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { Link } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import { BookOpen, Copy, ExternalLink, FileText } from "lucide-react"
 import { type ReactNode, useState } from "react"
 import { z } from "zod"
@@ -285,6 +285,7 @@ export function DispatchConnectionSection({
 }) {
   const queryClient = useQueryClient()
   const { toast } = useToast()
+  const navigate = useNavigate()
   const [confirmOpen, setConfirmOpen] = useState(false)
 
   const disconnectMutation = useMutation({
@@ -296,6 +297,9 @@ export function DispatchConnectionSection({
       await queryClient.invalidateQueries({ queryKey: sendToDestinationsQueryKey(projectId) })
       toast({ description: `${KIND_LABELS[kind]} disconnected` })
       setConfirmOpen(false)
+      if (canDisconnect) {
+        await navigate({ to: "/projects/$projectSlug/settings/global-integrations", params: { projectSlug } })
+      }
     },
     onError: (error) => {
       setConfirmOpen(false)
@@ -377,7 +381,6 @@ function DispatchBehaviorSection({
 }) {
   const queryClient = useQueryClient()
   const { toast } = useToast()
-  const [confirmingReset, setConfirmingReset] = useState(false)
   const [isResetting, setIsResetting] = useState(false)
 
   const { data: settings, isLoading } = useQuery({
@@ -399,7 +402,6 @@ function DispatchBehaviorSection({
     setIsResetting(true)
     try {
       await resetProjectDispatchOverride({ data: { projectId, integrationId: integration.id } })
-      setConfirmingReset(false)
       await invalidate()
       toast({ description: "This project now follows the organization default" })
     } catch (error) {
@@ -422,27 +424,11 @@ function DispatchBehaviorSection({
           <Text.H6 color="foregroundMuted">When Latitude dispatches to this integration, and what it sends.</Text.H6>
         </div>
         {isOverridden ? (
-          <Button variant="outline" onClick={() => setConfirmingReset(true)} disabled={isResetting}>
+          <Button variant="outline" onClick={() => void applyReset()} isLoading={isResetting}>
             Reset to default
           </Button>
         ) : null}
       </div>
-
-      {confirmingReset ? (
-        <div className="flex flex-row flex-wrap items-center justify-between gap-4 border-border border-t bg-warning-muted/40 p-5">
-          <Text.H6 color="foregroundMuted">
-            This discards this project's custom dispatch behavior and goes back to following the organization default.
-          </Text.H6>
-          <div className="flex shrink-0 flex-row items-center gap-2">
-            <Button variant="outline" onClick={() => setConfirmingReset(false)} disabled={isResetting}>
-              Cancel
-            </Button>
-            <Button onClick={() => void applyReset()} isLoading={isResetting}>
-              Reset to default
-            </Button>
-          </div>
-        </div>
-      ) : null}
 
       {!isOverridden ? (
         <div className="border-border border-t p-5">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
@@ -259,7 +259,7 @@ export function AgentDispatchIntegrationDetails({
   }
 
   return (
-    <div className="flex w-full flex-col gap-6 @[900px]:w-2/3">
+    <div className="flex w-full flex-col gap-6">
       <DispatchConnectionSection kind={kind} integration={integration} projectId={projectId} />
       <DispatchBehaviorSection
         kind={kind}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
@@ -54,17 +54,15 @@ import {
   upsertProjectDispatchOverride,
 } from "../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
 import {
+  AGENT_DISPATCH_KIND_ICONS,
   AGENT_DISPATCH_KIND_LABELS,
   type AgentDispatchKindKey,
 } from "../../../../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
-import { useIsOrganizationOwner } from "../../../../../../domains/members/members.collection.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../../lib/form-server-action.ts"
 import { useDebounce } from "../../../../../../lib/hooks/useDebounce.ts"
 import { maskSensitiveValue } from "../../../../../../lib/mask-sensitive-value.ts"
-import { useAuthenticatedUser } from "../../../../-route-data.ts"
 import { OrgDefaultBlastRadius, otherAffectedProjects, useOrgDefaultConfirm } from "./org-default-confirm.tsx"
-import { ScopedSetting, type SettingScope } from "./scoped-setting.tsx"
 
 export const AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY = ["agent-dispatch-integrations"] as const
 
@@ -225,12 +223,10 @@ export function AgentDispatchIntegrationDetails({
   projectId,
   projectSlug,
   kind,
-  projectCount,
 }: {
   readonly projectId: string
   readonly projectSlug: string
   readonly kind: AgentDispatchKindKey
-  readonly projectCount: number
 }) {
   const { data: integrations = [], isLoading } = useQuery({
     queryKey: AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY,
@@ -260,26 +256,32 @@ export function AgentDispatchIntegrationDetails({
 
   return (
     <div className="flex w-full flex-col gap-6">
-      <DispatchConnectionSection kind={kind} integration={integration} projectId={projectId} />
-      <DispatchBehaviorSection
+      <DispatchConnectionSection
         kind={kind}
         integration={integration}
         projectId={projectId}
-        projectCount={projectCount}
+        projectSlug={projectSlug}
+        canDisconnect={false}
       />
+      <DispatchBehaviorSection kind={kind} integration={integration} projectId={projectId} />
       <AgentDispatchHistorySection projectId={projectId} projectSlug={projectSlug} kind={kind} />
     </div>
   )
 }
 
-function DispatchConnectionSection({
+export function DispatchConnectionSection({
   kind,
   integration,
   projectId,
+  projectSlug,
+  canDisconnect,
 }: {
   readonly kind: AgentDispatchKindKey
   readonly integration: AgentDispatchIntegrationRecord
   readonly projectId: string
+  readonly projectSlug: string
+  /** Disconnecting is org-wide, so only the Defaults page — not a single project — can do it. */
+  readonly canDisconnect: boolean
 }) {
   const queryClient = useQueryClient()
   const { toast } = useToast()
@@ -303,30 +305,36 @@ function DispatchConnectionSection({
 
   return (
     <>
-      <ScopedSetting
-        idPrefix={`${kind}-connection`}
-        title="Connection"
-        description="Shared by every project in your organization."
-        scope={{ kind: "fixed", value: "organization" }}
-        footer={
-          <div className="flex flex-row flex-wrap items-center justify-between gap-4">
-            <Text.H6 color="foregroundMuted">
-              Setup, dispatch behavior, and troubleshooting for this integration.
-            </Text.H6>
-            <IntegrationDocsButton kind={kind} />
-          </div>
-        }
-      >
-        <div className="flex flex-row flex-wrap items-center justify-between gap-4">
+      <div className="flex w-full flex-col rounded-lg bg-muted/30">
+        <div className="flex w-full flex-col gap-1 p-5">
+          <Text.H5M>Connection</Text.H5M>
+          <Text.H6 color="foregroundMuted">Shared by every project in your organization.</Text.H6>
+        </div>
+        <div className="flex w-full flex-row flex-wrap items-center justify-between gap-4 border-border border-t p-5">
           <div className="flex min-w-0 flex-col gap-0.5">
             <Text.H5 weight="semibold">{integration.vendorAccountId}</Text.H5>
             <Text.H6 color="foregroundMuted">Connected {relativeTime(new Date(integration.installedAt))}</Text.H6>
           </div>
-          <Button variant="destructive" onClick={() => setConfirmOpen(true)}>
-            Disconnect
-          </Button>
+          {canDisconnect ? (
+            <Button variant="destructive" onClick={() => setConfirmOpen(true)}>
+              Disconnect
+            </Button>
+          ) : (
+            <Button asChild variant="ghost">
+              <Link
+                to="/projects/$projectSlug/settings/global-integrations/$integrationKind"
+                params={{ projectSlug, integrationKind: kind }}
+              >
+                Manage in Global integrations →
+              </Link>
+            </Button>
+          )}
         </div>
-      </ScopedSetting>
+        <div className="flex flex-row flex-wrap items-center justify-between gap-4 border-border border-t p-5">
+          <Text.H6 color="foregroundMuted">Setup, dispatch behavior, and troubleshooting for this integration.</Text.H6>
+          <IntegrationDocsButton kind={kind} />
+        </div>
+      </div>
 
       {confirmOpen ? (
         <Modal
@@ -362,20 +370,15 @@ function DispatchBehaviorSection({
   kind,
   integration,
   projectId,
-  projectCount,
 }: {
   readonly kind: AgentDispatchKindKey
   readonly integration: AgentDispatchIntegrationRecord
   readonly projectId: string
-  readonly projectCount: number
 }) {
   const queryClient = useQueryClient()
   const { toast } = useToast()
-  const user = useAuthenticatedUser()
-  const isOwner = useIsOrganizationOwner(user.id)
-  const [editingDefault, setEditingDefault] = useState(false)
-  const [isSwitching, setIsSwitching] = useState(false)
-  const [stagedScope, setStagedScope] = useState<SettingScope | null>(null)
+  const [confirmingReset, setConfirmingReset] = useState(false)
+  const [isResetting, setIsResetting] = useState(false)
 
   const { data: settings, isLoading } = useQuery({
     queryKey: projectDispatchSettingsQueryKey(projectId, kind),
@@ -390,84 +393,74 @@ function DispatchBehaviorSection({
   if (isLoading) return <Skeleton className="h-32 w-full" />
 
   const effective = settings?.effective ?? null
-  const overrideCount = settings?.overrideCount ?? 0
-  const storedScope: SettingScope = settings?.override != null ? "project" : "organization"
-  const scope = stagedScope ?? storedScope
-  // Dropping the override is the only destructive direction, so it waits for an explicit apply.
-  const pendingRemoval = storedScope === "project" && scope === "organization"
+  const isOverridden = settings?.override != null
 
-  const shown = scope === "organization" ? (settings?.defaultConfig ?? null) : effective
-
-  const applyRemoval = async () => {
-    setIsSwitching(true)
+  const applyReset = async () => {
+    setIsResetting(true)
     try {
       await resetProjectDispatchOverride({ data: { projectId, integrationId: integration.id } })
-      setStagedScope(null)
+      setConfirmingReset(false)
       await invalidate()
-      toast({ description: "This project now follows the organization" })
+      toast({ description: "This project now follows the organization default" })
     } catch (error) {
       toast({ variant: "destructive", description: toUserMessage(error) })
     } finally {
-      setIsSwitching(false)
+      setIsResetting(false)
     }
   }
 
   return (
-    <>
-      <ScopedSetting
-        idPrefix={`${kind}-behavior`}
-        title="Dispatch behavior"
-        description="When Latitude dispatches to this integration, and what it sends."
-        scope={{
-          kind: "selectable",
-          value: scope,
-          onChange: (next) => setStagedScope(next === storedScope ? null : next),
-        }}
-        pendingChange={
-          pendingRemoval
-            ? {
-                description:
-                  "This project will follow the organization default, and its own dispatch behavior is discarded.",
-                applyLabel: "Follow organization",
-                isApplying: isSwitching,
-                onApply: () => void applyRemoval(),
-                onDiscard: () => setStagedScope(null),
-              }
-            : undefined
-        }
-        notice={
-          storedScope === "organization" && scope === "project" ? (
-            <Text.H6 color="foregroundMuted">
-              This project has no behavior of its own yet. Saving copies these values into one, and replaces the whole
-              block, so later changes to the organization default won’t reach this project.
-            </Text.H6>
-          ) : null
-        }
-        footer={
-          <div className="flex flex-row flex-wrap items-center justify-between gap-4">
-            <Text.H6 color="foregroundMuted">
-              {overrideCount > 0
-                ? `Organization default in effect for ${projectCount - overrideCount} of ${projectCount} projects · ${overrideCount} override it`
-                : `Organization default in effect for all ${projectCount} projects`}
-            </Text.H6>
-            {isOwner ? (
-              <Button variant="outline" onClick={() => setEditingDefault(true)} disabled={isSwitching}>
-                Edit organization default
-              </Button>
-            ) : scope === "organization" ? (
-              <Text.H6 color="foregroundMuted">Ask an owner to change the default.</Text.H6>
-            ) : null}
+    <div className="flex w-full flex-col rounded-lg bg-muted/30">
+      <div className="flex w-full flex-row flex-wrap items-start justify-between gap-x-4 gap-y-2 p-5">
+        <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex flex-row items-center gap-2">
+            <Text.H5M>Dispatch behavior</Text.H5M>
+            <Badge variant={isOverridden ? "warningMuted" : "outlineMuted"} size="normal">
+              {isOverridden ? "Differs from default" : "Using default"}
+            </Badge>
           </div>
-        }
-      >
+          <Text.H6 color="foregroundMuted">When Latitude dispatches to this integration, and what it sends.</Text.H6>
+        </div>
+        {isOverridden ? (
+          <Button variant="outline" onClick={() => setConfirmingReset(true)} disabled={isResetting}>
+            Reset to default
+          </Button>
+        ) : null}
+      </div>
+
+      {confirmingReset ? (
+        <div className="flex flex-row flex-wrap items-center justify-between gap-4 border-border border-t bg-warning-muted/40 p-5">
+          <Text.H6 color="foregroundMuted">
+            This discards this project's custom dispatch behavior and goes back to following the organization default.
+          </Text.H6>
+          <div className="flex shrink-0 flex-row items-center gap-2">
+            <Button variant="outline" onClick={() => setConfirmingReset(false)} disabled={isResetting}>
+              Cancel
+            </Button>
+            <Button onClick={() => void applyReset()} isLoading={isResetting}>
+              Reset to default
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {!isOverridden ? (
+        <div className="border-border border-t p-5">
+          <Text.H6 color="foregroundMuted">
+            Editing and saving creates a custom dispatch behavior for this project — it never changes the organization
+            default.
+          </Text.H6>
+        </div>
+      ) : null}
+
+      <div className="flex w-full flex-col border-border border-t p-5">
         <AgentDispatchConfigFormInner
-          key={`${kind}:${scope}:${shown?.updatedAt ?? "new"}`}
+          key={`${kind}:${effective?.updatedAt ?? "new"}`}
           kind={kind}
           integrationId={integration.id}
           vendorAccountId={integration.vendorAccountId}
-          initial={shown}
+          initial={effective}
           webhookSecret={null}
-          readOnly={scope === "organization"}
           submitLabel="Save for this project"
           onSubmit={async (values) => {
             await upsertProjectDispatchOverride({
@@ -481,45 +474,29 @@ function DispatchBehaviorSection({
                 guardrails: values.guardrails,
               },
             })
-            setStagedScope(null)
             await invalidate()
             toast({ description: `${KIND_LABELS[kind]} settings saved for this project` })
           }}
         />
-      </ScopedSetting>
-
-      {editingDefault ? (
-        <OrganizationDispatchModal
-          kind={kind}
-          integrationId={integration.id}
-          vendorAccountId={integration.vendorAccountId}
-          projectCount={projectCount}
-          overrideCount={overrideCount}
-          currentProjectInherits={storedScope === "organization"}
-          onClose={() => setEditingDefault(false)}
-        />
-      ) : null}
-    </>
+      </div>
+    </div>
   )
 }
 
-/** Editing the organization default from a project page, so an org-wide write interrupts. */
-export function OrganizationDispatchModal({
+export function OrgDispatchDefaultCard({
   kind,
   integrationId,
   vendorAccountId,
   projectCount,
   overrideCount,
-  currentProjectInherits = false,
-  onClose,
+  canEdit,
 }: {
   readonly kind: AgentDispatchKindKey
   readonly integrationId: string
   readonly vendorAccountId: string
   readonly projectCount: number
   readonly overrideCount: number
-  readonly currentProjectInherits?: boolean
-  readonly onClose: () => void
+  readonly canEdit: boolean
 }) {
   const queryClient = useQueryClient()
   const { toast } = useToast()
@@ -528,20 +505,20 @@ export function OrganizationDispatchModal({
     queryFn: () => getOrgDefaultDispatchConfig({ data: { kind } }),
   })
 
-  const otherAffected = otherAffectedProjects({ projectCount, overrideCount, currentProjectInherits })
+  const otherAffected = otherAffectedProjects({ projectCount, overrideCount, currentProjectInherits: false })
   const confirm = useOrgDefaultConfirm(otherAffected)
 
   return (
-    <Modal
-      open
-      dismissible
-      onOpenChange={(next) => {
-        if (!next) onClose()
-      }}
-      title={`${KIND_LABELS[kind]} organization default`}
-      description="The dispatch behavior every project inherits unless it sets its own."
-    >
-      <div className="flex flex-col gap-6">
+    <div className="flex w-full flex-col rounded-lg bg-muted/30">
+      <div className="flex w-full flex-row items-center gap-3 p-5">
+        <Icon icon={AGENT_DISPATCH_KIND_ICONS[kind]} size="lg" />
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <Text.H5M>{KIND_LABELS[kind]}</Text.H5M>
+          <Text.H6 color="foregroundMuted">{vendorAccountId}</Text.H6>
+        </div>
+      </div>
+
+      <div className="flex w-full flex-col gap-4 border-border border-t p-5">
         <OrgDefaultBlastRadius
           projectCount={projectCount}
           overrideCount={overrideCount}
@@ -559,6 +536,7 @@ export function OrganizationDispatchModal({
             vendorAccountId={vendorAccountId}
             initial={config ?? null}
             webhookSecret={null}
+            readOnly={!canEdit}
             submitLabel={confirm.submitLabel}
             beforeSubmit={confirm.gate}
             onSubmit={async (values) => {
@@ -576,12 +554,19 @@ export function OrganizationDispatchModal({
               await queryClient.invalidateQueries({ queryKey: ["agent-dispatch-project-settings"] })
               await queryClient.invalidateQueries({ queryKey: ["send-to-destinations"] })
               toast({ description: "Organization default updated" })
-              onClose()
             }}
           />
         )}
       </div>
-    </Modal>
+
+      <div className="flex flex-row flex-wrap items-center justify-between gap-4 border-border border-t p-5">
+        <Text.H6 color="foregroundMuted">
+          {overrideCount > 0
+            ? `Organization default in effect for ${projectCount - overrideCount} of ${projectCount} projects · ${overrideCount} override it`
+            : `Organization default in effect for all ${projectCount} projects`}
+        </Text.H6>
+      </div>
+    </div>
   )
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/github-manage.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/github-manage.tsx
@@ -80,7 +80,7 @@ export function GithubIntegrationManage({
 
   return (
     <div className="flex flex-col gap-10">
-      <div className="flex w-full flex-col gap-6 @[900px]:w-2/3">
+      <div className="flex w-full flex-col gap-6">
         {integration.suspendedAt ? (
           <Alert
             variant="warning"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/integration-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/integration-row.tsx
@@ -1,6 +1,7 @@
 import { Icon, Status, Text } from "@repo/ui"
 import { Link } from "@tanstack/react-router"
 import { ChevronRight } from "lucide-react"
+import { isAgentDispatchKind } from "../../../../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
 import type {
   ConnectedIntegration,
   IntegrationCatalogEntry,
@@ -8,16 +9,22 @@ import type {
 
 /**
  * Typed link to an integration's detail page. Slack and GitHub have their own
- * routes; the four dispatch kinds share the `$integrationKind` route.
+ * routes; the four dispatch kinds share the `$integrationKind` route — either
+ * the project-scoped one (this project's override) or, from Global integrations,
+ * the org-default edit page. Slack/GitHub have no Global-integrations-scoped
+ * page, so they always go to their project-scoped route regardless of
+ * `toGlobalIntegrations`.
  */
 function IntegrationDetailLink({
   entry,
   projectSlug,
+  toGlobalIntegrations = false,
   className,
   children,
 }: {
   readonly entry: IntegrationCatalogEntry
   readonly projectSlug: string
+  readonly toGlobalIntegrations?: boolean
   readonly className?: string
   readonly children: React.ReactNode
 }) {
@@ -47,6 +54,18 @@ function IntegrationDetailLink({
       </Link>
     )
   }
+  if (toGlobalIntegrations && isAgentDispatchKind(entry.key)) {
+    return (
+      <Link
+        to="/projects/$projectSlug/settings/global-integrations/$integrationKind"
+        params={{ projectSlug, integrationKind: entry.key }}
+        aria-label={label}
+        className={className}
+      >
+        {children}
+      </Link>
+    )
+  }
   return (
     <Link
       to="/projects/$projectSlug/settings/integrations/$integrationKind"
@@ -63,9 +82,12 @@ function IntegrationDetailLink({
 export function IntegrationRow({
   integration,
   projectSlug,
+  toGlobalIntegrations = false,
 }: {
   readonly integration: ConnectedIntegration
   readonly projectSlug: string
+  /** True when this row is rendered on Global integrations — links to the org-default edit page instead of this project's. */
+  readonly toGlobalIntegrations?: boolean
 }) {
   const { entry, identity, detail, needsAttention, attentionLabel } = integration
 
@@ -73,6 +95,7 @@ export function IntegrationRow({
     <IntegrationDetailLink
       entry={entry}
       projectSlug={projectSlug}
+      toGlobalIntegrations={toGlobalIntegrations}
       className="flex flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2 p-4 transition-colors hover:bg-muted/50"
     >
       <div className="flex min-w-0 flex-row items-center gap-3">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
@@ -667,7 +667,7 @@ function AccountSettingsPage() {
   return (
     <SettingsPage title="Account" description="Manage your personal account">
       <form
-        className="flex w-full flex-col gap-3 @[800px]:w-1/2"
+        className="flex w-full flex-col gap-3"
         onSubmit={(e) => {
           e.preventDefault()
           void form.handleSubmit()

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/defaults.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/defaults.tsx
@@ -65,7 +65,7 @@ function OrganizationDefaultsPage() {
       title="Defaults"
       description="Organization-wide defaults that projects inherit unless they set their own."
     >
-      <div className="flex w-full flex-col gap-6 @[900px]:w-2/3">
+      <div className="flex w-full flex-col gap-6">
         <Text.H6 color="foregroundMuted">
           {isOwner
             ? "Each project can override these on its own settings pages. Changing a default here applies immediately to every project still inheriting it, and leaves projects that override it untouched."

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/defaults/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/defaults/index.tsx
@@ -6,32 +6,19 @@ import { createFileRoute } from "@tanstack/react-router"
 import { EyeOffIcon, type LucideProps } from "lucide-react"
 import { type ComponentType, useState } from "react"
 import {
-  type AgentDispatchIntegrationRecord,
-  getProjectDispatchSettings,
-  listAgentDispatchIntegrations,
-} from "../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
-import {
-  AGENT_DISPATCH_KIND_ICONS,
-  AGENT_DISPATCH_KIND_LABELS,
-  type AgentDispatchKindKey,
-} from "../../../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
-import { GITHUB_ORG_DEFAULTS_QUERY_KEY, getGithubOrgDefaults } from "../../../../../domains/github/github.functions.ts"
-import { integrationEntry } from "../../../../../domains/integrations/integration-catalog.ts"
-import { useIsOrganizationOwner } from "../../../../../domains/members/members.collection.ts"
-import { useOrganizationsCollection } from "../../../../../domains/organizations/organizations.collection.ts"
-import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
-import { useAuthenticatedOrganizationId, useAuthenticatedUser } from "../../../-route-data.ts"
-import { useRouteProject } from "../-route-data.ts"
-import {
-  AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY,
-  OrganizationDispatchModal,
-  projectDispatchSettingsQueryKey,
-} from "./-components/agent-dispatch-section.tsx"
-import { OrganizationGithubModal } from "./-components/github-manage.tsx"
-import { OrganizationRedactionModal } from "./-components/organization-redaction-modal.tsx"
-import { SettingsPage } from "./-components/settings-page.tsx"
+  GITHUB_ORG_DEFAULTS_QUERY_KEY,
+  getGithubOrgDefaults,
+} from "../../../../../../domains/github/github.functions.ts"
+import { integrationEntry } from "../../../../../../domains/integrations/integration-catalog.ts"
+import { useIsOrganizationOwner } from "../../../../../../domains/members/members.collection.ts"
+import { useOrganizationsCollection } from "../../../../../../domains/organizations/organizations.collection.ts"
+import { useProjectsCollection } from "../../../../../../domains/projects/projects.collection.ts"
+import { useAuthenticatedOrganizationId, useAuthenticatedUser } from "../../../../-route-data.ts"
+import { OrganizationGithubModal } from "../-components/github-manage.tsx"
+import { OrganizationRedactionModal } from "../-components/organization-redaction-modal.tsx"
+import { SettingsPage } from "../-components/settings-page.tsx"
 
-export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/defaults")({
+export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/defaults/")({
   component: OrganizationDefaultsPage,
 })
 
@@ -41,7 +28,6 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/sett
  * scope is the page's subject rather than a per-setting property.
  */
 function OrganizationDefaultsPage() {
-  const routeProject = useRouteProject()
   const organizationId = useAuthenticatedOrganizationId()
   const user = useAuthenticatedUser()
   const isOwner = useIsOrganizationOwner(user.id)
@@ -54,11 +40,6 @@ function OrganizationDefaultsPage() {
   const { data: org } = useOrganizationsCollection((orgs) =>
     orgs.where(({ organizations }) => eq(organizations.id, organizationId)).findOne(),
   )
-
-  const { data: dispatchIntegrations = [], isLoading: dispatchLoading } = useQuery({
-    queryKey: AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY,
-    queryFn: () => listAgentDispatchIntegrations(),
-  })
 
   return (
     <SettingsPage
@@ -81,23 +62,6 @@ function OrganizationDefaultsPage() {
           />
 
           <GithubDefaultRow canEdit={isOwner} projectCount={projectCount} />
-
-          {dispatchLoading ? (
-            <div className="p-4">
-              <Skeleton className="h-10 w-full" />
-            </div>
-          ) : (
-            dispatchIntegrations.map((integration: AgentDispatchIntegrationRecord) => (
-              <DispatchDefaultRow
-                key={integration.kind}
-                canEdit={isOwner}
-                kind={integration.kind}
-                integration={integration}
-                projectId={routeProject.id}
-                projectCount={projectCount}
-              />
-            ))
-          )}
         </div>
       </div>
     </SettingsPage>
@@ -244,72 +208,6 @@ function GithubDefaultRow({ projectCount, canEdit }: { readonly projectCount: nu
         <OrganizationGithubModal
           projectCount={projectCount}
           overrideCount={defaults.overrideCount}
-          onClose={() => setEditing(false)}
-        />
-      ) : null}
-    </>
-  )
-}
-
-function DispatchDefaultRow({
-  kind,
-  integration,
-  projectId,
-  projectCount,
-  canEdit,
-}: {
-  readonly canEdit: boolean
-  readonly kind: AgentDispatchKindKey
-  readonly integration: AgentDispatchIntegrationRecord
-  readonly projectId: string
-  readonly projectCount: number
-}) {
-  const [editing, setEditing] = useState(false)
-  const {
-    data: settings,
-    isLoading,
-    isError,
-  } = useQuery({
-    queryKey: projectDispatchSettingsQueryKey(projectId, kind),
-    queryFn: () => getProjectDispatchSettings({ data: { projectId, kind } }),
-  })
-
-  if (isLoading) {
-    return (
-      <div className="p-4">
-        <Skeleton className="h-10 w-full" />
-      </div>
-    )
-  }
-  if (isError) return <DefaultRowError title={`${AGENT_DISPATCH_KIND_LABELS[kind]} dispatch`} />
-
-  const config = settings?.defaultConfig ?? null
-  const triggerCount = config?.triggers.length ?? 0
-  const value =
-    config === null
-      ? "No default set"
-      : triggerCount === 0
-        ? "No triggers, so it never dispatches"
-        : `${triggerCount} ${triggerCount === 1 ? "trigger" : "triggers"} · ${config.guardrails.maxDispatchesPerDay} per day`
-
-  return (
-    <>
-      <DefaultRow
-        icon={AGENT_DISPATCH_KIND_ICONS[kind]}
-        title={`${AGENT_DISPATCH_KIND_LABELS[kind]} dispatch`}
-        value={value}
-        projectCount={projectCount}
-        overrideCount={settings?.overrideCount ?? 0}
-        canEdit={canEdit}
-        onEdit={() => setEditing(true)}
-      />
-      {editing ? (
-        <OrganizationDispatchModal
-          kind={kind}
-          integrationId={integration.id}
-          vendorAccountId={integration.vendorAccountId}
-          projectCount={projectCount}
-          overrideCount={settings?.overrideCount ?? 0}
           onClose={() => setEditing(false)}
         />
       ) : null}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -167,7 +167,7 @@ function ProjectFlaggersSettingsPage() {
       }
       headerSticky={hasDirty}
     >
-      <div className="flex w-full max-w-2xl flex-col gap-8">
+      <div className="flex w-full flex-col gap-8">
         {isLoadingFlaggers ? null : flaggers.length === 0 ? (
           <Text.H5 color="foregroundMuted">No flaggers have been provisioned for this project yet</Text.H5>
         ) : (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
@@ -103,7 +103,7 @@ function ProjectGeneralSettingsPage() {
       }
       headerSticky={hasDirty}
     >
-      <div className="flex w-full flex-col gap-3 @[800px]:w-1/2">
+      <div className="flex w-full flex-col gap-3">
         <Input
           type="text"
           label={
@@ -149,7 +149,7 @@ function TraceSamplingSection({
   onRateChange: (percent: number) => void
 }) {
   return (
-    <div className="flex w-full flex-col @[800px]:w-1/2">
+    <div className="flex w-full flex-col">
       <div className="flex w-full flex-col rounded-lg bg-muted/30">
         <div className="flex w-full flex-row items-start justify-between gap-4 p-4">
           <div className="flex flex-col gap-1">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/global-integrations/$integrationKind.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/global-integrations/$integrationKind.tsx
@@ -1,0 +1,133 @@
+import { Alert, Button, Icon, Skeleton, Text, Tooltip } from "@repo/ui"
+import { useQuery } from "@tanstack/react-query"
+import { createFileRoute, Link, notFound } from "@tanstack/react-router"
+import { ArrowLeftIcon } from "lucide-react"
+import {
+  type AgentDispatchIntegrationRecord,
+  getProjectDispatchSettings,
+  listAgentDispatchIntegrations,
+} from "../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
+import {
+  AGENT_DISPATCH_KIND_ICONS,
+  AGENT_DISPATCH_KIND_LABELS,
+  type AgentDispatchKindKey,
+  isAgentDispatchKind,
+} from "../../../../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
+import { useIsOrganizationOwner } from "../../../../../../domains/members/members.collection.ts"
+import { useProjectsCollection } from "../../../../../../domains/projects/projects.collection.ts"
+import { useAuthenticatedUser } from "../../../../-route-data.ts"
+import { useRouteProject } from "../../-route-data.ts"
+import {
+  AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY,
+  DispatchConnectionSection,
+  OrgDispatchDefaultCard,
+  projectDispatchSettingsQueryKey,
+} from "../-components/agent-dispatch-section.tsx"
+import { SettingsPage } from "../-components/settings-page.tsx"
+
+export const Route = createFileRoute(
+  "/_authenticated/projects/$projectSlug/settings/global-integrations/$integrationKind",
+)({
+  beforeLoad: ({ params }) => {
+    if (!isAgentDispatchKind(params.integrationKind)) throw notFound()
+  },
+  component: GlobalIntegrationDetailPage,
+})
+
+function GlobalIntegrationDetailPage() {
+  const { projectSlug, integrationKind } = Route.useParams()
+  const kind = integrationKind as AgentDispatchKindKey
+  const routeProject = useRouteProject()
+  const user = useAuthenticatedUser()
+  const isOwner = useIsOrganizationOwner(user.id)
+
+  const { data: allProjects } = useProjectsCollection()
+  // The shared Showcase project is merged into this collection but isn't the org's.
+  const projectCount = (allProjects ?? []).filter((row) => !row.isShowcase).length
+
+  const { data: integrations = [], isLoading: integrationsLoading } = useQuery({
+    queryKey: AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY,
+    queryFn: () => listAgentDispatchIntegrations(),
+  })
+  const integration = integrations.find((row: AgentDispatchIntegrationRecord) => row.kind === kind) ?? null
+
+  const { data: settings, isLoading: settingsLoading } = useQuery({
+    queryKey: projectDispatchSettingsQueryKey(routeProject.id, kind),
+    queryFn: () => getProjectDispatchSettings({ data: { projectId: routeProject.id, kind } }),
+    enabled: integration !== null,
+  })
+
+  const title = (
+    <div className="flex min-w-0 flex-row items-center gap-2">
+      <Tooltip
+        asChild
+        side="bottom"
+        trigger={
+          <Button asChild variant="ghost" className="h-7 w-7 p-0" aria-label="Back to global integrations">
+            <Link to="/projects/$projectSlug/settings/global-integrations" params={{ projectSlug }}>
+              <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
+            </Link>
+          </Button>
+        }
+      >
+        Back to global integrations
+      </Tooltip>
+      <Icon icon={AGENT_DISPATCH_KIND_ICONS[kind]} />
+      <Text.H3M>{AGENT_DISPATCH_KIND_LABELS[kind]}</Text.H3M>
+    </div>
+  )
+
+  if (integrationsLoading) {
+    return (
+      <SettingsPage title={title} description="Connection and organization-wide default dispatch behavior.">
+        <Skeleton className="h-32 w-full" />
+      </SettingsPage>
+    )
+  }
+
+  if (!integration) {
+    return (
+      <SettingsPage title={title} description="Connection and organization-wide default dispatch behavior.">
+        <Alert
+          variant="default"
+          showIcon
+          title={`${AGENT_DISPATCH_KIND_LABELS[kind]} is not connected`}
+          description="Connect it from Global integrations to configure its organization-wide default."
+          cta={
+            <Button asChild variant="outline">
+              <Link to="/projects/$projectSlug/settings/global-integrations" params={{ projectSlug }}>
+                Back to global integrations
+              </Link>
+            </Button>
+          }
+        />
+      </SettingsPage>
+    )
+  }
+
+  return (
+    <SettingsPage title={title} description="Connection and organization-wide default dispatch behavior.">
+      <div className="flex w-full flex-col gap-6">
+        <DispatchConnectionSection
+          kind={kind}
+          integration={integration}
+          projectId={routeProject.id}
+          projectSlug={projectSlug}
+          canDisconnect={isOwner}
+        />
+        {settingsLoading ? (
+          <Skeleton className="h-32 w-full" />
+        ) : (
+          <OrgDispatchDefaultCard
+            kind={kind}
+            integrationId={integration.id}
+            vendorAccountId={integration.vendorAccountId}
+            projectCount={projectCount}
+            overrideCount={settings?.overrideCount ?? 0}
+            canEdit={isOwner}
+          />
+        )}
+      </div>
+    </SettingsPage>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/global-integrations/$integrationKind.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/global-integrations/$integrationKind.tsx
@@ -113,7 +113,7 @@ function GlobalIntegrationDetailPage() {
           integration={integration}
           projectId={routeProject.id}
           projectSlug={projectSlug}
-          canDisconnect={isOwner}
+          canDisconnect
         />
         {settingsLoading ? (
           <Skeleton className="h-32 w-full" />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/global-integrations/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/global-integrations/index.tsx
@@ -1,0 +1,181 @@
+import { Skeleton, Text } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import { useQuery } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
+import {
+  type AgentDispatchIntegrationRecord,
+  listAgentDispatchIntegrations,
+} from "../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
+import {
+  type AgentDispatchKindKey,
+  isAgentDispatchKind,
+} from "../../../../../../domains/agent-dispatch/agent-dispatch-kinds.ts"
+import {
+  GITHUB_INTEGRATION_QUERY_KEY,
+  getActiveGithubIntegration,
+  isGithubIntegrationConfigured,
+} from "../../../../../../domains/github/github.functions.ts"
+import {
+  type ConnectedIntegration,
+  type IntegrationKey,
+  integrationEntry,
+  sortConnectedIntegrations,
+} from "../../../../../../domains/integrations/integration-catalog.ts"
+import {
+  getActiveSlackIntegration,
+  isSlackConfigured,
+} from "../../../../../../domains/integrations/integrations.functions.ts"
+import { useRouteProject } from "../../-route-data.ts"
+import {
+  AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY,
+  ConnectAgentDispatchModal,
+} from "../-components/agent-dispatch-section.tsx"
+import { AvailableIntegrations } from "../-components/available-integrations.tsx"
+import { IntegrationRow } from "../-components/integration-row.tsx"
+import { SettingsPage } from "../-components/settings-page.tsx"
+import { SLACK_INTEGRATION_QUERY_KEY } from "../-components/slack-route-row.tsx"
+
+const GITHUB_CONFIGURED_QUERY_KEY = ["github-integration", "configured"] as const
+const SLACK_CONFIGURED_QUERY_KEY = ["slack-integration", "configured"] as const
+
+export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/global-integrations/")({
+  component: GlobalIntegrationsPage,
+})
+
+/**
+ * Where an org-wide integration is connected, disconnected, and browsed from —
+ * the connection itself is shared by every project, so this is the one place
+ * for it, distinct from a project's own Integrations tab (which only shows
+ * status and links back here for anything org-wide).
+ */
+function GlobalIntegrationsPage() {
+  const { projectSlug } = Route.useParams()
+  const routeProject = useRouteProject()
+  const [connectingKind, setConnectingKind] = useState<AgentDispatchKindKey | null>(null)
+
+  const { data: slackConfigured } = useQuery({
+    queryKey: SLACK_CONFIGURED_QUERY_KEY,
+    queryFn: () => isSlackConfigured(),
+  })
+  const { data: githubConfigured } = useQuery({
+    queryKey: GITHUB_CONFIGURED_QUERY_KEY,
+    queryFn: () => isGithubIntegrationConfigured(),
+  })
+  const { data: slack, isLoading: slackLoading } = useQuery({
+    queryKey: SLACK_INTEGRATION_QUERY_KEY,
+    queryFn: () => getActiveSlackIntegration(),
+    enabled: slackConfigured === true,
+  })
+  const { data: github, isLoading: githubLoading } = useQuery({
+    queryKey: GITHUB_INTEGRATION_QUERY_KEY,
+    queryFn: () => getActiveGithubIntegration(),
+    enabled: githubConfigured === true,
+  })
+  const { data: dispatchIntegrations = [], isLoading: dispatchLoading } = useQuery({
+    queryKey: AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY,
+    queryFn: () => listAgentDispatchIntegrations(),
+  })
+
+  const isLoading =
+    slackConfigured === undefined || githubConfigured === undefined || slackLoading || githubLoading || dispatchLoading
+
+  // A deployment without the Slack or GitHub app configured can't connect them at all,
+  // so they are never offered.
+  const available: IntegrationKey[] = [
+    ...(slackConfigured === true ? (["slack"] as const) : []),
+    ...(githubConfigured === true ? (["github"] as const) : []),
+    "cursor",
+    "claude_code",
+    "linear",
+    "webhook",
+  ]
+
+  const connectedRows: ConnectedIntegration[] = [
+    ...(slack
+      ? [
+          {
+            entry: integrationEntry("slack"),
+            identity: slack.teamName,
+            detail: `Connected ${relativeTime(new Date(slack.installedAt))}`,
+            needsAttention: slack.needsReconnect,
+            attentionLabel: slack.needsReconnect ? "Reconnect needed" : undefined,
+          },
+        ]
+      : []),
+    ...(github
+      ? [
+          {
+            entry: integrationEntry("github"),
+            identity: github.accountLogin,
+            detail: `${github.repositorySelection === "all" ? "All repositories" : "Selected repositories"} · Connected ${relativeTime(new Date(github.installedAt))}`,
+            needsAttention: github.suspendedAt !== null,
+            attentionLabel: github.suspendedAt !== null ? "Suspended" : undefined,
+          },
+        ]
+      : []),
+    ...dispatchIntegrations.map((integration: AgentDispatchIntegrationRecord) => ({
+      entry: integrationEntry(integration.kind),
+      identity: integration.vendorAccountId,
+      detail: `Connected ${relativeTime(new Date(integration.installedAt))}`,
+      needsAttention: false,
+    })),
+  ]
+
+  const connected = sortConnectedIntegrations(connectedRows)
+  const connectedKeys = new Set(connected.map((row) => row.entry.key))
+  const openConnect = (key: IntegrationKey) => {
+    if (!isAgentDispatchKind(key)) return
+    setConnectingKind(key)
+  }
+
+  return (
+    <SettingsPage
+      title="Global integrations"
+      description="Connections shared by every project, and their organization-wide default behavior."
+    >
+      <div className="flex w-full flex-col gap-8">
+        {isLoading ? (
+          <Skeleton className="h-32 w-full" />
+        ) : (
+          <>
+            {connected.length > 0 ? (
+              <div className="flex flex-col gap-3">
+                <Text.H6M color="foregroundMuted">Connected</Text.H6M>
+                <div className="flex flex-col divide-y divide-border overflow-hidden rounded-lg border border-border">
+                  {connected.map((integration) => (
+                    <IntegrationRow
+                      key={integration.entry.key}
+                      integration={integration}
+                      projectSlug={projectSlug}
+                      toGlobalIntegrations
+                    />
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div className="flex flex-col gap-3">
+              <Text.H6M color="foregroundMuted">{connected.length > 0 ? "Available" : "Get started"}</Text.H6M>
+              <AvailableIntegrations
+                available={available}
+                connected={connectedKeys}
+                onConnectDispatchKind={openConnect}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      {connectingKind ? (
+        <ConnectAgentDispatchModal
+          kind={connectingKind}
+          projectId={routeProject.id}
+          open
+          onClose={() => setConnectingKind(null)}
+          onWebhookSecret={() => undefined}
+        />
+      ) : null}
+    </SettingsPage>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind.tsx
@@ -30,10 +30,6 @@ function AgentDispatchIntegrationSettingsPage() {
   )
   const currentProject = project ?? routeProject
 
-  const { data: allProjects } = useProjectsCollection()
-  // The shared Showcase project is merged into this collection but isn't the org's.
-  const projectCount = (allProjects ?? []).filter((row) => !row.isShowcase).length
-
   return (
     <SettingsPage
       title={
@@ -57,12 +53,7 @@ function AgentDispatchIntegrationSettingsPage() {
       }
       description="Connection, dispatch behavior, and history for this integration."
     >
-      <AgentDispatchIntegrationDetails
-        projectId={currentProject.id}
-        projectSlug={currentProject.slug}
-        kind={kind}
-        projectCount={projectCount}
-      />
+      <AgentDispatchIntegrationDetails projectId={currentProject.id} projectSlug={currentProject.slug} kind={kind} />
     </SettingsPage>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations/index.tsx
@@ -187,7 +187,7 @@ function IntegrationsSettingsPage() {
 
   return (
     <SettingsPage title="Integrations" description="Connect Latitude to the tools your team already uses.">
-      <div className="flex w-full flex-col gap-8 @[900px]:w-2/3">
+      <div className="flex w-full flex-col gap-8">
         {isLoading ? (
           <Skeleton className="h-32 w-full" />
         ) : (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations/slack.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations/slack.tsx
@@ -76,7 +76,7 @@ function SlackIntegrationDetails({ integration }: { readonly integration: SlackI
   const [disconnectOpen, setDisconnectOpen] = useState(false)
 
   return (
-    <div className="flex w-full flex-col gap-6 @[900px]:w-2/3">
+    <div className="flex w-full flex-col gap-6">
       {/* Should never appear while on-use refresh is healthy; when it does, the rotation
           chain is broken (refresh token revoked) and the workspace must be reconnected. */}
       {integration.needsReconnect ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/organization.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/organization.tsx
@@ -203,7 +203,7 @@ function DeleteOrganizationConfirmModal({
 function OrganizationSettingsPage() {
   return (
     <SettingsPage title="Organization" description="Manage your organization details">
-      <div className="flex w-full flex-col gap-6 @[800px]:w-1/2">
+      <div className="flex w-full flex-col gap-6">
         <OrganizationNameSection />
         <DeleteOrganizationSection />
       </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/privacy.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/privacy.tsx
@@ -195,7 +195,7 @@ function ProjectPrivacySettingsPage() {
       }
       headerSticky={valueDirty}
     >
-      <div className="flex w-full flex-col gap-8 @[900px]:w-2/3">
+      <div className="flex w-full flex-col gap-8">
         {/* The irreversibility and shape-matching caveats live on the card, next to the controls they qualify. */}
         <Text.H6 color="foregroundMuted">
           Matching values are replaced with a labelled placeholder before the span is stored. A change takes effect

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/sso.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/sso.tsx
@@ -40,7 +40,7 @@ function SsoSettingsPage() {
 
   return (
     <SettingsPage title={PAGE_TITLE} description={PAGE_DESCRIPTION}>
-      <div className="flex w-full flex-col gap-6 @[800px]:w-2/3">
+      <div className="flex w-full flex-col gap-6">
         <SsoProviderSection />
       </div>
     </SettingsPage>
@@ -49,7 +49,7 @@ function SsoSettingsPage() {
 
 function SsoUpsellCard() {
   return (
-    <div className="flex w-full flex-col gap-6 @[800px]:w-2/3">
+    <div className="flex w-full flex-col gap-6">
       <div className="flex flex-row flex-wrap items-center justify-between gap-4 rounded-lg border border-primary/20 bg-primary/5 p-6">
         <div className="flex min-w-0 flex-row items-start gap-4">
           <Icon icon={ShieldCheck} size="md" color="primary" className="shrink-0 pt-0.5" />


### PR DESCRIPTION
## What

- Consistent, centered max-width for every settings tab (was a different ad-hoc width per page).
- Reworked how org-wide dispatch integrations (Cursor, Claude Code, Linear, Webhook) are managed:
  - New **Global integrations** section under Organization settings: connect/disconnect and edit the organization default from one place.
  - A project's own integration page now just shows **Using default** / **Differs from default**, with the option to override or reset to the org default.
  - `Defaults` page is back to just PII redaction + GitHub monitoring.

## Why

The old "Set by: Organization ▾" control on a project page let you edit the org-wide default from inside a single project, which was confusing and scattered across pages. This puts org-wide connection/default editing in one place and keeps project pages focused on that project's own override.

https://github.com/user-attachments/assets/515628a0-6c47-4f1a-8cd9-f63d5ccab272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Global Integrations section to project settings.
  * View and manage Slack, GitHub, and agent-dispatch integrations from one location.
  * Configure organization-wide defaults and project-specific dispatch behavior.
  * Added controls to reset project overrides and manage connections based on permissions.

* **Improvements**
  * Expanded settings pages to use the available screen width.
  * Simplified organization defaults by removing agent-dispatch settings from that page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->