### PR TITLE
ci: always post a Claude PR review summary comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,11 +50,11 @@ jobs:
 
             How to post the review:
             - Read the PR with `mcp__github__get_pull_request`, `mcp__github__get_pull_request_files`, and `mcp__github__get_pull_request_diff`.
-            - For line-specific findings, create a pending review with `mcp__github__create_pending_pull_request_review`, add each finding with `mcp__github__add_comment_to_pending_review`, then submit with `mcp__github__submit_pending_pull_request_review` using event `COMMENT`. Never `APPROVE` or `REQUEST_CHANGES`.
+            - For line-specific findings, create a pending review with `mcp__github__create_pending_pull_request_review`, add each finding with `mcp__github__add_comment_to_pending_review`, then submit with `mcp__github__submit_pending_pull_request_review` using event `COMMENT`. Never `APPROVE` or `REQUEST_CHANGES`. Leave the pending-review body empty; the summary goes in the PR-wide comment.
             - The add-comment tool is `mcp__github__add_comment_to_pending_review`. Do not call `add_comment_to_pending_pull_request_review` or `pull_request_review_write`; those names are not available on this server.
             - If GitHub MCP cannot attach a comment to a line, fall back to `mcp__github_inline_comment__create_inline_comment` (pass `confirmed: true`).
-            - Use `gh pr comment` only for findings that cannot be attached to a line, or if both inline paths fail. Keep that comment short.
-            - If there are no high-confidence issues, do not create or submit a review. If a pending review already exists, delete it with `mcp__github__delete_pending_pull_request_review`.
+            - Always finish by posting a PR-wide summary with `gh pr comment ${{ github.event.pull_request.number }}`. Do this even when there are no inline findings, including a clean bill of health. Cover what you reviewed, the main findings or that you found no high-confidence issues, and any notes that cannot attach to a line. Keep it concise.
+            - If there are no line-specific findings, do not create or submit a pending review. If a pending review already exists with no comments, delete it with `mcp__github__delete_pending_pull_request_review`, then still post the PR-wide summary.
             - Do not push commits or edit the branch.
             - Only post via these GitHub tools. Do not submit the review as assistant text.
           claude_args: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Claude Code Review workflow stayed silent when it had nothing to attach to a line. A clean review still finished green, but the PR conversation got no comment at all.

The prompt now requires a PR-wide `gh pr comment` at the end of every run, including when there are no inline findings. That summary covers what was reviewed and either the main issues or that none were found. Line-specific notes still go through the pending-review path; the summary is not duplicated there.

`gh pr comment` was already in the allowed tools. This is a prompt-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a6409d4-fd39-4a1a-b348-f707c8e1d177?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a6409d4-fd39-4a1a-b348-f707c8e1d177&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review guidance to provide a pull request summary for every review, including reviews with no findings.
  * Improved handling of reviews without line-specific issues by avoiding unnecessary pending reviews and removing empty pending reviews.
  * Preserved fallback support for inline review comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->