### PR TITLE
Add status page to docs header

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -83,6 +83,11 @@
           "anchor": "Slack Community",
           "icon": "slack",
           "href": "https://join.slack.com/t/trylatitude/shared_invite/zt-35wu2h9es-N419qlptPMhyOeIpj3vjzw"
+        },
+        {
+          "anchor": "Status",
+          "icon": "activity",
+          "href": "https://status.latitude.so"
         }
       ]
     },


### PR DESCRIPTION
Adds a Status shortcut to the global docs header, pointing readers to `status.latitude.so` for current service health.

Validation:
- `jq empty docs/docs.json`
- `pnpm format`
- `pnpm knip`
- confirmed `https://status.latitude.so` returns HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global navigation link to the service status page.
  * The link includes an activity icon for easy identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->