### PR TITLE
feat(telemetry): add a tools-app example for inspecting how tool calls reach Latitude

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -32,6 +32,7 @@
       "!!**/node_modules",
       "!**/*.gen.ts",
       "!**/models.dev.json",
+      "!**/.spans",
       "!**/drizzle/**/*.json"
     ]
   },

--- a/packages/telemetry/typescript/examples/tools-app/.env.example
+++ b/packages/telemetry/typescript/examples/tools-app/.env.example
@@ -1,0 +1,16 @@
+# Latitude (local instance — apps/ingest listens on 3002)
+LATITUDE_API_KEY=your-latitude-api-key
+LATITUDE_PROJECT_SLUG=your-project-slug
+LATITUDE_TELEMETRY_URL=http://localhost:3002
+
+# OpenAI (Responses API — provider-executed tools live here)
+OPENAI_API_KEY=your-openai-key
+OPENAI_MODEL=gpt-5.5
+
+# Hosted MCP server for the `mcp` scenario (defaults to the public DeepWiki server)
+MCP_SERVER_URL=https://mcp.deepwiki.com/mcp
+MCP_SERVER_LABEL=deepwiki
+# MCP_AUTHORIZATION=oauth-access-token
+
+# Only needed for the `file-search` scenario
+# OPENAI_VECTOR_STORE_ID=vs_...

--- a/packages/telemetry/typescript/examples/tools-app/.gitignore
+++ b/packages/telemetry/typescript/examples/tools-app/.gitignore
@@ -1,0 +1,2 @@
+.spans/
+.env

--- a/packages/telemetry/typescript/examples/tools-app/README.md
+++ b/packages/telemetry/typescript/examples/tools-app/README.md
@@ -1,0 +1,99 @@
+# Tools app
+
+A sample app for inspecting how tool calls reach Latitude. It drives the Vercel AI SDK against
+OpenAI-hosted, provider-executed tools (MCP, web search, tool search, code interpreter, file search)
+plus an app-executed tool as a control, sends telemetry to a local Latitude instance using the SDK
+source in this repo, and prints what the app process saw next to what telemetry actually carried.
+
+It exists because provider-executed tools do not bubble their outputs into Latitude. See
+[what is missing](#what-is-missing-and-why) below.
+
+Nothing here is wired into CI. It imports `../../src` directly, so edits to the telemetry SDK take
+effect on the next run with no build step.
+
+## Setup
+
+The app reads env from wherever you point `--env-file`. `examples/.env` is already set up for the
+local instance (`LATITUDE_API_KEY`, `LATITUDE_PROJECT_SLUG=saloon`,
+`LATITUDE_TELEMETRY_URL=http://localhost:3002`) but has **no `OPENAI_API_KEY`** — add one, or copy
+`.env.example` here and use that file instead.
+
+Start the local Latitude instance yourself (`apps/ingest` on port 3002). The app runs without it;
+the OTLP export just fails and the span dump is still written.
+
+## Running
+
+From `packages/telemetry/typescript`:
+
+```bash
+pnpm tsx --env-file=examples/.env examples/tools-app/run.ts web-search
+pnpm tsx --env-file=examples/.env examples/tools-app/run.ts all
+pnpm tsx examples/tools-app/inspect.ts web-search   # re-read a dump, no API calls
+```
+
+| Scenario | Tool | Executed by |
+| --- | --- | --- |
+| `client-tool` | `getWeather` | app (control) |
+| `web-search` | `openai.tools.webSearch` | provider |
+| `web-search-stream` | `openai.tools.webSearch` via `streamText` | provider |
+| `mcp` | `openai.tools.mcp` (hosted MCP server) | provider |
+| `code-interpreter` | `openai.tools.codeInterpreter` | provider |
+| `tool-search` | `openai.tools.toolSearch` + a deferred app tool | provider + app |
+| `mixed` | web search + `getWeather` in one call | both |
+| `file-search` | `openai.tools.fileSearch` | provider (needs `OPENAI_VECTOR_STORE_ID`) |
+
+`mcp` defaults to the public DeepWiki server; override with `MCP_SERVER_URL`, `MCP_SERVER_LABEL`,
+and `MCP_AUTHORIZATION`.
+
+## What it produces
+
+Each run writes `.spans/<scenario>.json` (gitignored): every span the AI SDK emitted, snapshotted
+pre-redaction, with `passesSmartFilter` recording whether Latitude's export filter would keep it.
+`inspect.ts` then replays each span through the **real ingest parsers** (`parseContent`,
+`resolveOperation`, `resolveToolExecution` from `packages/domain/spans`) and prints a verdict:
+
+```
+── verdict
+  app process received   1 tool call(s), 1 result(s)
+  telemetry carried      1 tool call(s), 0 result(s)
+  execute_tool spans     0
+  Latitude would show    1 tool_call, 0 tool_call_response
+  MISSING                0 input(s), 1 output(s)
+```
+
+So a fix can be validated from the dump alone, without reading the Latitude UI.
+
+## What is missing, and why
+
+Verified against `ai@7.0.66`, `@ai-sdk/openai@4.0.42` and `@ai-sdk/otel@1.0.66`, and filed upstream
+as [vercel/ai#19007](https://github.com/vercel/ai/issues/19007). Three gaps, all upstream of
+Latitude:
+
+1. **No tool span.** `@ai-sdk/otel` opens its `execute_tool` span from `onToolExecutionStart`, which
+   fires out of the AI SDK's tool-execution path. A provider-executed tool has no `execute`, so that
+   path returns early and no span is created. The remote call's duration is invisible as a result: it
+   sits inside the `chat` span with no attribution. Latitude's `resolveToolExecution` already reads
+   `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result`, so it would render such a span correctly
+   if one existed.
+2. **No tool output.** `formatOutputMessages` builds `gen_ai.output.messages` from text, reasoning,
+   `tool-call` and file parts only; `tool-result` parts are dropped. For OpenAI-hosted tools the
+   call, the result and the final text all arrive in a single step, so there is no following step
+   whose `gen_ai.input.messages` would re-carry the result. The output reaches nothing.
+3. **Incomplete tool definitions.** Hosted MCP calls are named `mcp.<remoteTool>`, but
+   `gen_ai.tool.definitions` carries only the container tool `mcp`. The provider receives the real
+   list as an `mcp_list_tools` item and discards it, so nothing describes the tools that were
+   actually called and any check reconciling calls against declarations reports a false mismatch.
+
+Tool call arguments do arrive intact for hosted MCP. What is lost is the outputs, the timing, and the
+definitions.
+
+The payloads exist in-process the whole time: `result.steps[].content` holds the
+`tool-call`/`tool-result` pair with `providerExecuted: true`, which is what the `app process
+received` line above counts.
+
+## Version note
+
+The app targets AI SDK **v7** (`ai7` + `@ai-sdk/openai7` + `@ai-sdk/otel`), the pair that works in
+this repo. The v6 stack cannot run here at all: the root `pnpm.overrides` pin of
+`@ai-sdk/provider: 4.0.0-beta.7` makes `@ai-sdk/openai@4` emit a spec-v4 model that `ai@6` rejects
+with `AI_UnsupportedModelVersionError`. `examples/test_vercel_ai.ts` fails the same way today.

--- a/packages/telemetry/typescript/examples/tools-app/inspect.ts
+++ b/packages/telemetry/typescript/examples/tools-app/inspect.ts
@@ -1,0 +1,284 @@
+/**
+ * Reads a span dump and reports what actually reached telemetry, then what Latitude's own OTLP
+ * parsers extract from it. Runs the real `@domain/spans` code by relative path so the verdict
+ * matches ingest without a Latitude instance running.
+ *
+ * Usage: pnpm tsx examples/tools-app/inspect.ts <scenario|all>
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { parseContent } from "../../../../domain/spans/src/otlp/content/index.ts"
+import { resolveOperation } from "../../../../domain/spans/src/otlp/resolvers/operation.ts"
+import { resolveToolExecution } from "../../../../domain/spans/src/otlp/resolvers/tool-execution.ts"
+import type { OtlpKeyValue } from "../../../../domain/spans/src/otlp/types.ts"
+import type { DumpedSpan, SpanDump } from "./telemetry.ts"
+import { SPANS_DIR } from "./telemetry.ts"
+
+type GenAIPart = { type: string; id?: string | null; name?: string; arguments?: unknown; response?: unknown }
+type GenAIMessageLike = { role: string; parts?: GenAIPart[] }
+
+export type ToolObservation = {
+  toolCallId: string
+  toolName: string
+  payload: unknown
+  source: string
+}
+
+export type Inspection = {
+  /** Tool call inputs telemetry carried, keyed by tool call id. */
+  calls: Map<string, ToolObservation>
+  /** Tool outputs telemetry carried, keyed by tool call id. */
+  results: Map<string, ToolObservation>
+  executeToolSpans: number
+  /** What Latitude's ingest parsers would surface in the conversation view. */
+  latitudeCalls: Set<string>
+  latitudeResults: Set<string>
+}
+
+function toOtlpAttrs(attributes: Record<string, unknown>): OtlpKeyValue[] {
+  return Object.entries(attributes).map(([key, value]) => {
+    if (typeof value === "string") return { key, value: { stringValue: value } }
+    if (typeof value === "boolean") return { key, value: { boolValue: value } }
+    if (typeof value === "number") {
+      return Number.isInteger(value)
+        ? { key, value: { intValue: String(value) } }
+        : { key, value: { doubleValue: value } }
+    }
+    if (Array.isArray(value)) {
+      return {
+        key,
+        value: {
+          arrayValue: {
+            values: value.map((item) =>
+              typeof item === "string" ? { stringValue: item } : { stringValue: JSON.stringify(item) },
+            ),
+          },
+        },
+      }
+    }
+    return { key, value: { stringValue: JSON.stringify(value) } }
+  })
+}
+
+function parseJson(value: unknown): unknown {
+  if (typeof value !== "string") return undefined
+  try {
+    return JSON.parse(value)
+  } catch {
+    return undefined
+  }
+}
+
+function preview(value: unknown, max = 100): string {
+  if (value === undefined) return "–"
+  const text = typeof value === "string" ? value : JSON.stringify(value)
+  if (text === undefined) return "–"
+  return text.length > max ? `${text.slice(0, max)}…` : text
+}
+
+/** GenAI semconv messages (`@ai-sdk/otel`, AI SDK v7). */
+function readGenAiMessages(attributes: Record<string, unknown>, key: string): GenAIMessageLike[] {
+  const parsed = parseJson(attributes[key])
+  return Array.isArray(parsed) ? (parsed as GenAIMessageLike[]) : []
+}
+
+/** Vercel `ai.*` messages (AI SDK v6): prompt messages carry `tool-result` content parts. */
+function readVercelPromptToolResults(attributes: Record<string, unknown>): ToolObservation[] {
+  const messages = parseJson(attributes["ai.prompt.messages"])
+  if (!Array.isArray(messages)) return []
+  const observations: ToolObservation[] = []
+  for (const message of messages as { content?: unknown }[]) {
+    if (!Array.isArray(message.content)) continue
+    for (const raw of message.content as {
+      type?: string
+      toolCallId?: string
+      toolName?: string
+      output?: unknown
+    }[]) {
+      if (raw.type !== "tool-result" && raw.type !== "tool-error") continue
+      observations.push({
+        toolCallId: raw.toolCallId ?? "?",
+        toolName: raw.toolName ?? "?",
+        payload: raw.output,
+        source: "ai.prompt.messages",
+      })
+    }
+  }
+  return observations
+}
+
+function readVercelResponseToolCalls(attributes: Record<string, unknown>): ToolObservation[] {
+  const parsed = parseJson(attributes["ai.response.toolCalls"])
+  if (!Array.isArray(parsed)) return []
+  return (parsed as { toolCallId?: string; toolName?: string; input?: unknown }[]).map((call) => ({
+    toolCallId: call.toolCallId ?? "?",
+    toolName: call.toolName ?? "?",
+    payload: call.input,
+    source: "ai.response.toolCalls",
+  }))
+}
+
+function observationsFromGenAiMessages(messages: GenAIMessageLike[], key: string) {
+  const calls: ToolObservation[] = []
+  const results: ToolObservation[] = []
+  for (const message of messages) {
+    for (const part of message.parts ?? []) {
+      if (part.type === "tool_call") {
+        calls.push({
+          toolCallId: part.id ?? "?",
+          toolName: part.name ?? "?",
+          payload: part.arguments,
+          source: key,
+        })
+      } else if (part.type === "tool_call_response") {
+        results.push({ toolCallId: part.id ?? "?", toolName: "", payload: part.response, source: key })
+      }
+    }
+  }
+  return { calls, results }
+}
+
+function orderSpans(spans: DumpedSpan[]): (DumpedSpan & { depth: number })[] {
+  const childrenOf = new Map<string, DumpedSpan[]>()
+  const known = new Set(spans.map((span) => span.spanId))
+  for (const span of spans) {
+    const parentKey = span.parentSpanId && known.has(span.parentSpanId) ? span.parentSpanId : "root"
+    childrenOf.set(parentKey, [...(childrenOf.get(parentKey) ?? []), span])
+  }
+  const ordered: (DumpedSpan & { depth: number })[] = []
+  const walk = (parentKey: string, depth: number) => {
+    for (const child of (childrenOf.get(parentKey) ?? []).sort((a, b) => a.startTimeMs - b.startTimeMs)) {
+      ordered.push({ ...child, depth })
+      walk(child.spanId, depth + 1)
+    }
+  }
+  walk("root", 0)
+  return ordered
+}
+
+export function inspectDump(dump: SpanDump): Inspection {
+  const inspection: Inspection = {
+    calls: new Map(),
+    results: new Map(),
+    executeToolSpans: 0,
+    latitudeCalls: new Set(),
+    latitudeResults: new Set(),
+  }
+
+  console.log(
+    `\n── spans (${dump.spans.length}) ─ scenario: ${dump.scenario} ─ ai ${dump.aiSdkVersion} ─ ${dump.model}`,
+  )
+
+  for (const span of orderSpans(dump.spans)) {
+    const attrs = toOtlpAttrs(span.attributes)
+    const operation = resolveOperation(attrs, span.name, span.scope, Boolean(span.parentSpanId))
+    const indent = "  ".repeat(span.depth)
+    const dropped = span.passesSmartFilter ? "" : "  [dropped by smart filter]"
+    console.log(`${indent}▸ ${span.name}  op=${operation}${dropped}`)
+
+    const output = observationsFromGenAiMessages(
+      readGenAiMessages(span.attributes, "gen_ai.output.messages"),
+      "gen_ai.output.messages",
+    )
+    const input = observationsFromGenAiMessages(
+      readGenAiMessages(span.attributes, "gen_ai.input.messages"),
+      "gen_ai.input.messages",
+    )
+    const observedCalls = [...output.calls, ...readVercelResponseToolCalls(span.attributes)]
+    const observedResults = [...output.results, ...input.results, ...readVercelPromptToolResults(span.attributes)]
+
+    if (operation === "execute_tool") {
+      const execution = resolveToolExecution(attrs, operation)
+      inspection.executeToolSpans++
+      const toolCallId = execution.toolCallId || span.name
+      if (execution.toolInput) {
+        observedCalls.push({
+          toolCallId,
+          toolName: execution.toolName,
+          payload: execution.toolInput,
+          source: "tool span arguments",
+        })
+      }
+      if (execution.toolOutput) {
+        observedResults.push({
+          toolCallId,
+          toolName: execution.toolName,
+          payload: execution.toolOutput,
+          source: "tool span result",
+        })
+      }
+      console.log(`${indent}    execute_tool ${execution.toolName || "?"}`)
+      console.log(`${indent}      arguments  ${preview(execution.toolInput)}`)
+      console.log(`${indent}      result     ${preview(execution.toolOutput)}`)
+    }
+
+    for (const call of observedCalls) {
+      if (!inspection.calls.has(call.toolCallId)) inspection.calls.set(call.toolCallId, call)
+      console.log(`${indent}    tool call   ${call.toolName || "?"}  ${preview(call.payload)}   (${call.source})`)
+    }
+    for (const result of observedResults) {
+      if (!inspection.results.has(result.toolCallId)) inspection.results.set(result.toolCallId, result)
+      console.log(`${indent}    tool result ${result.toolName || "?"}  ${preview(result.payload)}   (${result.source})`)
+    }
+
+    const parsed = parseContent(attrs)
+    for (const message of [...parsed.outputMessages, ...parsed.inputMessages] as GenAIMessageLike[]) {
+      for (const part of message.parts ?? []) {
+        if (part.type === "tool_call") inspection.latitudeCalls.add(part.id ?? "?")
+        if (part.type === "tool_call_response") inspection.latitudeResults.add(part.id ?? "?")
+      }
+    }
+    if (parsed.inputMessages.length || parsed.outputMessages.length || parsed.toolDefinitions.length) {
+      console.log(
+        `${indent}    latitude parse  in=${parsed.inputMessages.length}msg out=${parsed.outputMessages.length}msg ` +
+          `toolDefs=${parsed.toolDefinitions.length}`,
+      )
+    }
+  }
+
+  return inspection
+}
+
+export function reportTotals(inspection: Inspection, appSide: { calls: string[]; results: string[] }): void {
+  const missingCalls = appSide.calls.filter((id) => !inspection.calls.has(id))
+  const missingResults = appSide.results.filter((id) => !inspection.results.has(id))
+
+  console.log("\n── verdict")
+  console.log(`  app process received   ${appSide.calls.length} tool call(s), ${appSide.results.length} result(s)`)
+  console.log(`  telemetry carried      ${inspection.calls.size} tool call(s), ${inspection.results.size} result(s)`)
+  console.log(`  execute_tool spans     ${inspection.executeToolSpans}`)
+  console.log(
+    `  Latitude would show    ${inspection.latitudeCalls.size} tool_call, ${inspection.latitudeResults.size} tool_call_response`,
+  )
+  if (missingCalls.length || missingResults.length) {
+    console.log(`  MISSING                ${missingCalls.length} input(s), ${missingResults.length} output(s)`)
+    for (const id of missingResults) console.log(`    no output in telemetry for tool call ${id}`)
+  } else {
+    console.log("  MISSING                nothing — telemetry matches what the app saw")
+  }
+}
+
+function main(): void {
+  const target = process.argv[2] ?? "all"
+  if (!existsSync(SPANS_DIR)) {
+    console.log(`No dumps in ${SPANS_DIR}. Run run.ts first.`)
+    return
+  }
+  const scenarios =
+    target === "all"
+      ? readdirSync(SPANS_DIR)
+          .filter((file) => file.endsWith(".json"))
+          .map((file) => file.replace(/\.json$/, ""))
+      : [target]
+
+  if (scenarios.length === 0) {
+    console.log(`No dumps in ${SPANS_DIR}. Run run.ts first.`)
+    return
+  }
+
+  for (const scenario of scenarios) {
+    inspectDump(JSON.parse(readFileSync(join(SPANS_DIR, `${scenario}.json`), "utf8")) as SpanDump)
+  }
+}
+
+if (process.argv[1]?.endsWith("inspect.ts")) main()

--- a/packages/telemetry/typescript/examples/tools-app/run.ts
+++ b/packages/telemetry/typescript/examples/tools-app/run.ts
@@ -1,0 +1,107 @@
+/**
+ * Runs one or more provider-executed tool scenarios against a local Latitude instance, then reports
+ * what the app process saw versus what telemetry carried.
+ *
+ * Usage: pnpm tsx --env-file=examples/.env examples/tools-app/run.ts <scenario|all>
+ */
+import { randomUUID } from "node:crypto"
+import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { OpenTelemetry } from "@ai-sdk/otel"
+import { registerTelemetry } from "ai7"
+import { capture } from "../../src/index.ts"
+import { findScenario, MODEL, SCENARIOS, type Scenario, type ScenarioResult } from "./scenarios.ts"
+import { setupTelemetry } from "./telemetry.ts"
+
+const AI_SDK_VERSION = (createRequire(import.meta.url)("ai7/package.json") as { version: string }).version
+const SESSION_ID = `provider-tools-${randomUUID().slice(0, 8)}`
+
+function requireEnv(name: string): void {
+  if (!process.env[name]) {
+    console.error(`Missing ${name}. See examples/tools-app/README.md.`)
+    process.exit(1)
+  }
+}
+
+function resolveScenarios(target: string): Scenario[] {
+  if (target === "all") return SCENARIOS
+  const scenario = findScenario(target)
+  if (!scenario) {
+    console.error(`Unknown scenario "${target}". Available: ${SCENARIOS.map((s) => s.name).join(", ")}`)
+    process.exit(1)
+  }
+  return [scenario]
+}
+
+function printAppSide(result: ScenarioResult): { calls: string[]; results: string[] } {
+  console.log(`\n── app process saw (${result.toolParts.length} tool part(s))`)
+  for (const part of result.toolParts) {
+    const origin = part.providerExecuted ? "provider-executed" : "app-executed"
+    const payload = JSON.stringify(part.payload) ?? "undefined"
+    console.log(
+      `  [${part.kind}] ${part.toolName} (${origin}) ${payload.length > 160 ? `${payload.slice(0, 160)}…` : payload}`,
+    )
+  }
+  console.log(`\n── answer\n  ${result.text.replace(/\n/g, "\n  ")}`)
+  return {
+    calls: result.toolParts.filter((part) => part.kind === "call").map((part) => part.toolCallId),
+    results: result.toolParts.filter((part) => part.kind === "result").map((part) => part.toolCallId),
+  }
+}
+
+async function main(): Promise<void> {
+  requireEnv("LATITUDE_API_KEY")
+  requireEnv("OPENAI_API_KEY")
+
+  const scenarios = resolveScenarios(process.argv[2] ?? "all")
+  const telemetry = setupTelemetry()
+
+  // Must register after Latitude has registered the global tracer provider.
+  registerTelemetry(new OpenTelemetry({ tracer: telemetry.tracer }))
+
+  const inspector = await import("./inspect.ts").catch((error) => {
+    console.warn(`\n[warn] could not load the inspector (${error}); dumps are still written to disk.`)
+    return undefined
+  })
+
+  for (const scenario of scenarios) {
+    const unavailable = scenario.unavailable?.()
+    if (unavailable) {
+      console.log(`\n══ ${scenario.name} — skipped: ${unavailable}`)
+      continue
+    }
+
+    console.log(`\n══ ${scenario.name} — ${scenario.description}`)
+    const meta = { scenario: scenario.name, model: MODEL, aiSdkVersion: AI_SDK_VERSION }
+    let result: ScenarioResult
+    try {
+      result = (await capture(`provider-tools-${scenario.name}`, () => scenario.run(), {
+        tags: ["example", "provider-executed-tools", scenario.name],
+        sessionId: SESSION_ID,
+        userId: "provider-tools-example",
+        metadata: meta,
+      })) as ScenarioResult
+    } catch (error) {
+      console.error(`  failed: ${error}`)
+      await telemetry.flush()
+      telemetry.writeDump(meta)
+      continue
+    }
+
+    const appSide = printAppSide(result)
+    await telemetry.flush()
+    const path = telemetry.writeDump(meta)
+
+    if (inspector) {
+      inspector.reportTotals(inspector.inspectDump(JSON.parse(readFileSync(path, "utf8"))), appSide)
+    }
+    console.log(`\n  span dump: ${path}`)
+  }
+
+  await telemetry.flush()
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/packages/telemetry/typescript/examples/tools-app/scenarios.ts
+++ b/packages/telemetry/typescript/examples/tools-app/scenarios.ts
@@ -1,0 +1,219 @@
+/**
+ * Vercel AI SDK v7 (`ai7`) + OpenAI Responses API scenarios.
+ *
+ * `client-tool` is the control: a tool the app executes, which `@ai-sdk/otel` traces with an
+ * `execute_tool` span carrying arguments and result. Every other scenario uses a provider-executed
+ * (OpenAI-hosted) tool, where the tool loop runs inside the provider and the app never executes
+ * anything — so the AI SDK's tool-execution hooks never fire.
+ *
+ * v6 (`ai` + `@ai-sdk/openai`) cannot run in this repo: the root `@ai-sdk/provider` override makes
+ * the openai provider emit a spec-v4 model that `ai@6` rejects. `examples/test_vercel_ai.ts` fails
+ * the same way.
+ */
+import { openai } from "@ai-sdk/openai7"
+import { generateText, stepCountIs, streamText, tool } from "ai7"
+import { z } from "zod"
+
+export const MODEL = process.env.OPENAI_MODEL ?? "gpt-5.5"
+
+const MAX_TOKENS = 4000
+const INSTRUCTIONS = "You are a helpful assistant. Answer in one or two short sentences."
+
+export type ToolPart = {
+  kind: "call" | "result"
+  toolName: string
+  toolCallId: string
+  providerExecuted: boolean
+  payload: unknown
+}
+
+export type ScenarioResult = {
+  text: string
+  /** Tool activity the AI SDK handed back to the app process, from every step's content. */
+  toolParts: ToolPart[]
+}
+
+export type Scenario = {
+  name: string
+  description: string
+  /** Returns a reason when the scenario cannot run in this environment. */
+  unavailable?: () => string | undefined
+  run: () => Promise<ScenarioResult>
+}
+
+type ContentPart = {
+  type: string
+  toolName?: string
+  toolCallId?: string
+  providerExecuted?: boolean
+  input?: unknown
+  output?: unknown
+  error?: unknown
+}
+
+function collectToolParts(steps: readonly { content: readonly unknown[] }[]): ToolPart[] {
+  const parts: ToolPart[] = []
+  for (const step of steps) {
+    for (const raw of step.content) {
+      const part = raw as ContentPart
+      if (part.type === "tool-call") {
+        parts.push({
+          kind: "call",
+          toolName: part.toolName ?? "?",
+          toolCallId: part.toolCallId ?? "?",
+          providerExecuted: part.providerExecuted === true,
+          payload: part.input,
+        })
+      } else if (part.type === "tool-result" || part.type === "tool-error") {
+        parts.push({
+          kind: "result",
+          toolName: part.toolName ?? "?",
+          toolCallId: part.toolCallId ?? "?",
+          providerExecuted: part.providerExecuted === true,
+          payload: part.type === "tool-error" ? part.error : part.output,
+        })
+      }
+    }
+  }
+  return parts
+}
+
+const weatherTool = tool({
+  description: "Get the current weather for a city",
+  inputSchema: z.object({ city: z.string().describe("The city to get the weather for") }),
+  execute: async ({ city }) => ({ city, temperatureC: 21, conditions: "sunny" }),
+})
+
+const currencyToolConfig = {
+  description: "Convert an amount between two currencies",
+  inputSchema: z.object({ amount: z.number(), from: z.string(), to: z.string() }),
+  execute: async ({ amount, from, to }: { amount: number; from: string; to: string }) => ({
+    amount,
+    from,
+    to,
+    converted: amount * 1.08,
+  }),
+}
+
+type GenerateOptions = Omit<Parameters<typeof generateText>[0], "model">
+
+async function runGenerate(options: GenerateOptions): Promise<ScenarioResult> {
+  const result = await generateText({
+    model: openai(MODEL),
+    instructions: INSTRUCTIONS,
+    maxOutputTokens: MAX_TOKENS,
+    stopWhen: stepCountIs(5),
+    ...options,
+  })
+  return { text: result.text, toolParts: collectToolParts(result.steps) }
+}
+
+export const SCENARIOS: Scenario[] = [
+  {
+    name: "client-tool",
+    description: "Control: app-executed tool. Emits an execute_tool span with arguments + result.",
+    run: () =>
+      runGenerate({
+        prompt: "What's the weather in San Francisco? Use the getWeather tool, then answer.",
+        tools: { getWeather: weatherTool },
+      }),
+  },
+  {
+    name: "web-search",
+    description: "Provider-executed openai.tools.webSearch — runs inside the Responses API.",
+    run: () =>
+      runGenerate({
+        prompt: "Search the web for what was announced at the latest OpenAI DevDay and summarize it.",
+        tools: { web_search: openai.tools.webSearch({}) },
+      }),
+  },
+  {
+    name: "web-search-stream",
+    description: "Same provider-executed web search through streamText, to cover the streaming path.",
+    run: async () => {
+      const result = streamText({
+        model: openai(MODEL),
+        instructions: INSTRUCTIONS,
+        prompt: "Search the web for today's top technology headline and summarize it.",
+        tools: { web_search: openai.tools.webSearch({}) },
+        stopWhen: stepCountIs(5),
+        maxOutputTokens: MAX_TOKENS,
+      })
+      for await (const _chunk of result.fullStream) {
+        // Drain the stream so the AI SDK closes its spans.
+      }
+      return { text: await result.text, toolParts: collectToolParts(await result.steps) }
+    },
+  },
+  {
+    name: "mcp",
+    description: "Provider-executed hosted MCP server (openai.tools.mcp) — the user's reported case.",
+    run: () => {
+      const serverUrl = process.env.MCP_SERVER_URL ?? "https://mcp.deepwiki.com/mcp"
+      const serverLabel = process.env.MCP_SERVER_LABEL ?? "deepwiki"
+      return runGenerate({
+        prompt: `Use the ${serverLabel} MCP tools to tell me what the "vercel/ai" repository is for.`,
+        tools: {
+          mcp: openai.tools.mcp({
+            serverLabel,
+            serverUrl,
+            ...(process.env.MCP_AUTHORIZATION ? { authorization: process.env.MCP_AUTHORIZATION } : {}),
+          }),
+        },
+      })
+    },
+  },
+  {
+    name: "code-interpreter",
+    description: "Provider-executed openai.tools.codeInterpreter — code in, logs out, all server-side.",
+    run: () =>
+      runGenerate({
+        prompt: "Use the code interpreter to compute the 30th Fibonacci number, then tell me the value.",
+        tools: { code_interpreter: openai.tools.codeInterpreter({}) },
+      }),
+  },
+  {
+    name: "tool-search",
+    description: "Provider-executed openai.tools.toolSearch loading a deferred app tool on demand.",
+    run: () =>
+      runGenerate({
+        prompt: "Convert 250 EUR to USD. Find the right tool first if you need to.",
+        tools: {
+          tool_search: openai.tools.toolSearch({}),
+          convertCurrency: tool({
+            ...currencyToolConfig,
+            providerOptions: { openai: { deferLoading: true } },
+          }),
+        },
+      }),
+  },
+  {
+    name: "mixed",
+    description: "One call with both a provider-executed and an app-executed tool, to contrast them in one trace.",
+    run: () =>
+      runGenerate({
+        prompt:
+          "First search the web for the current weather in Barcelona, then call getWeather for Barcelona and " +
+          "compare both answers.",
+        tools: { web_search: openai.tools.webSearch({}), getWeather: weatherTool },
+        stopWhen: stepCountIs(6),
+      }),
+  },
+  {
+    name: "file-search",
+    description: "Provider-executed openai.tools.fileSearch over a vector store.",
+    unavailable: () =>
+      process.env.OPENAI_VECTOR_STORE_ID ? undefined : "set OPENAI_VECTOR_STORE_ID to run this scenario",
+    run: () =>
+      runGenerate({
+        prompt: "Search the knowledge base and summarize what it covers.",
+        tools: {
+          file_search: openai.tools.fileSearch({ vectorStoreIds: [process.env.OPENAI_VECTOR_STORE_ID as string] }),
+        },
+      }),
+  },
+]
+
+export function findScenario(name: string): Scenario | undefined {
+  return SCENARIOS.find((scenario) => scenario.name === name)
+}

--- a/packages/telemetry/typescript/examples/tools-app/telemetry.ts
+++ b/packages/telemetry/typescript/examples/tools-app/telemetry.ts
@@ -1,0 +1,118 @@
+/**
+ * Latitude telemetry wiring for the provider-executed tools repro app.
+ *
+ * Uses the local repo SDK source (`../../src`) in composable mode so a second span processor can
+ * snapshot every span the AI SDK emits before Latitude's redaction rewrites it. The snapshot is
+ * what `inspect.ts` reads, so the repro is diagnosable without a running Latitude instance.
+ */
+import { mkdirSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { Context, Tracer } from "@opentelemetry/api"
+import { hrTimeToMilliseconds } from "@opentelemetry/core"
+import { NodeTracerProvider, type ReadableSpan, type Span, type SpanProcessor } from "@opentelemetry/sdk-trace-node"
+import { getLatitudeTracer, isDefaultExportSpan, LatitudeSpanProcessor } from "../../src/index.ts"
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+export const SPANS_DIR = join(HERE, ".spans")
+
+export type DumpedSpanEvent = {
+  name: string
+  attributes: Record<string, unknown>
+}
+
+export type DumpedSpan = {
+  traceId: string
+  spanId: string
+  parentSpanId: string | undefined
+  name: string
+  scope: string
+  startTimeMs: number
+  durationMs: number
+  passesSmartFilter: boolean
+  statusCode: number
+  statusMessage: string | undefined
+  attributes: Record<string, unknown>
+  events: DumpedSpanEvent[]
+}
+
+export type SpanDump = {
+  scenario: string
+  model: string
+  aiSdkVersion: string
+  spans: DumpedSpan[]
+}
+
+function cloneAttributes(attributes: unknown): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(attributes ?? {})) as Record<string, unknown>
+}
+
+/** Snapshots spans on end. Registered before the Latitude processor so attributes are pre-redaction. */
+class SpanDumpProcessor implements SpanProcessor {
+  readonly spans: DumpedSpan[] = []
+
+  onStart(_span: Span, _parentContext: Context): void {}
+
+  onEnd(span: ReadableSpan): void {
+    this.spans.push({
+      traceId: span.spanContext().traceId,
+      spanId: span.spanContext().spanId,
+      parentSpanId: span.parentSpanContext?.spanId,
+      name: span.name,
+      scope: span.instrumentationScope?.name ?? "",
+      startTimeMs: hrTimeToMilliseconds(span.startTime),
+      durationMs: hrTimeToMilliseconds(span.duration),
+      passesSmartFilter: isDefaultExportSpan(span),
+      statusCode: span.status.code,
+      statusMessage: span.status.message,
+      attributes: cloneAttributes(span.attributes),
+      events: span.events.map((event) => ({ name: event.name, attributes: cloneAttributes(event.attributes) })),
+    })
+  }
+
+  /** Empties the buffer so a multi-scenario run writes one dump per scenario. */
+  drain(): DumpedSpan[] {
+    return this.spans.splice(0, this.spans.length)
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+export type Telemetry = {
+  tracer: Tracer
+  flush: () => Promise<void>
+  /** Writes the spans buffered since the previous call and returns the file path. */
+  writeDump: (dump: Omit<SpanDump, "spans">) => string
+}
+
+export function setupTelemetry(): Telemetry {
+  const apiKey = process.env.LATITUDE_API_KEY
+  if (!apiKey) throw new Error("LATITUDE_API_KEY is required")
+
+  const dumper = new SpanDumpProcessor()
+  const provider = new NodeTracerProvider({
+    spanProcessors: [
+      dumper,
+      new LatitudeSpanProcessor(apiKey, process.env.LATITUDE_PROJECT_SLUG, { disableBatch: true }),
+    ],
+  })
+  provider.register()
+
+  return {
+    tracer: getLatitudeTracer("tools-app"),
+    flush: () => provider.forceFlush(),
+    writeDump: (meta) => {
+      const path = join(SPANS_DIR, `${meta.scenario}.json`)
+      mkdirSync(dirname(path), { recursive: true })
+      const dump: SpanDump = { ...meta, spans: dumper.drain() }
+      writeFileSync(path, `${JSON.stringify(dump, null, 2)}\n`)
+      return path
+    },
+  }
+}


### PR DESCRIPTION
Adds `packages/telemetry/typescript/examples/tools-app`, a sample app for inspecting how tool calls
reach Latitude. It came out of a user report that provider-executed tools (OpenAI-hosted MCP, web
search, tool search) do not bubble their inputs and outputs into Latitude, and it was what let us
pin the cause down to the AI SDK rather than our ingest.

## what it does

Eight scenarios against the OpenAI Responses API through the Vercel AI SDK: an app-executed tool as
a control, then hosted MCP, web search (buffered and streamed), code interpreter, tool search,
a mixed call, and file search. Each run sends telemetry to a local instance using the SDK source in
this repo (`../../src`), so a change to the telemetry SDK takes effect on the next run with no build
step.

Two things make it useful beyond a one-off script:

`telemetry.ts` registers a second span processor that snapshots every span pre-redaction to
`.spans/<scenario>.json`, recording `passesSmartFilter` per span so it is visible whether our export
filter would have dropped it.

`inspect.ts` replays that dump through the real ingest parsers (`parseContent`, `resolveOperation`,
`resolveToolExecution` from `@domain/spans`, imported by relative path) and prints what the app
process received next to what telemetry carried:

```
── verdict
  app process received   2 tool call(s), 2 result(s)
  telemetry carried      2 tool call(s), 0 result(s)
  execute_tool spans     0
  Latitude would show    2 tool_call, 0 tool_call_response
  MISSING                0 input(s), 2 output(s)
```

So a fix can be validated from a dump, without a running instance and without reading the UI.

## what it found

Three gaps, all upstream of Latitude, reproduced on `ai@7.0.66` / `@ai-sdk/openai@4.0.42` /
`@ai-sdk/otel@1.0.66` and filed as [vercel/ai#19007](https://github.com/vercel/ai/issues/19007):
no span is created for a provider-executed tool call so its duration is invisible, `tool-result`
parts are dropped from `gen_ai.output.messages` so the outputs reach nothing, and hosted MCP calls
are named `mcp.<remoteTool>` while `gen_ai.tool.definitions` carries only the container tool `mcp`.

That last one is why `screenSessionFlaggers` reports `Assistant called tool
"mcp.read_wiki_structure" which is not in the declared toolset` on any hosted MCP session. The
false positive is ours to fix in `packages/domain/flaggers/src/helpers.ts` and is not part of this
PR.

## notes

The example targets AI SDK v7 through the existing `ai7` / `@ai-sdk/openai7` aliases. v6 cannot run
in this repo: the root `pnpm.overrides` pin of `@ai-sdk/provider: 4.0.0-beta.7` makes
`@ai-sdk/openai@4` emit a spec-v4 model that `ai@6` rejects, so `examples/test_vercel_ai.ts` fails
today with `AI_UnsupportedModelVersionError`. Those aliases also still point at betas while stable
`7.0.66` is out; bumping them touches the lockfile and is left for a separate change.

No `package.json`, so pnpm does not adopt the folder as a workspace package and no
`pnpm-workspace.yaml` exclusion is needed. Span dumps and `.env` are gitignored. The one change
outside the new folder is a `!**/.spans` entry in `biome.json`, because Biome has no `vcs` block and
so lints gitignored files, and a root `biome check` would otherwise fail on a dump.

Refs [vercel/ai#19007](https://github.com/vercel/ai/issues/19007)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a telemetry tools sample app with scenarios for web search, MCP, code interpreter, file search, and other tool executions.
  * Added command-line scenario execution with support for running individual scenarios or the full suite.
  * Added telemetry inspection and reporting for tool calls, results, and missing data.
  * Added span dump generation for reviewing captured telemetry.

* **Documentation**
  * Added setup instructions, configuration guidance, supported scenarios, and telemetry limitations.

* **Chores**
  * Added environment configuration templates and ignore rules for local settings and span dumps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->