### PR TITLE
fix(scores): hide absent evaluation runs from the Scores UI

### DIFF
--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -272,7 +272,7 @@ export const listAnnotationsBySession = createServerFn({ method: "POST" })
     return toListResult(result)
   })
 
-/** Positive/negative score counts per trace for Indicators. Includes every source except absent evaluation runs. */
+/** Positive/negative score counts per trace for Indicators. Includes every source except signal-less absent evaluation runs. */
 export const listAnnotationCountsByTraceIds = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({

--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -272,7 +272,7 @@ export const listAnnotationsBySession = createServerFn({ method: "POST" })
     return toListResult(result)
   })
 
-/** Positive/negative score counts per trace for Indicators; includes every source. */
+/** Positive/negative score counts per trace for Indicators. Includes every source except absent evaluation runs. */
 export const listAnnotationCountsByTraceIds = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({

--- a/apps/web/src/domains/scores/scores.functions.ts
+++ b/apps/web/src/domains/scores/scores.functions.ts
@@ -107,6 +107,7 @@ export const listScoresByTrace = createServerFn({ method: "GET" })
         limit: data.limit,
         offset: data.offset,
         draftMode: data.draftMode ?? "include",
+        omitAbsentEvaluations: true,
       }).pipe(
         Effect.flatMap(attachEvaluationParentSignalsUseCase),
         Effect.map(toListResult),
@@ -147,6 +148,7 @@ export const listScoresBySession = createServerFn({ method: "POST" })
         limit: data.limit,
         offset: data.offset,
         draftMode: data.draftMode ?? "include",
+        omitAbsentEvaluations: true,
       }).pipe(
         Effect.flatMap(attachEvaluationParentSignalsUseCase),
         Effect.map(toListResult),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
@@ -38,32 +38,61 @@ describe("scoreCardSignalLabel", () => {
 })
 
 describe("scoreCardIsAbsentEvaluation", () => {
-  it("treats a failed, non-errored evaluation as absent", () => {
-    expect(scoreCardIsAbsentEvaluation({ source: "evaluation", errored: false, passed: false })).toBe(true)
+  it("treats a failed, non-errored, signal-less evaluation as absent", () => {
+    expect(
+      scoreCardIsAbsentEvaluation({ source: "evaluation", errored: false, passed: false, signalId: null }),
+    ).toBe(true)
   })
 
-  it("does not treat present, errored, or non-evaluation scores as absent", () => {
-    expect(scoreCardIsAbsentEvaluation({ source: "evaluation", errored: false, passed: true })).toBe(false)
-    expect(scoreCardIsAbsentEvaluation({ source: "evaluation", errored: true, passed: false })).toBe(false)
-    expect(scoreCardIsAbsentEvaluation({ source: "annotation", errored: false, passed: false })).toBe(false)
+  it("does not treat signaled failures, present, errored, or non-evaluation scores as absent", () => {
+    expect(
+      scoreCardIsAbsentEvaluation({
+        source: "evaluation",
+        errored: false,
+        passed: false,
+        signalId: "iiiiiiiiiiiiiiiiiiiiiiii",
+      }),
+    ).toBe(false)
+    expect(
+      scoreCardIsAbsentEvaluation({ source: "evaluation", errored: false, passed: true, signalId: null }),
+    ).toBe(false)
+    expect(
+      scoreCardIsAbsentEvaluation({ source: "evaluation", errored: true, passed: false, signalId: null }),
+    ).toBe(false)
+    expect(
+      scoreCardIsAbsentEvaluation({ source: "annotation", errored: false, passed: false, signalId: null }),
+    ).toBe(false)
   })
 })
 
 describe("scoreCardShouldShowValue", () => {
-  it("hides the 0% value on absent evaluation runs", () => {
-    expect(scoreCardShouldShowValue({ source: "evaluation", errored: false, passed: false })).toBe(false)
-    expect(scoreCardShouldShowValue({ source: "evaluation", errored: false, passed: true })).toBe(true)
-    expect(scoreCardShouldShowValue({ source: "custom", errored: false, passed: false })).toBe(true)
+  it("hides the 0% value on signal-less absent evaluation runs", () => {
+    expect(
+      scoreCardShouldShowValue({ source: "evaluation", errored: false, passed: false, signalId: null }),
+    ).toBe(false)
+    expect(
+      scoreCardShouldShowValue({
+        source: "evaluation",
+        errored: false,
+        passed: false,
+        signalId: "iiiiiiiiiiiiiiiiiiiiiiii",
+      }),
+    ).toBe(true)
+    expect(
+      scoreCardShouldShowValue({ source: "evaluation", errored: false, passed: true, signalId: null }),
+    ).toBe(true)
+    expect(scoreCardShouldShowValue({ source: "custom", errored: false, passed: false, signalId: null })).toBe(true)
   })
 })
 
 describe("scoreCardShouldShowFeedback", () => {
-  it("hides feedback on absent evaluations", () => {
+  it("hides feedback on signal-less absent evaluations", () => {
     expect(
       scoreCardShouldShowFeedback({
         source: "evaluation",
         errored: false,
         passed: false,
+        signalId: null,
         feedback: "No condition matched",
       }),
     ).toBe(false)
@@ -72,17 +101,28 @@ describe("scoreCardShouldShowFeedback", () => {
         source: "evaluation",
         errored: false,
         passed: false,
+        signalId: null,
         feedback: "No tool call named search",
       }),
     ).toBe(false)
   })
 
-  it("keeps feedback on present evaluations and other sources", () => {
+  it("keeps feedback on signaled failures, present evaluations, and other sources", () => {
+    expect(
+      scoreCardShouldShowFeedback({
+        source: "evaluation",
+        errored: false,
+        passed: false,
+        signalId: "iiiiiiiiiiiiiiiiiiiiiiii",
+        feedback: "Detector fired with a low score",
+      }),
+    ).toBe(true)
     expect(
       scoreCardShouldShowFeedback({
         source: "evaluation",
         errored: false,
         passed: true,
+        signalId: null,
         feedback: "Tool call named search",
       }),
     ).toBe(true)
@@ -91,6 +131,7 @@ describe("scoreCardShouldShowFeedback", () => {
         source: "annotation",
         errored: false,
         passed: false,
+        signalId: null,
         feedback: "Needs a better answer",
       }),
     ).toBe(true)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
@@ -58,7 +58,7 @@ describe("scoreCardShouldShowValue", () => {
 })
 
 describe("scoreCardShouldShowFeedback", () => {
-  it("hides the default no-condition-matched copy on absent evaluations", () => {
+  it("hides feedback on absent evaluations", () => {
     expect(
       scoreCardShouldShowFeedback({
         source: "evaluation",
@@ -67,9 +67,6 @@ describe("scoreCardShouldShowFeedback", () => {
         feedback: "No condition matched",
       }),
     ).toBe(false)
-  })
-
-  it("keeps specific feedback and non-evaluation comments", () => {
     expect(
       scoreCardShouldShowFeedback({
         source: "evaluation",
@@ -77,13 +74,24 @@ describe("scoreCardShouldShowFeedback", () => {
         passed: false,
         feedback: "No tool call named search",
       }),
+    ).toBe(false)
+  })
+
+  it("keeps feedback on present evaluations and other sources", () => {
+    expect(
+      scoreCardShouldShowFeedback({
+        source: "evaluation",
+        errored: false,
+        passed: true,
+        feedback: "Tool call named search",
+      }),
     ).toBe(true)
     expect(
       scoreCardShouldShowFeedback({
         source: "annotation",
         errored: false,
         passed: false,
-        feedback: "No condition matched",
+        feedback: "Needs a better answer",
       }),
     ).toBe(true)
   })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
@@ -39,9 +39,9 @@ describe("scoreCardSignalLabel", () => {
 
 describe("scoreCardIsAbsentEvaluation", () => {
   it("treats a failed, non-errored, signal-less evaluation as absent", () => {
-    expect(
-      scoreCardIsAbsentEvaluation({ source: "evaluation", errored: false, passed: false, signalId: null }),
-    ).toBe(true)
+    expect(scoreCardIsAbsentEvaluation({ source: "evaluation", errored: false, passed: false, signalId: null })).toBe(
+      true,
+    )
   })
 
   it("does not treat signaled failures, present, errored, or non-evaluation scores as absent", () => {
@@ -53,23 +53,23 @@ describe("scoreCardIsAbsentEvaluation", () => {
         signalId: "iiiiiiiiiiiiiiiiiiiiiiii",
       }),
     ).toBe(false)
-    expect(
-      scoreCardIsAbsentEvaluation({ source: "evaluation", errored: false, passed: true, signalId: null }),
-    ).toBe(false)
-    expect(
-      scoreCardIsAbsentEvaluation({ source: "evaluation", errored: true, passed: false, signalId: null }),
-    ).toBe(false)
-    expect(
-      scoreCardIsAbsentEvaluation({ source: "annotation", errored: false, passed: false, signalId: null }),
-    ).toBe(false)
+    expect(scoreCardIsAbsentEvaluation({ source: "evaluation", errored: false, passed: true, signalId: null })).toBe(
+      false,
+    )
+    expect(scoreCardIsAbsentEvaluation({ source: "evaluation", errored: true, passed: false, signalId: null })).toBe(
+      false,
+    )
+    expect(scoreCardIsAbsentEvaluation({ source: "annotation", errored: false, passed: false, signalId: null })).toBe(
+      false,
+    )
   })
 })
 
 describe("scoreCardShouldShowValue", () => {
   it("hides the 0% value on signal-less absent evaluation runs", () => {
-    expect(
-      scoreCardShouldShowValue({ source: "evaluation", errored: false, passed: false, signalId: null }),
-    ).toBe(false)
+    expect(scoreCardShouldShowValue({ source: "evaluation", errored: false, passed: false, signalId: null })).toBe(
+      false,
+    )
     expect(
       scoreCardShouldShowValue({
         source: "evaluation",
@@ -78,9 +78,7 @@ describe("scoreCardShouldShowValue", () => {
         signalId: "iiiiiiiiiiiiiiiiiiiiiiii",
       }),
     ).toBe(true)
-    expect(
-      scoreCardShouldShowValue({ source: "evaluation", errored: false, passed: true, signalId: null }),
-    ).toBe(true)
+    expect(scoreCardShouldShowValue({ source: "evaluation", errored: false, passed: true, signalId: null })).toBe(true)
     expect(scoreCardShouldShowValue({ source: "custom", errored: false, passed: false, signalId: null })).toBe(true)
   })
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest"
-import { scoreCardEvaluationVerdict, scoreCardLinkedSignalId, scoreCardSourceTitle } from "./score-card-display.ts"
+import {
+  scoreCardEvaluationVerdict,
+  scoreCardIsAbsentEvaluation,
+  scoreCardLinkedSignalId,
+  scoreCardShouldShowFeedback,
+  scoreCardShouldShowValue,
+  scoreCardSignalLabel,
+  scoreCardSourceTitle,
+} from "./score-card-display.ts"
 
 describe("scoreCardSourceTitle", () => {
   it("does not surface evaluation identity", () => {
@@ -18,6 +26,66 @@ describe("scoreCardLinkedSignalId", () => {
 
   it("falls back to a stamped signal id when the evaluation has no parent", () => {
     expect(scoreCardLinkedSignalId({ signalId: "stamped", evaluationSignalId: null })).toBe("stamped")
+  })
+})
+
+describe("scoreCardSignalLabel", () => {
+  it("prefers the signal name, then the slug, and never a raw id", () => {
+    expect(scoreCardSignalLabel({ name: "Hallucination", slug: "LAT-ABCD" })).toBe("Hallucination")
+    expect(scoreCardSignalLabel({ name: null, slug: "LAT-ABCD" })).toBe("LAT-ABCD")
+    expect(scoreCardSignalLabel({ name: null, slug: null })).toBeNull()
+  })
+})
+
+describe("scoreCardIsAbsentEvaluation", () => {
+  it("treats a failed, non-errored evaluation as absent", () => {
+    expect(scoreCardIsAbsentEvaluation({ source: "evaluation", errored: false, passed: false })).toBe(true)
+  })
+
+  it("does not treat present, errored, or non-evaluation scores as absent", () => {
+    expect(scoreCardIsAbsentEvaluation({ source: "evaluation", errored: false, passed: true })).toBe(false)
+    expect(scoreCardIsAbsentEvaluation({ source: "evaluation", errored: true, passed: false })).toBe(false)
+    expect(scoreCardIsAbsentEvaluation({ source: "annotation", errored: false, passed: false })).toBe(false)
+  })
+})
+
+describe("scoreCardShouldShowValue", () => {
+  it("hides the 0% value on absent evaluation runs", () => {
+    expect(scoreCardShouldShowValue({ source: "evaluation", errored: false, passed: false })).toBe(false)
+    expect(scoreCardShouldShowValue({ source: "evaluation", errored: false, passed: true })).toBe(true)
+    expect(scoreCardShouldShowValue({ source: "custom", errored: false, passed: false })).toBe(true)
+  })
+})
+
+describe("scoreCardShouldShowFeedback", () => {
+  it("hides the default no-condition-matched copy on absent evaluations", () => {
+    expect(
+      scoreCardShouldShowFeedback({
+        source: "evaluation",
+        errored: false,
+        passed: false,
+        feedback: "No condition matched",
+      }),
+    ).toBe(false)
+  })
+
+  it("keeps specific feedback and non-evaluation comments", () => {
+    expect(
+      scoreCardShouldShowFeedback({
+        source: "evaluation",
+        errored: false,
+        passed: false,
+        feedback: "No tool call named search",
+      }),
+    ).toBe(true)
+    expect(
+      scoreCardShouldShowFeedback({
+        source: "annotation",
+        errored: false,
+        passed: false,
+        feedback: "No condition matched",
+      }),
+    ).toBe(true)
   })
 })
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
@@ -1,5 +1,3 @@
-const NO_CONDITION_MATCHED_FEEDBACK = "No condition matched"
-
 export function scoreCardSourceTitle(score: { readonly source: string; readonly sourceId: string }): string | null {
   if (score.source === "evaluation") return null
   return score.sourceId
@@ -41,10 +39,8 @@ export function scoreCardShouldShowFeedback(score: {
   readonly passed: boolean
   readonly feedback: string | null
 }): boolean {
-  const feedback = score.feedback?.trim()
-  if (!feedback) return false
-  if (scoreCardIsAbsentEvaluation(score) && feedback === NO_CONDITION_MATCHED_FEEDBACK) return false
-  return true
+  if (scoreCardIsAbsentEvaluation(score)) return false
+  return Boolean(score.feedback?.trim())
 }
 
 export function scoreCardEvaluationVerdict(score: {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
@@ -21,14 +21,16 @@ export function scoreCardIsAbsentEvaluation(score: {
   readonly source: string
   readonly errored: boolean
   readonly passed: boolean
+  readonly signalId: string | null
 }): boolean {
-  return score.source === "evaluation" && !score.errored && !score.passed
+  return score.source === "evaluation" && !score.errored && !score.passed && score.signalId === null
 }
 
 export function scoreCardShouldShowValue(score: {
   readonly source: string
   readonly errored: boolean
   readonly passed: boolean
+  readonly signalId: string | null
 }): boolean {
   return !scoreCardIsAbsentEvaluation(score)
 }
@@ -37,6 +39,7 @@ export function scoreCardShouldShowFeedback(score: {
   readonly source: string
   readonly errored: boolean
   readonly passed: boolean
+  readonly signalId: string | null
   readonly feedback: string | null
 }): boolean {
   if (scoreCardIsAbsentEvaluation(score)) return false

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card-display.ts
@@ -1,3 +1,5 @@
+const NO_CONDITION_MATCHED_FEEDBACK = "No condition matched"
+
 export function scoreCardSourceTitle(score: { readonly source: string; readonly sourceId: string }): string | null {
   if (score.source === "evaluation") return null
   return score.sourceId
@@ -8,6 +10,41 @@ export function scoreCardLinkedSignalId(score: {
   readonly evaluationSignalId: string | null
 }): string | null {
   return score.evaluationSignalId ?? score.signalId
+}
+
+export function scoreCardSignalLabel(signal: {
+  readonly name: string | null
+  readonly slug: string | null
+}): string | null {
+  return signal.name ?? signal.slug
+}
+
+export function scoreCardIsAbsentEvaluation(score: {
+  readonly source: string
+  readonly errored: boolean
+  readonly passed: boolean
+}): boolean {
+  return score.source === "evaluation" && !score.errored && !score.passed
+}
+
+export function scoreCardShouldShowValue(score: {
+  readonly source: string
+  readonly errored: boolean
+  readonly passed: boolean
+}): boolean {
+  return !scoreCardIsAbsentEvaluation(score)
+}
+
+export function scoreCardShouldShowFeedback(score: {
+  readonly source: string
+  readonly errored: boolean
+  readonly passed: boolean
+  readonly feedback: string | null
+}): boolean {
+  const feedback = score.feedback?.trim()
+  if (!feedback) return false
+  if (scoreCardIsAbsentEvaluation(score) && feedback === NO_CONDITION_MATCHED_FEEDBACK) return false
+  return true
 }
 
 export function scoreCardEvaluationVerdict(score: {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
@@ -5,7 +5,14 @@ import { Link, useParams } from "@tanstack/react-router"
 import { AlertCircleIcon, ShieldAlertIcon, ThumbsDownIcon, ThumbsUpIcon } from "lucide-react"
 import type { ScoreRecord } from "../../../../../../domains/scores/scores.functions.ts"
 import { useSignal } from "../../../../../../domains/signals/signals.collection.ts"
-import { scoreCardEvaluationVerdict, scoreCardLinkedSignalId, scoreCardSourceTitle } from "./score-card-display.ts"
+import {
+  scoreCardEvaluationVerdict,
+  scoreCardLinkedSignalId,
+  scoreCardShouldShowFeedback,
+  scoreCardShouldShowValue,
+  scoreCardSignalLabel,
+  scoreCardSourceTitle,
+} from "./score-card-display.ts"
 
 const SOURCE_LABELS: Record<ScoreSourceType, string> = {
   annotation: "Annotation",
@@ -31,7 +38,8 @@ function ScoreSignalLink({
   readonly slug: string | null
   readonly description: string | undefined
 }) {
-  const label = name ?? slug ?? signalId
+  const label = scoreCardSignalLabel({ name, slug })
+  if (!label) return null
   const signalSlug = slug ?? signalId
   const isNavigable = Boolean(projectSlug && signalSlug)
   const badge = (
@@ -89,6 +97,8 @@ export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
   const sourceLabel = SOURCE_LABELS[score.source]
   const sourceTitle = scoreCardSourceTitle(score)
   const feedback = score.feedback?.trim()
+  const showValue = scoreCardShouldShowValue(score)
+  const showFeedback = scoreCardShouldShowFeedback(score)
   const evaluationVerdict = scoreCardEvaluationVerdict(score)
   const signalLink = linkedSignalId ? (
     <ScoreSignalLink
@@ -130,7 +140,7 @@ export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
             >
               {score.error ?? "Score generation failed"}
             </Tooltip>
-          ) : (
+          ) : evaluationVerdict ? null : (
             <div className="flex h-8 w-8 items-center justify-center">
               <Icon
                 icon={score.passed ? ThumbsUpIcon : ThumbsDownIcon}
@@ -142,9 +152,9 @@ export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
         </div>
       </div>
 
-      <Text.H6 color="foregroundMuted">Value: {Math.round(score.value * 100)}%</Text.H6>
+      {showValue ? <Text.H6 color="foregroundMuted">Value: {Math.round(score.value * 100)}%</Text.H6> : null}
 
-      {feedback ? <Text.H5 className="whitespace-pre-wrap">{feedback}</Text.H5> : null}
+      {showFeedback && feedback ? <Text.H5 className="whitespace-pre-wrap">{feedback}</Text.H5> : null}
 
       {score.source !== "evaluation" && signalLink ? (
         <div className="flex items-center gap-2 pt-1">{signalLink}</div>

--- a/packages/domain/scores/src/ports/score-repository.ts
+++ b/packages/domain/scores/src/ports/score-repository.ts
@@ -20,6 +20,8 @@ export interface ScoreListOptions {
   readonly limit?: number
   readonly offset?: number
   readonly draftMode?: ScoreDraftMode
+  /** Drop failed, non-errored evaluation runs (detector absents / "No condition matched"). */
+  readonly omitAbsentEvaluations?: boolean
 }
 
 export interface ScoreListPage {
@@ -89,7 +91,7 @@ export interface ScoreRepositoryShape {
     readonly source?: ScoreSourceType
     readonly options?: ScoreListOptions
   }): Effect.Effect<ScoreListPage, RepositoryError, SqlClient>
-  /** Per-trace +/- score counts. Omit `source` for all sources; pass `"annotation"` for the public API fields. */
+  /** Per-trace +/- score counts. Omit `source` for all sources; pass `"annotation"` for the public API fields. Absent evaluation runs are excluded from the negative count. */
   countAnnotationsByTraceIds(input: {
     readonly projectId: ProjectId
     readonly traceIds: readonly TraceId[]

--- a/packages/domain/scores/src/ports/score-repository.ts
+++ b/packages/domain/scores/src/ports/score-repository.ts
@@ -20,7 +20,7 @@ export interface ScoreListOptions {
   readonly limit?: number
   readonly offset?: number
   readonly draftMode?: ScoreDraftMode
-  /** Drop failed, non-errored evaluation runs (detector absents / "No condition matched"). */
+  /** Drop failed, non-errored evaluation runs that have no stamped signal (`signalId` is null). */
   readonly omitAbsentEvaluations?: boolean
 }
 
@@ -91,7 +91,7 @@ export interface ScoreRepositoryShape {
     readonly source?: ScoreSourceType
     readonly options?: ScoreListOptions
   }): Effect.Effect<ScoreListPage, RepositoryError, SqlClient>
-  /** Per-trace +/- score counts. Omit `source` for all sources; pass `"annotation"` for the public API fields. Absent evaluation runs are excluded from the negative count. */
+  /** Per-trace +/- score counts. Omit `source` for all sources; pass `"annotation"` for the public API fields. Signal-less absent evaluation runs are excluded from the negative count. */
   countAnnotationsByTraceIds(input: {
     readonly projectId: ProjectId
     readonly traceIds: readonly TraceId[]

--- a/packages/domain/scores/src/use-cases/list-trace-scores.test.ts
+++ b/packages/domain/scores/src/use-cases/list-trace-scores.test.ts
@@ -87,6 +87,22 @@ describe("listTraceScoresUseCase", () => {
     expect(page.items).toHaveLength(3)
     expect(page.items.map((score) => score.sourceType).sort()).toEqual(["annotation", "custom", "evaluation"])
   })
+
+  it("forwards omitAbsentEvaluations to the repository", async () => {
+    let receivedOmitAbsentEvaluations: boolean | undefined
+    const { repository } = createFakeScoreRepository({
+      listByTraceId: ({ options }) => {
+        receivedOmitAbsentEvaluations = options?.omitAbsentEvaluations
+        return Effect.succeed({ items: [], hasMore: false, limit: 50, offset: 0 })
+      },
+    })
+
+    await Effect.runPromise(
+      listTraceScoresUseCase({ projectId, traceId, omitAbsentEvaluations: true }).pipe(provideTestServices(repository)),
+    )
+
+    expect(receivedOmitAbsentEvaluations).toBe(true)
+  })
 })
 
 describe("listScoresByTraceIdsUseCase", () => {

--- a/packages/domain/scores/src/use-cases/list-trace-scores.ts
+++ b/packages/domain/scores/src/use-cases/list-trace-scores.ts
@@ -22,6 +22,7 @@ export const listTraceScoresInputSchema = z.object({
   limit: baseListScoresInputSchema.shape.limit,
   offset: baseListScoresInputSchema.shape.offset,
   draftMode: scoreDraftModeSchema.default("include"),
+  omitAbsentEvaluations: z.boolean().optional(),
 })
 export type ListTraceScoresInput = z.input<typeof listTraceScoresInputSchema>
 
@@ -31,6 +32,7 @@ export const listScoresByTraceIdsInputSchema = z.object({
   limit: baseListScoresInputSchema.shape.limit,
   offset: baseListScoresInputSchema.shape.offset,
   draftMode: scoreDraftModeSchema.default("include"),
+  omitAbsentEvaluations: z.boolean().optional(),
 })
 export type ListScoresByTraceIdsInput = z.input<typeof listScoresByTraceIdsInputSchema>
 
@@ -50,6 +52,7 @@ export const listTraceScoresUseCase = Effect.fn("scores.listTraceScores")(functi
       limit: parsed.limit,
       offset: parsed.offset,
       draftMode: parsed.draftMode,
+      ...(parsed.omitAbsentEvaluations ? { omitAbsentEvaluations: true } : {}),
     },
   })
 })
@@ -88,6 +91,7 @@ export const listScoresByTraceIdsUseCase = Effect.fn("scores.listScoresByTraceId
       limit: parsed.limit,
       offset: parsed.offset,
       draftMode: parsed.draftMode,
+      ...(parsed.omitAbsentEvaluations ? { omitAbsentEvaluations: true } : {}),
     },
   })
 })

--- a/packages/platform/db-postgres/src/repositories/score-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.test.ts
@@ -738,6 +738,20 @@ describe("ScoreRepositoryLive + score use cases", () => {
     await Effect.runPromise(
       writeScoreUseCase({
         projectId: annotationProjectId,
+        sourceType: "evaluation",
+        sourceId: "ffffffffffffffffffffffff",
+        signalId: SignalId("iiiiiiiiiiiiiiiiiiiiiiii"),
+        traceId: mixedTraceId,
+        value: 0,
+        passed: false,
+        feedback: "Failed evaluation already linked to a signal",
+        metadata: { evaluationHash: "eval-hash-signaled-fail" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
         sourceType: "custom",
         sourceId: "api-source",
         traceId: mixedTraceId,
@@ -759,7 +773,7 @@ describe("ScoreRepositoryLive + score use cases", () => {
       }).pipe(withPostgres(ScoreRepositoryLive, database.appPostgresClient, OrganizationId(organizationId))),
     )
 
-    expect(counts).toEqual([expect.objectContaining({ traceId: mixedTraceId, positiveCount: 1, negativeCount: 1 })])
+    expect(counts).toEqual([expect.objectContaining({ traceId: mixedTraceId, positiveCount: 1, negativeCount: 2 })])
   })
 
   it("omits absent evaluation runs from listByTraceId when asked", async () => {
@@ -805,6 +819,20 @@ describe("ScoreRepositoryLive + score use cases", () => {
       }).pipe(createWriteProvider(database, organizationId)),
     )
 
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        sourceType: "evaluation",
+        sourceId: "aaaaaaaaaaaaaaaaaaaaaaaa",
+        signalId: SignalId("iiiiiiiiiiiiiiiiiiiiiiii"),
+        traceId,
+        value: 0,
+        passed: false,
+        feedback: "Failed evaluation already linked to a signal",
+        metadata: { evaluationHash: "eval-hash-signaled-fail" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
     const page = await Effect.runPromise(
       Effect.gen(function* () {
         const repository = yield* ScoreRepository
@@ -816,8 +844,11 @@ describe("ScoreRepositoryLive + score use cases", () => {
       }).pipe(withPostgres(ScoreRepositoryLive, database.appPostgresClient, OrganizationId(organizationId))),
     )
 
-    expect(page.items.map((score) => score.sourceType).sort()).toEqual(["annotation", "evaluation"])
-    expect(page.items.find((score) => score.sourceType === "evaluation")?.passed).toBe(true)
+    const evaluationScores = page.items.filter((score) => score.sourceType === "evaluation")
+    expect(page.items.map((score) => score.sourceType).sort()).toEqual(["annotation", "evaluation", "evaluation"])
+    expect(evaluationScores.some((score) => score.passed)).toBe(true)
+    expect(evaluationScores.some((score) => !score.passed && score.signalId !== null)).toBe(true)
+    expect(evaluationScores.every((score) => score.passed || score.signalId !== null)).toBe(true)
   })
 
   it("findPublishedSystemAnnotationByTraceAndFeedback finds existing system annotation score", async () => {

--- a/packages/platform/db-postgres/src/repositories/score-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.test.ts
@@ -705,7 +705,7 @@ describe("ScoreRepositoryLive + score use cases", () => {
     expect(countsByTraceId.has(TraceId("cccccccccccccccccccccccccccccccc"))).toBe(false)
   })
 
-  it("counts every score source by trace when source is omitted", async () => {
+  it("counts every score source by trace when source is omitted, except absent evaluations", async () => {
     const organizationId = "dddddddddddddddddddddddd"
     const mixedTraceId = TraceId("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
 
@@ -759,7 +759,65 @@ describe("ScoreRepositoryLive + score use cases", () => {
       }).pipe(withPostgres(ScoreRepositoryLive, database.appPostgresClient, OrganizationId(organizationId))),
     )
 
-    expect(counts).toEqual([expect.objectContaining({ traceId: mixedTraceId, positiveCount: 1, negativeCount: 2 })])
+    expect(counts).toEqual([expect.objectContaining({ traceId: mixedTraceId, positiveCount: 1, negativeCount: 1 })])
+  })
+
+  it("omits absent evaluation runs from listByTraceId when asked", async () => {
+    const organizationId = "ffffffffffffffffffffaaaa"
+    const traceId = TraceId("ffffffffffffffffffffffffffffffff")
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        sourceType: "evaluation",
+        sourceId: evaluationSourceId,
+        traceId,
+        value: 0,
+        passed: false,
+        feedback: "No condition matched",
+        metadata: { evaluationHash: "eval-hash-absent" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        sourceType: "evaluation",
+        sourceId: "ffffffffffffffffffffffff",
+        traceId,
+        value: 1,
+        passed: true,
+        feedback: "Issue present",
+        metadata: { evaluationHash: "eval-hash-present" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        sourceType: "annotation",
+        sourceId: "UI",
+        traceId,
+        value: 0,
+        passed: false,
+        feedback: "Human thumbs down",
+        metadata: { rawFeedback: "Human thumbs down" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    const page = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* ScoreRepository
+        return yield* repository.listByTraceId({
+          projectId: annotationProjectId,
+          traceId,
+          options: { draftMode: "include", omitAbsentEvaluations: true },
+        })
+      }).pipe(withPostgres(ScoreRepositoryLive, database.appPostgresClient, OrganizationId(organizationId))),
+    )
+
+    expect(page.items.map((score) => score.sourceType).sort()).toEqual(["annotation", "evaluation"])
+    expect(page.items.find((score) => score.sourceType === "evaluation")?.passed).toBe(true)
   })
 
   it("findPublishedSystemAnnotationByTraceAndFeedback finds existing system annotation score", async () => {

--- a/packages/platform/db-postgres/src/repositories/score-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.ts
@@ -100,7 +100,12 @@ const applyDraftMode = (options: ScoreListOptions | undefined) => {
 
 const applyAbsentEvaluationFilter = (options: ScoreListOptions | undefined) => {
   if (!options?.omitAbsentEvaluations) return undefined
-  return or(ne(scores.sourceType, "evaluation"), eq(scores.passed, true), eq(scores.errored, true))
+  return or(
+    ne(scores.sourceType, "evaluation"),
+    eq(scores.passed, true),
+    eq(scores.errored, true),
+    isNotNull(scores.signalId),
+  )
 }
 
 export const ScoreRepositoryLive = Layer.effect(
@@ -419,7 +424,7 @@ export const ScoreRepositoryLive = Layer.effect(
                 .select({
                   traceId: scores.traceId,
                   positiveCount: sql<number>`count(*) filter (where ${scores.passed} = true and ${scores.errored} = false)::int`,
-                  negativeCount: sql<number>`count(*) filter (where ${scores.passed} = false and ${scores.errored} = false and ${scores.sourceType} <> 'evaluation')::int`,
+                  negativeCount: sql<number>`count(*) filter (where ${scores.passed} = false and ${scores.errored} = false and not (${scores.sourceType} = 'evaluation' and ${scores.signalId} is null))::int`,
                 })
                 .from(scores)
                 .where(whereClause)

--- a/packages/platform/db-postgres/src/repositories/score-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.ts
@@ -12,7 +12,7 @@ import {
   type TraceId,
 } from "@domain/shared"
 import { createLogger } from "@repo/observability"
-import { and, desc, eq, inArray, isNotNull, isNull, type SQL, sql } from "drizzle-orm"
+import { and, desc, eq, inArray, isNotNull, isNull, ne, or, type SQL, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { scores } from "../schema/scores.ts"
@@ -98,6 +98,11 @@ const applyDraftMode = (options: ScoreListOptions | undefined) => {
   return isNull(scores.draftedAt)
 }
 
+const applyAbsentEvaluationFilter = (options: ScoreListOptions | undefined) => {
+  if (!options?.omitAbsentEvaluations) return undefined
+  return or(ne(scores.sourceType, "evaluation"), eq(scores.passed, true), eq(scores.errored, true))
+}
+
 export const ScoreRepositoryLive = Layer.effect(
   ScoreRepository,
   Effect.gen(function* () {
@@ -129,9 +134,13 @@ export const ScoreRepositoryLive = Layer.effect(
             const limit = input.options?.limit ?? 50
             const offset = input.options?.offset ?? 0
             const draftClause = applyDraftMode(input.options)
-            const whereClause = draftClause
-              ? and(eq(scores.organizationId, organizationId), input.baseWhere, draftClause)
-              : and(eq(scores.organizationId, organizationId), input.baseWhere)
+            const absentEvaluationClause = applyAbsentEvaluationFilter(input.options)
+            const whereClause = and(
+              eq(scores.organizationId, organizationId),
+              input.baseWhere,
+              draftClause,
+              absentEvaluationClause,
+            )
 
             return db
               .select()
@@ -410,7 +419,7 @@ export const ScoreRepositoryLive = Layer.effect(
                 .select({
                   traceId: scores.traceId,
                   positiveCount: sql<number>`count(*) filter (where ${scores.passed} = true and ${scores.errored} = false)::int`,
-                  negativeCount: sql<number>`count(*) filter (where ${scores.passed} = false and ${scores.errored} = false)::int`,
+                  negativeCount: sql<number>`count(*) filter (where ${scores.passed} = false and ${scores.errored} = false and ${scores.sourceType} <> 'evaluation')::int`,
                 })
                 .from(scores)
                 .where(whereClause)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Failed live evaluations (`Failed(0, "No condition matched")`) are stored as real scores with `signalId: null`. After #4440 those detector-absent runs showed up in the session/trace Scores tab as `Evaluation <cuid>`, `Value: 0%`, and a thumbs-down, and they also incremented the Indicators negative count.

This PR:

- Omits absent evaluation runs (failed, not errored) from the web Scores lists
- Stops counting them as negative scores in the Indicators column
- Never renders a raw CUID as the evaluation identity; hides the default `0%` / `No condition matched` body if an absent card still appears

Present and errored evaluation scores stay visible, as do annotations and custom scores. Alignment and other consumers that read evaluation scores directly are unchanged.

## Related issue (if applicable)

Follow-up to #4440. Raised in Slack: scores showing `0%` / "No condition matched" with the evaluation CUID.

## How was this tested?

- Unit tests for score-card display helpers (absent vs present, CUID never used as a label)
- Domain test that `omitAbsentEvaluations` is forwarded to the repository
- Postgres repository tests: indicator counts ignore absent evaluations; `listByTraceId` drops them when the flag is set

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C0672DS68DD/p1786723601593689?thread_ts=1786723601.593689&cid=C0672DS68DD)

<div><a href="https://cursor.com/agents/bc-2704dc5b-3353-5d55-9086-d9c97124c239?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2704dc5b-3353-5d55-9086-d9c97124c239&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Score listings now exclude evaluations absent from the requested score data.
  * Annotation counts exclude absent evaluation runs more accurately.
  * Score cards hide unavailable values, feedback, and verdict icons when appropriate.
  * Empty or non-applicable feedback is no longer displayed.

* **UI Improvements**
  * Signal labels are displayed more consistently.
  * Score cards clearly distinguish evaluations with missing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->