### PR TITLE
fix(spans): stop OpenInference reasoning items rendering as empty bubbles

### DIFF
--- a/packages/domain/spans/src/otlp/content/openinference.test.ts
+++ b/packages/domain/spans/src/otlp/content/openinference.test.ts
@@ -406,6 +406,24 @@ describe("parseContent (OpenInference)", () => {
       )
       expect((toolResult as { id: string }).id).toBe((toolCall as { id: string }).id)
     })
+
+    it("still extracts a Gemini-style tool result that carries no content at all", () => {
+      const result = parseContent([
+        str("llm.input_messages.0.message.role", "assistant"),
+        str("llm.input_messages.0.message.tool_calls.0.tool_call.id", "call_xyz"),
+        str("llm.input_messages.0.message.tool_calls.0.tool_call.function.name", "lookup"),
+        str("llm.input_messages.0.message.tool_calls.0.tool_call.function.arguments", "{}"),
+        str("llm.input_messages.1.message.role", "user"),
+        str("llm.input_messages.1.message.tool_call_id", "call_xyz"),
+      ])
+
+      const tool = result.inputMessages.find((m) => m.role === "tool")
+      expect(tool).toBeDefined()
+      const toolResult = (tool as { parts: { type: string; id?: string }[] }).parts.find(
+        (p) => p.type === "tool_call_response",
+      )
+      expect((toolResult as { id: string }).id).toBe("call_xyz")
+    })
   })
 
   describe("tool definitions", () => {

--- a/packages/domain/spans/src/otlp/content/openinference.test.ts
+++ b/packages/domain/spans/src/otlp/content/openinference.test.ts
@@ -66,10 +66,21 @@ describe("parseContent (OpenInference)", () => {
       expect(result.inputMessages).toEqual([{ role: "user", parts: [{ type: "text", content: "no role here" }] }])
     })
 
-    it("defaults missing content to an empty string", () => {
+    it("drops a message that carries no content", () => {
       const result = parseContent([str("llm.input_messages.0.message.role", "user")])
 
-      expect(result.inputMessages).toEqual([{ role: "user", parts: [{ type: "text", content: "" }] }])
+      expect(result.inputMessages).toEqual([])
+    })
+
+    it("drops a message whose content is blank", () => {
+      const result = parseContent([
+        str("llm.input_messages.0.message.role", "user"),
+        str("llm.input_messages.0.message.content", "hi"),
+        str("llm.input_messages.1.message.role", "assistant"),
+        str("llm.input_messages.1.message.content", "   "),
+      ])
+
+      expect(result.inputMessages).toEqual([{ role: "user", parts: [{ type: "text", content: "hi" }] }])
     })
 
     it("preserves message ordering by index", () => {
@@ -86,7 +97,7 @@ describe("parseContent (OpenInference)", () => {
       ])
     })
 
-    it("fills gaps in indices with default user messages", () => {
+    it("closes gaps in indices instead of emitting placeholder messages", () => {
       const result = parseContent([
         str("llm.input_messages.0.message.role", "user"),
         str("llm.input_messages.0.message.content", "zero"),
@@ -96,7 +107,6 @@ describe("parseContent (OpenInference)", () => {
 
       expect(result.inputMessages).toEqual([
         { role: "user", parts: [{ type: "text", content: "zero" }] },
-        { role: "user", parts: [{ type: "text", content: "" }] },
         { role: "user", parts: [{ type: "text", content: "two" }] },
       ])
     })
@@ -146,16 +156,24 @@ describe("parseContent (OpenInference)", () => {
       expect(parts.some((p) => p.type === "text" && p.content === "only text supplied")).toBe(true)
     })
 
-    it("falls back to an empty text part when an image part has no url", () => {
+    it("drops an image part that has no url rather than emitting an empty text part", () => {
+      const result = parseContent([
+        str("llm.input_messages.0.message.role", "user"),
+        str("llm.input_messages.0.message.contents.0.message_content.type", "image"),
+        str("llm.input_messages.0.message.contents.1.message_content.type", "text"),
+        str("llm.input_messages.0.message.contents.1.message_content.text", "look"),
+      ])
+
+      expect(result.inputMessages).toEqual([{ role: "user", parts: [{ type: "text", content: "look" }] }])
+    })
+
+    it("drops the whole message when an urlless image part is its only content", () => {
       const result = parseContent([
         str("llm.input_messages.0.message.role", "user"),
         str("llm.input_messages.0.message.contents.0.message_content.type", "image"),
       ])
 
-      const userMsg = result.inputMessages.find((m) => m.role === "user")
-      const parts = (userMsg as { parts: { type: string; content?: string }[] }).parts
-      expect(parts.some((p) => p.type === "text" && p.content === "")).toBe(true)
-      expect(parts.some((p) => p.type === "uri")).toBe(false)
+      expect(result.inputMessages).toEqual([])
     })
 
     it("prefers content parts over a plain content string when both are present", () => {
@@ -169,6 +187,63 @@ describe("parseContent (OpenInference)", () => {
       const userMsg = result.inputMessages.find((m) => m.role === "user")
       const parts = (userMsg as { parts: { type: string; content?: string }[] }).parts
       expect(parts.map((p) => p.content)).toEqual(["from parts"])
+    })
+  })
+
+  describe("reasoning parts", () => {
+    it("drops an assistant turn whose only reasoning part is encrypted", () => {
+      const result = parseContent([
+        str("llm.input_messages.0.message.role", "user"),
+        str("llm.input_messages.0.message.content", "hi"),
+        str("llm.input_messages.1.message.role", "assistant"),
+        str("llm.input_messages.1.message.contents.0.message_content.type", "reasoning"),
+        str("llm.input_messages.1.message.contents.0.message_content.encrypted_content", "gAAAAABqfn9xBE78"),
+      ])
+
+      expect(result.inputMessages).toEqual([{ role: "user", parts: [{ type: "text", content: "hi" }] }])
+    })
+
+    it("emits a reasoning part when the reasoning summary text is present", () => {
+      const result = parseContent([
+        str("llm.input_messages.0.message.role", "assistant"),
+        str("llm.input_messages.0.message.contents.0.message_content.type", "reasoning"),
+        str("llm.input_messages.0.message.contents.0.message_content.text", "Evaluating the Airtable issue"),
+      ])
+
+      expect(result.inputMessages).toEqual([
+        { role: "assistant", parts: [{ type: "reasoning", content: "Evaluating the Airtable issue" }] },
+      ])
+    })
+
+    it("keeps the readable half of a reasoning part that also carries encrypted content", () => {
+      const result = parseContent([
+        str("llm.input_messages.0.message.role", "assistant"),
+        str("llm.input_messages.0.message.contents.0.message_content.type", "reasoning"),
+        str("llm.input_messages.0.message.contents.0.message_content.encrypted_content", "gAAAAABqfn_k"),
+        str("llm.input_messages.0.message.contents.0.message_content.text", "Weighing the rollout"),
+      ])
+
+      expect(result.inputMessages).toEqual([
+        { role: "assistant", parts: [{ type: "reasoning", content: "Weighing the rollout" }] },
+      ])
+    })
+
+    it("keeps a tool call on a turn whose reasoning part is encrypted", () => {
+      const result = parseContent([
+        str("llm.input_messages.0.message.role", "assistant"),
+        str("llm.input_messages.0.message.contents.0.message_content.type", "reasoning"),
+        str("llm.input_messages.0.message.contents.0.message_content.encrypted_content", "gAAAAABqfn_k"),
+        str("llm.input_messages.0.message.tool_calls.0.tool_call.id", "call_IkYeKNxq"),
+        str("llm.input_messages.0.message.tool_calls.0.tool_call.function.name", "delegate_task"),
+        str("llm.input_messages.0.message.tool_calls.0.tool_call.function.arguments", '{"goal":"inventory"}'),
+      ])
+
+      expect(result.inputMessages).toEqual([
+        {
+          role: "assistant",
+          parts: [{ type: "tool_call", id: "call_IkYeKNxq", name: "delegate_task", arguments: { goal: "inventory" } }],
+        },
+      ])
     })
   })
 

--- a/packages/domain/spans/src/otlp/content/openinference.ts
+++ b/packages/domain/spans/src/otlp/content/openinference.ts
@@ -12,6 +12,11 @@
  *
  * Output messages follow the same pattern with llm.output_messages.{i}.
  *
+ * A part carrying no renderable payload is dropped rather than emitted as empty text, and a
+ * message left with nothing at all is dropped entirely — OpenAI reasoning items arrive as
+ * `message_content.type=reasoning` with the payload in an `encrypted_content` field we cannot
+ * decrypt, so a reasoning model produces one such part per assistant turn.
+ *
  * Tool definitions use:
  *   llm.tools.{i}.tool.json_schema — JSON string of tool schema
  *
@@ -36,11 +41,18 @@ interface ContentPartData {
   imageUrl?: string
 }
 
-type MessageContent = string | { type: string; text?: string; image_url?: { url: string } }[]
+// rosetta-ai passes a reasoning part through verbatim, so it must already carry the GenAI
+// `content` key here — a `text` key survives translation and then renders blank.
+type MessageContentPart =
+  | { type: "text"; text: string }
+  | { type: "reasoning"; content: string }
+  | { type: "image_url"; image_url: { url: string } }
+
+type MessageContent = string | MessageContentPart[]
 
 interface ReassembledMessage {
   role: string
-  content: MessageContent
+  content?: MessageContent | undefined
   tool_calls?: { id: string; type: string; function: { name: string; arguments: string } }[]
   tool_call_id?: string
 }
@@ -103,21 +115,24 @@ function collectContentPartField(
   else if (parsed.field === "message_content.image.image.url") part.imageUrl = value
 }
 
-/** Resolves content for a single message: multipart array if parts exist, otherwise plain string. */
+/** Resolves content for a single message, or undefined when it carries nothing renderable. */
 function buildMessageContent(
   parts: Map<number, ContentPartData> | undefined,
   plainContent: string | undefined,
-): MessageContent {
+): MessageContent | undefined {
   if (parts && parts.size > 0) {
     const sorted = [...parts.entries()].sort(([a], [b]) => a - b)
-    return sorted.map(([, part]) => {
+    const built = sorted.flatMap(([, part]): MessageContentPart[] => {
       if (part.type === "image" && part.imageUrl) {
-        return { type: "image_url" as const, image_url: { url: part.imageUrl } }
+        return [{ type: "image_url", image_url: { url: part.imageUrl } }]
       }
-      return { type: "text" as const, text: part.text ?? "" }
+      if (!part.text?.trim()) return []
+      if (part.type === "reasoning") return [{ type: "reasoning", content: part.text }]
+      return [{ type: "text", text: part.text }]
     })
+    if (built.length > 0) return built
   }
-  return plainContent ?? ""
+  return plainContent?.trim() ? plainContent : undefined
 }
 
 /** Resolves the id a tool result pairs with (explicit tool_call_id → name match → oldest pending), consuming it. */
@@ -158,9 +173,16 @@ function assembleMessages(
     const msgFields = fields.get(i)
     const role = msgFields?.get("role") ?? "user"
     const content = buildMessageContent(contentParts.get(i), msgFields?.get("content"))
+    const msgToolCalls = toolCalls.get(i)
+    const hasToolCalls = !!msgToolCalls && msgToolCalls.size > 0
+    const explicitId = msgFields?.get("tool_call_id")
+
+    // A turn left with nothing renderable — an undecryptable reasoning item, or a blank content
+    // string — would otherwise reach the conversation view as an empty bubble.
+    if (content === undefined && !hasToolCalls && role !== "tool" && explicitId === undefined) continue
+
     const msg: ReassembledMessage = { role, content }
 
-    const msgToolCalls = toolCalls.get(i)
     if (msgToolCalls && msgToolCalls.size > 0) {
       const sorted = [...msgToolCalls.entries()].sort(([a], [b]) => a - b)
       msg.tool_calls = sorted.map(([j, tc]) => {
@@ -170,20 +192,22 @@ function assembleMessages(
       })
     }
 
-    const explicitId = msgFields?.get("tool_call_id")
-    const hasToolCalls = !!msgToolCalls && msgToolCalls.size > 0
     // Gemini delivers function responses on a role:"user" turn tagged only with tool_call_id.
     // Extract those into their own role:"tool" message (mirrors hoistToolResults — don't relabel
     // the turn). Single-content only: a multi-part turn could mix in real text we can't split.
     const extractAsToolResult =
-      role !== "tool" && explicitId !== undefined && !hasToolCalls && typeof content === "string"
+      role !== "tool" &&
+      explicitId !== undefined &&
+      !hasToolCalls &&
+      (content === undefined || typeof content === "string")
 
     if (role === "tool") {
       const id = resolvePendingToolCallId(explicitId, msgFields?.get("name"), pendingToolCalls)
       if (id) msg.tool_call_id = id
+      msg.content = content ?? ""
       messages.push(msg)
     } else if (extractAsToolResult) {
-      const toolMsg: ReassembledMessage = { role: "tool", content }
+      const toolMsg: ReassembledMessage = { role: "tool", content: content ?? "" }
       const id = resolvePendingToolCallId(explicitId, msgFields?.get("name"), pendingToolCalls)
       if (id) toolMsg.tool_call_id = id
       messages.push(toolMsg)


### PR DESCRIPTION
## Problem

Found OpenInference chats that had issues (`llm.input_messages.{i}.message.*`), and the conversation was full of turns shaped like this:

```
llm.input_messages.444.message.role = "assistant"
llm.input_messages.444.message.contents.0.message_content.type = "reasoning"
llm.input_messages.444.message.contents.0.message_content.encrypted_content = "gAAAAABqfn9x…"
```

These are OpenAI reasoning items. The payload is in `encrypted_content` — a field `collectContentPartField` never read, since it only handles `.type`, `.text`, and `.image.image.url`.

`buildMessageContent` then collapsed every non-image part to `{ type: "text", text: part.text ?? "" }`, so each reasoning item became an **empty text part** and the conversation view drew an empty bubble. With a reasoning model that is one empty bubble per assistant turn, which buried the turns that did have content.

Two adjacent cases had the same cause: a plain `content: ""` message also produced an empty bubble, and an assistant turn with tool calls carried a spurious empty text part alongside them.

## Fix

- **Drop parts with no renderable payload** instead of emitting empty text (`flatMap` rather than `map`), and drop a message left with nothing at all — it has nothing to show, and keeping it is what produced the bubble.
- **Emit a real reasoning part** when a reasoning item does carry summary text. Built with the GenAI `content` key: rosetta-ai passes reasoning parts through verbatim, and `part.tsx` reads `content`, so a `text` key would survive translation and then render blank — swapping one invisible-part bug for another.
- **Preserve tool calls** on turns whose only content part was encrypted reasoning, and preserve the Gemini tool-result extraction path for empty tool results.

Encrypted reasoning can never be displayed, so the correct outcome is those turns disappearing rather than rendering hollow.

## Behavior change

Three existing tests asserted the empty-text-part behavior directly and were rewritten to the new contract, keeping their original intent:

| Test | Before | After |
|---|---|---|
| role-only message | `parts: [{type:"text", content:""}]` | dropped |
| index gap between messages | placeholder empty message | gap closed |
| image part with no url | empty text part | part dropped (still no `uri` part) |

## Verification

- 4 new tests in a `reasoning parts` block, using the attribute shapes from the customer's actual span
- `@domain/spans`: 2156 tests pass, typecheck clean

## Scope

This does not touch the Hermes telemetry plugin — the plugin emits `gen_ai.*` and its traces render correctly. These spans come from a separate OpenInference exporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation rendering by omitting empty or whitespace-only messages.
  * Removed image content without valid URLs and messages containing only invalid images.
  * Prevented placeholder messages when message indices are missing.
  * Preserved readable reasoning while hiding encrypted-only reasoning content.
  * Kept associated tool calls visible even when reasoning content is unavailable.
  * Improved handling of tool results with missing content while maintaining tool-call pairing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->