### PR TITLE
fix(spans): skip Wrapped report generation when project or org was deleted

### DIFF
--- a/packages/domain/spans/src/wrapped/use-cases/run-wrapped.test.ts
+++ b/packages/domain/spans/src/wrapped/use-cases/run-wrapped.test.ts
@@ -126,13 +126,13 @@ const makeOrganization = (): Organization => ({
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 })
 
-const makeOrganizationRepository = (organization: Organization): (typeof OrganizationRepository)["Service"] => ({
+const makeOrganizationRepository = (organization: Organization | null): (typeof OrganizationRepository)["Service"] => ({
   findById: (id) =>
-    id === organization.id
+    organization && id === organization.id
       ? Effect.succeed(organization)
       : Effect.fail(new NotFoundError({ entity: "Organization", id })),
   findByIdForUpdate: (id) =>
-    id === organization.id
+    organization && id === organization.id
       ? Effect.succeed(organization)
       : Effect.fail(new NotFoundError({ entity: "Organization", id })),
   listByUserId: () => Effect.die("listByUserId not used"),
@@ -143,11 +143,11 @@ const makeOrganizationRepository = (organization: Organization): (typeof Organiz
   listExpiredUnclaimed: () => Effect.die("listExpiredUnclaimed not used"),
 })
 
-const makeProjectRepository = (project: Project): (typeof ProjectRepository)["Service"] => ({
+const makeProjectRepository = (project: Project | null): (typeof ProjectRepository)["Service"] => ({
   findById: (id) =>
-    id === project.id ? Effect.succeed(project) : Effect.fail(new NotFoundError({ entity: "Project", id })),
+    project && id === project.id ? Effect.succeed(project) : Effect.fail(new NotFoundError({ entity: "Project", id })),
   findByIdForUpdate: (id) =>
-    id === project.id ? Effect.succeed(project) : Effect.fail(new NotFoundError({ entity: "Project", id })),
+    project && id === project.id ? Effect.succeed(project) : Effect.fail(new NotFoundError({ entity: "Project", id })),
   findBySlug: () => Effect.die("findBySlug not used"),
   list: () => Effect.die("list not used"),
   listIncludingDeleted: () => Effect.die("listIncludingDeleted not used"),
@@ -174,12 +174,14 @@ interface TestHarness {
 const setupHarness = (options: {
   readonly members: readonly MemberWithUser[]
   readonly sessions: number
+  readonly projectExists?: boolean
+  readonly organizationExists?: boolean
 }): TestHarness => {
   const { repository: memberships } = createFakeMembershipRepository({
     listMembersWithUser: () => Effect.succeed([...options.members]),
   })
-  const projectRepo = makeProjectRepository(makeProject())
-  const organizationRepo = makeOrganizationRepository(makeOrganization())
+  const projectRepo = makeProjectRepository(options.projectExists === false ? null : makeProject())
+  const organizationRepo = makeOrganizationRepository(options.organizationExists === false ? null : makeOrganization())
   const reader = makeReader({
     countSessionsForProjectInWindow: () => Effect.succeed(options.sessions),
   })
@@ -325,5 +327,35 @@ describe("runWrappedUseCase", () => {
     await runUseCase(harness)
 
     expect(harness.saved[0]?.ownerName).toBe("Acme")
+  })
+
+  it("skips instead of throwing when the project was deleted before the job ran", async () => {
+    // Regression: the fan-out enumerates eligible projects from ClickHouse
+    // ahead of publishing this task, so the project can be deleted by the
+    // time the job runs. `findById` used to propagate `NotFoundError`
+    // uncaught, failing the whole BullMQ job.
+    harness = setupHarness({
+      members: [makeMember("a", "a@test.com", true)],
+      sessions: 5,
+      projectExists: false,
+    })
+
+    const result = await runUseCase(harness)
+
+    expect(result).toEqual({ status: "skipped", reason: "project-not-found" })
+    expect(harness.saved).toHaveLength(0)
+  })
+
+  it("skips instead of throwing when the organization was deleted before the job ran", async () => {
+    harness = setupHarness({
+      members: [makeMember("a", "a@test.com", true)],
+      sessions: 5,
+      organizationExists: false,
+    })
+
+    const result = await runUseCase(harness)
+
+    expect(result).toEqual({ status: "skipped", reason: "organization-not-found" })
+    expect(harness.saved).toHaveLength(0)
   })
 })

--- a/packages/domain/spans/src/wrapped/use-cases/run-wrapped.ts
+++ b/packages/domain/spans/src/wrapped/use-cases/run-wrapped.ts
@@ -14,7 +14,7 @@ export interface RunWrappedInput {
   readonly windowEnd: Date
 }
 
-export type RunWrappedSkippedReason = "no-activity"
+export type RunWrappedSkippedReason = "no-activity" | "project-not-found" | "organization-not-found"
 
 export type RunWrappedResult =
   | {
@@ -66,8 +66,22 @@ export const runWrappedUseCase = Effect.fn("wrapped.runForProject")(function* (i
   const projectRepo = yield* ProjectRepository
   const membershipRepo = yield* MembershipRepository
   const organizationRepo = yield* OrganizationRepository
-  const project = yield* projectRepo.findById(input.projectId)
-  const organization = yield* organizationRepo.findById(input.organizationId)
+  // The fan-out enumerates eligible projects from ClickHouse ahead of publishing
+  // this task, so the project (or its org) may be deleted by the time the job
+  // runs — treat that race as a skip, not a failure, same as
+  // `requestAgentDispatchUseCase`'s handling of the equivalent race.
+  const project = yield* projectRepo
+    .findById(input.projectId)
+    .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+  if (project === null) {
+    return { status: "skipped", reason: "project-not-found" } satisfies RunWrappedResult
+  }
+  const organization = yield* organizationRepo
+    .findById(input.organizationId)
+    .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+  if (organization === null) {
+    return { status: "skipped", reason: "organization-not-found" } satisfies RunWrappedResult
+  }
   // Fetch the full member list to snapshot the org owner's display name
   // onto the persisted row (`owner_name` anchors the web view's greeting).
   // Recipient resolution + delivery happens downstream in the notification


### PR DESCRIPTION
## What does this PR do?

Fixes an uncaught `NotFoundError` in the weekly Wrapped report worker (`runWrappedUseCase`, `packages/domain/spans/src/wrapped/use-cases/run-wrapped.ts`).

**Datadog issues addressed:**
- [`ET-375` (`NotFoundError`)](https://app.datadoghq.eu/error-tracking/issue/4dea99da-6bbd-11f1-9869-da7ad0900005) — `workers`, regressed 2026-08-14 (previously resolved 2026-07-20)
- [`ET-376` (`NotFoundError$1`)](https://app.datadoghq.eu/error-tracking/issue/4deecbfe-6bbd-11f1-bca4-da7ad0900005) — same underlying event (Datadog's minifier-fingerprint split of the same stack), regressed 2026-08-14

Both are low-volume so far (1 occurrence each in the 7d window) but flagged as regressions of an issue that was already fixed once, in a different call site of the exact same bug class — worth catching before it becomes a recurring pile-up.

**Root cause:** `fanOutWeeklyRunUseCase` enumerates projects with Claude Code activity from ClickHouse, then publishes one `runForProject` BullMQ job per project on the `wrapped` topic. If a project (or its organization) is deleted between that enumeration and the job actually running, `ProjectRepository.findById` / `OrganizationRepository.findById` throw `NotFoundError`, which was previously uncaught — failing the whole BullMQ job and surfacing as an unhandled exception in Error Tracking.

This is the same race condition class as [PR #4099](https://github.com/latitude-dev/latitude-llm/pull/4099), which fixed the equivalent issue for `organizations.findById` / `incidents.findById` in `requestAgentDispatchUseCase` by wrapping the lookup in `Effect.catchTag("NotFoundError", ...)` and returning a skip result instead of propagating the failure. This PR applies the identical pattern to `runWrappedUseCase`, which wasn't covered by that earlier fix.

**Fix:** wrap both `findById` calls with `Effect.catchTag("NotFoundError", () => Effect.succeed(null))` and return `{ status: "skipped", reason: "project-not-found" | "organization-not-found" }` instead of letting the error propagate.

## Related issue (if applicable)

Closes #

## How was this tested?

- Added two regression tests to `run-wrapped.test.ts`: one where the project has been deleted, one where the organization has been deleted. Both assert the use case returns a `skipped` result instead of throwing, and that no report is persisted.
- Confirmed both new tests **fail** against the pre-fix code (uncaught `NotFoundError` propagates and the job errors) and **pass** with the fix applied.
- Full `@domain/spans` test suite passes except for 28 pre-existing failures in an unrelated file (`ingest-spans.test.ts`, a `Uint8Array.prototype.toBase64` Node-version mismatch in this sandbox) — confirmed identical failure count/content on `development` before this change, so unrelated to this fix.
- `pnpm exec biome check` clean on both changed files.

**Post-deploy verification:** occurrences of Datadog issues `ET-375` / `ET-376` should stop appearing for this failure mode (the underlying race can still occur, but it will now resolve as a silent skip rather than an error).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tnt3JSaoeDDrLEW278AVK9)_