### PR TITLE
fix(sessions): count all scores in session indicators

### DIFF
--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -272,6 +272,12 @@ export const listAnnotationsBySession = createServerFn({ method: "POST" })
     return toListResult(result)
   })
 
+/**
+ * Positive/negative score counts per trace for the traces and sessions
+ * Indicators column. Counts every score source (annotation, evaluation,
+ * custom). The public API's `positiveAnnotationCount` still uses the
+ * annotation-only repository filter.
+ */
 export const listAnnotationCountsByTraceIds = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({

--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -272,12 +272,7 @@ export const listAnnotationsBySession = createServerFn({ method: "POST" })
     return toListResult(result)
   })
 
-/**
- * Positive/negative score counts per trace for the traces and sessions
- * Indicators column. Counts every score source (annotation, evaluation,
- * custom). The public API's `positiveAnnotationCount` still uses the
- * annotation-only repository filter.
- */
+/** Positive/negative score counts per trace for Indicators; includes every source. */
 export const listAnnotationCountsByTraceIds = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({

--- a/apps/web/src/domains/scores/scores.functions.ts
+++ b/apps/web/src/domains/scores/scores.functions.ts
@@ -28,7 +28,6 @@ export interface ScoreRecord {
   readonly sourceId: string
   readonly simulationId: string | null
   readonly signalId: string | null
-  readonly evaluationName: string | null
   readonly evaluationSignalId: string | null
   readonly value: number
   readonly passed: boolean
@@ -47,7 +46,6 @@ export interface ScoreRecord {
 }
 
 interface EvaluationLookup {
-  readonly name: string
   readonly signalId: string
 }
 
@@ -62,7 +60,6 @@ const toRecord = (score: Score, evaluation: EvaluationLookup | undefined): Score
   sourceId: score.sourceId,
   simulationId: score.simulationId ? (score.simulationId as string) : null,
   signalId: score.signalId ? (score.signalId as string) : null,
-  evaluationName: score.sourceType === "evaluation" ? (evaluation?.name ?? null) : null,
   evaluationSignalId: score.sourceType === "evaluation" ? (evaluation?.signalId ?? null) : null,
   value: score.value,
   passed: score.passed,
@@ -95,7 +92,7 @@ const loadEvaluationsById = (sourceIds: readonly string[]) =>
     const byId = new Map<string, EvaluationLookup>()
     for (const evaluation of found) {
       if (!evaluation) continue
-      byId.set(evaluation.id as string, { name: evaluation.name, signalId: evaluation.signalId })
+      byId.set(evaluation.id as string, { signalId: evaluation.signalId })
     }
     return byId
   })

--- a/apps/web/src/domains/scores/scores.functions.ts
+++ b/apps/web/src/domains/scores/scores.functions.ts
@@ -108,7 +108,7 @@ const toListResult = (page: ScoreListPage, evaluationsById: ReadonlyMap<string, 
 
 const scoresWithEvaluationsLayer = Layer.mergeAll(ScoreRepositoryLive, EvaluationRepositoryLive)
 
-const withEvaluationNames = (page: ScoreListPage) =>
+const withEvaluationSignals = (page: ScoreListPage) =>
   Effect.gen(function* () {
     const evaluationsById = yield* loadEvaluationsById(
       page.items.filter((score) => score.sourceType === "evaluation").map((score) => score.sourceId),
@@ -140,7 +140,7 @@ export const listScoresByTrace = createServerFn({ method: "GET" })
         offset: data.offset,
         draftMode: data.draftMode ?? "include",
       }).pipe(
-        Effect.flatMap(withEvaluationNames),
+        Effect.flatMap(withEvaluationSignals),
         withScopedPostgres(scoresWithEvaluationsLayer, client, organizationId),
         withTracing,
       ),
@@ -179,7 +179,7 @@ export const listScoresBySession = createServerFn({ method: "POST" })
         offset: data.offset,
         draftMode: data.draftMode ?? "include",
       }).pipe(
-        Effect.flatMap(withEvaluationNames),
+        Effect.flatMap(withEvaluationSignals),
         withScopedPostgres(scoresWithEvaluationsLayer, client, organizationId),
         withTracing,
       ),

--- a/apps/web/src/domains/scores/scores.functions.ts
+++ b/apps/web/src/domains/scores/scores.functions.ts
@@ -1,9 +1,11 @@
-import { EvaluationRepository } from "@domain/evaluations"
+import {
+  attachEvaluationParentSignalsUseCase,
+  type ScoreListPageWithEvaluationSignals,
+  type ScoreWithEvaluationSignal,
+} from "@domain/evaluations"
 import {
   listScoresByTraceIdsUseCase,
   listTraceScoresUseCase,
-  type Score,
-  type ScoreListPage,
   type ScoreSourceType,
   scoreDraftModeSchema,
 } from "@domain/scores"
@@ -45,11 +47,7 @@ export interface ScoreRecord {
   readonly updatedAt: string
 }
 
-interface EvaluationLookup {
-  readonly signalId: string
-}
-
-const toRecord = (score: Score, evaluation: EvaluationLookup | undefined): ScoreRecord => ({
+const toRecord = (score: ScoreWithEvaluationSignal): ScoreRecord => ({
   id: score.id as string,
   organizationId: score.organizationId as string,
   projectId: score.projectId as string,
@@ -60,7 +58,7 @@ const toRecord = (score: Score, evaluation: EvaluationLookup | undefined): Score
   sourceId: score.sourceId,
   simulationId: score.simulationId ? (score.simulationId as string) : null,
   signalId: score.signalId ? (score.signalId as string) : null,
-  evaluationSignalId: score.sourceType === "evaluation" ? (evaluation?.signalId ?? null) : null,
+  evaluationSignalId: score.evaluationSignalId,
   value: score.value,
   passed: score.passed,
   feedback: score.feedback,
@@ -77,44 +75,14 @@ const toRecord = (score: Score, evaluation: EvaluationLookup | undefined): Score
   updatedAt: score.updatedAt.toISOString(),
 })
 
-const loadEvaluationsById = (sourceIds: readonly string[]) =>
-  Effect.gen(function* () {
-    const uniqueIds = [...new Set(sourceIds)]
-    if (uniqueIds.length === 0) return new Map<string, EvaluationLookup>()
-
-    const evaluationRepository = yield* EvaluationRepository
-    const found = yield* Effect.forEach(
-      uniqueIds,
-      (id) => evaluationRepository.findById(id).pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null))),
-      { concurrency: 8 },
-    )
-
-    const byId = new Map<string, EvaluationLookup>()
-    for (const evaluation of found) {
-      if (!evaluation) continue
-      byId.set(evaluation.id as string, { signalId: evaluation.signalId })
-    }
-    return byId
-  })
-
-const toListResult = (page: ScoreListPage, evaluationsById: ReadonlyMap<string, EvaluationLookup>) => ({
-  items: page.items.map((score) =>
-    toRecord(score, score.sourceType === "evaluation" ? evaluationsById.get(score.sourceId) : undefined),
-  ),
+const toListResult = (page: ScoreListPageWithEvaluationSignals) => ({
+  items: page.items.map(toRecord),
   hasMore: page.hasMore,
   limit: page.limit,
   offset: page.offset,
 })
 
 const scoresWithEvaluationsLayer = Layer.mergeAll(ScoreRepositoryLive, EvaluationRepositoryLive)
-
-const withEvaluationSignals = (page: ScoreListPage) =>
-  Effect.gen(function* () {
-    const evaluationsById = yield* loadEvaluationsById(
-      page.items.filter((score) => score.sourceType === "evaluation").map((score) => score.sourceId),
-    )
-    return toListResult(page, evaluationsById)
-  })
 
 type ScoreListResult = ReturnType<typeof toListResult>
 
@@ -140,7 +108,8 @@ export const listScoresByTrace = createServerFn({ method: "GET" })
         offset: data.offset,
         draftMode: data.draftMode ?? "include",
       }).pipe(
-        Effect.flatMap(withEvaluationSignals),
+        Effect.flatMap(attachEvaluationParentSignalsUseCase),
+        Effect.map(toListResult),
         withScopedPostgres(scoresWithEvaluationsLayer, client, organizationId),
         withTracing,
       ),
@@ -179,7 +148,8 @@ export const listScoresBySession = createServerFn({ method: "POST" })
         offset: data.offset,
         draftMode: data.draftMode ?? "include",
       }).pipe(
-        Effect.flatMap(withEvaluationSignals),
+        Effect.flatMap(attachEvaluationParentSignalsUseCase),
+        Effect.map(toListResult),
         withScopedPostgres(scoresWithEvaluationsLayer, client, organizationId),
         withTracing,
       ),

--- a/apps/web/src/domains/scores/scores.functions.ts
+++ b/apps/web/src/domains/scores/scores.functions.ts
@@ -1,3 +1,4 @@
+import { EvaluationRepository } from "@domain/evaluations"
 import {
   listScoresByTraceIdsUseCase,
   listTraceScoresUseCase,
@@ -6,10 +7,10 @@ import {
   type ScoreSourceType,
   scoreDraftModeSchema,
 } from "@domain/scores"
-import { ScoreRepositoryLive } from "@platform/db-postgres"
+import { EvaluationRepositoryLive, ScoreRepositoryLive } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 import { z } from "zod"
 import { getPostgresClient } from "../../server/clients.ts"
 import { traceIdSchema } from "../../server/id-validation.ts"
@@ -27,6 +28,8 @@ export interface ScoreRecord {
   readonly sourceId: string
   readonly simulationId: string | null
   readonly signalId: string | null
+  readonly evaluationName: string | null
+  readonly evaluationSignalId: string | null
   readonly value: number
   readonly passed: boolean
   readonly feedback: string
@@ -43,7 +46,12 @@ export interface ScoreRecord {
   readonly updatedAt: string
 }
 
-const toRecord = (score: Score): ScoreRecord => ({
+interface EvaluationLookup {
+  readonly name: string
+  readonly signalId: string
+}
+
+const toRecord = (score: Score, evaluation: EvaluationLookup | undefined): ScoreRecord => ({
   id: score.id as string,
   organizationId: score.organizationId as string,
   projectId: score.projectId as string,
@@ -54,6 +62,8 @@ const toRecord = (score: Score): ScoreRecord => ({
   sourceId: score.sourceId,
   simulationId: score.simulationId ? (score.simulationId as string) : null,
   signalId: score.signalId ? (score.signalId as string) : null,
+  evaluationName: score.sourceType === "evaluation" ? (evaluation?.name ?? null) : null,
+  evaluationSignalId: score.sourceType === "evaluation" ? (evaluation?.signalId ?? null) : null,
   value: score.value,
   passed: score.passed,
   feedback: score.feedback,
@@ -70,12 +80,44 @@ const toRecord = (score: Score): ScoreRecord => ({
   updatedAt: score.updatedAt.toISOString(),
 })
 
-const toListResult = (page: ScoreListPage) => ({
-  items: page.items.map(toRecord),
+const loadEvaluationsById = (sourceIds: readonly string[]) =>
+  Effect.gen(function* () {
+    const uniqueIds = [...new Set(sourceIds)]
+    if (uniqueIds.length === 0) return new Map<string, EvaluationLookup>()
+
+    const evaluationRepository = yield* EvaluationRepository
+    const found = yield* Effect.forEach(
+      uniqueIds,
+      (id) => evaluationRepository.findById(id).pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null))),
+      { concurrency: 8 },
+    )
+
+    const byId = new Map<string, EvaluationLookup>()
+    for (const evaluation of found) {
+      if (!evaluation) continue
+      byId.set(evaluation.id as string, { name: evaluation.name, signalId: evaluation.signalId })
+    }
+    return byId
+  })
+
+const toListResult = (page: ScoreListPage, evaluationsById: ReadonlyMap<string, EvaluationLookup>) => ({
+  items: page.items.map((score) =>
+    toRecord(score, score.sourceType === "evaluation" ? evaluationsById.get(score.sourceId) : undefined),
+  ),
   hasMore: page.hasMore,
   limit: page.limit,
   offset: page.offset,
 })
+
+const scoresWithEvaluationsLayer = Layer.mergeAll(ScoreRepositoryLive, EvaluationRepositoryLive)
+
+const withEvaluationNames = (page: ScoreListPage) =>
+  Effect.gen(function* () {
+    const evaluationsById = yield* loadEvaluationsById(
+      page.items.filter((score) => score.sourceType === "evaluation").map((score) => score.sourceId),
+    )
+    return toListResult(page, evaluationsById)
+  })
 
 type ScoreListResult = ReturnType<typeof toListResult>
 
@@ -93,17 +135,19 @@ export const listScoresByTrace = createServerFn({ method: "GET" })
     const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
 
-    const result = await Effect.runPromise(
+    return await Effect.runPromise(
       listTraceScoresUseCase({
         projectId: data.projectId,
         traceId: data.traceId,
         limit: data.limit,
         offset: data.offset,
         draftMode: data.draftMode ?? "include",
-      }).pipe(withScopedPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
+      }).pipe(
+        Effect.flatMap(withEvaluationNames),
+        withScopedPostgres(scoresWithEvaluationsLayer, client, organizationId),
+        withTracing,
+      ),
     )
-
-    return toListResult(result)
   })
 
 /**
@@ -130,15 +174,17 @@ export const listScoresBySession = createServerFn({ method: "POST" })
     const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
 
-    const result = await Effect.runPromise(
+    return await Effect.runPromise(
       listScoresByTraceIdsUseCase({
         projectId: data.projectId,
         traceIds: data.traceIds,
         limit: data.limit,
         offset: data.offset,
         draftMode: data.draftMode ?? "include",
-      }).pipe(withScopedPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
+      }).pipe(
+        Effect.flatMap(withEvaluationNames),
+        withScopedPostgres(scoresWithEvaluationsLayer, client, organizationId),
+        withTracing,
+      ),
     )
-
-    return toListResult(result)
   })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
@@ -2,22 +2,12 @@ import { describe, expect, it } from "vitest"
 import { scoreCardEvaluationVerdict, scoreCardLinkedSignalId, scoreCardSourceTitle } from "./score-card-display.ts"
 
 describe("scoreCardSourceTitle", () => {
-  it("uses the evaluation name when present", () => {
-    expect(
-      scoreCardSourceTitle({
-        source: "evaluation",
-        sourceId: "eval-id",
-        evaluationName: "Incompletion detector",
-      }),
-    ).toBe("Incompletion detector")
-  })
-
-  it("falls back to the source id when the evaluation name is missing", () => {
-    expect(scoreCardSourceTitle({ source: "evaluation", sourceId: "eval-id", evaluationName: null })).toBe("eval-id")
+  it("does not surface evaluation identity", () => {
+    expect(scoreCardSourceTitle({ source: "evaluation", sourceId: "eval-id" })).toBeNull()
   })
 
   it("keeps custom source ids as the title", () => {
-    expect(scoreCardSourceTitle({ source: "custom", sourceId: "api-source", evaluationName: null })).toBe("api-source")
+    expect(scoreCardSourceTitle({ source: "custom", sourceId: "api-source" })).toBe("api-source")
   })
 })
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
@@ -12,12 +12,12 @@ describe("scoreCardSourceTitle", () => {
 })
 
 describe("scoreCardLinkedSignalId", () => {
-  it("prefers the occurrence signal id", () => {
-    expect(scoreCardLinkedSignalId({ signalId: "occurrence", evaluationSignalId: "detector" })).toBe("occurrence")
+  it("always uses the evaluation's parent signal when present", () => {
+    expect(scoreCardLinkedSignalId({ signalId: "occurrence", evaluationSignalId: "detector" })).toBe("detector")
   })
 
-  it("falls back to the evaluation's parent signal for absent runs", () => {
-    expect(scoreCardLinkedSignalId({ signalId: null, evaluationSignalId: "detector" })).toBe("detector")
+  it("falls back to a stamped signal id when the evaluation has no parent", () => {
+    expect(scoreCardLinkedSignalId({ signalId: "stamped", evaluationSignalId: null })).toBe("stamped")
   })
 })
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+import { scoreCardEvaluationVerdict, scoreCardLinkedSignalId, scoreCardSourceTitle } from "./score-card-display.ts"
+
+describe("scoreCardSourceTitle", () => {
+  it("uses the evaluation name when present", () => {
+    expect(
+      scoreCardSourceTitle({
+        source: "evaluation",
+        sourceId: "eval-id",
+        evaluationName: "Incompletion detector",
+      }),
+    ).toBe("Incompletion detector")
+  })
+
+  it("falls back to the source id when the evaluation name is missing", () => {
+    expect(scoreCardSourceTitle({ source: "evaluation", sourceId: "eval-id", evaluationName: null })).toBe("eval-id")
+  })
+
+  it("keeps custom source ids as the title", () => {
+    expect(scoreCardSourceTitle({ source: "custom", sourceId: "api-source", evaluationName: null })).toBe("api-source")
+  })
+})
+
+describe("scoreCardLinkedSignalId", () => {
+  it("prefers the occurrence signal id", () => {
+    expect(scoreCardLinkedSignalId({ signalId: "occurrence", evaluationSignalId: "detector" })).toBe("occurrence")
+  })
+
+  it("falls back to the evaluation's parent signal for absent runs", () => {
+    expect(scoreCardLinkedSignalId({ signalId: null, evaluationSignalId: "detector" })).toBe("detector")
+  })
+})
+
+describe("scoreCardEvaluationVerdict", () => {
+  it("labels a passing evaluation as Present", () => {
+    expect(scoreCardEvaluationVerdict({ source: "evaluation", errored: false, passed: true })).toBe("Present")
+  })
+
+  it("labels a failing evaluation as Absent", () => {
+    expect(scoreCardEvaluationVerdict({ source: "evaluation", errored: false, passed: false })).toBe("Absent")
+  })
+
+  it("hides the verdict for errored evaluations and other sources", () => {
+    expect(scoreCardEvaluationVerdict({ source: "evaluation", errored: true, passed: false })).toBeNull()
+    expect(scoreCardEvaluationVerdict({ source: "annotation", errored: false, passed: false })).toBeNull()
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
@@ -1,0 +1,23 @@
+export function scoreCardSourceTitle(score: {
+  readonly source: string
+  readonly sourceId: string
+  readonly evaluationName: string | null
+}): string {
+  return score.source === "evaluation" ? (score.evaluationName ?? score.sourceId) : score.sourceId
+}
+
+export function scoreCardLinkedSignalId(score: {
+  readonly signalId: string | null
+  readonly evaluationSignalId: string | null
+}): string | null {
+  return score.signalId ?? score.evaluationSignalId
+}
+
+export function scoreCardEvaluationVerdict(score: {
+  readonly source: string
+  readonly errored: boolean
+  readonly passed: boolean
+}): "Present" | "Absent" | null {
+  if (score.source !== "evaluation" || score.errored) return null
+  return score.passed ? "Present" : "Absent"
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
@@ -1,9 +1,9 @@
 export function scoreCardSourceTitle(score: {
   readonly source: string
   readonly sourceId: string
-  readonly evaluationName: string | null
-}): string {
-  return score.source === "evaluation" ? (score.evaluationName ?? score.sourceId) : score.sourceId
+}): string | null {
+  if (score.source === "evaluation") return null
+  return score.sourceId
 }
 
 export function scoreCardLinkedSignalId(score: {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
@@ -1,7 +1,4 @@
-export function scoreCardSourceTitle(score: {
-  readonly source: string
-  readonly sourceId: string
-}): string | null {
+export function scoreCardSourceTitle(score: { readonly source: string; readonly sourceId: string }): string | null {
   if (score.source === "evaluation") return null
   return score.sourceId
 }
@@ -10,7 +7,7 @@ export function scoreCardLinkedSignalId(score: {
   readonly signalId: string | null
   readonly evaluationSignalId: string | null
 }): string | null {
-  return score.signalId ?? score.evaluationSignalId
+  return score.evaluationSignalId ?? score.signalId
 }
 
 export function scoreCardEvaluationVerdict(score: {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
@@ -31,7 +31,7 @@ function ScoreSignalLink({
   readonly slug: string | null
   readonly description: string | undefined
 }) {
-  const label = name ?? "Signal"
+  const label = name ?? slug ?? signalId
   const signalSlug = slug ?? signalId
   const isNavigable = Boolean(projectSlug && signalSlug)
   const badge = (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
@@ -5,6 +5,7 @@ import { Link, useParams } from "@tanstack/react-router"
 import { AlertCircleIcon, ShieldAlertIcon, ThumbsDownIcon, ThumbsUpIcon } from "lucide-react"
 import type { ScoreRecord } from "../../../../../../domains/scores/scores.functions.ts"
 import { useSignal } from "../../../../../../domains/signals/signals.collection.ts"
+import { scoreCardEvaluationVerdict, scoreCardLinkedSignalId, scoreCardSourceTitle } from "./score-card-display.ts"
 
 const SOURCE_LABELS: Record<ScoreSourceType, string> = {
   annotation: "Annotation",
@@ -19,17 +20,21 @@ interface ScoreCardProps {
 
 export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
   const { projectSlug } = useParams({ strict: false })
+  const linkedSignalId = scoreCardLinkedSignalId(score)
+  const isOccurrence = score.signalId !== null
   const { data: linkedSignal } = useSignal({
     projectId,
-    signalId: score.signalId ?? "",
-    enabled: score.signalId !== null,
+    signalId: linkedSignalId ?? "",
+    enabled: linkedSignalId !== null,
   })
 
   const linkedSignalName = linkedSignal?.name ?? null
   const linkedSignalSlug = linkedSignal?.slug ?? null
   const linkedSignalDescription = linkedSignal?.description?.trim()
   const sourceLabel = SOURCE_LABELS[score.source]
+  const sourceTitle = scoreCardSourceTitle(score)
   const feedback = score.feedback?.trim()
+  const evaluationVerdict = scoreCardEvaluationVerdict(score)
 
   return (
     <div data-score-card-id={score.id} tabIndex={-1} className="flex flex-col gap-1 m-1 p-1 rounded-lg outline-none">
@@ -38,8 +43,13 @@ export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
           {sourceLabel}
         </Badge>
         <Text.H6 color="foregroundMuted" className="truncate">
-          {score.sourceId}
+          {sourceTitle}
         </Text.H6>
+        {evaluationVerdict ? (
+          <Badge variant="secondary" size="small">
+            {evaluationVerdict}
+          </Badge>
+        ) : null}
         <Text.H6 color="foregroundMuted">{relativeTime(new Date(score.createdAt))}</Text.H6>
         <div className="ml-auto flex items-center gap-x-1">
           {score.errored ? (
@@ -72,7 +82,7 @@ export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
       {linkedSignalName ? (
         <div className="flex items-center gap-2 pt-1">
           {(() => {
-            const isNavigable = Boolean(projectSlug && score.signalId)
+            const isNavigable = Boolean(projectSlug && linkedSignalId)
             const badge = (
               <Badge
                 variant="outline"
@@ -104,9 +114,12 @@ export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
               ) : (
                 badge
               )
-            return linkedSignalDescription ? (
+            const tooltip = isOccurrence
+              ? linkedSignalDescription
+              : `This evaluation monitors ${linkedSignalName}. This run did not record an occurrence.`
+            return tooltip ? (
               <Tooltip asChild trigger={trigger}>
-                <span className="block max-w-xs whitespace-pre-wrap text-left">{linkedSignalDescription}</span>
+                <span className="block max-w-xs whitespace-pre-wrap text-left">{tooltip}</span>
               </Tooltip>
             ) : (
               trigger

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
@@ -27,11 +27,13 @@ function ScoreSignalLink({
 }: {
   readonly projectSlug: string | undefined
   readonly signalId: string
-  readonly name: string
+  readonly name: string | null
   readonly slug: string | null
   readonly description: string | undefined
 }) {
-  const isNavigable = Boolean(projectSlug && signalId)
+  const label = name ?? "Signal"
+  const signalSlug = slug ?? signalId
+  const isNavigable = Boolean(projectSlug && signalSlug)
   const badge = (
     <Badge
       variant="outline"
@@ -45,16 +47,16 @@ function ScoreSignalLink({
         className: "stroke-[2.5]",
       }}
     >
-      {name}
+      {label}
     </Badge>
   )
   const trigger =
-    projectSlug && slug ? (
+    projectSlug && signalSlug ? (
       <Link
         data-no-navigate
         to="/projects/$projectSlug/signals/$signalSlug"
-        params={{ projectSlug, signalSlug: slug }}
-        aria-label={`Open signal ${name}`}
+        params={{ projectSlug, signalSlug }}
+        aria-label={`Open signal ${label}`}
         onClick={(event) => event.stopPropagation()}
         className="inline-flex min-w-0"
       >
@@ -88,16 +90,15 @@ export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
   const sourceTitle = scoreCardSourceTitle(score)
   const feedback = score.feedback?.trim()
   const evaluationVerdict = scoreCardEvaluationVerdict(score)
-  const signalLink =
-    linkedSignalId && linkedSignalName ? (
-      <ScoreSignalLink
-        projectSlug={projectSlug}
-        signalId={linkedSignalId}
-        name={linkedSignalName}
-        slug={linkedSignalSlug}
-        description={linkedSignalDescription}
-      />
-    ) : null
+  const signalLink = linkedSignalId ? (
+    <ScoreSignalLink
+      projectSlug={projectSlug}
+      signalId={linkedSignalId}
+      name={linkedSignalName}
+      slug={linkedSignalSlug}
+      description={linkedSignalDescription}
+    />
+  ) : null
 
   return (
     <div data-score-card-id={score.id} tabIndex={-1} className="flex flex-col gap-1 m-1 p-1 rounded-lg outline-none">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
@@ -18,10 +18,63 @@ interface ScoreCardProps {
   readonly projectId: string
 }
 
+function ScoreSignalLink({
+  projectSlug,
+  signalId,
+  name,
+  slug,
+  description,
+}: {
+  readonly projectSlug: string | undefined
+  readonly signalId: string
+  readonly name: string
+  readonly slug: string | null
+  readonly description: string | undefined
+}) {
+  const isNavigable = Boolean(projectSlug && signalId)
+  const badge = (
+    <Badge
+      variant="outline"
+      size="small"
+      ellipsis
+      {...(isNavigable ? { className: "cursor-pointer hover:bg-muted" } : {})}
+      iconProps={{
+        icon: ShieldAlertIcon,
+        color: "foregroundMuted",
+        placement: "start",
+        className: "stroke-[2.5]",
+      }}
+    >
+      {name}
+    </Badge>
+  )
+  const trigger =
+    projectSlug && slug ? (
+      <Link
+        data-no-navigate
+        to="/projects/$projectSlug/signals/$signalSlug"
+        params={{ projectSlug, signalSlug: slug }}
+        aria-label={`Open signal ${name}`}
+        onClick={(event) => event.stopPropagation()}
+        className="inline-flex min-w-0"
+      >
+        {badge}
+      </Link>
+    ) : (
+      badge
+    )
+
+  if (!description) return trigger
+  return (
+    <Tooltip asChild trigger={trigger}>
+      <span className="block max-w-xs whitespace-pre-wrap text-left">{description}</span>
+    </Tooltip>
+  )
+}
+
 export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
   const { projectSlug } = useParams({ strict: false })
   const linkedSignalId = scoreCardLinkedSignalId(score)
-  const isOccurrence = score.signalId !== null
   const { data: linkedSignal } = useSignal({
     projectId,
     signalId: linkedSignalId ?? "",
@@ -35,6 +88,16 @@ export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
   const sourceTitle = scoreCardSourceTitle(score)
   const feedback = score.feedback?.trim()
   const evaluationVerdict = scoreCardEvaluationVerdict(score)
+  const signalLink =
+    linkedSignalId && linkedSignalName ? (
+      <ScoreSignalLink
+        projectSlug={projectSlug}
+        signalId={linkedSignalId}
+        name={linkedSignalName}
+        slug={linkedSignalSlug}
+        description={linkedSignalDescription}
+      />
+    ) : null
 
   return (
     <div data-score-card-id={score.id} tabIndex={-1} className="flex flex-col gap-1 m-1 p-1 rounded-lg outline-none">
@@ -42,9 +105,12 @@ export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
         <Badge variant="outline" size="small">
           {sourceLabel}
         </Badge>
-        <Text.H6 color="foregroundMuted" className="truncate">
-          {sourceTitle}
-        </Text.H6>
+        {score.source === "evaluation" ? signalLink : null}
+        {sourceTitle ? (
+          <Text.H6 color="foregroundMuted" className="truncate">
+            {sourceTitle}
+          </Text.H6>
+        ) : null}
         {evaluationVerdict ? (
           <Badge variant="secondary" size="small">
             {evaluationVerdict}
@@ -79,53 +145,8 @@ export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
 
       {feedback ? <Text.H5 className="whitespace-pre-wrap">{feedback}</Text.H5> : null}
 
-      {linkedSignalName ? (
-        <div className="flex items-center gap-2 pt-1">
-          {(() => {
-            const isNavigable = Boolean(projectSlug && linkedSignalId)
-            const badge = (
-              <Badge
-                variant="outline"
-                size="small"
-                ellipsis
-                {...(isNavigable ? { className: "cursor-pointer hover:bg-muted" } : {})}
-                iconProps={{
-                  icon: ShieldAlertIcon,
-                  color: "foregroundMuted",
-                  placement: "start",
-                  className: "stroke-[2.5]",
-                }}
-              >
-                {linkedSignalName}
-              </Badge>
-            )
-            const trigger =
-              projectSlug && linkedSignalSlug ? (
-                <Link
-                  data-no-navigate
-                  to="/projects/$projectSlug/signals/$signalSlug"
-                  params={{ projectSlug, signalSlug: linkedSignalSlug }}
-                  aria-label={`Open signal ${linkedSignalName}`}
-                  onClick={(event) => event.stopPropagation()}
-                  className="inline-flex min-w-0"
-                >
-                  {badge}
-                </Link>
-              ) : (
-                badge
-              )
-            const tooltip = isOccurrence
-              ? linkedSignalDescription
-              : `This evaluation monitors ${linkedSignalName}. This run did not record an occurrence.`
-            return tooltip ? (
-              <Tooltip asChild trigger={trigger}>
-                <span className="block max-w-xs whitespace-pre-wrap text-left">{tooltip}</span>
-              </Tooltip>
-            ) : (
-              trigger
-            )
-          })()}
-        </div>
+      {score.source !== "evaluation" && signalLink ? (
+        <div className="flex items-center gap-2 pt-1">{signalLink}</div>
       ) : null}
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -14,7 +14,7 @@ import { formatCount, formatDuration, formatPercentage, relativeTime } from "@re
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { useQueries } from "@tanstack/react-query"
 import { ChevronsDownUpIcon, ChevronsUpDownIcon } from "lucide-react"
-import { type ReactNode, useCallback, useMemo, useState } from "react"
+import { type MouseEvent, type ReactNode, useCallback, useMemo, useState } from "react"
 import { useAnnotationCountsByTraceIds } from "../../../../../domains/annotations/annotations.collection.ts"
 import { sandboxOrgIdForScope, useProjectScope } from "../../../../../domains/projects/project-scope.tsx"
 import {
@@ -330,10 +330,11 @@ export function SessionsView({
     return "No sessions found"
   }, [hasOrphanFragmentSessions, hasUserAppliedFilters, onShowAllSessions, searchQuery])
 
-  // Fetch annotation counts for every trace that could show in the visible
+  // Fetch score counts for every trace that could show in the visible
   // session rows (trace_ids on each session) so the Indicators column can
-  // surface positive / negative annotation badges. For multi-trace sessions
-  // the badge totals are the sum across the session's traces.
+  // surface positive / negative score badges (annotations, evaluations,
+  // custom). For multi-trace sessions the badge totals are the sum across
+  // the session's traces.
   const sessionRelevantTraceIds = useMemo(() => {
     const set = new Set<string>()
     for (const s of sessions) {
@@ -376,6 +377,23 @@ export function SessionsView({
     [annotationCountsPendingTraceIds],
   )
 
+  const [activeTraceTab, setActiveTraceTab] = useParamState("traceTab", "trace")
+  const [activeSessionTab, setActiveSessionTab] = useParamState("sessionTab", "session")
+
+  const openScoresForRow = useCallback(
+    (row: SessionTableRow, event: MouseEvent) => {
+      event.stopPropagation()
+      if (row.kind === "session") {
+        onOpenSession(row.session.sessionId)
+        setActiveSessionTab("scores")
+        return
+      }
+      onOpenSession(row.trace.sessionId, row.trace.traceId)
+      setActiveTraceTab("scores")
+    },
+    [onOpenSession, setActiveSessionTab, setActiveTraceTab],
+  )
+
   const allColumns = useMemo((): InfiniteTableColumn<SessionTableRow>[] => {
     return [
       {
@@ -392,6 +410,11 @@ export function SessionsView({
             errorCount={field(row, "errorCount")}
             annotationCounts={getRowAnnotationCounts(row)}
             annotationCountsPending={isRowAnnotationCountsPending(row)}
+            {...(annotationsEnabled
+              ? {
+                  onAnnotationClick: (event: MouseEvent) => openScoresForRow(row, event),
+                }
+              : {})}
           />
         ),
       },
@@ -627,6 +650,8 @@ export function SessionsView({
     isRowAnnotationCountsPending,
     searchMatches,
     isRelevanceSort,
+    annotationsEnabled,
+    openScoresForRow,
   ])
 
   const columns = useMemo(() => {
@@ -721,8 +746,6 @@ export function SessionsView({
   // J/K navigate sessions, except when a spans tree is showing (it takes over
   // J/K, mirroring traces-view): the open trace's spans tab (`traceTab`), or a
   // single-trace session's own spans tab (`sessionTab`) when no trace is open.
-  const [activeTraceTab] = useParamState("traceTab", "trace")
-  const [activeSessionTab] = useParamState("sessionTab", "session")
   const spansTreeActive = activeTraceId
     ? activeTraceTab === "spans"
     : Boolean(activeSessionId) && activeSessionTab === "spans"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -30,7 +30,7 @@ import { ListingLayout as Layout, listingLayoutIntrinsicScroll } from "../../../
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import type { SelectionState } from "../../../../../lib/hooks/useSelectableRows.ts"
 import { FiltersSidebar } from "./filters-sidebar.tsx"
-import { isLargeSession } from "./session-detail-drawer/session-size.ts"
+import { isLargeSession, MAX_SESSION_ANALYSIS_TRACE_COUNT } from "./session-detail-drawer/session-size.ts"
 import { sessionTracePageQueryOptions } from "./session-detail-drawer/use-session-traces.ts"
 import { SessionOutlierBadge } from "./session-outlier-badge.tsx"
 import { SessionsOrphanFragmentsBlankSlate } from "./sessions-orphan-fragments-blank-slate.tsx"
@@ -330,11 +330,6 @@ export function SessionsView({
     return "No sessions found"
   }, [hasOrphanFragmentSessions, hasUserAppliedFilters, onShowAllSessions, searchQuery])
 
-  // Fetch score counts for every trace that could show in the visible
-  // session rows (trace_ids on each session) so the Indicators column can
-  // surface positive / negative score badges (annotations, evaluations,
-  // custom). For multi-trace sessions the badge totals are the sum across
-  // the session's traces.
   const sessionRelevantTraceIds = useMemo(() => {
     const set = new Set<string>()
     for (const s of sessions) {
@@ -410,7 +405,8 @@ export function SessionsView({
             errorCount={field(row, "errorCount")}
             annotationCounts={getRowAnnotationCounts(row)}
             annotationCountsPending={isRowAnnotationCountsPending(row)}
-            {...(annotationsEnabled
+            {...(annotationsEnabled &&
+            (row.kind === "trace" || row.session.traceIds.length <= MAX_SESSION_ANALYSIS_TRACE_COUNT)
               ? {
                   onAnnotationClick: (event: MouseEvent) => openScoresForRow(row, event),
                 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/table/indicators-cell.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/table/indicators-cell.tsx
@@ -10,9 +10,8 @@ export interface IndicatorAnnotationCounts {
 
 /**
  * Inline cell that surfaces "needs-attention" signals at the row grain:
- * positive/negative annotations and an error count. Used by both the traces
- * and sessions list — sessions pass `annotationCounts: undefined` because
- * annotation rollups don't exist at the session grain.
+ * positive/negative scores (annotations, evaluations, custom) and an error
+ * count. Used by both the traces and sessions list.
  */
 export function IndicatorsCell({
   errorCount,
@@ -43,12 +42,12 @@ export function IndicatorsCell({
               indicator={<Icon icon={ThumbsUpIcon} size="xs" weight="L" />}
               label={showIconOnly ? "" : formatCount(positiveCount)}
               className={showIconOnly ? "gap-0 px-1.5" : onAnnotationClick ? "cursor-pointer" : undefined}
-              aria-label={`${positiveCount} positive ${positiveCount === 1 ? "annotation" : "annotations"}`}
+              aria-label={`${positiveCount} positive ${positiveCount === 1 ? "score" : "scores"}`}
               onClick={onAnnotationClick}
             />
           }
         >
-          {positiveCount} positive {positiveCount === 1 ? "annotation" : "annotations"}
+          {positiveCount} positive {positiveCount === 1 ? "score" : "scores"}
         </Tooltip>
       ) : null}
       {negativeCount > 0 ? (
@@ -60,12 +59,12 @@ export function IndicatorsCell({
               indicator={<Icon icon={ThumbsDownIcon} size="xs" weight="L" />}
               label={showIconOnly ? "" : formatCount(negativeCount)}
               className={showIconOnly ? "gap-0 px-1.5" : onAnnotationClick ? "cursor-pointer" : undefined}
-              aria-label={`${negativeCount} negative ${negativeCount === 1 ? "annotation" : "annotations"}`}
+              aria-label={`${negativeCount} negative ${negativeCount === 1 ? "score" : "scores"}`}
               onClick={onAnnotationClick}
             />
           }
         >
-          {negativeCount} negative {negativeCount === 1 ? "annotation" : "annotations"}
+          {negativeCount} negative {negativeCount === 1 ? "score" : "scores"}
         </Tooltip>
       ) : null}
       {errorCount > 0 ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/table/indicators-cell.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/table/indicators-cell.tsx
@@ -8,11 +8,7 @@ export interface IndicatorAnnotationCounts {
   readonly negativeCount: number
 }
 
-/**
- * Inline cell that surfaces "needs-attention" signals at the row grain:
- * positive/negative scores (annotations, evaluations, custom) and an error
- * count. Used by both the traces and sessions list.
- */
+/** Row-level positive/negative score and error counts for traces and sessions lists. */
 export function IndicatorsCell({
   errorCount,
   annotationCounts,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -339,7 +339,7 @@ export function TraceDetailBody({
 
   function handleScoreClick(score: ScoreRecord) {
     if (score.source !== "annotation") return
-    const annotation = score as AnnotationRecord
+    const annotation = score as unknown as AnnotationRecord
     if (isGlobalAnnotation(annotation)) return
     scrollToAnnotation(annotation)
   }

--- a/packages/domain/evaluations/src/index.ts
+++ b/packages/domain/evaluations/src/index.ts
@@ -155,11 +155,6 @@ export {
   SIGNAL_PREVIEW_RESULT_TTL_SECONDS,
   type SignalPreviewResult,
 } from "./runtime/signal-preview-result.ts"
-export {
-  attachEvaluationParentSignalsUseCase,
-  type ScoreListPageWithEvaluationSignals,
-  type ScoreWithEvaluationSignal,
-} from "./use-cases/attach-evaluation-parent-signals.ts"
 export { collectAlignmentExamplesUseCase } from "./use-cases/alignment/collect-alignment-examples.ts"
 export { evaluateBaselineDraftUseCase } from "./use-cases/alignment/evaluate-baseline-draft.ts"
 export { evaluateDraftAgainstExamplesUseCase } from "./use-cases/alignment/evaluate-draft-against-examples.ts"
@@ -171,6 +166,11 @@ export {
   loadAlignmentStateOrInactiveUseCase,
 } from "./use-cases/alignment/load-alignment-state-or-inactive.ts"
 export { persistAlignmentResultUseCase } from "./use-cases/alignment/persist-alignment-result.ts"
+export {
+  attachEvaluationParentSignalsUseCase,
+  type ScoreListPageWithEvaluationSignals,
+  type ScoreWithEvaluationSignal,
+} from "./use-cases/attach-evaluation-parent-signals.ts"
 export {
   type CreateEvaluationError,
   type CreateEvaluationInput,

--- a/packages/domain/evaluations/src/index.ts
+++ b/packages/domain/evaluations/src/index.ts
@@ -155,6 +155,11 @@ export {
   SIGNAL_PREVIEW_RESULT_TTL_SECONDS,
   type SignalPreviewResult,
 } from "./runtime/signal-preview-result.ts"
+export {
+  attachEvaluationParentSignalsUseCase,
+  type ScoreListPageWithEvaluationSignals,
+  type ScoreWithEvaluationSignal,
+} from "./use-cases/attach-evaluation-parent-signals.ts"
 export { collectAlignmentExamplesUseCase } from "./use-cases/alignment/collect-alignment-examples.ts"
 export { evaluateBaselineDraftUseCase } from "./use-cases/alignment/evaluate-baseline-draft.ts"
 export { evaluateDraftAgainstExamplesUseCase } from "./use-cases/alignment/evaluate-draft-against-examples.ts"

--- a/packages/domain/evaluations/src/use-cases/attach-evaluation-parent-signals.test.ts
+++ b/packages/domain/evaluations/src/use-cases/attach-evaluation-parent-signals.test.ts
@@ -1,0 +1,198 @@
+import { scoreSchema } from "@domain/scores"
+import {
+  EvaluationId,
+  NotFoundError,
+  OrganizationId,
+  ProjectId,
+  ScoreId,
+  SignalId,
+  SqlClient,
+  TraceId,
+} from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { defaultEvaluationTrigger, type Evaluation, emptyEvaluationAlignment } from "../entities/evaluation.ts"
+import { EvaluationRepository, type EvaluationRepositoryShape } from "../ports/evaluation-repository.ts"
+import { attachEvaluationParentSignalsUseCase } from "./attach-evaluation-parent-signals.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const signalId = SignalId("i".repeat(24))
+const evaluationId = EvaluationId("e".repeat(24))
+const traceId = TraceId("t".repeat(32))
+
+const makeEvaluation = (overrides: Partial<Evaluation> = {}): Evaluation =>
+  ({
+    id: evaluationId,
+    organizationId,
+    projectId,
+    signalId,
+    name: "Eval",
+    description: "Generated description",
+    script: "return { passed: false }",
+    trigger: defaultEvaluationTrigger(),
+    alignment: emptyEvaluationAlignment("hash-1"),
+    alignedAt: new Date("2026-04-01T00:00:00.000Z"),
+    archivedAt: null,
+    deletedAt: null,
+    createdAt: new Date("2026-04-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    ...overrides,
+  }) as Evaluation
+
+const makeScore = (overrides: Record<string, unknown> = {}) =>
+  scoreSchema.parse({
+    id: ScoreId("s".repeat(24)),
+    organizationId: organizationId as string,
+    projectId,
+    sessionId: null,
+    traceId,
+    spanId: null,
+    simulationId: null,
+    signalId: null,
+    sourceType: "custom",
+    sourceId: "api-pipeline",
+    value: 0.2,
+    passed: false,
+    feedback: "Wrong answer",
+    metadata: {},
+    error: null,
+    errored: false,
+    duration: 0,
+    tokens: 0,
+    cost: 0,
+    draftedAt: null,
+    annotatorId: null,
+    createdAt: new Date("2026-03-31T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-31T00:00:00.000Z"),
+    ...overrides,
+  })
+
+const unused = () => Effect.die("Unexpected EvaluationRepository call")
+
+const createEvaluationRepository = (evaluations: readonly Evaluation[]) => {
+  const findByIdCalls: string[] = []
+  const byId = new Map(evaluations.map((evaluation) => [String(evaluation.id), evaluation]))
+  const repository: EvaluationRepositoryShape = {
+    findById: (id) =>
+      Effect.gen(function* () {
+        findByIdCalls.push(id)
+        const evaluation = byId.get(id)
+        if (!evaluation) return yield* new NotFoundError({ entity: "Evaluation", id })
+        return evaluation
+      }),
+    save: unused,
+    listByProjectId: unused,
+    listBySignalId: unused,
+    listBySignalIds: unused,
+    archive: unused,
+    unarchive: unused,
+    softDelete: unused,
+    softDeleteBySignalId: unused,
+  }
+  return { repository, findByIdCalls }
+}
+
+const provide = (repository: EvaluationRepositoryShape) =>
+  Layer.mergeAll(
+    Layer.succeed(EvaluationRepository, repository),
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+  )
+
+describe("attachEvaluationParentSignalsUseCase", () => {
+  it("attaches the evaluation's parent signal to evaluation scores", async () => {
+    const evaluation = makeEvaluation()
+    const score = makeScore({
+      sourceType: "evaluation",
+      sourceId: evaluationId,
+      metadata: { evaluationHash: "hash-1" },
+    })
+    const { repository, findByIdCalls } = createEvaluationRepository([evaluation])
+
+    const page = await Effect.runPromise(
+      attachEvaluationParentSignalsUseCase({
+        items: [score],
+        hasMore: false,
+        limit: 50,
+        offset: 0,
+      }).pipe(Effect.provide(provide(repository))),
+    )
+
+    expect(page.items[0]?.evaluationSignalId).toBe(signalId)
+    expect(findByIdCalls).toEqual([evaluationId])
+  })
+
+  it("leaves evaluationSignalId null when the evaluation is missing", async () => {
+    const score = makeScore({
+      sourceType: "evaluation",
+      sourceId: evaluationId,
+      metadata: { evaluationHash: "hash-1" },
+    })
+    const { repository } = createEvaluationRepository([])
+
+    const page = await Effect.runPromise(
+      attachEvaluationParentSignalsUseCase({
+        items: [score],
+        hasMore: false,
+        limit: 50,
+        offset: 0,
+      }).pipe(Effect.provide(provide(repository))),
+    )
+
+    expect(page.items[0]?.evaluationSignalId).toBeNull()
+  })
+
+  it("does not look up evaluations for annotation or custom scores", async () => {
+    const custom = makeScore()
+    const annotation = makeScore({
+      id: ScoreId("a".repeat(24)),
+      sourceType: "annotation",
+      sourceId: "UI",
+      metadata: { rawFeedback: "note" },
+    })
+    const { repository, findByIdCalls } = createEvaluationRepository([makeEvaluation()])
+
+    const page = await Effect.runPromise(
+      attachEvaluationParentSignalsUseCase({
+        items: [custom, annotation],
+        hasMore: false,
+        limit: 50,
+        offset: 0,
+      }).pipe(Effect.provide(provide(repository))),
+    )
+
+    expect(findByIdCalls).toEqual([])
+    expect(page.items.map((item) => item.evaluationSignalId)).toEqual([null, null])
+  })
+
+  it("looks up each evaluation id once when several scores share it", async () => {
+    const first = makeScore({
+      sourceType: "evaluation",
+      sourceId: evaluationId,
+      metadata: { evaluationHash: "hash-1" },
+    })
+    const second = makeScore({
+      id: ScoreId("b".repeat(24)),
+      sourceType: "evaluation",
+      sourceId: evaluationId,
+      metadata: { evaluationHash: "hash-1" },
+      passed: true,
+      signalId,
+    })
+    const { repository, findByIdCalls } = createEvaluationRepository([makeEvaluation()])
+
+    const page = await Effect.runPromise(
+      attachEvaluationParentSignalsUseCase({
+        items: [first, second],
+        hasMore: true,
+        limit: 50,
+        offset: 0,
+      }).pipe(Effect.provide(provide(repository))),
+    )
+
+    expect(findByIdCalls).toEqual([evaluationId])
+    expect(page.items.map((item) => item.evaluationSignalId)).toEqual([signalId, signalId])
+    expect(page.hasMore).toBe(true)
+  })
+})

--- a/packages/domain/evaluations/src/use-cases/attach-evaluation-parent-signals.ts
+++ b/packages/domain/evaluations/src/use-cases/attach-evaluation-parent-signals.ts
@@ -1,0 +1,59 @@
+import type { Score, ScoreListPage } from "@domain/scores"
+import { Effect } from "effect"
+import { EvaluationRepository } from "../ports/evaluation-repository.ts"
+
+export type ScoreWithEvaluationSignal = Score & {
+  readonly evaluationSignalId: string | null
+}
+
+export type ScoreListPageWithEvaluationSignals = {
+  readonly items: readonly ScoreWithEvaluationSignal[]
+  readonly hasMore: boolean
+  readonly limit: number
+  readonly offset: number
+}
+
+const evaluationIdsForPage = (page: ScoreListPage): readonly string[] => [
+  ...new Set(page.items.filter((score) => score.sourceType === "evaluation").map((score) => score.sourceId)),
+]
+
+const loadParentSignalByEvaluationId = (evaluationIds: readonly string[]) =>
+  Effect.gen(function* () {
+    const signalByEvaluationId = new Map<string, string>()
+    if (evaluationIds.length === 0) return signalByEvaluationId
+
+    const evaluationRepository = yield* EvaluationRepository
+    const found = yield* Effect.forEach(
+      evaluationIds,
+      (id) => evaluationRepository.findById(id).pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null))),
+      { concurrency: 8 },
+    )
+
+    for (const evaluation of found) {
+      if (!evaluation) continue
+      signalByEvaluationId.set(String(evaluation.id), evaluation.signalId)
+    }
+    return signalByEvaluationId
+  })
+
+const withParentSignal =
+  (signalByEvaluationId: ReadonlyMap<string, string>) =>
+  (score: Score): ScoreWithEvaluationSignal => ({
+    ...score,
+    evaluationSignalId: score.sourceType === "evaluation" ? (signalByEvaluationId.get(score.sourceId) ?? null) : null,
+  })
+
+export const attachEvaluationParentSignalsUseCase = Effect.fn("evaluations.attachEvaluationParentSignals")(function* (
+  page: ScoreListPage,
+) {
+  const evaluationIds = evaluationIdsForPage(page)
+  yield* Effect.annotateCurrentSpan("evaluation.count", evaluationIds.length)
+
+  const signalByEvaluationId = yield* loadParentSignalByEvaluationId(evaluationIds)
+  return {
+    items: page.items.map(withParentSignal(signalByEvaluationId)),
+    hasMore: page.hasMore,
+    limit: page.limit,
+    offset: page.offset,
+  } satisfies ScoreListPageWithEvaluationSignals
+})

--- a/packages/domain/scores/src/ports/score-repository.ts
+++ b/packages/domain/scores/src/ports/score-repository.ts
@@ -89,12 +89,7 @@ export interface ScoreRepositoryShape {
     readonly source?: ScoreSourceType
     readonly options?: ScoreListOptions
   }): Effect.Effect<ScoreListPage, RepositoryError, SqlClient>
-  /**
-   * Positive/negative score counts per trace (errored rows excluded).
-   * When `source` is omitted, every score source is counted; pass
-   * `"annotation"` for the public trace `positiveAnnotationCount` /
-   * `negativeAnnotationCount` fields.
-   */
+  /** Per-trace +/- score counts. Omit `source` for all sources; pass `"annotation"` for the public API fields. */
   countAnnotationsByTraceIds(input: {
     readonly projectId: ProjectId
     readonly traceIds: readonly TraceId[]

--- a/packages/domain/scores/src/ports/score-repository.ts
+++ b/packages/domain/scores/src/ports/score-repository.ts
@@ -89,9 +89,16 @@ export interface ScoreRepositoryShape {
     readonly source?: ScoreSourceType
     readonly options?: ScoreListOptions
   }): Effect.Effect<ScoreListPage, RepositoryError, SqlClient>
+  /**
+   * Positive/negative score counts per trace (errored rows excluded).
+   * When `source` is omitted, every score source is counted; pass
+   * `"annotation"` for the public trace `positiveAnnotationCount` /
+   * `negativeAnnotationCount` fields.
+   */
   countAnnotationsByTraceIds(input: {
     readonly projectId: ProjectId
     readonly traceIds: readonly TraceId[]
+    readonly source?: ScoreSourceType
     readonly options?: Pick<ScoreListOptions, "draftMode">
   }): Effect.Effect<readonly TraceAnnotationCounts[], RepositoryError, SqlClient>
   listBySessionId(input: {

--- a/packages/operations/src/openapi/entities/trace.ts
+++ b/packages/operations/src/openapi/entities/trace.ts
@@ -133,7 +133,7 @@ export const fetchTraceIndicators = (input: {
   Effect.gen(function* () {
     if (input.traceIds.length === 0) return new Map<string, TraceAnnotationCounts>()
     const scoreRepo = yield* ScoreRepository
-    const counts = yield* scoreRepo.countAnnotationsByTraceIds(input)
+    const counts = yield* scoreRepo.countAnnotationsByTraceIds({ ...input, source: "annotation" })
     return new Map(counts.map((entry) => [entry.traceId as string, entry] as const))
   })
 

--- a/packages/platform/db-postgres/src/repositories/score-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.test.ts
@@ -692,6 +692,7 @@ describe("ScoreRepositoryLive + score use cases", () => {
         return yield* repository.countAnnotationsByTraceIds({
           projectId: annotationProjectId,
           traceIds: [positiveTraceId, mixedTraceId, TraceId("cccccccccccccccccccccccccccccccc")],
+          source: "annotation",
           options: { draftMode: "include" },
         })
       }).pipe(withPostgres(ScoreRepositoryLive, database.appPostgresClient, OrganizationId(organizationId))),
@@ -702,6 +703,65 @@ describe("ScoreRepositoryLive + score use cases", () => {
     expect(countsByTraceId.get(positiveTraceId)).toMatchObject({ positiveCount: 1, negativeCount: 0 })
     expect(countsByTraceId.get(mixedTraceId)).toMatchObject({ positiveCount: 1, negativeCount: 1 })
     expect(countsByTraceId.has(TraceId("cccccccccccccccccccccccccccccccc"))).toBe(false)
+  })
+
+  it("counts every score source by trace when source is omitted", async () => {
+    const organizationId = "dddddddddddddddddddddddd"
+    const mixedTraceId = TraceId("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        sourceType: "annotation",
+        sourceId: "UI",
+        traceId: mixedTraceId,
+        value: 0.1,
+        passed: false,
+        feedback: "Bad answer",
+        metadata: { rawFeedback: "Bad answer" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        sourceType: "evaluation",
+        sourceId: evaluationSourceId,
+        traceId: mixedTraceId,
+        value: 0,
+        passed: false,
+        feedback: "Issue absent",
+        metadata: { evaluationHash: "eval-hash-counts" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        sourceType: "custom",
+        sourceId: "api-source",
+        traceId: mixedTraceId,
+        value: 0.99,
+        passed: true,
+        feedback: "Custom score",
+        metadata: { channel: "api" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    const counts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* ScoreRepository
+        return yield* repository.countAnnotationsByTraceIds({
+          projectId: annotationProjectId,
+          traceIds: [mixedTraceId],
+          options: { draftMode: "include" },
+        })
+      }).pipe(withPostgres(ScoreRepositoryLive, database.appPostgresClient, OrganizationId(organizationId))),
+    )
+
+    expect(counts).toEqual([
+      expect.objectContaining({ traceId: mixedTraceId, positiveCount: 1, negativeCount: 2 }),
+    ])
   })
 
   it("findPublishedSystemAnnotationByTraceAndFeedback finds existing system annotation score", async () => {

--- a/packages/platform/db-postgres/src/repositories/score-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.test.ts
@@ -759,9 +759,7 @@ describe("ScoreRepositoryLive + score use cases", () => {
       }).pipe(withPostgres(ScoreRepositoryLive, database.appPostgresClient, OrganizationId(organizationId))),
     )
 
-    expect(counts).toEqual([
-      expect.objectContaining({ traceId: mixedTraceId, positiveCount: 1, negativeCount: 2 }),
-    ])
+    expect(counts).toEqual([expect.objectContaining({ traceId: mixedTraceId, positiveCount: 1, negativeCount: 2 })])
   })
 
   it("findPublishedSystemAnnotationByTraceAndFeedback finds existing system annotation score", async () => {

--- a/packages/platform/db-postgres/src/repositories/score-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.ts
@@ -385,18 +385,21 @@ export const ScoreRepositoryLive = Layer.effect(
         })
       },
 
-      countAnnotationsByTraceIds: ({ projectId, traceIds, options }) =>
+      countAnnotationsByTraceIds: ({ projectId, traceIds, source, options }) =>
         Effect.gen(function* () {
           if (traceIds.length === 0) return []
 
           const sqlClient = yield* resolveSqlClient()
           const draftClause = applyDraftMode(options)
           const traceIdValues = traceIds.map((traceId) => String(traceId))
-          const baseWhere = and(
-            eq(scores.projectId, projectId),
-            eq(scores.sourceType, "annotation"),
-            inArray(scores.traceId, traceIdValues),
-          )
+          const baseWhere =
+            source !== undefined
+              ? and(
+                  eq(scores.projectId, projectId),
+                  eq(scores.sourceType, source),
+                  inArray(scores.traceId, traceIdValues),
+                )
+              : and(eq(scores.projectId, projectId), inArray(scores.traceId, traceIdValues))
           const whereClause = draftClause
             ? and(eq(scores.organizationId, sqlClient.organizationId), baseWhere, draftClause)
             : and(eq(scores.organizationId, sqlClient.organizationId), baseWhere)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

The Sessions Indicators column only counted `source=annotation` scores (human thumbs and flaggers). The Scores tab lists every score, so a session with 2 flagger annotations and 6 evaluation runs showed **2** in the table and **Scores 8** in the drawer.

This change:

- Counts every score source (annotation, evaluation, custom) in the traces and sessions Indicators badges. Public API `positiveAnnotationCount` / `negativeAnnotationCount` stay annotation-only.
- Evaluation score cards no longer show the evaluation name or CUID. They always link to the parent signal (including absent runs, where `score.signalId` is null). That parent-signal resolution lives in `attachEvaluationParentSignalsUseCase`; web score listing only routes to the use-case and maps DTOs.
- Labels evaluation runs Present / Absent (`passed` is the detector verdict).
- Clicking a session indicator opens the Scores tab, matching traces. Sessions with more than 500 traces do not get that click, matching the Scores tab limit.

## Related issue (if applicable)

Fixes Linear project [Fix score annotation inconsistencies in Sessions](https://linear.app/latitude/project/fix-score-annotation-inconsistencies-in-sessions-042c33baee09).

## How was this tested?

- `@platform/db-postgres` `score-repository.test.ts -t counts`: 2 passed (annotation-only counts stay filtered; omitting `source` includes evaluation and custom scores).
- `@domain/evaluations` `attach-evaluation-parent-signals.test.ts`: 4 passed (parent signal attached, missing evaluation yields null, non-evaluation sources skipped, duplicate evaluation ids looked up once).
- `@app/web` `score-card-display.test.ts`: 7 passed (evaluation identity omitted; parent signal preferred; Present/Absent labels).
- Pre-commit lint, typecheck, and knip passed on commit.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C038XEZRDCJ/p1784733707718889?thread_ts=1784733707.718889&cid=C038XEZRDCJ)

<div><a href="https://cursor.com/agents/bc-05cea804-9b18-5378-a74d-d57504ab36a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05cea804-9b18-5378-a74d-d57504ab36a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation-linked scores now display their signal, source, and Present/Absent verdict.
  * Score listings include linked evaluation details when available.
  * Session and trace score indicators link directly to relevant scores.
  * Score counts can include annotation, evaluation, and custom scores.

* **Bug Fixes**
  * Annotation-only counts remain accurately filtered.
  * Improved score indicator labels, tooltips, and accessibility text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->