### PR TITLE
General UI QA [LAT-755]

### DIFF
--- a/apps/web/src/components/hotkey-badge.tsx
+++ b/apps/web/src/components/hotkey-badge.tsx
@@ -1,13 +1,22 @@
-import { Text } from "@repo/ui"
+import { cn, Text } from "@repo/ui"
 import { formatForDisplay, type RegisterableHotkey } from "@tanstack/react-hotkeys"
 
 export function HotkeyBadge({ hotkey }: { readonly hotkey: RegisterableHotkey }) {
-  const label = formatForDisplay(hotkey)
+  const keys = formatForDisplay(hotkey)
+    .split(/[\s+]+/)
+    .filter(Boolean)
   return (
-    <span className="inline-flex shrink-0 items-center rounded border border-current/30 px-1">
-      <Text.H7 asChild color="inherit">
-        <kbd>{label}</kbd>
-      </Text.H7>
+    <span className="inline-flex shrink-0 items-center gap-1 align-middle">
+      {keys.map((key, index) => (
+        <span
+          key={`${key}-${index}`}
+          className="inline-flex size-5 shrink-0 items-center justify-center rounded border border-current/30"
+        >
+          <Text.H7 asChild color="inherit" weight="bold" className={cn("leading-none", key.length > 1 && "text-[7px]")}>
+            <kbd>{key}</kbd>
+          </Text.H7>
+        </span>
+      ))}
     </span>
   )
 }

--- a/apps/web/src/domains/taxonomy/trend-display.tsx
+++ b/apps/web/src/domains/taxonomy/trend-display.tsx
@@ -1,6 +1,6 @@
 import type { TaxonomyClusterTrendStatus } from "@domain/taxonomy"
-import { Badge } from "@repo/ui"
-import { ArrowDownIcon, ArrowUpIcon, FlameIcon, type LucideIcon, MinusIcon, SparklesIcon } from "lucide-react"
+import type { BadgeProps } from "@repo/ui"
+import { ArrowDownIcon, ArrowUpIcon, FlameIcon, MinusIcon, SparklesIcon } from "lucide-react"
 
 export const trendLabel = (status: TaxonomyClusterTrendStatus): string => {
   switch (status) {
@@ -35,16 +35,19 @@ export const trendIcon = (status: TaxonomyClusterTrendStatus) => {
   }
 }
 
-/**
- * The pill used for a behavior's status badges (parent, sessions, trend, first
- * seen, facet timing), on the tree, the catalog, and the facet header alike —
- * the app's shared `Badge`, not a bespoke one, so it stays in step with every
- * other badge in the product.
- */
-export function BehaviourBadge({ label, icon }: { readonly label: string; readonly icon: LucideIcon }) {
-  return (
-    <Badge variant="outlineMuted" shape="rounded" ellipsis iconProps={{ icon, placement: "start" }}>
-      {label}
-    </Badge>
-  )
+export const trendBadgeVariant = (status: TaxonomyClusterTrendStatus): NonNullable<BadgeProps["variant"]> => {
+  switch (status) {
+    case "new":
+      return "accent"
+    case "spike":
+      return "yellow"
+    case "rising":
+      return "successMuted"
+    case "steady":
+      return "muted"
+    case "cooling":
+      return "purple"
+    case "fading":
+      return "destructiveMuted"
+  }
 }

--- a/apps/web/src/layouts/ListingLayout/index.tsx
+++ b/apps/web/src/layouts/ListingLayout/index.tsx
@@ -1,5 +1,5 @@
 import { cn, Text } from "@repo/ui"
-import { Children, isValidElement, type ReactElement, type ReactNode } from "react"
+import { Children, forwardRef, isValidElement, type ReactElement, type ReactNode } from "react"
 
 interface ListingLayoutProps {
   readonly children: ReactNode
@@ -132,9 +132,13 @@ interface ListProps {
   readonly className?: string
 }
 
-function List({ children, className }: ListProps) {
-  return <div className={cn("min-h-0 min-w-0 grow p-6 pt-0 flex flex-col", className)}>{children}</div>
-}
+const List = forwardRef<HTMLDivElement, ListProps>(function List({ children, className }, ref) {
+  return (
+    <div ref={ref} className={cn("min-h-0 min-w-0 grow p-6 pt-0 flex flex-col", className)}>
+      {children}
+    </div>
+  )
+})
 
 function Body({ children, className }: { readonly children: ReactNode; readonly className?: string }) {
   return (

--- a/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
+++ b/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
@@ -122,9 +122,7 @@ export function ProjectBreadcrumbSegment() {
               label="Create new"
               icon={<Icon icon={Plus} size="sm" color="foregroundMuted" />}
               onClick={() => {
-                // The button lives inside the combobox's own floating popup, so Base UI's
-                // outside-click dismissal never treats clicking it as "outside" — it has to
-                // be closed explicitly, or it stays open (and painting above the modal) after.
+                // Explicitly close the combobox because this footer action lives inside its popup.
                 setComboboxOpen(false)
                 setCreateOpen(true)
               }}

--- a/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
+++ b/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
@@ -49,6 +49,7 @@ export function ProjectBreadcrumbSegment() {
   const navigate = useNavigate()
   const routeProject = useRouteProject()
   const [createOpen, setCreateOpen] = useState(false)
+  const [comboboxOpen, setComboboxOpen] = useState(false)
   const [inputValue, setInputValue] = useState("")
   const triggerRef = useRef<HTMLButtonElement>(null)
 
@@ -87,6 +88,8 @@ export function ProjectBreadcrumbSegment() {
         <Combobox
           autoHighlight
           modal
+          open={comboboxOpen}
+          onOpenChange={(open) => setComboboxOpen(open)}
           value={selectedOption}
           onValueChange={(picked: ProjectOption | null) => {
             setInputValue("")
@@ -118,7 +121,13 @@ export function ProjectBreadcrumbSegment() {
             <ComboboxFooterAction
               label="Create new"
               icon={<Icon icon={Plus} size="sm" color="foregroundMuted" />}
-              onClick={() => setCreateOpen(true)}
+              onClick={() => {
+                // The button lives inside the combobox's own floating popup, so Base UI's
+                // outside-click dismissal never treats clicking it as "outside" — it has to
+                // be closed explicitly, or it stays open (and painting above the modal) after.
+                setComboboxOpen(false)
+                setCreateOpen(true)
+              }}
             />
           </ComboboxContent>
         </Combobox>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -216,9 +216,6 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   // Ref to the ordered list of trace IDs from the currently loaded table page
   const traceIdsRef = useRef<string[]>([])
 
-  // Shared scroll container for both tabs: holds the aggregations chart and the
-  // table together, so scrolling moves them as one and the table's header sticks
-  // once it reaches the top instead of the table scrolling alone in its own small box.
   const sessionsScrollAreaRef = useRef<HTMLDivElement>(null)
 
   const filters = useMemo(() => parseFilters(rawFilters || undefined), [rawFilters])
@@ -667,9 +664,6 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
           </div>
         )}
 
-        {/* `sticky left-0`: this section doesn't need the horizontal scroll that only the
-            wide table (below) triggers on the shared container — pin it to the viewport's
-            left edge instead of letting it slide away with the table's columns. */}
         <div className="sticky left-0 z-[1] bg-background px-6">
           <TraceAggregationsPanel
             projectId={currentProject.id}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -216,6 +216,11 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   // Ref to the ordered list of trace IDs from the currently loaded table page
   const traceIdsRef = useRef<string[]>([])
 
+  // Shared scroll container for both tabs: holds the aggregations chart and the
+  // table together, so scrolling moves them as one and the table's header sticks
+  // once it reaches the top instead of the table scrolling alone in its own small box.
+  const sessionsScrollAreaRef = useRef<HTMLDivElement>(null)
+
   const filters = useMemo(() => parseFilters(rawFilters || undefined), [rawFilters])
   // Sessions/Traces date filter: default is "All time"; a picked range lives in `filters.startTime`,
   // and the histogram stays clamped (anchored to latest activity when All time). See the hook.
@@ -490,6 +495,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
     onFiltersClose: () => setFiltersOpen(false),
     onActiveTraceChange,
     traceIdsRef,
+    scrollContainerRef: sessionsScrollAreaRef,
   }
 
   return (
@@ -647,59 +653,65 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
         </Layout.ActionsRow>
       </Layout.Actions>
 
-      {selectedCount > 0 && (
-        <div className="flex items-center gap-2 px-6">
-          <Button variant="outline" size="sm" onClick={() => setExportModalOpen(true)} disabled={exporting}>
-            <Icon icon={DownloadIcon} size="sm" />
-            Export Traces ({selectedCount.toLocaleString()})
-          </Button>
-          <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
-            <Icon icon={DatabaseIcon} size="sm" />
-            Add to Dataset ({selectedCount})
-          </Button>
+      <div ref={sessionsScrollAreaRef} className="flex flex-1 min-h-0 flex-col gap-4 overflow-y-auto">
+        {selectedCount > 0 && (
+          <div className="sticky left-0 z-[1] flex items-center gap-2 bg-background px-6">
+            <Button variant="outline" size="sm" onClick={() => setExportModalOpen(true)} disabled={exporting}>
+              <Icon icon={DownloadIcon} size="sm" />
+              Export Traces ({selectedCount.toLocaleString()})
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
+              <Icon icon={DatabaseIcon} size="sm" />
+              Add to Dataset ({selectedCount})
+            </Button>
+          </div>
+        )}
+
+        {/* `sticky left-0`: this section doesn't need the horizontal scroll that only the
+            wide table (below) triggers on the shared container — pin it to the viewport's
+            left edge instead of letting it slide away with the table's columns. */}
+        <div className="sticky left-0 z-[1] bg-background px-6">
+          <TraceAggregationsPanel
+            projectId={currentProject.id}
+            projectSlug={currentProject.slug}
+            filters={filtersWithDefaultTime}
+            mode={activeTab}
+            onTimeRangeSelect={onTimeRangeSelect}
+            {...(histogramRangeOverride ? { histogramRangeOverride } : {})}
+          />
         </div>
-      )}
 
-      <div className="px-6">
-        <TraceAggregationsPanel
-          projectId={currentProject.id}
-          projectSlug={currentProject.slug}
-          filters={filtersWithDefaultTime}
-          mode={activeTab}
-          onTimeRangeSelect={onTimeRangeSelect}
-          {...(histogramRangeOverride ? { histogramRangeOverride } : {})}
-        />
+        {isSessions ? (
+          <SessionsView
+            projectId={currentProject.id}
+            filters={filtersWithDefaultTime}
+            filtersOpen={filtersOpen}
+            activeSessionId={activeSessionId || undefined}
+            activeTraceId={activeTraceId || undefined}
+            sorting={sorting}
+            onSortingChange={onSortingChange}
+            selectionState={selectionState}
+            onSelectionChange={setSelectionState}
+            totalTraceCount={totalTraceCount}
+            onFiltersChange={onFiltersChange}
+            onShowAllSessions={onShowAllSessions}
+            onFiltersClose={() => setFiltersOpen(false)}
+            onOpenSession={onOpenSession}
+            onCloseSession={closeSessionPanel}
+            visibleColumnIds={sessionColumnSettings.visibleColumnIds}
+            isSearching={hasSearchQuery}
+            hasUserAppliedFilters={hasActiveFilters}
+            scrollContainerRef={sessionsScrollAreaRef}
+            {...(hasSearchQuery ? { searchQuery: query } : {})}
+          />
+        ) : (
+          <TracesView
+            {...sharedViewProps}
+            visibleColumnIds={traceColumnSettings.visibleColumnIds}
+            {...(hasSearchQuery ? { searchQuery: query } : {})}
+          />
+        )}
       </div>
-
-      {isSessions ? (
-        <SessionsView
-          projectId={currentProject.id}
-          filters={filtersWithDefaultTime}
-          filtersOpen={filtersOpen}
-          activeSessionId={activeSessionId || undefined}
-          activeTraceId={activeTraceId || undefined}
-          sorting={sorting}
-          onSortingChange={onSortingChange}
-          selectionState={selectionState}
-          onSelectionChange={setSelectionState}
-          totalTraceCount={totalTraceCount}
-          onFiltersChange={onFiltersChange}
-          onShowAllSessions={onShowAllSessions}
-          onFiltersClose={() => setFiltersOpen(false)}
-          onOpenSession={onOpenSession}
-          onCloseSession={closeSessionPanel}
-          visibleColumnIds={sessionColumnSettings.visibleColumnIds}
-          isSearching={hasSearchQuery}
-          hasUserAppliedFilters={hasActiveFilters}
-          {...(hasSearchQuery ? { searchQuery: query } : {})}
-        />
-      ) : (
-        <TracesView
-          {...sharedViewProps}
-          visibleColumnIds={traceColumnSettings.visibleColumnIds}
-          {...(hasSearchQuery ? { searchQuery: query } : {})}
-        />
-      )}
 
       {!isSessions && activeTraceId ? (
         <Layout.Aside>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -531,7 +531,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
                 >
                   <FilterIcon className="h-4 w-4" />
                   Filters
-                  <kbd className="rounded bg-muted px-1 font-mono text-xs text-muted-foreground">F</kbd>
+                  <HotkeyBadge hotkey="F" />
                   {hasActiveFilters && (
                     <span className="inline-flex items-center justify-center rounded-full bg-primary px-1.5 text-[10px] leading-4 font-medium text-primary-foreground">
                       {Object.keys(filters).length}
@@ -600,8 +600,6 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
             <Tabs
               variant="bordered"
               size="sm"
-              className="border-none bg-muted"
-              indicatorClassName="border-none"
               options={[
                 {
                   id: "sessions",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -68,13 +68,20 @@ interface ProjectTracesTableProps {
   readonly metricsLoading?: boolean | undefined
   readonly annotationCounts?: ReadonlyMap<string, TraceAnnotationCounts> | undefined
   readonly annotationCountsPendingTraceIds?: ReadonlySet<string> | undefined
-  readonly scrollAreaLayout?: "fill" | "intrinsic" | "external"
   readonly scrollContainerClassName?: string
-  /** Required when `scrollAreaLayout` is `"external"` — see `InfiniteTable`. */
-  readonly scrollContainerRef?: RefObject<HTMLDivElement | null>
   readonly onErrorClick?: (trace: TraceRecord) => void
   readonly onAnnotationClick?: (trace: TraceRecord) => void
 }
+
+type ProjectTracesTableScrollProps =
+  | {
+      readonly scrollAreaLayout: "external"
+      readonly scrollContainerRef: RefObject<HTMLDivElement | null>
+    }
+  | {
+      readonly scrollAreaLayout?: "fill" | "intrinsic"
+      readonly scrollContainerRef?: RefObject<HTMLDivElement | null>
+    }
 
 export function ProjectTracesTable({
   projectId,
@@ -103,7 +110,7 @@ export function ProjectTracesTable({
   scrollContainerRef,
   onErrorClick,
   onAnnotationClick,
-}: ProjectTracesTableProps) {
+}: ProjectTracesTableProps & ProjectTracesTableScrollProps) {
   const showMetricSubheaders = traceMetrics !== undefined || metricsLoading !== undefined
   const isRelevanceSort = sorting?.column === RELEVANCE_SORT_COLUMN
 
@@ -388,13 +395,20 @@ export function ProjectTracesTable({
     return `View trace ${shortName}`
   }, [])
 
+  const scrollAreaProps =
+    scrollAreaLayout === "external"
+      ? ({ scrollAreaLayout: "external", scrollContainerRef } as const)
+      : {
+          ...(scrollAreaLayout !== undefined ? { scrollAreaLayout } : {}),
+          ...(scrollContainerRef !== undefined ? { scrollContainerRef } : {}),
+        }
+
   return (
     <InfiniteTable
       data={data}
       {...(isLoading !== undefined ? { isLoading } : {})}
-      {...(scrollAreaLayout !== undefined ? { scrollAreaLayout } : {})}
+      {...scrollAreaProps}
       {...(scrollContainerClassName !== undefined ? { className: scrollContainerClassName } : {})}
-      {...(scrollContainerRef !== undefined ? { scrollContainerRef } : {})}
       columns={columns}
       getRowKey={(trace) => trace.traceId}
       {...(onTraceClick

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -11,7 +11,7 @@ import {
 } from "@repo/ui"
 import { formatCount, formatDuration, formatPercentage, relativeTime } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
-import { type MouseEvent, type ReactNode, useCallback, useMemo } from "react"
+import { type MouseEvent, type ReactNode, type RefObject, useCallback, useMemo } from "react"
 import { rollupCostDisplay } from "../../../../../domains/spans/cost-display.ts"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
 import { CacheHitRateSubheader } from "./table/cache-hit-rate-subheader.tsx"
@@ -68,8 +68,10 @@ interface ProjectTracesTableProps {
   readonly metricsLoading?: boolean | undefined
   readonly annotationCounts?: ReadonlyMap<string, TraceAnnotationCounts> | undefined
   readonly annotationCountsPendingTraceIds?: ReadonlySet<string> | undefined
-  readonly scrollAreaLayout?: "fill" | "intrinsic"
+  readonly scrollAreaLayout?: "fill" | "intrinsic" | "external"
   readonly scrollContainerClassName?: string
+  /** Required when `scrollAreaLayout` is `"external"` — see `InfiniteTable`. */
+  readonly scrollContainerRef?: RefObject<HTMLDivElement | null>
   readonly onErrorClick?: (trace: TraceRecord) => void
   readonly onAnnotationClick?: (trace: TraceRecord) => void
 }
@@ -98,6 +100,7 @@ export function ProjectTracesTable({
   annotationCountsPendingTraceIds,
   scrollAreaLayout,
   scrollContainerClassName,
+  scrollContainerRef,
   onErrorClick,
   onAnnotationClick,
 }: ProjectTracesTableProps) {
@@ -391,6 +394,7 @@ export function ProjectTracesTable({
       {...(isLoading !== undefined ? { isLoading } : {})}
       {...(scrollAreaLayout !== undefined ? { scrollAreaLayout } : {})}
       {...(scrollContainerClassName !== undefined ? { className: scrollContainerClassName } : {})}
+      {...(scrollContainerRef !== undefined ? { scrollContainerRef } : {})}
       columns={columns}
       getRowKey={(trace) => trace.traceId}
       {...(onTraceClick

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/section-header.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/section-header.tsx
@@ -1,0 +1,34 @@
+import { cn, Text } from "@repo/ui"
+import type { ReactNode } from "react"
+
+interface SectionHeaderProps {
+  readonly title: ReactNode
+  readonly description?: ReactNode
+  readonly badge?: ReactNode
+  readonly className?: string
+  readonly variant?: "default" | "xl"
+}
+
+export function SectionHeader({ title, description, badge, className, variant = "default" }: SectionHeaderProps) {
+  return (
+    <div className={cn("flex min-w-0 flex-1 flex-col", variant === "xl" ? "gap-0.5" : "gap-1", className)}>
+      <div className="flex min-w-0 flex-row flex-wrap items-center gap-x-2 gap-y-1">
+        {typeof title === "string" ? (
+          variant === "xl" ? (
+            <Text.H3M className="min-w-0 shrink">{title}</Text.H3M>
+          ) : (
+            <Text.H4M className="min-w-0 shrink">{title}</Text.H4M>
+          )
+        ) : (
+          title
+        )}
+        {badge ? <span className="flex shrink-0">{badge}</span> : null}
+      </div>
+      {description !== undefined && description !== null ? (
+        <div className="max-w-[400px]">
+          {typeof description === "string" ? <Text.H5 color="foregroundMuted">{description}</Text.H5> : description}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -170,12 +170,7 @@ interface SessionsViewProps {
   readonly searchQuery?: string
   /** Filter fields to hide in the built-in sidebar (e.g. `topics`). */
   readonly excludeFilterFields?: readonly string[]
-  /**
-   * The ancestor scroll container to virtualize against — shared with whatever else
-   * the caller stacks above it (e.g. an aggregations chart), so the page scrolls as
-   * one and the table's header sticks once it reaches the top. When omitted the
-   * table falls back to scrolling within its own bounded box, as before.
-   */
+  /** Optional shared ancestor scroll container for page-level scrolling + sticky headers. */
   readonly scrollContainerRef?: RefObject<HTMLDivElement | null>
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -14,7 +14,7 @@ import { formatCount, formatDuration, formatPercentage, relativeTime } from "@re
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { useQueries } from "@tanstack/react-query"
 import { ChevronsDownUpIcon, ChevronsUpDownIcon } from "lucide-react"
-import { type MouseEvent, type ReactNode, useCallback, useMemo, useState } from "react"
+import { type MouseEvent, type ReactNode, type RefObject, useCallback, useMemo, useState } from "react"
 import { useAnnotationCountsByTraceIds } from "../../../../../domains/annotations/annotations.collection.ts"
 import { sandboxOrgIdForScope, useProjectScope } from "../../../../../domains/projects/project-scope.tsx"
 import {
@@ -170,6 +170,13 @@ interface SessionsViewProps {
   readonly searchQuery?: string
   /** Filter fields to hide in the built-in sidebar (e.g. `topics`). */
   readonly excludeFilterFields?: readonly string[]
+  /**
+   * The ancestor scroll container to virtualize against — shared with whatever else
+   * the caller stacks above it (e.g. an aggregations chart), so the page scrolls as
+   * one and the table's header sticks once it reaches the top. When omitted the
+   * table falls back to scrolling within its own bounded box, as before.
+   */
+  readonly scrollContainerRef?: RefObject<HTMLDivElement | null>
 }
 
 export function SessionsView({
@@ -194,6 +201,7 @@ export function SessionsView({
   searchQuery,
   selectable = true,
   excludeFilterFields,
+  scrollContainerRef,
 }: SessionsViewProps) {
   // Annotations are an LLM-feedback feature — off under a sandbox scope. Skip
   // the counts fetch so the Indicators column shows errors only (mirrors the
@@ -844,8 +852,15 @@ export function SessionsView({
     return paginateTraces(entry.data, row.session.traceCount)
   }
 
+  const hasExternalScrollArea = scrollContainerRef !== undefined
+
   return (
-    <Layout.Body>
+    // `flex-none overflow-visible`: the default `flex-1 min-h-0 overflow-hidden` bounds
+    // and clips this to the visible viewport, which is right when the table scrolls
+    // itself — but with an external scroll container the table grows to its full row
+    // count and that ancestor (shared with content stacked above it, e.g. an
+    // aggregations chart) scrolls for it instead, so nothing here should clip.
+    <Layout.Body {...(hasExternalScrollArea ? { className: "flex-none overflow-visible" } : {})}>
       {filtersOpen && (
         <FiltersSidebar
           mode="sessions"
@@ -858,7 +873,9 @@ export function SessionsView({
       )}
       <Layout.List>
         <InfiniteTable
-          {...listingLayoutIntrinsicScroll.infiniteTable}
+          {...(hasExternalScrollArea
+            ? { scrollAreaLayout: "external" as const, scrollContainerRef }
+            : listingLayoutIntrinsicScroll.infiniteTable)}
           data={tableData}
           isLoading={isLoading}
           columns={columns}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
@@ -31,12 +31,7 @@ interface TracesViewProps {
   readonly visibleColumnIds: readonly TraceColumnId[]
   readonly searchQuery?: string
   readonly selectable?: boolean
-  /**
-   * The ancestor scroll container to virtualize against — shared with whatever else
-   * the caller stacks above it (e.g. an aggregations chart), so the page scrolls as
-   * one and the table's header sticks once it reaches the top. When omitted the
-   * table falls back to scrolling within its own bounded box, as before.
-   */
+  /** Optional shared ancestor scroll container for page-level scrolling + sticky headers. */
   readonly scrollContainerRef?: RefObject<HTMLDivElement | null>
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
@@ -31,6 +31,13 @@ interface TracesViewProps {
   readonly visibleColumnIds: readonly TraceColumnId[]
   readonly searchQuery?: string
   readonly selectable?: boolean
+  /**
+   * The ancestor scroll container to virtualize against — shared with whatever else
+   * the caller stacks above it (e.g. an aggregations chart), so the page scrolls as
+   * one and the table's header sticks once it reaches the top. When omitted the
+   * table falls back to scrolling within its own bounded box, as before.
+   */
+  readonly scrollContainerRef?: RefObject<HTMLDivElement | null>
 }
 
 export function TracesView({
@@ -51,6 +58,7 @@ export function TracesView({
   visibleColumnIds,
   searchQuery,
   selectable = true,
+  scrollContainerRef,
 }: TracesViewProps) {
   const hasActiveFilters = Object.keys(filters).length > 0
   const hasSearchQuery = !!searchQuery && searchQuery.length > 0
@@ -147,8 +155,10 @@ export function TracesView({
     },
   ])
 
+  const hasExternalScrollArea = scrollContainerRef !== undefined
+
   return (
-    <Layout.Body>
+    <Layout.Body {...(hasExternalScrollArea ? { className: "flex-none overflow-visible" } : {})}>
       {filtersOpen && (
         <FiltersSidebar
           mode="traces"
@@ -160,7 +170,9 @@ export function TracesView({
       )}
       <Layout.List>
         <ProjectTracesTable
-          {...listingLayoutIntrinsicScroll.projectTracesTable}
+          {...(hasExternalScrollArea
+            ? { scrollAreaLayout: "external" as const, scrollContainerRef }
+            : listingLayoutIntrinsicScroll.projectTracesTable)}
           projectId={projectId}
           data={traces}
           isLoading={isLoading}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-catalog-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-catalog-panel.tsx
@@ -1,4 +1,4 @@
-import { cn, Icon, Text, Tooltip } from "@repo/ui"
+import { Badge, cn, Icon, Text, Tooltip } from "@repo/ui"
 import { formatCount, formatPercentage } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import { ClockArrowUpIcon, GlobeIcon } from "lucide-react"
@@ -10,7 +10,7 @@ import {
   FACET_SCOPE_GLOBAL_TOOLTIP,
   FACET_SCOPE_WINDOWED_TOOLTIP,
 } from "../../../../../../domains/taxonomy/facet-scope-copy.ts"
-import { BehaviourBadge, trendIcon, trendLabel } from "../../../../../../domains/taxonomy/trend-display.tsx"
+import { trendBadgeVariant, trendIcon, trendLabel } from "../../../../../../domains/taxonomy/trend-display.tsx"
 import { PreviewPlaceholder } from "./behaviour-catalog-card.tsx"
 
 /** The Behaviors home: a full-width panel per behavior, stacked top to bottom. */
@@ -70,7 +70,9 @@ function GroupRow({
             {`${formatCount(group.sessionCount)} sessions`}
           </Text.H5>
         </div>
-        <BehaviourBadge label={trendLabel(group.trend)} icon={trendIcon(group.trend)} />
+        <Badge variant={trendBadgeVariant(group.trend)} ellipsis iconProps={{ icon: trendIcon(group.trend), placement: "start" }}>
+          {trendLabel(group.trend)}
+        </Badge>
       </div>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-catalog-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-catalog-panel.tsx
@@ -70,7 +70,11 @@ function GroupRow({
             {`${formatCount(group.sessionCount)} sessions`}
           </Text.H5>
         </div>
-        <Badge variant={trendBadgeVariant(group.trend)} ellipsis iconProps={{ icon: trendIcon(group.trend), placement: "start" }}>
+        <Badge
+          variant={trendBadgeVariant(group.trend)}
+          ellipsis
+          iconProps={{ icon: trendIcon(group.trend), placement: "start" }}
+        >
           {trendLabel(group.trend)}
         </Badge>
       </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-view-chips.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-view-chips.tsx
@@ -3,9 +3,9 @@ import { Link } from "@tanstack/react-router"
 import type { CustomBehaviorRecord } from "../../../../../../domains/taxonomy/custom-behaviors.functions.ts"
 
 const chipClass = (active: boolean) =>
-  cn("flex h-7 max-w-48 items-center rounded px-2 transition-colors", {
-    "border border-border bg-background": active,
-    "border border-transparent hover:bg-background/60": !active,
+  cn("flex h-6.5 max-w-48 items-center rounded px-2 transition-colors", {
+    "bg-background": active,
+    "bg-transparent hover:bg-background/60": !active,
   })
 
 /**
@@ -28,7 +28,7 @@ export function BehaviourViewChips({
   if (views.length === 0) return null
 
   return (
-    <div className="flex w-fit max-w-full flex-row flex-wrap items-center gap-1 rounded-lg border border-border bg-secondary p-1">
+    <div className="flex w-fit max-w-full flex-row flex-wrap items-center gap-1 rounded-md bg-muted p-1">
       <Link
         to="/projects/$projectSlug/behaviours/$behaviourSlug"
         params={{ projectSlug, behaviourSlug }}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-view-chips.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-view-chips.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router"
 import type { CustomBehaviorRecord } from "../../../../../../domains/taxonomy/custom-behaviors.functions.ts"
 
 const chipClass = (active: boolean) =>
-  cn("flex h-6.5 max-w-48 items-center rounded px-2 transition-colors", {
+  cn("flex h-6.5 max-w-48 shrink-0 items-center rounded px-2 transition-colors", {
     "bg-background": active,
     "bg-transparent hover:bg-background/60": !active,
   })
@@ -28,28 +28,30 @@ export function BehaviourViewChips({
   if (views.length === 0) return null
 
   return (
-    <div className="flex w-fit max-w-full flex-row flex-wrap items-center gap-1 rounded-md bg-muted p-1">
-      <Link
-        to="/projects/$projectSlug/behaviours/$behaviourSlug"
-        params={{ projectSlug, behaviourSlug }}
-        className={chipClass(activeViewSlug === null)}
-      >
-        <Text.H5 color={activeViewSlug === null ? "foreground" : "foregroundMuted"} ellipsis noWrap>
-          All sessions
-        </Text.H5>
-      </Link>
-      {views.map((view) => (
+    <div className="w-fit max-w-full overflow-x-auto rounded-md bg-muted p-1">
+      <div className="flex w-max min-w-max flex-nowrap items-center gap-1">
         <Link
-          key={view.id}
-          to="/projects/$projectSlug/behaviours/$behaviourSlug/views/$viewSlug"
-          params={{ projectSlug, behaviourSlug, viewSlug: view.slug }}
-          className={chipClass(activeViewSlug === view.slug)}
+          to="/projects/$projectSlug/behaviours/$behaviourSlug"
+          params={{ projectSlug, behaviourSlug }}
+          className={chipClass(activeViewSlug === null)}
         >
-          <Text.H5 color={activeViewSlug === view.slug ? "foreground" : "foregroundMuted"} ellipsis noWrap>
-            {view.name}
+          <Text.H5 color={activeViewSlug === null ? "foreground" : "foregroundMuted"} ellipsis noWrap>
+            All sessions
           </Text.H5>
         </Link>
-      ))}
+        {views.map((view) => (
+          <Link
+            key={view.id}
+            to="/projects/$projectSlug/behaviours/$behaviourSlug/views/$viewSlug"
+            params={{ projectSlug, behaviourSlug, viewSlug: view.slug }}
+            className={chipClass(activeViewSlug === view.slug)}
+          >
+            <Text.H5 color={activeViewSlug === view.slug ? "foreground" : "foregroundMuted"} ellipsis noWrap>
+              {view.name}
+            </Text.H5>
+          </Link>
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-catalog-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-catalog-page.tsx
@@ -1,9 +1,10 @@
 import type { FilterSet } from "@domain/shared"
-import { Button, Icon, Skeleton, Text } from "@repo/ui"
+import { Button, Icon, Skeleton } from "@repo/ui"
 import { PlusIcon } from "lucide-react"
 import { useMemo, useState } from "react"
 import { useBehaviourCatalog } from "../../../../../../domains/taxonomy/behaviour-catalog.collection.ts"
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
+import { SectionHeader } from "../../-components/section-header.tsx"
 import type { useRouteProject } from "../../-route-data.ts"
 import { BEHAVIOUR_LIST_CLASS, BehaviourCatalogPanel } from "./behaviour-catalog-panel.tsx"
 import { BehaviourFormModal } from "./behaviour-form-modal.tsx"
@@ -54,12 +55,11 @@ export function BehavioursCatalogPage({
         <Layout.Content>
           {showEmpty ? null : (
             <Layout.Header
-              title="Behaviors"
-              description={
-                <Text.H5 color="foregroundMuted" className="max-w-[400px]">
-                  Each behavior groups your sessions by a different question: what they were about, what the user
-                  wanted, how they ended. Open one to explore its groups.
-                </Text.H5>
+              title={
+                <SectionHeader
+                  title="Behaviors"
+                  description="Each behavior groups your sessions by a different question: what they were about, what the user wanted, how they ended. Open one to explore its groups."
+                />
               }
               actions={
                 <Button onClick={() => setNewBehaviorOpen(true)}>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-scope-header.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-scope-header.tsx
@@ -21,6 +21,7 @@ import { summarizeFilterSet } from "../../../../../../components/filters-builder
 import { useDeleteCustomBehavior } from "../../../../../../domains/taxonomy/custom-behaviors.collection.ts"
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
+import { SectionHeader } from "../../-components/section-header.tsx"
 import type { useRouteProject } from "../../-route-data.ts"
 import { BehaviourFormModal } from "./behaviour-form-modal.tsx"
 import type { BehaviourScope } from "./behaviour-scope.ts"
@@ -175,24 +176,24 @@ export function BehavioursScopeHeader({
     <>
       <Layout.Header
         title={
-          <div className="flex min-w-0 flex-row items-center gap-3">
+          <div className="flex min-w-0 flex-col gap-3">
             <Tooltip
               asChild
               side="bottom"
               trigger={
-                <Button asChild variant="ghost" className="h-8 w-8 p-0" aria-label="Back to behaviors">
+                <Button asChild variant="ghost" size="sm" className="w-fit" aria-label="Back to behaviors">
                   <Link to="/projects/$projectSlug/behaviours" params={{ projectSlug }}>
-                    <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
+                    <Icon icon={ArrowLeftIcon} size="sm" />
+                    Back
                   </Link>
                 </Button>
               }
             >
               Back to behaviors
             </Tooltip>
-            <Text.H4M className="min-w-0 truncate">{view ? view.name : main.name}</Text.H4M>
+            <SectionHeader title={view ? view.name : main.name} description={main.description ?? undefined} />
           </div>
         }
-        description={main.description ? <Text.H5 color="foregroundMuted">{main.description}</Text.H5> : null}
         actions={
           <div className="flex flex-row items-center gap-2">
             {view ? null : behaviorCooking ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -1,5 +1,6 @@
 import { MOMENT_KINDS, type MomentKind } from "@domain/conversation-intelligence"
 import {
+  Badge,
   BarChart,
   Button,
   cn,
@@ -38,7 +39,7 @@ import type {
   BehaviourTimeRangeRecord,
   BehaviourTrajectoryMetric,
 } from "../../../../../../domains/taxonomy/taxonomy.functions.ts"
-import { BehaviourBadge, trendIcon, trendLabel } from "../../../../../../domains/taxonomy/trend-display.tsx"
+import { trendBadgeVariant, trendIcon, trendLabel } from "../../../../../../domains/taxonomy/trend-display.tsx"
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import {
   EMPTY_SELECTION,
@@ -327,11 +328,29 @@ export function BehaviourDetailDrawer({
         <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-6">
           <div className="flex flex-col gap-3">
             <div className="flex flex-wrap items-center gap-2">
-              {parentName ? <BehaviourBadge label={parentName} icon={TagIcon} /> : null}
-              <BehaviourBadge label={`${formatCount(node.subtreeSessionCount)} sessions`} icon={TagIcon} />
-              <BehaviourBadge label={trendLabel(node.trend.status)} icon={trendIcon(node.trend.status)} />
+              {parentName ? (
+                <Badge variant="muted" ellipsis iconProps={{ icon: TagIcon, placement: "start" }}>
+                  {parentName}
+                </Badge>
+              ) : null}
+              <Badge variant="muted" ellipsis iconProps={{ icon: TagIcon, placement: "start" }}>
+                {`${formatCount(node.subtreeSessionCount)} sessions`}
+              </Badge>
+              <Badge
+                variant={trendBadgeVariant(node.trend.status)}
+                ellipsis
+                iconProps={{ icon: trendIcon(node.trend.status), placement: "start" }}
+              >
+                {trendLabel(node.trend.status)}
+              </Badge>
               {node.firstSeenLabel === "older" || node.firstSeenLabel === "unknown" ? null : (
-                <BehaviourBadge label={`First seen ${node.firstSeenLabel.replaceAll("_", " ")}`} icon={SparklesIcon} />
+                <Badge
+                  variant="muted"
+                  ellipsis
+                  iconProps={{ icon: SparklesIcon, placement: "start" }}
+                >
+                  {`First seen ${node.firstSeenLabel.replaceAll("_", " ")}`}
+                </Badge>
               )}
             </div>
             <Text.H6 color="foregroundMuted">
@@ -1015,7 +1034,11 @@ export function BehavioursView({
       width: 130,
       render: (row) => {
         const status = row.hasChildren ? subtreeTrendStatus(row.node) : row.node.trend.status
-        return <BehaviourBadge label={trendLabel(status)} icon={trendIcon(status)} />
+        return (
+          <Badge variant={trendBadgeVariant(status)} ellipsis iconProps={{ icon: trendIcon(status), placement: "start" }}>
+            {trendLabel(status)}
+          </Badge>
+        )
       },
     },
     {
@@ -1059,7 +1082,11 @@ export function BehavioursView({
         <Layout.ActionsRow>
           <Layout.ActionRowItem>
             {timeFilter}
-            {momentRange ? <BehaviourBadge label={selectedMomentRangeLabel(momentRange)} icon={TagIcon} /> : null}
+            {momentRange ? (
+              <Badge variant="muted" ellipsis iconProps={{ icon: TagIcon, placement: "start" }}>
+                {selectedMomentRangeLabel(momentRange)}
+              </Badge>
+            ) : null}
           </Layout.ActionRowItem>
           {onSegmentChange ? (
             <Layout.ActionRowItem>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -850,9 +850,6 @@ export function BehavioursView({
   readonly onMomentRangeChange: (range: BehaviourMomentRangeRecord | undefined, maxTurn?: number) => void
 }) {
   const activeBehaviourId = behaviourPath.at(-1)
-  // Shared scroll container: holds the trajectory chart and the table together, so
-  // scrolling moves them as one and the table's header sticks once it reaches the top
-  // instead of the table scrolling alone in its own small box.
   const scrollAreaRef = useRef<HTMLDivElement>(null)
   const expandableKeys = useMemo(() => {
     const keys = new Set<string>()

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -19,7 +19,7 @@ import {
 import { formatCount, relativeTime } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { BrainIcon, ChevronRightIcon, DatabaseIcon, SparklesIcon, TagIcon, XIcon } from "lucide-react"
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   addClusterSessionsToDatasetFunction,
   type ClusterSource,
@@ -39,10 +39,7 @@ import type {
   BehaviourTrajectoryMetric,
 } from "../../../../../../domains/taxonomy/taxonomy.functions.ts"
 import { BehaviourBadge, trendIcon, trendLabel } from "../../../../../../domains/taxonomy/trend-display.tsx"
-import {
-  ListingLayout as Layout,
-  listingLayoutIntrinsicScroll,
-} from "../../../../../../layouts/ListingLayout/index.tsx"
+import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import {
   EMPTY_SELECTION,
   type SelectionState,
@@ -838,6 +835,10 @@ export function BehavioursView({
   readonly onMomentRangeChange: (range: BehaviourMomentRangeRecord | undefined, maxTurn?: number) => void
 }) {
   const activeBehaviourId = behaviourPath.at(-1)
+  // Shared scroll container: holds the trajectory chart and the table together, so
+  // scrolling moves them as one and the table's header sticks once it reaches the top
+  // instead of the table scrolling alone in its own small box.
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
   const expandableKeys = useMemo(() => {
     const keys = new Set<string>()
     const walk = (nodes: readonly BehaviourNodeRecord[]) => {
@@ -1074,7 +1075,7 @@ export function BehavioursView({
         </Layout.ActionsRow>
       </Layout.Actions>
       <Layout.Body>
-        <Layout.List className="gap-3">
+        <Layout.List ref={scrollAreaRef} className="gap-3 overflow-y-auto">
           {isLoading ? (
             <div className="flex flex-col gap-2 p-6">
               <Skeleton className="h-12 rounded-xl" />
@@ -1094,7 +1095,8 @@ export function BehavioursView({
                 onSelectPoint={handleDotChartPointSelect}
               />
               <InfiniteTable
-                {...listingLayoutIntrinsicScroll.infiniteTable}
+                scrollAreaLayout="external"
+                scrollContainerRef={scrollAreaRef}
                 data={rows}
                 isLoading={false}
                 columns={columns}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -344,11 +344,7 @@ export function BehaviourDetailDrawer({
                 {trendLabel(node.trend.status)}
               </Badge>
               {node.firstSeenLabel === "older" || node.firstSeenLabel === "unknown" ? null : (
-                <Badge
-                  variant="muted"
-                  ellipsis
-                  iconProps={{ icon: SparklesIcon, placement: "start" }}
-                >
+                <Badge variant="muted" ellipsis iconProps={{ icon: SparklesIcon, placement: "start" }}>
                   {`First seen ${node.firstSeenLabel.replaceAll("_", " ")}`}
                 </Badge>
               )}
@@ -1035,7 +1031,11 @@ export function BehavioursView({
       render: (row) => {
         const status = row.hasChildren ? subtreeTrendStatus(row.node) : row.node.trend.status
         return (
-          <Badge variant={trendBadgeVariant(status)} ellipsis iconProps={{ icon: trendIcon(status), placement: "start" }}>
+          <Badge
+            variant={trendBadgeVariant(status)}
+            ellipsis
+            iconProps={{ icon: trendIcon(status), placement: "start" }}
+          >
             {trendLabel(status)}
           </Badge>
         )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cache-economics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cache-economics-panel.tsx
@@ -735,8 +735,6 @@ export function CacheEconomicsPanel({
         <Tabs<CacheView>
           variant="bordered"
           size="sm"
-          className="border-none bg-muted"
-          indicatorClassName="border-none"
           options={CACHE_VIEW_OPTIONS.map((option) => ({
             id: option.key,
             label: option.label,
@@ -752,8 +750,6 @@ export function CacheEconomicsPanel({
           <Tabs
             variant="bordered"
             size="sm"
-            className="border-none bg-muted"
-            indicatorClassName="border-none"
             options={CACHE_LIFETIME_OPTIONS.map((option) => ({
               id: option === "documented" ? "documented" : String(option),
               label: lifetimeOptionLabel(option),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-breakdown-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-breakdown-panel.tsx
@@ -371,8 +371,6 @@ export function CostBreakdownPanel({
         <Tabs
           variant="bordered"
           size="sm"
-          className="border-none bg-muted"
-          indicatorClassName="border-none"
           options={COST_BREAKDOWN_DIMENSIONS.map((value) => ({
             id: value,
             label: DIMENSION_META[value].label,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-over-time-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/cost-over-time-panel.tsx
@@ -140,8 +140,6 @@ export function CostOverTimePanel({
           <Tabs
             variant="bordered"
             size="sm"
-            className="border-none bg-muted"
-            indicatorClassName="border-none"
             options={METRIC_OPTIONS.map((option) => ({
               id: option.id,
               label: option.label,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/model-usage-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/model-usage-panel.tsx
@@ -117,8 +117,6 @@ export function ModelUsagePanel({
           <Tabs
             variant="bordered"
             size="sm"
-            className="border-none bg-muted"
-            indicatorClassName="border-none"
             options={MEASURE_OPTIONS.map((option) => ({
               id: option.id,
               label: option.label,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
@@ -17,6 +17,7 @@ import { useProjectFirstTraceAt, useProjectLastTraceAt } from "../../../../../do
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { BreadcrumbText } from "../../../-components/breadcrumb-ui.tsx"
+import { SectionHeader } from "../-components/section-header.tsx"
 import { useRouteProject } from "../-route-data.ts"
 import { CacheEconomicsPanel } from "./-components/cache-economics-panel.tsx"
 import { CostBreakdownPanel } from "./-components/cost-breakdown-panel.tsx"
@@ -193,9 +194,13 @@ function CostPageContent() {
   return (
     <Layout>
       <Layout.Header
-        title="Cost dashboard"
-        badge={<PricingCoverageBadge confidence={overview?.confidence} isLoading={overviewLoading} />}
-        description="Optimize your spending"
+        title={
+          <SectionHeader
+            title="Cost dashboard"
+            badge={<PricingCoverageBadge confidence={overview?.confidence} isLoading={overviewLoading} />}
+            description="Optimize your spending"
+          />
+        }
         actions={
           <TimeFilterDropdown
             {...(tw.pickerStartFrom ? { startTimeFrom: tw.pickerStartFrom } : {})}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/experiment-detail-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/experiment-detail-page.tsx
@@ -127,14 +127,15 @@ export function ExperimentDetailPage() {
       <Layout.Content>
         <Layout.Header
           title={
-            <div className="flex min-w-0 flex-row items-center gap-3">
+            <div className="flex min-w-0 flex-col gap-3">
               <Tooltip
                 asChild
                 side="bottom"
                 trigger={
-                  <Button asChild variant="ghost" className="h-8 w-8 p-0" aria-label="Back to experiments">
+                  <Button asChild variant="ghost" size="sm" className="w-fit" aria-label="Back to experiments">
                     <Link to="/projects/$projectSlug/experiments" params={{ projectSlug: project.slug }}>
-                      <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
+                      <Icon icon={ArrowLeftIcon} size="sm" />
+                      Back
                     </Link>
                   </Button>
                 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Text, Tooltip } from "@repo/ui"
+import { Button, Icon, Text, Tooltip } from "@repo/ui"
 import { createFileRoute, Link, useParams } from "@tanstack/react-router"
 import { ArrowLeftIcon, DatabaseIcon } from "lucide-react"
 import { useMemoryStoreSnapshot } from "../../../../../../domains/memories/memories.collection.ts"
@@ -52,24 +52,27 @@ function StoreDetailPage() {
       <Layout.Header
         className="border-b px-6 py-4"
         title={
-          <div className="flex min-w-0 items-center gap-3">
+          <div className="flex min-w-0 flex-col gap-3">
             <Tooltip
               asChild
               side="bottom"
               trigger={
-                <Button asChild variant="ghost" className="h-8 w-8 shrink-0 p-0" aria-label="Back to memory stores">
+                <Button asChild variant="ghost" size="sm" className="w-fit" aria-label="Back to stores">
                   <Link to="/projects/$projectSlug/memory" params={{ projectSlug }}>
-                    <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
+                    <Icon icon={ArrowLeftIcon} size="sm" />
+                    Back
                   </Link>
                 </Button>
               }
             >
               Back to stores
             </Tooltip>
-            <DatabaseIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <Text.H4 className={storeId === "" ? "italic text-muted-foreground" : "font-mono"} noWrap ellipsis>
-              {storeDisplayLabel(storeId)}
-            </Text.H4>
+            <div className="flex min-w-0 items-center gap-3">
+              <DatabaseIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <Text.H4 className={storeId === "" ? "italic text-muted-foreground" : "font-mono"} noWrap ellipsis>
+                {storeDisplayLabel(storeId)}
+              </Text.H4>
+            </div>
           </div>
         }
         description={<StoreUsersList projectId={project.id} projectSlug={projectSlug} storeId={storeId} />}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index.tsx
@@ -116,9 +116,6 @@ function MonitorDetailPage() {
   const [muteConfirmOpen, setMuteConfirmOpen] = useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [ruleModal, setRuleModal] = useState<MonitorRuleRecord | null>(null)
-  // Shared scroll container: holds the config card, metric chart, and incidents table
-  // together, so scrolling moves them as one and the table's header sticks once it
-  // reaches the top instead of the table scrolling alone in its own small box.
   const scrollAreaRef = useRef<HTMLDivElement>(null)
 
   const window = useMemo(() => {
@@ -195,7 +192,7 @@ function MonitorDetailPage() {
                 <SectionHeader
                   title={monitor?.name ?? ""}
                   badge={monitor?.system ? <SystemTag /> : undefined}
-                  description={rule?.summary ?? undefined}
+                  description={monitor?.description ?? rule?.summary ?? undefined}
                 />
               )}
             </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index.tsx
@@ -17,7 +17,15 @@ import {
 } from "@repo/ui"
 import { formatCount } from "@repo/utils"
 import { createFileRoute, getRouteApi, Link, useNavigate } from "@tanstack/react-router"
-import { ArrowLeftIcon, BellIcon, BellOffIcon, EllipsisVerticalIcon, PencilIcon, Trash2Icon } from "lucide-react"
+import {
+  ArrowLeftIcon,
+  BellIcon,
+  BellOffIcon,
+  EllipsisVerticalIcon,
+  ExternalLinkIcon,
+  PencilIcon,
+  Trash2Icon,
+} from "lucide-react"
 import { type ReactNode, useMemo, useRef, useState } from "react"
 import { SeverityStatus } from "../../../../../../domains/alerts/severity-selector.tsx"
 import { describeMonitorTarget, targetToSessionFilters } from "../../../../../../domains/monitors/monitor-target.ts"
@@ -26,6 +34,7 @@ import type { MonitorRuleRecord } from "../../../../../../domains/monitors/monit
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { BreadcrumbLink, BreadcrumbSeparator, BreadcrumbText } from "../../../../-components/breadcrumb-ui.tsx"
+import { SectionHeader } from "../../-components/section-header.tsx"
 import { serializeFilters } from "../../-components/trace-page-state.ts"
 import { useRouteProject } from "../../-route-data.ts"
 import { MonitorDeleteConfirmModal } from "../-components/monitor-delete-confirm-modal.tsx"
@@ -165,14 +174,15 @@ function MonitorDetailPage() {
       <Layout.Content>
         <Layout.Header
           title={
-            <div className="flex min-w-0 flex-row items-center gap-3">
+            <div className="flex min-w-0 flex-col gap-3">
               <Tooltip
                 asChild
                 side="bottom"
                 trigger={
-                  <Button asChild variant="ghost" className="h-8 w-8 p-0" aria-label="Back to monitors">
+                  <Button asChild variant="ghost" size="sm" className="w-fit" aria-label="Back to monitors">
                     <Link to="/projects/$projectSlug/monitors/search" params={{ projectSlug }}>
-                      <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
+                      <Icon icon={ArrowLeftIcon} size="sm" />
+                      Back
                     </Link>
                   </Button>
                 }
@@ -182,14 +192,14 @@ function MonitorDetailPage() {
               {isLoading ? (
                 <Skeleton className="h-7 w-56" />
               ) : (
-                <>
-                  <Text.H4M className="min-w-0 truncate">{monitor?.name}</Text.H4M>
-                  {monitor?.system ? <SystemTag /> : null}
-                </>
+                <SectionHeader
+                  title={monitor?.name ?? ""}
+                  badge={monitor?.system ? <SystemTag /> : undefined}
+                  description={rule?.summary ?? undefined}
+                />
               )}
             </div>
           }
-          description={rule?.summary ?? undefined}
           actions={
             monitor ? (
               <>
@@ -259,18 +269,24 @@ function MonitorDetailPage() {
                             to="/projects/$projectSlug"
                             params={{ projectSlug }}
                             search={{ tab: "sessions", savedSearch: savedSearchTarget.slug }}
-                            className="hover:underline"
+                            className="group inline-flex min-w-0 items-center gap-1"
                           >
-                            <Text.H5 color="primary">{savedSearchTarget.name}</Text.H5>
+                            <Text.H5 color="foreground" className="min-w-0 group-hover:underline">
+                              {savedSearchTarget.name}
+                            </Text.H5>
+                            <Icon icon={ExternalLinkIcon} size="xs" color="foregroundMuted" className="shrink-0" />
                           </Link>
                         ) : sessionTargetSearch ? (
                           <Link
                             to="/projects/$projectSlug"
                             params={{ projectSlug }}
                             search={sessionTargetSearch}
-                            className="hover:underline"
+                            className="group inline-flex min-w-0 items-center gap-1"
                           >
-                            <Text.H5 color="primary">{description?.label ?? savedSearchTarget?.name}</Text.H5>
+                            <Text.H5 color="foreground" className="min-w-0 group-hover:underline">
+                              {description?.label ?? savedSearchTarget?.name}
+                            </Text.H5>
+                            <Icon icon={ExternalLinkIcon} size="xs" color="foregroundMuted" className="shrink-0" />
                           </Link>
                         ) : (
                           <Text.H5 color="foreground">{description?.label ?? savedSearchTarget?.name}</Text.H5>
@@ -279,17 +295,18 @@ function MonitorDetailPage() {
                     ) : null}
                     {rule ? (
                       <ConfigField label="Trigger">
-                        <div className="flex items-center gap-2">
-                          <Text.H5 color="foreground">{INCIDENT_NOTIFICATION_KEY_LABEL[rule.kind]}</Text.H5>
-                          <SeverityStatus severity={rule.severity} />
-                        </div>
+                        <Text.H5 color="foreground">{INCIDENT_NOTIFICATION_KEY_LABEL[rule.kind]}</Text.H5>
+                      </ConfigField>
+                    ) : null}
+                    {rule ? (
+                      <ConfigField label="Severity">
+                        <SeverityStatus severity={rule.severity} />
                       </ConfigField>
                     ) : null}
                     <ConfigField label="Incidents">
                       <Text.H5 color="foreground">{incidentStats ? formatCount(incidentStats.total) : "—"}</Text.H5>
                     </ConfigField>
                   </div>
-                  {monitor.description ? <Text.H6 color="foregroundMuted">{monitor.description}</Text.H6> : null}
                 </div>
 
                 {target ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index.tsx
@@ -18,7 +18,7 @@ import {
 import { formatCount } from "@repo/utils"
 import { createFileRoute, getRouteApi, Link, useNavigate } from "@tanstack/react-router"
 import { ArrowLeftIcon, BellIcon, BellOffIcon, EllipsisVerticalIcon, PencilIcon, Trash2Icon } from "lucide-react"
-import { type ReactNode, useMemo, useState } from "react"
+import { type ReactNode, useMemo, useRef, useState } from "react"
 import { SeverityStatus } from "../../../../../../domains/alerts/severity-selector.tsx"
 import { describeMonitorTarget, targetToSessionFilters } from "../../../../../../domains/monitors/monitor-target.ts"
 import { useMonitor, useMonitorIncidentStats } from "../../../../../../domains/monitors/monitors.collection.ts"
@@ -107,6 +107,10 @@ function MonitorDetailPage() {
   const [muteConfirmOpen, setMuteConfirmOpen] = useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [ruleModal, setRuleModal] = useState<MonitorRuleRecord | null>(null)
+  // Shared scroll container: holds the config card, metric chart, and incidents table
+  // together, so scrolling moves them as one and the table's header sticks once it
+  // reaches the top instead of the table scrolling alone in its own small box.
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
 
   const window = useMemo(() => {
     const spec = RANGE_SPEC[range]
@@ -234,7 +238,7 @@ function MonitorDetailPage() {
           }
         />
 
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div ref={scrollAreaRef} className="flex min-h-0 flex-1 flex-col overflow-y-auto">
           {isLoading || !monitor ? (
             <div className="p-6 pt-2">
               <Skeleton className="h-48 w-full" />
@@ -300,9 +304,14 @@ function MonitorDetailPage() {
                 ) : null}
               </div>
 
-              <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-3 px-6 pb-6">
+              <div className="flex min-w-0 flex-col gap-3 px-6 pb-6">
                 <Text.H6 color="foregroundMuted">Incidents</Text.H6>
-                <MonitorIncidentsTable projectId={project.id} projectSlug={projectSlug} monitorId={monitor.id} />
+                <MonitorIncidentsTable
+                  projectId={project.id}
+                  projectSlug={projectSlug}
+                  monitorId={monitor.id}
+                  scrollContainerRef={scrollAreaRef}
+                />
               </div>
 
               {target ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
@@ -1,7 +1,7 @@
 import { InfiniteTable, type InfiniteTableColumn, Status, Text } from "@repo/ui"
 import { formatDuration } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
-import { type ReactNode, useCallback, useState } from "react"
+import { type ReactNode, type RefObject, useCallback, useState } from "react"
 import {
   type MonitorIncidentRecord,
   useMonitorIncidents,
@@ -106,13 +106,22 @@ export function MonitorIncidentsTable({
   projectId,
   projectSlug,
   monitorId,
+  scrollContainerRef,
 }: {
   readonly projectId: string
   readonly projectSlug: string
   readonly monitorId: string
+  /**
+   * The ancestor scroll container to virtualize against — shared with whatever else
+   * the caller stacks above it (e.g. the monitor's config card and metric chart), so
+   * the page scrolls as one and the table's header sticks once it reaches the top.
+   * When omitted the table falls back to scrolling within its own bounded box.
+   */
+  readonly scrollContainerRef?: RefObject<HTMLDivElement | null>
 }) {
   const { incidents, isLoading, infiniteScroll } = useMonitorIncidents({ projectId, monitorId })
   const [resolveTarget, setResolveTarget] = useState<string | null>(null)
+  const hasExternalScrollArea = scrollContainerRef !== undefined
 
   // Rows whose producer was deleted (or can't be deep-linked) return null and aren't navigable.
   const renderRowLink = useCallback(
@@ -135,7 +144,9 @@ export function MonitorIncidentsTable({
   return (
     <>
       <InfiniteTable
-        {...listingLayoutIntrinsicScroll.infiniteTable}
+        {...(hasExternalScrollArea
+          ? { scrollAreaLayout: "external" as const, scrollContainerRef }
+          : listingLayoutIntrinsicScroll.infiniteTable)}
         data={incidents}
         isLoading={isLoading}
         columns={incidentColumns(setResolveTarget)}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
@@ -111,12 +111,7 @@ export function MonitorIncidentsTable({
   readonly projectId: string
   readonly projectSlug: string
   readonly monitorId: string
-  /**
-   * The ancestor scroll container to virtualize against — shared with whatever else
-   * the caller stacks above it (e.g. the monitor's config card and metric chart), so
-   * the page scrolls as one and the table's header sticks once it reaches the top.
-   * When omitted the table falls back to scrolling within its own bounded box.
-   */
+  /** Optional shared ancestor scroll container for page-level scrolling + sticky headers. */
   readonly scrollContainerRef?: RefObject<HTMLDivElement | null>
 }) {
   const { incidents, isLoading, infiniteScroll } = useMonitorIncidents({ projectId, monitorId })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/integration-detail-header.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/integration-detail-header.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Icon, Text, Tooltip } from "@repo/ui"
+import { Alert, Button, Icon, Text } from "@repo/ui"
 import { Link } from "@tanstack/react-router"
 import { ArrowLeftIcon } from "lucide-react"
 import type { IntegrationCatalogEntry } from "../../../../../../domains/integrations/integration-catalog.ts"
@@ -41,28 +41,24 @@ export function IntegrationDetailHeader({
   const label = scope === "organization" ? "Back to organization integrations" : "Back to integrations"
 
   return (
-    <div className="flex min-w-0 flex-row items-center gap-2">
-      <Tooltip
-        asChild
-        side="bottom"
-        trigger={
-          <Button asChild variant="ghost" className="h-7 w-7 p-0" aria-label={label}>
-            {scope === "organization" ? (
-              <Link to="/projects/$projectSlug/settings/organization/integrations" params={{ projectSlug }}>
-                <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
-              </Link>
-            ) : (
-              <Link to="/projects/$projectSlug/settings/integrations" params={{ projectSlug }}>
-                <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
-              </Link>
-            )}
-          </Button>
-        }
-      >
-        {label}
-      </Tooltip>
-      <Icon icon={entry.icon} />
-      <Text.H3M>{entry.label}</Text.H3M>
+    <div className="flex min-w-0 flex-col gap-3">
+      <Button asChild variant="ghost" size="sm" className="w-fit" aria-label={label}>
+        {scope === "organization" ? (
+          <Link to="/projects/$projectSlug/settings/organization/integrations" params={{ projectSlug }}>
+            <Icon icon={ArrowLeftIcon} size="sm" />
+            Back
+          </Link>
+        ) : (
+          <Link to="/projects/$projectSlug/settings/integrations" params={{ projectSlug }}>
+            <Icon icon={ArrowLeftIcon} size="sm" />
+            Back
+          </Link>
+        )}
+      </Button>
+      <div className="flex min-w-0 items-center gap-2">
+        <Icon icon={entry.icon} />
+        <Text.H3M>{entry.label}</Text.H3M>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
@@ -1,12 +1,13 @@
-import { cn, Text } from "@repo/ui"
+import { cn } from "@repo/ui"
 import type { ReactNode } from "react"
+import { SectionHeader } from "../../-components/section-header.tsx"
 
 interface SettingsPageTitleProps {
   readonly children: ReactNode
 }
 
 export function SettingsPageTitle({ children }: SettingsPageTitleProps) {
-  return <Text.H3M>{children}</Text.H3M>
+  return <SectionHeader title={children} variant="xl" />
 }
 
 interface SettingsPageProps {
@@ -26,12 +27,7 @@ export function SettingsPage({
   headerSticky = false,
   fillHeight = false,
 }: SettingsPageProps) {
-  const header = (
-    <div className="flex min-w-48 flex-1 flex-col gap-1">
-      {typeof title === "string" ? <SettingsPageTitle>{title}</SettingsPageTitle> : title}
-      {description ? <Text.H6M color="foregroundMuted">{description}</Text.H6M> : null}
-    </div>
-  )
+  const header = <SectionHeader title={title} description={description} variant="xl" className="min-w-48" />
 
   return (
     <>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId.tsx
@@ -1,7 +1,7 @@
-import { Icon, Text } from "@repo/ui"
+import { Button, Icon, Text, Tooltip } from "@repo/ui"
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { ArrowLeft } from "lucide-react"
+import { ArrowLeftIcon } from "lucide-react"
 import { listDestinations } from "../../../../../../domains/destinations/destinations.functions.ts"
 import { useRouteProject } from "../../-route-data.ts"
 import { DestinationCard } from "../-components/destination-card.tsx"
@@ -17,14 +17,20 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/sett
 
 function BackLink({ projectSlug }: { readonly projectSlug: string }) {
   return (
-    <Link
-      to="/projects/$projectSlug/settings/data-destinations"
-      params={{ projectSlug }}
-      className="flex w-fit flex-row items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
+    <Tooltip
+      asChild
+      side="bottom"
+      trigger={
+        <Button asChild variant="ghost" size="sm" className="w-fit" aria-label="Back to data destinations">
+          <Link to="/projects/$projectSlug/settings/data-destinations" params={{ projectSlug }}>
+            <Icon icon={ArrowLeftIcon} size="sm" />
+            Back
+          </Link>
+        </Button>
+      }
     >
-      <Icon icon={ArrowLeft} size="sm" />
-      <Text.H6 color="foregroundMuted">Data destinations</Text.H6>
-    </Link>
+      Back to data destinations
+    </Tooltip>
   )
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalSlug/index.tsx
@@ -81,21 +81,21 @@ function SignalDetailPage() {
         <Layout.Header
           title={
             <div className="flex min-w-0 flex-col gap-1.5">
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-2">
                 <Tooltip
                   asChild
                   side="bottom"
                   trigger={
-                    <Button asChild variant="ghost" className="h-7 w-7 p-0" aria-label="Back to signals">
+                    <Button asChild variant="ghost" size="sm" className="w-fit" aria-label="Back to signals">
                       <Link to="/projects/$projectSlug/signals" params={{ projectSlug }}>
-                        <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
+                        <Icon icon={ArrowLeftIcon} size="sm" />
+                        Back
                       </Link>
                     </Button>
                   }
                 >
                   Back to signals
                 </Tooltip>
-                <div className="h-4 w-px bg-border" />
                 <SignalNeighborNav
                   projectId={project.id}
                   projectSlug={projectSlug}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
@@ -113,22 +113,25 @@ function ToolDetailPageContent() {
       <Layout.Content>
         <Layout.Header
           title={
-            <div className="flex min-w-0 flex-row items-center gap-3">
+            <div className="flex min-w-0 flex-col gap-3">
               <Tooltip
                 asChild
                 side="bottom"
                 trigger={
-                  <Button asChild variant="ghost" className="h-8 w-8 p-0" aria-label="Back to tools">
+                  <Button asChild variant="ghost" size="sm" className="w-fit" aria-label="Back to tools">
                     <Link to="/projects/$projectSlug/tools" params={{ projectSlug }}>
-                      <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
+                      <Icon icon={ArrowLeftIcon} size="sm" />
+                      Back
                     </Link>
                   </Button>
                 }
               >
                 Back to tools
               </Tooltip>
-              <WrenchIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <Text.H4M className="min-w-0 truncate font-mono">{notFound ? "Tool not found" : toolName}</Text.H4M>
+              <div className="flex min-w-0 items-center gap-3">
+                <WrenchIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <Text.H4M className="min-w-0 truncate font-mono">{notFound ? "Tool not found" : toolName}</Text.H4M>
+              </div>
             </div>
           }
           actions={

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-view.tsx
@@ -88,11 +88,7 @@ export function ToolsView({
   readonly focusedToolName?: string | undefined
   readonly onFocusedToolChange?: (toolName: string | undefined) => void
   readonly keyboardNavEnabled?: boolean
-  /**
-   * The ancestor scroll container to virtualize against — shared with the
-   * analytics panel stacked above it, so the page scrolls as one and the
-   * table's header sticks once it reaches the top.
-   */
+  /** Shared ancestor scroll container for page-level scrolling + sticky headers. */
   readonly scrollContainerRef: RefObject<HTMLDivElement | null>
 }) {
   const navigate = useNavigate()

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-view.tsx
@@ -2,12 +2,9 @@ import { InfiniteTable, type InfiniteTableColumn, Text, Tooltip } from "@repo/ui
 import { formatCount, formatDuration, relativeTime } from "@repo/utils"
 import { Link, useNavigate } from "@tanstack/react-router"
 import { WrenchIcon } from "lucide-react"
-import { useCallback, useMemo } from "react"
+import { type RefObject, useCallback, useMemo } from "react"
 import type { ToolSummaryRecord } from "../../../../../../domains/tools/tools.functions.ts"
-import {
-  ListingLayout as Layout,
-  listingLayoutIntrinsicScroll,
-} from "../../../../../../layouts/ListingLayout/index.tsx"
+import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import { useListRowKeyboardNav } from "../../../../../../lib/hooks/useListRowKeyboardNav.ts"
 import { formatPercent, TOOL_FAILING_ERROR_RATE } from "./tool-formatters.ts"
 import { ToolStatusBadges } from "./tool-status-badges.tsx"
@@ -76,6 +73,7 @@ export function ToolsView({
   focusedToolName,
   onFocusedToolChange,
   keyboardNavEnabled = true,
+  scrollContainerRef,
 }: {
   readonly tools: readonly ToolSummaryRecord[]
   readonly isLoading: boolean
@@ -90,6 +88,12 @@ export function ToolsView({
   readonly focusedToolName?: string | undefined
   readonly onFocusedToolChange?: (toolName: string | undefined) => void
   readonly keyboardNavEnabled?: boolean
+  /**
+   * The ancestor scroll container to virtualize against — shared with the
+   * analytics panel stacked above it, so the page scrolls as one and the
+   * table's header sticks once it reaches the top.
+   */
+  readonly scrollContainerRef: RefObject<HTMLDivElement | null>
 }) {
   const navigate = useNavigate()
   const toolNames = useMemo(() => tools.map((tool) => tool.name), [tools])
@@ -321,10 +325,11 @@ export function ToolsView({
   })
 
   return (
-    <Layout.Body>
+    <Layout.Body className="flex-none overflow-visible">
       <Layout.List>
         <InfiniteTable
-          {...listingLayoutIntrinsicScroll.infiniteTable}
+          scrollAreaLayout="external"
+          scrollContainerRef={scrollContainerRef}
           data={tools}
           isLoading={isLoading}
           columns={columns}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/index.tsx
@@ -1,7 +1,7 @@
 import { Input, Tabs, useValueWithDefault } from "@repo/ui"
 import { createFileRoute } from "@tanstack/react-router"
 import { CircleSlashIcon, LayoutGridIcon, SearchIcon, TriangleAlertIcon } from "lucide-react"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { TimeFilterDropdown } from "../../../../../components/time-filter-dropdown.tsx"
 import { allToolsMonitorTarget } from "../../../../../domains/monitors/monitor-target.ts"
 import { useAnalyticsTimeWindow } from "../../../../../domains/projects/use-analytics-time-window.ts"
@@ -70,6 +70,10 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/tool
 
 function ToolsPageContent() {
   const project = useRouteProject()
+  // Shared scroll container: holds the analytics panel and the table together, so
+  // scrolling moves them as one and the table's header sticks once it reaches the
+  // top instead of the table scrolling alone in its own small box.
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
   const { firstTraceAt } = useProjectFirstTraceAt({ projectId: project.id })
   const { lastTraceAt } = useProjectLastTraceAt({ projectId: project.id })
   const tw = useAnalyticsTimeWindow({
@@ -216,7 +220,7 @@ function ToolsPageContent() {
       {showEmptyState ? (
         <ToolsEmptyState isLoading={isLoading} />
       ) : (
-        <>
+        <div ref={scrollAreaRef} className="flex flex-1 min-h-0 flex-col gap-4 overflow-y-auto">
           {hasOnlyDefinedTools ? (
             <div className="px-6 pb-2">
               <ToolsDiscoveryBanner projectId={project.id} />
@@ -246,8 +250,9 @@ function ToolsPageContent() {
             trendBucketSeconds={trendBucketSeconds}
             focusedToolName={focusedToolName}
             onFocusedToolChange={setFocusedToolName}
+            scrollContainerRef={scrollAreaRef}
           />
-        </>
+        </div>
       )}
     </Layout>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/index.tsx
@@ -70,9 +70,6 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/tool
 
 function ToolsPageContent() {
   const project = useRouteProject()
-  // Shared scroll container: holds the analytics panel and the table together, so
-  // scrolling moves them as one and the table's header sticks once it reaches the
-  // top instead of the table scrolling alone in its own small box.
   const scrollAreaRef = useRef<HTMLDivElement>(null)
   const { firstTraceAt } = useProjectFirstTraceAt({ projectId: project.id })
   const { lastTraceAt } = useProjectLastTraceAt({ projectId: project.id })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/index.tsx
@@ -173,8 +173,6 @@ function ToolsPageContent() {
               <Tabs
                 variant="bordered"
                 size="sm"
-                className="border-none bg-muted"
-                indicatorClassName="border-none"
                 options={[
                   { id: "all", label: "All", icon: <LayoutGridIcon className="w-4 h-4" /> },
                   {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/users/$userId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/users/$userId/index.tsx
@@ -198,14 +198,15 @@ function UserDetailPage() {
       <Layout.Content>
         <Layout.Header
           title={
-            <div className="flex min-w-0 flex-row items-center gap-3">
+            <div className="flex min-w-0 flex-col gap-3">
               <Tooltip
                 asChild
                 side="bottom"
                 trigger={
-                  <Button asChild variant="ghost" className="h-8 w-8 p-0" aria-label="Back to users">
+                  <Button asChild variant="ghost" size="sm" className="w-fit" aria-label="Back to users">
                     <Link to="/projects/$projectSlug/users" params={{ projectSlug }}>
-                      <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
+                      <Icon icon={ArrowLeftIcon} size="sm" />
+                      Back
                     </Link>
                   </Button>
                 }
@@ -215,10 +216,10 @@ function UserDetailPage() {
               {profileLoading ? (
                 <Skeleton className="h-7 w-56" />
               ) : (
-                <>
+                <div className="flex min-w-0 items-center gap-3">
                   <Avatar size="sm" name={profile ? userDisplayName(profile) : userId} imageSrc={null} />
                   <Text.H4M className="min-w-0 truncate">{profile ? userDisplayName(profile) : userId}</Text.H4M>
-                </>
+                </div>
               )}
             </div>
           }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/users/-components/users-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/users/-components/users-view.tsx
@@ -8,12 +8,9 @@ import {
 } from "@repo/ui"
 import { formatCount, formatPrice } from "@repo/utils"
 import { Link, useNavigate } from "@tanstack/react-router"
-import { useCallback, useMemo, useState } from "react"
+import { type RefObject, useCallback, useMemo, useState } from "react"
 import type { ProjectUserRecord } from "../../../../../../domains/end-users/end-users.functions.ts"
-import {
-  ListingLayout as Layout,
-  listingLayoutIntrinsicScroll,
-} from "../../../../../../layouts/ListingLayout/index.tsx"
+import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import { useListRowKeyboardNav } from "../../../../../../lib/hooks/useListRowKeyboardNav.ts"
 import { UserActivityBar } from "./user-activity-bar.tsx"
 import {
@@ -137,6 +134,7 @@ export function UsersView({
   focusedUserId,
   onFocusedUserChange,
   keyboardNavEnabled = true,
+  scrollContainerRef,
 }: {
   readonly users: readonly ProjectUserRecord[]
   readonly isLoading: boolean
@@ -151,6 +149,12 @@ export function UsersView({
   readonly focusedUserId?: string | undefined
   readonly onFocusedUserChange?: (userId: string | undefined) => void
   readonly keyboardNavEnabled?: boolean
+  /**
+   * The ancestor scroll container to virtualize against — shared with the
+   * analytics panel stacked above it, so the page scrolls as one and the
+   * table's header sticks once it reaches the top.
+   */
+  readonly scrollContainerRef: RefObject<HTMLDivElement | null>
 }) {
   const navigate = useNavigate()
   const userIds = useMemo(() => users.map((user) => user.userId), [users])
@@ -305,10 +309,11 @@ export function UsersView({
   })
 
   return (
-    <Layout.Body>
+    <Layout.Body className="flex-none overflow-visible">
       <Layout.List>
         <InfiniteTable
-          {...listingLayoutIntrinsicScroll.infiniteTable}
+          scrollAreaLayout="external"
+          scrollContainerRef={scrollContainerRef}
           data={users}
           isLoading={isLoading}
           columns={columns}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/users/-components/users-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/users/-components/users-view.tsx
@@ -149,11 +149,7 @@ export function UsersView({
   readonly focusedUserId?: string | undefined
   readonly onFocusedUserChange?: (userId: string | undefined) => void
   readonly keyboardNavEnabled?: boolean
-  /**
-   * The ancestor scroll container to virtualize against — shared with the
-   * analytics panel stacked above it, so the page scrolls as one and the
-   * table's header sticks once it reaches the top.
-   */
+  /** Shared ancestor scroll container for page-level scrolling + sticky headers. */
   readonly scrollContainerRef: RefObject<HTMLDivElement | null>
 }) {
   const navigate = useNavigate()

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/users/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/users/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon, Input, Text, useValueWithDefault } from "@repo/ui"
 import { createFileRoute } from "@tanstack/react-router"
 import { ExternalLinkIcon, SearchIcon, UsersRoundIcon } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { TimeFilterDropdown } from "../../../../../components/time-filter-dropdown.tsx"
 import { useProjectUsers, useUsersOverview } from "../../../../../domains/end-users/end-users.collection.ts"
 import { allUsersMonitorTarget } from "../../../../../domains/monitors/monitor-target.ts"
@@ -89,6 +89,10 @@ function UsersPage() {
   })
   const sorting = useMemo(() => parseSorting(rawSorting), [rawSorting])
   const [focusedUserId, setFocusedUserId] = useState<string | undefined>()
+  // Shared scroll container: holds the analytics panel and the table together, so
+  // scrolling moves them as one and the table's header sticks once it reaches the
+  // top instead of the table scrolling alone in its own small box.
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
 
   useDebounce(
     () => {
@@ -197,30 +201,33 @@ function UsersPage() {
             </Layout.ActionRowItem>
           </Layout.ActionsRow>
         </Layout.Actions>
-        <div className="px-6">
-          <UsersAnalyticsPanel
-            overview={overview}
-            isLoading={overviewLoading}
-            rangeFromIso={overviewRange.fromIso}
-            rangeToIso={overviewRange.toIso}
-            isAllTime={tw.isAllTime}
-            onRangeSelect={tw.onBrushSelect}
+        <div ref={scrollAreaRef} className="flex flex-1 min-h-0 flex-col gap-4 overflow-y-auto">
+          <div className="px-6">
+            <UsersAnalyticsPanel
+              overview={overview}
+              isLoading={overviewLoading}
+              rangeFromIso={overviewRange.fromIso}
+              rangeToIso={overviewRange.toIso}
+              isAllTime={tw.isAllTime}
+              onRangeSelect={tw.onBrushSelect}
+            />
+          </div>
+          <UsersView
+            users={users}
+            isLoading={showSkeletons}
+            infiniteScroll={infiniteScroll}
+            sorting={sorting}
+            totalCount={totalCount}
+            activityBucketSeconds={activityBucketSeconds ?? trendBucketSeconds}
+            costRollup={costRollup}
+            visibleColumnIds={columnSettings.visibleColumnIds}
+            onSortChange={(next) => setRawSorting(serializeSorting(next))}
+            projectSlug={project.slug}
+            focusedUserId={focusedUserId}
+            onFocusedUserChange={setFocusedUserId}
+            scrollContainerRef={scrollAreaRef}
           />
         </div>
-        <UsersView
-          users={users}
-          isLoading={showSkeletons}
-          infiniteScroll={infiniteScroll}
-          sorting={sorting}
-          totalCount={totalCount}
-          activityBucketSeconds={activityBucketSeconds ?? trendBucketSeconds}
-          costRollup={costRollup}
-          visibleColumnIds={columnSettings.visibleColumnIds}
-          onSortChange={(next) => setRawSorting(serializeSorting(next))}
-          projectSlug={project.slug}
-          focusedUserId={focusedUserId}
-          onFocusedUserChange={setFocusedUserId}
-        />
       </Layout.Content>
     </Layout>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/users/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/users/index.tsx
@@ -89,9 +89,6 @@ function UsersPage() {
   })
   const sorting = useMemo(() => parseSorting(rawSorting), [rawSorting])
   const [focusedUserId, setFocusedUserId] = useState<string | undefined>()
-  // Shared scroll container: holds the analytics panel and the table together, so
-  // scrolling moves them as one and the table's header sticks once it reaches the
-  // top instead of the table scrolling alone in its own small box.
   const scrollAreaRef = useRef<HTMLDivElement>(null)
 
   useDebounce(

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
@@ -13,6 +13,7 @@ import { useHotkeys } from "@tanstack/react-hotkeys"
 import { createFileRoute } from "@tanstack/react-router"
 import { FilterIcon, MessagesSquareIcon, TextIcon, XIcon } from "lucide-react"
 import { useCallback, useMemo, useRef, useState } from "react"
+import { HotkeyBadge } from "../../../../components/hotkey-badge.tsx"
 import { ProjectScopeProvider } from "../../../../domains/projects/project-scope.tsx"
 import { useSandboxDefaultApiKey } from "../../../../domains/sandbox/sandbox.collection.ts"
 import { rememberLastSandboxProjectSlug } from "../../../../domains/sandbox/sandbox-navigation.functions.ts"
@@ -271,7 +272,7 @@ function SandboxTracesContent({ sandboxOrgId, projectSlug }: { sandboxOrgId: str
                 >
                   <FilterIcon className="h-4 w-4" />
                   Filters
-                  <kbd className="rounded bg-muted px-1 font-mono text-xs text-muted-foreground">F</kbd>
+                  <HotkeyBadge hotkey="F" />
                   {hasActiveFilters ? (
                     <span className="inline-flex items-center justify-center rounded-full bg-primary px-1.5 text-[10px] font-medium leading-4 text-primary-foreground">
                       {Object.keys(filters).length}

--- a/packages/ui/src/components/infinite-table/headers/header-cell.tsx
+++ b/packages/ui/src/components/infinite-table/headers/header-cell.tsx
@@ -36,6 +36,7 @@ export function HeaderCell({
   onSortClick,
   subheader,
   showSubheaderSlot = false,
+  bottomBorder = false,
 }: {
   children?: ReactNode
   align?: "start" | "end"
@@ -53,6 +54,8 @@ export function HeaderCell({
   subheader?: ReactNode
   /** When true, reserve a bottom row so all header cells align when only some have `subheader`. */
   showSubheaderSlot?: boolean
+  /** Shown once the sticky header is pinned over scrolled rows. Cell border, not `<thead>`'s — row groups don't paint borders under `border-separate`. */
+  bottomBorder?: boolean
 }) {
   const TextComp = sortable ? "button" : "div"
   const textProps = sortable ? { type: "button" as const, onClick: onSortClick } : {}
@@ -142,7 +145,8 @@ export function HeaderCell({
     <th
       ref={thRef}
       className={cn(
-        "relative overflow-hidden",
+        "relative overflow-hidden border-b",
+        bottomBorder ? "border-border" : "border-transparent",
         resizable ? RESIZABLE_HEADER_PADDING : "px-4",
         showSubheaderSlot ? "py-1.5 align-top" : "h-12 align-middle",
         className,

--- a/packages/ui/src/components/infinite-table/headers/header-cell.tsx
+++ b/packages/ui/src/components/infinite-table/headers/header-cell.tsx
@@ -54,7 +54,7 @@ export function HeaderCell({
   subheader?: ReactNode
   /** When true, reserve a bottom row so all header cells align when only some have `subheader`. */
   showSubheaderSlot?: boolean
-  /** Shown once the sticky header is pinned over scrolled rows. Cell border, not `<thead>`'s — row groups don't paint borders under `border-separate`. */
+  /** Paint the sticky-header bottom border on each cell because grouped rows use `border-separate`. */
   bottomBorder?: boolean
 }) {
   const TextComp = sortable ? "button" : "div"

--- a/packages/ui/src/components/infinite-table/infinite-table.test.ts
+++ b/packages/ui/src/components/infinite-table/infinite-table.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { distanceToTableBottom, externalScrollMargin } from "./infinite-table.tsx"
+
+describe("externalScrollMargin", () => {
+  it("includes sibling content above the table inside a shared scroll container", () => {
+    expect(
+      externalScrollMargin({
+        containerTop: 100,
+        containerScrollTop: 240,
+        wrapperTop: 460,
+      }),
+    ).toBe(600)
+  })
+
+  it("updates when content above the table changes the wrapper offset", () => {
+    const before = externalScrollMargin({
+      containerTop: 100,
+      containerScrollTop: 240,
+      wrapperTop: 460,
+    })
+    const after = externalScrollMargin({
+      containerTop: 100,
+      containerScrollTop: 240,
+      wrapperTop: 520,
+    })
+
+    expect(after - before).toBe(60)
+  })
+})
+
+describe("distanceToTableBottom", () => {
+  it("loads more when the table bottom nears the container viewport", () => {
+    expect(
+      distanceToTableBottom({
+        containerBottom: 800,
+        tableBottom: 930,
+      }),
+    ).toBe(130)
+  })
+
+  it("ignores sibling content rendered after the table", () => {
+    expect(
+      distanceToTableBottom({
+        containerBottom: 800,
+        tableBottom: 760,
+      }),
+    ).toBe(-40)
+  })
+})

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -128,6 +128,7 @@ export function InfiniteTable<T>({
   const [containerWidth, setContainerWidth] = useState(0)
   const [theadHeight, setTheadHeight] = useState(0)
   const [scrollTop, setScrollTop] = useState(0)
+  const [isHeaderCoveringRows, setIsHeaderCoveringRows] = useState(false)
 
   useLayoutEffect(() => {
     if (!hasGrouping) return
@@ -214,6 +215,13 @@ export function InfiniteTable<T>({
       // group-header overlay re-evaluates on every scroll tick, not only
       // when the virtual window shifts.
       if (hasGrouping) setScrollTop(target.scrollTop)
+      // Compare rects rather than a precomputed scroll offset: the thead is "covering"
+      // rows exactly when it's pinned flush against the container's top edge, which is
+      // true regardless of how much (if any) content sits above the table in flow.
+      const thead = theadRef.current
+      if (thead) {
+        setIsHeaderCoveringRows(thead.getBoundingClientRect().top <= target.getBoundingClientRect().top + 0.5)
+      }
       if (!infiniteScroll || !hasMore || infiniteScroll.isLoadingMore) return
       const distanceToBottom = target.scrollHeight - target.scrollTop - target.clientHeight
       if (distanceToBottom < ROW_HEIGHT * 5) {
@@ -350,9 +358,16 @@ export function InfiniteTable<T>({
             ref={tableRef}
             className={cn("min-w-full border-separate border-spacing-y-1", { "table-fixed": layoutFixed })}
           >
-            <thead ref={theadRef} className="sticky top-0 z-10 border-b border-border bg-background">
+            <thead ref={theadRef} className="sticky top-0 z-10 bg-background">
               <tr>
-                {hasExpansion && <HeaderCell resizable={false} className="w-8" showSubheaderSlot={hasSubheaderRow} />}
+                {hasExpansion && (
+                  <HeaderCell
+                    resizable={false}
+                    className="w-8"
+                    showSubheaderSlot={hasSubheaderRow}
+                    bottomBorder={isHeaderCoveringRows}
+                  />
+                )}
                 {selection && (
                   <HeaderCell
                     resizable={false}
@@ -360,6 +375,7 @@ export function InfiniteTable<T>({
                     minWidth={SELECTION_COLUMN_WIDTH}
                     maxWidth={SELECTION_COLUMN_WIDTH}
                     showSubheaderSlot={hasSubheaderRow}
+                    bottomBorder={isHeaderCoveringRows}
                   >
                     <Checkbox checked={selection.headerState} onCheckedChange={() => selection.toggleAll()} />
                   </HeaderCell>
@@ -382,6 +398,7 @@ export function InfiniteTable<T>({
                       {...(col.width !== undefined ? { width: col.width } : {})}
                       {...(col.maxWidth !== undefined ? { maxWidth: col.maxWidth } : {})}
                       showSubheaderSlot={hasSubheaderRow}
+                      bottomBorder={isHeaderCoveringRows}
                       {...(hasSubheaderRow ? { subheader: col.renderSubheader?.(col, i) } : {})}
                       {...(sortDir ? { sortDirection: sortDir } : {})}
                       {...(isSortable && col.sortKey

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -32,10 +32,7 @@ export function externalScrollMargin(input: {
   return wrapperTop - containerTop + containerScrollTop
 }
 
-export function distanceToTableBottom(input: {
-  readonly containerBottom: number
-  readonly tableBottom: number
-}) {
+export function distanceToTableBottom(input: { readonly containerBottom: number; readonly tableBottom: number }) {
   const { containerBottom, tableBottom } = input
   return tableBottom - containerBottom
 }
@@ -184,8 +181,7 @@ export function InfiniteTable<T>({
     const resizeObserver = new ResizeObserver(measure)
     resizeObserver.observe(container)
     resizeObserver.observe(wrapper)
-    const mutationObserver =
-      typeof MutationObserver === "undefined" ? null : new MutationObserver(() => measure())
+    const mutationObserver = typeof MutationObserver === "undefined" ? null : new MutationObserver(() => measure())
     mutationObserver?.observe(container, { childList: true, subtree: true })
     return () => {
       resizeObserver.disconnect()
@@ -252,7 +248,8 @@ export function InfiniteTable<T>({
       const distanceToBottom = isExternalScrollArea
         ? distanceToTableBottom({
             containerBottom: target.getBoundingClientRect().bottom,
-            tableBottom: tableWrapperRef.current?.getBoundingClientRect().bottom ?? target.getBoundingClientRect().bottom,
+            tableBottom:
+              tableWrapperRef.current?.getBoundingClientRect().bottom ?? target.getBoundingClientRect().bottom,
           })
         : target.scrollHeight - target.scrollTop - target.clientHeight
       if (distanceToBottom < ROW_HEIGHT * 5) {

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -1,6 +1,6 @@
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { InfoIcon } from "lucide-react"
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { cn } from "../../utils/cn.ts"
 import type { SortDirection } from "../../utils/filtersHelpers.ts"
 import { Checkbox } from "../checkbox/checkbox.tsx"
@@ -88,6 +88,7 @@ export function InfiniteTable<T>({
   onSortChange,
   blankSlate,
   scrollAreaLayout = "fill",
+  scrollContainerRef: externalScrollContainerRef,
   className,
   expandedRowKeys,
   getExpandedRows,
@@ -111,8 +112,13 @@ export function InfiniteTable<T>({
 
   const totalVirtualRows = displayRows.length + (hasMore || (isLoading && data.length === 0) ? SKELETON_ROW_COUNT : 0)
 
-  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const isExternalScrollArea = scrollAreaLayout === "external"
+  const ownScrollContainerRef = useRef<HTMLDivElement>(null)
+  const scrollContainerRef =
+    isExternalScrollArea && externalScrollContainerRef ? externalScrollContainerRef : ownScrollContainerRef
+  const tableWrapperRef = useRef<HTMLDivElement>(null)
   const theadRef = useRef<HTMLTableSectionElement>(null)
+  const [scrollMargin, setScrollMargin] = useState(0)
 
   // Group headers are pinned to the visible viewport on both axes: in-flow
   // header rows get an explicit `clientWidth` + sticky-left wrapper (so they
@@ -138,6 +144,27 @@ export function InfiniteTable<T>({
     if (theadRef.current) resizeObserver.observe(theadRef.current)
     return () => resizeObserver.disconnect()
   }, [hasGrouping])
+
+  // The virtualizer's row math is relative to the scroll container's own top, but in
+  // external mode that container also holds content above the table (e.g. a chart).
+  // scrollMargin tells it how far down the table's own start actually sits.
+  useLayoutEffect(() => {
+    if (!isExternalScrollArea) return
+    const container = scrollContainerRef.current
+    const wrapper = tableWrapperRef.current
+    if (!container || !wrapper) return
+
+    const measure = () => {
+      const wrapperRect = wrapper.getBoundingClientRect()
+      const containerRect = container.getBoundingClientRect()
+      setScrollMargin(wrapperRect.top - containerRect.top + container.scrollTop)
+    }
+    measure()
+    const resizeObserver = new ResizeObserver(measure)
+    resizeObserver.observe(container)
+    resizeObserver.observe(wrapper)
+    return () => resizeObserver.disconnect()
+  }, [isExternalScrollArea, scrollContainerRef])
 
   const handleSortClick = useCallback(
     (sortKey: string) => {
@@ -178,11 +205,11 @@ export function InfiniteTable<T>({
       return displayRow.kind === "group" ? `group-${displayRow.groupKey}` : `row-${rowKeys[displayRow.dataIndex]}`
     },
     overscan: 10,
+    ...(isExternalScrollArea ? { scrollMargin } : {}),
   })
 
-  const handleScroll = useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      const target = e.currentTarget
+  const handleScrollElement = useCallback(
+    (target: HTMLDivElement) => {
       // Tracked in state (not read from the virtualizer) so the sticky
       // group-header overlay re-evaluates on every scroll tick, not only
       // when the virtual window shifts.
@@ -195,6 +222,22 @@ export function InfiniteTable<T>({
     },
     [infiniteScroll, hasMore, hasGrouping],
   )
+
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => handleScrollElement(e.currentTarget),
+    [handleScrollElement],
+  )
+
+  // In external mode the scroll container belongs to the caller, so there's no
+  // owned element to attach the `onScroll` JSX prop to — listen natively instead.
+  useEffect(() => {
+    if (!isExternalScrollArea) return
+    const container = scrollContainerRef.current
+    if (!container) return
+    const listener = () => handleScrollElement(container)
+    container.addEventListener("scroll", listener, { passive: true })
+    return () => container.removeEventListener("scroll", listener)
+  }, [isExternalScrollArea, handleScrollElement, scrollContainerRef])
 
   const virtualRows = virtualizer.getVirtualItems()
 
@@ -253,9 +296,20 @@ export function InfiniteTable<T>({
     return () => cancelAnimationFrame(rafId)
   }, [activeRowAutoScroll, activeRowIndex, virtualizer])
 
-  const paddingTop = virtualRows[0]?.start ?? 0
+  // In external mode `virtualRow.start`/`.end` are measured from the scroll
+  // container's own origin, so they already bake in `scrollMargin` (the space the
+  // table's preceding in-flow siblings occupy there). The `paddingTop` spacer lives
+  // inside the table itself though, which is already positioned past that content by
+  // normal document flow — so `scrollMargin` must be subtracted back out, or that
+  // offset gets counted twice, opening a gap above the first row equal to its size.
+  const paddingTop = (virtualRows[0]?.start ?? 0) - (isExternalScrollArea ? scrollMargin : 0)
   const lastRow = virtualRows[virtualRows.length - 1]
-  const paddingBottom = lastRow ? virtualizer.getTotalSize() - lastRow.end : 0
+  // `getTotalSize()` subtracts `scrollMargin` back out internally (it describes the
+  // list's own size, not its offset within the scroll container), while `lastRow.end`
+  // still includes it — add it back so the two are comparable, mirroring `paddingTop`.
+  const paddingBottom = lastRow
+    ? virtualizer.getTotalSize() + (isExternalScrollArea ? scrollMargin : 0) - lastRow.end
+    : 0
   const showBlankSlate = !isLoading && data.length === 0
   const blankSlateContent =
     showBlankSlate && blankSlate !== undefined
@@ -269,13 +323,17 @@ export function InfiniteTable<T>({
         blankSlateContent
       ) : (
         <div
-          ref={scrollContainerRef}
-          onScroll={handleScroll}
-          className={cn(
-            scrollAreaLayout === "fill" ? "min-h-0 flex-1" : "min-h-0 w-full max-w-full",
-            "overflow-auto",
-            className,
-          )}
+          ref={isExternalScrollArea ? tableWrapperRef : scrollContainerRef}
+          {...(isExternalScrollArea ? {} : { onScroll: handleScroll })}
+          className={
+            isExternalScrollArea
+              ? cn("w-full max-w-full", className)
+              : cn(
+                  scrollAreaLayout === "fill" ? "min-h-0 flex-1" : "min-h-0 w-full max-w-full",
+                  "overflow-auto",
+                  className,
+                )
+          }
         >
           {/* Sticky mirror of the active group's header. A zero-height sticky
               box pinned below the thead (and to the container's left edge, so

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -23,6 +23,23 @@ const SELECTION_COLUMN_WIDTH = 48
 const EXPANDED_SKELETON_CELL_CLASS =
   "px-4 py-2 first:rounded-l-lg last:rounded-r-lg overflow-hidden align-middle text-sm leading-5"
 
+export function externalScrollMargin(input: {
+  readonly containerTop: number
+  readonly containerScrollTop: number
+  readonly wrapperTop: number
+}) {
+  const { containerTop, containerScrollTop, wrapperTop } = input
+  return wrapperTop - containerTop + containerScrollTop
+}
+
+export function distanceToTableBottom(input: {
+  readonly containerBottom: number
+  readonly tableBottom: number
+}) {
+  const { containerBottom, tableBottom } = input
+  return tableBottom - containerBottom
+}
+
 function renderExpandedSkeletonRows<T>(
   columns: readonly InfiniteTableColumn<T>[],
   hasExpansion: boolean,
@@ -146,9 +163,6 @@ export function InfiniteTable<T>({
     return () => resizeObserver.disconnect()
   }, [hasGrouping])
 
-  // The virtualizer's row math is relative to the scroll container's own top, but in
-  // external mode that container also holds content above the table (e.g. a chart).
-  // scrollMargin tells it how far down the table's own start actually sits.
   useLayoutEffect(() => {
     if (!isExternalScrollArea) return
     const container = scrollContainerRef.current
@@ -158,13 +172,25 @@ export function InfiniteTable<T>({
     const measure = () => {
       const wrapperRect = wrapper.getBoundingClientRect()
       const containerRect = container.getBoundingClientRect()
-      setScrollMargin(wrapperRect.top - containerRect.top + container.scrollTop)
+      setScrollMargin(
+        externalScrollMargin({
+          wrapperTop: wrapperRect.top,
+          containerTop: containerRect.top,
+          containerScrollTop: container.scrollTop,
+        }),
+      )
     }
     measure()
     const resizeObserver = new ResizeObserver(measure)
     resizeObserver.observe(container)
     resizeObserver.observe(wrapper)
-    return () => resizeObserver.disconnect()
+    const mutationObserver =
+      typeof MutationObserver === "undefined" ? null : new MutationObserver(() => measure())
+    mutationObserver?.observe(container, { childList: true, subtree: true })
+    return () => {
+      resizeObserver.disconnect()
+      mutationObserver?.disconnect()
+    }
   }, [isExternalScrollArea, scrollContainerRef])
 
   const handleSortClick = useCallback(
@@ -223,12 +249,17 @@ export function InfiniteTable<T>({
         setIsHeaderCoveringRows(thead.getBoundingClientRect().top <= target.getBoundingClientRect().top + 0.5)
       }
       if (!infiniteScroll || !hasMore || infiniteScroll.isLoadingMore) return
-      const distanceToBottom = target.scrollHeight - target.scrollTop - target.clientHeight
+      const distanceToBottom = isExternalScrollArea
+        ? distanceToTableBottom({
+            containerBottom: target.getBoundingClientRect().bottom,
+            tableBottom: tableWrapperRef.current?.getBoundingClientRect().bottom ?? target.getBoundingClientRect().bottom,
+          })
+        : target.scrollHeight - target.scrollTop - target.clientHeight
       if (distanceToBottom < ROW_HEIGHT * 5) {
         infiniteScroll.onLoadMore()
       }
     },
-    [infiniteScroll, hasMore, hasGrouping],
+    [infiniteScroll, hasMore, hasGrouping, isExternalScrollArea],
   )
 
   const handleScroll = useCallback(
@@ -236,8 +267,6 @@ export function InfiniteTable<T>({
     [handleScrollElement],
   )
 
-  // In external mode the scroll container belongs to the caller, so there's no
-  // owned element to attach the `onScroll` JSX prop to — listen natively instead.
   useEffect(() => {
     if (!isExternalScrollArea) return
     const container = scrollContainerRef.current

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -81,17 +81,6 @@ export interface InfiniteTableSharedProps<T> {
   defaultSorting?: InfiniteTableSorting
   onSortChange?: (sorting: InfiniteTableSorting) => void
   blankSlate?: ReactNode | string
-  /**
-   * `fill` (default) stretches in a fixed parent; `intrinsic` sizes to content up to
-   * scroll `className` max-height; `external` delegates scrolling and row
-   * virtualization to an ancestor element supplied via `scrollContainerRef` — e.g. a
-   * shared scroll area that also holds content above the table, so the page scrolls
-   * as one and the table's sticky header pins against that shared container once it
-   * reaches the top, instead of confining the table to its own bounded box.
-   */
-  scrollAreaLayout?: "fill" | "intrinsic" | "external"
-  /** The ancestor scroll container to virtualize against. Required when `scrollAreaLayout` is `"external"`. */
-  scrollContainerRef?: RefObject<HTMLDivElement | null>
   className?: string
   expandedRowKeys?: ReadonlySet<string>
   getExpandedRows?: (row: T) => ExpandedRows<T>
@@ -137,15 +126,28 @@ export interface InfiniteTableSharedProps<T> {
   groupOrder?: readonly string[]
 }
 
+type InfiniteTableScrollAreaProps =
+  | {
+      scrollAreaLayout: "external"
+      /** Shared ancestor scroll container used for sticky headers and virtualization. */
+      scrollContainerRef: RefObject<HTMLDivElement | null>
+    }
+  | {
+      scrollAreaLayout?: "fill" | "intrinsic"
+      scrollContainerRef?: RefObject<HTMLDivElement | null>
+    }
+
 export type InfiniteTableProps<T> =
-  | (InfiniteTableSharedProps<T> & {
+  | (InfiniteTableSharedProps<T> &
+      InfiniteTableScrollAreaProps & {
       onRowClick: (row: T) => void
       getRowAriaLabel: (row: T) => string
       /** Semantic role for clickable rows (`link` when the action navigates). Defaults to `button`. */
       rowInteractionRole?: "button" | "link"
       renderRowLink?: undefined
     })
-  | (InfiniteTableSharedProps<T> & {
+  | (InfiniteTableSharedProps<T> &
+      InfiniteTableScrollAreaProps & {
       /**
        * Render a real anchor for navigation rows (router-agnostic — the app provides the element).
        * The `props.className` must be spread onto the anchor to apply the stretched-link overlay.
@@ -161,7 +163,8 @@ export type InfiniteTableProps<T> =
       getRowAriaLabel?: undefined
       rowInteractionRole?: undefined
     })
-  | (InfiniteTableSharedProps<T> & {
+  | (InfiniteTableSharedProps<T> &
+      InfiniteTableScrollAreaProps & {
       onRowClick?: undefined
       getRowAriaLabel?: undefined
       rowInteractionRole?: undefined

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -140,33 +140,33 @@ type InfiniteTableScrollAreaProps =
 export type InfiniteTableProps<T> =
   | (InfiniteTableSharedProps<T> &
       InfiniteTableScrollAreaProps & {
-      onRowClick: (row: T) => void
-      getRowAriaLabel: (row: T) => string
-      /** Semantic role for clickable rows (`link` when the action navigates). Defaults to `button`. */
-      rowInteractionRole?: "button" | "link"
-      renderRowLink?: undefined
-    })
+        onRowClick: (row: T) => void
+        getRowAriaLabel: (row: T) => string
+        /** Semantic role for clickable rows (`link` when the action navigates). Defaults to `button`. */
+        rowInteractionRole?: "button" | "link"
+        renderRowLink?: undefined
+      })
   | (InfiniteTableSharedProps<T> &
       InfiniteTableScrollAreaProps & {
-      /**
-       * Render a real anchor for navigation rows (router-agnostic — the app provides the element).
-       * The `props.className` must be spread onto the anchor to apply the stretched-link overlay.
-       * Use this instead of `onRowClick` whenever clicking navigates to a different page.
-       *
-       * @example
-       * renderRowLink={(row, props) => (
-       *   <Link to="/items/$id" params={{ id: row.id }} {...props} aria-label={`Open ${row.name}`} />
-       * )}
-       */
-      renderRowLink: (row: T, props: { className: string }) => ReactNode
-      onRowClick?: undefined
-      getRowAriaLabel?: undefined
-      rowInteractionRole?: undefined
-    })
+        /**
+         * Render a real anchor for navigation rows (router-agnostic — the app provides the element).
+         * The `props.className` must be spread onto the anchor to apply the stretched-link overlay.
+         * Use this instead of `onRowClick` whenever clicking navigates to a different page.
+         *
+         * @example
+         * renderRowLink={(row, props) => (
+         *   <Link to="/items/$id" params={{ id: row.id }} {...props} aria-label={`Open ${row.name}`} />
+         * )}
+         */
+        renderRowLink: (row: T, props: { className: string }) => ReactNode
+        onRowClick?: undefined
+        getRowAriaLabel?: undefined
+        rowInteractionRole?: undefined
+      })
   | (InfiniteTableSharedProps<T> &
       InfiniteTableScrollAreaProps & {
-      onRowClick?: undefined
-      getRowAriaLabel?: undefined
-      rowInteractionRole?: undefined
-      renderRowLink?: undefined
-    })
+        onRowClick?: undefined
+        getRowAriaLabel?: undefined
+        rowInteractionRole?: undefined
+        renderRowLink?: undefined
+      })

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react"
+import type { ReactNode, RefObject } from "react"
 import type { SortDirection } from "../../utils/filtersHelpers.ts"
 import type { CheckedState } from "../checkbox/checkbox.tsx"
 
@@ -81,8 +81,17 @@ export interface InfiniteTableSharedProps<T> {
   defaultSorting?: InfiniteTableSorting
   onSortChange?: (sorting: InfiniteTableSorting) => void
   blankSlate?: ReactNode | string
-  /** `fill` (default) stretches in a fixed parent; `intrinsic` sizes to content up to scroll `className` max-height. */
-  scrollAreaLayout?: "fill" | "intrinsic"
+  /**
+   * `fill` (default) stretches in a fixed parent; `intrinsic` sizes to content up to
+   * scroll `className` max-height; `external` delegates scrolling and row
+   * virtualization to an ancestor element supplied via `scrollContainerRef` — e.g. a
+   * shared scroll area that also holds content above the table, so the page scrolls
+   * as one and the table's sticky header pins against that shared container once it
+   * reaches the top, instead of confining the table to its own bounded box.
+   */
+  scrollAreaLayout?: "fill" | "intrinsic" | "external"
+  /** The ancestor scroll container to virtualize against. Required when `scrollAreaLayout` is `"external"`. */
+  scrollContainerRef?: RefObject<HTMLDivElement | null>
   className?: string
   expandedRowKeys?: ReadonlySet<string>
   getExpandedRows?: (row: T) => ExpandedRows<T>

--- a/packages/ui/src/components/tabs/tabs.tsx
+++ b/packages/ui/src/components/tabs/tabs.tsx
@@ -9,7 +9,7 @@ const tabsListVariants = cva("relative flex flex-row", {
   variants: {
     variant: {
       secondary: "",
-      bordered: "w-fit border border-border bg-secondary",
+      bordered: "w-fit bg-muted",
     },
     size: {
       md: "gap-2",
@@ -25,7 +25,7 @@ const tabsListVariants = cva("relative flex flex-row", {
   },
   compoundVariants: [
     { variant: "bordered", size: "md", className: "rounded-lg p-1" },
-    { variant: "bordered", size: "sm", className: "h-8 items-center rounded-md p-1" },
+    { variant: "bordered", size: "sm", className: "items-center rounded-md p-1" },
   ],
   defaultVariants: {
     variant: "secondary",
@@ -40,7 +40,7 @@ const tabTriggerVariants = cva(
     variants: {
       variant: {
         secondary: "text-xs leading-4 font-medium",
-        bordered: "border border-transparent bg-transparent",
+        bordered: "bg-transparent",
       },
       hideLabels: {
         true: "",
@@ -119,7 +119,7 @@ const tabIndicatorVariants = cva("pointer-events-none absolute left-0 top-0", {
   variants: {
     variant: {
       secondary: "rounded-md bg-muted",
-      bordered: "rounded border border-border bg-background",
+      bordered: "rounded bg-background",
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## Summary

This PR cleans up several project detail pages and shared list surfaces to make headers, back navigation, time controls, badges, and sticky table behavior more consistent across the app.

## What changed

### Shared section headers

- Added a shared `SectionHeader` component with:
  - optional description
  - optional badge
  - `default` and `xl` variants
- Replaced hardcoded section headers across project pages with `SectionHeader`, including:
  - behaviors
  - cost
  - settings
  - monitor details

### Detail-page header cleanup

- Moved detail-page back buttons above the title block instead of letting them push titles sideways.
- Reused the existing button component for back navigation instead of introducing a new back-button abstraction.
- Kept the back button on the `ghost` variant and adjusted spacing around those header stacks.

### Behavior pages

- Fixed behavior-group topic chips so they:
  - wrap when the container has enough room
  - scroll horizontally inside the component when space gets too tight
- Updated the chip/tabs container styling so narrow windows do not break vertical layout constraints.
- Replaced bespoke behavior trend pills with shared badge components.
- Switched behavior trend badges from outline styling to filled, color-coded shared badge variants.
- Centralized behavior trend badge mapping in `trend-display.tsx` for:
  - label
  - icon
  - filled variant
- Cleaned up badge formatting in the behavior catalog panel and behaviors view.

### Monitor detail page

- Unified the monitor detail header under the new shared section-header pattern.
- Swapped the monitor detail time-range control to the shared time-range picker pattern used on sessions, with monitor-specific presets.
- Changed monitor detail range handling from a local select to `from/to` URL params and responsive bucket sizing.
- Split monitor configuration display so `Trigger` and `Severity` are separate fields.
- Restyled monitor target links and added the external-link icon treatment.
- Removed the redundant configuration description line that duplicated the page-level description.

### Shared list and sticky table behavior

- Updated users, tools, sessions/traces, monitors, and related list pages to the newer sticky-scroll table pattern.
- Fixed sticky table header border painting by moving the border treatment to header cells instead of the whole `thead`.
- Expanded infinite-table support in `@repo/ui` to better support the sticky header and scroll behavior used across these pages.
- Adjusted `ListingLayout`, sessions/traces views, users/tools views, and related project page scaffolding to support the new sticky list behavior consistently.

https://github.com/user-attachments/assets/971e8b3e-f502-4a83-a146-d0525a850535


### Small supporting UI cleanup

- Touched a few small shared UI pieces to align them with the refreshed layout behavior:
  - `hotkey-badge`
  - tabs
  - breadcrumb segment
- Trimmed redundant cost panel headings while moving the cost page onto the shared section-header treatment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coordinated scrolling for project tables, analytics panels, and detail views, with improved sticky headers.
  * Added reusable section headers with titles, descriptions, badges, and size options.
  * Filter buttons now display keyboard shortcuts as individual key badges.
  * Project creation menus close automatically before opening the creation dialog.

* **Improvements**
  * Refined trend badges, behavior chips, tabs, and table borders for a cleaner interface.
  * Updated detail-page navigation with clearer “Back” buttons and more consistent headers.
  * Improved monitor links and configuration presentation.
  * Enhanced table scrolling and loading behavior across shared scroll containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->