### PR TITLE
Make a score's conversation anchor shareable, and focus it when opening a session from a signal

### DIFF
--- a/apps/web/src/domains/scores/scores.collection.ts
+++ b/apps/web/src/domains/scores/scores.collection.ts
@@ -74,7 +74,7 @@ export function useScoresBySession({
         data: {
           projectId,
           traceIds: [...traceIds],
-          ...(signalId ? { signalId } : {}),
+          ...(signalId !== undefined ? { signalId } : {}),
           limit,
           offset,
           draftMode: effectiveDraftMode,

--- a/apps/web/src/domains/scores/scores.collection.ts
+++ b/apps/web/src/domains/scores/scores.collection.ts
@@ -14,10 +14,11 @@ const scoresByTraceQueryKey = (
 const scoresBySessionQueryKey = (
   projectId: string,
   traceIds: readonly string[],
+  signalId: string | undefined,
   limit?: number,
   offset?: number,
   draftMode: "exclude" | "include" | "only" = DEFAULT_TRACE_DRAFT_MODE,
-) => ["scores", "session", projectId, [...traceIds].sort(), limit, offset, draftMode] as const
+) => ["scores", "session", projectId, [...traceIds].sort(), signalId ?? null, limit, offset, draftMode] as const
 
 export function useScoresByTrace({
   projectId,
@@ -49,6 +50,7 @@ export function useScoresByTrace({
 export function useScoresBySession({
   projectId,
   traceIds,
+  signalId,
   limit,
   offset,
   draftMode,
@@ -56,6 +58,8 @@ export function useScoresBySession({
 }: {
   readonly projectId: string
   readonly traceIds: readonly string[]
+  /** Narrows to one signal's scores, so the page limit can't hide them behind a busy session. */
+  readonly signalId?: string
   readonly limit?: number
   readonly offset?: number
   readonly draftMode?: "exclude" | "include" | "only"
@@ -64,10 +68,17 @@ export function useScoresBySession({
   const effectiveDraftMode = draftMode ?? DEFAULT_TRACE_DRAFT_MODE
 
   return useQuery({
-    queryKey: scoresBySessionQueryKey(projectId, traceIds, limit, offset, effectiveDraftMode),
+    queryKey: scoresBySessionQueryKey(projectId, traceIds, signalId, limit, offset, effectiveDraftMode),
     queryFn: () =>
       listScoresBySession({
-        data: { projectId, traceIds: [...traceIds], limit, offset, draftMode: effectiveDraftMode },
+        data: {
+          projectId,
+          traceIds: [...traceIds],
+          ...(signalId ? { signalId } : {}),
+          limit,
+          offset,
+          draftMode: effectiveDraftMode,
+        },
       }),
     enabled: enabled && projectId.length > 0 && traceIds.length > 0,
   })

--- a/apps/web/src/domains/scores/scores.functions.ts
+++ b/apps/web/src/domains/scores/scores.functions.ts
@@ -128,6 +128,7 @@ export const listScoresBySession = createServerFn({ method: "POST" })
     z.object({
       projectId: z.string(),
       traceIds: z.array(traceIdSchema).max(500),
+      signalId: z.string().optional(),
       limit: z.number().optional(),
       offset: z.number().optional(),
       draftMode: scoreDraftModeSchema.optional(),
@@ -145,6 +146,7 @@ export const listScoresBySession = createServerFn({ method: "POST" })
       listScoresByTraceIdsUseCase({
         projectId: data.projectId,
         traceIds: data.traceIds,
+        ...(data.signalId ? { signalId: data.signalId } : {}),
         limit: data.limit,
         offset: data.offset,
         draftMode: data.draftMode ?? "include",

--- a/apps/web/src/domains/scores/scores.functions.ts
+++ b/apps/web/src/domains/scores/scores.functions.ts
@@ -146,7 +146,7 @@ export const listScoresBySession = createServerFn({ method: "POST" })
       listScoresByTraceIdsUseCase({
         projectId: data.projectId,
         traceIds: data.traceIds,
-        ...(data.signalId ? { signalId: data.signalId } : {}),
+        ...(data.signalId !== undefined ? { signalId: data.signalId } : {}),
         limit: data.limit,
         offset: data.offset,
         draftMode: data.draftMode ?? "include",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.test.ts
@@ -3,7 +3,7 @@ import { TraceId } from "@domain/shared"
 import { act, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { AnnotationRecord } from "../../../../../../../domains/annotations/annotations.functions.ts"
-import { useAnnotationNavigation } from "./use-annotation-navigation.ts"
+import { SETTLE_QUIET_MS, useAnnotationNavigation } from "./use-annotation-navigation.ts"
 import type { TextSelectionPopoverControls } from "./use-annotation-popover.ts"
 
 function createRect(left: number, bottom: number): DOMRect {
@@ -114,6 +114,14 @@ describe("useAnnotationNavigation", () => {
       result.current.scrollToAnnotation(annotation)
     })
 
+    // The conversation is still laying out right after the request, so the scroll
+    // waits for it to settle instead of landing short of the anchor.
+    expect(textElement.scrollIntoView).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(SETTLE_QUIET_MS * 2)
+    })
+
     expect(textElement.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" })
     expect(openExistingAnnotationPopover).not.toHaveBeenCalled()
     expect(updateTextSelectionPopoverPosition).not.toHaveBeenCalled()
@@ -128,5 +136,39 @@ describe("useAnnotationNavigation", () => {
     expect(openExistingAnnotationPopover).toHaveBeenCalledWith(annotation, { x: 72, y: 220 })
     expect(updateTextSelectionPopoverPosition).not.toHaveBeenCalled()
     expect(clickSpy).not.toHaveBeenCalled()
+  })
+
+  it("holds the scroll while the conversation is still growing", () => {
+    const container = document.createElement("div")
+    const messageElement = document.createElement("div")
+    messageElement.setAttribute("data-message-index", "1")
+    messageElement.scrollIntoView = vi.fn()
+    container.appendChild(messageElement)
+    document.body.appendChild(container)
+
+    let scrollHeight = 500
+    Object.defineProperty(container, "scrollHeight", { get: () => scrollHeight })
+
+    const annotation = { ...createAnnotationRecord(), metadata: { rawFeedback: "Looks good", messageIndex: 1 } }
+    const { result } = renderHook(() => useAnnotationNavigation({ scrollContainerRef: { current: container } }))
+
+    act(() => {
+      result.current.scrollToAnnotation(annotation)
+    })
+
+    // Messages laying out above the anchor keep pushing it down, so each change
+    // restarts the wait rather than scrolling against a stale layout.
+    for (let step = 0; step < 6; step++) {
+      scrollHeight += 100
+      act(() => {
+        vi.advanceTimersByTime(SETTLE_QUIET_MS)
+      })
+    }
+    expect(messageElement.scrollIntoView).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(SETTLE_QUIET_MS * 2)
+    })
+    expect(messageElement.scrollIntoView).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.ts
@@ -5,6 +5,12 @@ import type { TextSelectionPopoverControls } from "./use-annotation-popover.ts"
 const HIGHLIGHT_BOX_SHADOW = "0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--primary) / 0.5)"
 const HIGHLIGHT_DURATION_MS = 4000
 const POPOVER_VIEWPORT_PADDING = 24
+/** How often the conversation's scroll height is sampled while waiting for it to settle. */
+const SETTLE_POLL_MS = 50
+/** How long that height must hold steady before the conversation counts as laid out. */
+export const SETTLE_QUIET_MS = 200
+/** Upper bound on the wait, so a conversation that never settles still scrolls. */
+const SETTLE_TIMEOUT_MS = 5000
 /**
  * `scrollend` does not bubble — it fires only on the element whose scroll offset changed.
  * `scrollIntoView` may scroll an ancestor of `container`, so we walk up from the target.
@@ -60,6 +66,14 @@ export function useAnnotationNavigation({
   const currentPopoverCardRef = useRef<HTMLElement | null>(null)
   const observerRef = useRef<MutationObserver | null>(null)
   const observerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const settleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const cancelSettle = useCallback(() => {
+    if (settleTimeoutRef.current) {
+      clearTimeout(settleTimeoutRef.current)
+      settleTimeoutRef.current = null
+    }
+  }, [])
 
   const clearObserver = useCallback(() => {
     if (observerRef.current) {
@@ -98,7 +112,8 @@ export function useAnnotationNavigation({
     clearHighlight()
     clearPopoverCardHighlight()
     clearObserver()
-  }, [clearHighlight, clearPopoverCardHighlight, clearObserver])
+    cancelSettle()
+  }, [clearHighlight, clearPopoverCardHighlight, clearObserver, cancelSettle])
 
   useEffect(() => () => clearAll(), [clearAll])
 
@@ -292,59 +307,69 @@ export function useAnnotationNavigation({
 
   const findAndScrollToAnnotation = useCallback(
     (annotation: AnnotationRecord) => {
-      clearObserver()
+      cancelSettle()
 
       const container = scrollContainerRef.current
-      if (!container) return false
+      if (!container) return
 
       const { messageIndex, partIndex, startOffset, endOffset } = annotation.metadata
-      if (messageIndex === undefined) return false
+      if (messageIndex === undefined) return
 
       const isTextSelection = partIndex !== undefined && startOffset !== undefined && endOffset !== undefined
 
-      // Try to resolve the target element now; returns true once it scrolls.
-      // Both branches may run before the conversation DOM mounts (e.g. sliding
-      // into a freshly opened trace), so the caller falls back to an observer.
-      const tryScroll = (): boolean => {
+      const resolveTarget = (): ScrollToElementOptions | null => {
         if (isTextSelection) {
           const textElement = container.querySelector<HTMLElement>(`[data-annotation-id="${annotation.id}"]`)
-          if (!textElement) return false
-          scrollToElement({
+          if (!textElement) return null
+          return {
             element: textElement,
             clickTarget: textElement,
             annotation,
             openTextSelectionPopoverImmediately: true,
-          })
-          return true
+          }
         }
 
         const messageElement = container.querySelector<HTMLElement>(`[data-message-index="${messageIndex}"]`)
-        if (!messageElement) return false
+        if (!messageElement) return null
         const triggerElement = container.querySelector<HTMLElement>(
           `[data-message-annotation-trigger="${messageIndex}"]`,
         )
-        scrollToElement({ element: messageElement, clickTarget: triggerElement, annotation })
-        return true
+        return { element: messageElement, clickTarget: triggerElement, annotation }
       }
 
-      if (tryScroll()) return true
+      // The target renders asynchronously (the conversation chunk has to land and,
+      // for a substring anchor, its highlight spans have to be painted), and even
+      // once it exists the messages above it keep laying out, pushing it further
+      // down — scrolling before that settles lands short of the anchor. Sampling
+      // the scroll height covers node insertions and pure reflows alike; scroll
+      // once it holds steady.
+      let elapsed = 0
+      let quietFor = 0
+      let lastScrollHeight = -1
 
-      const observer = new MutationObserver((_, obs) => {
-        if (tryScroll()) {
-          obs.disconnect()
-          observerRef.current = null
+      const scrollWhenSettled = () => {
+        settleTimeoutRef.current = null
+        elapsed += SETTLE_POLL_MS
+        if (container.scrollHeight === lastScrollHeight) {
+          quietFor += SETTLE_POLL_MS
+        } else {
+          lastScrollHeight = container.scrollHeight
+          quietFor = 0
         }
-      })
-      observerRef.current = observer
-      observer.observe(container, { childList: true, subtree: true })
-      observerTimeoutRef.current = setTimeout(() => {
-        observer.disconnect()
-        observerRef.current = null
-        observerTimeoutRef.current = null
-      }, 5000)
-      return false
+
+        const timedOut = elapsed >= SETTLE_TIMEOUT_MS
+        const target = resolveTarget()
+        if (target && (quietFor >= SETTLE_QUIET_MS || timedOut)) {
+          scrollToElement(target)
+          return
+        }
+        if (timedOut) return
+        settleTimeoutRef.current = setTimeout(scrollWhenSettled, SETTLE_POLL_MS)
+      }
+
+      settleTimeoutRef.current = setTimeout(scrollWhenSettled, SETTLE_POLL_MS)
     },
-    [scrollContainerRef, scrollToElement, clearObserver],
+    [scrollContainerRef, scrollToElement, cancelSettle],
   )
 
   const scrollToAnnotation = useCallback(

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-conversation-annotation-focus.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-conversation-annotation-focus.ts
@@ -10,9 +10,9 @@ import type { TextSelectionPopoverControls } from "./use-annotation-popover.ts"
  * `<ConversationTab>`). Owns the scroll container + text-selection popover refs
  * and the navigation hook, and drives:
  *
- * - `focusAnnotationId`: when navigation requests an annotation (e.g. clicking an
- *   inline annotation in the session Annotations tab), scroll to it and open its
- *   popover. We only fire once the conversation is *active* (so its scroll
+ * - `focusScoreId`: the score whose anchor the conversation should focus (the
+ *   shareable `scoreId` URL param). Scrolls to its anchored message and opens
+ *   its popover. We only fire once the conversation is *active* (so its scroll
  *   container is mounted) AND its messages have *loaded* — otherwise the scroll
  *   target doesn't exist yet and the navigation hook would no-op without retrying.
  *   The hook itself observes the DOM for any remaining render lag.
@@ -21,18 +21,16 @@ import type { TextSelectionPopoverControls } from "./use-annotation-popover.ts"
 export function useConversationAnnotationFocus({
   projectId,
   traceId,
-  focusAnnotationId,
+  focusScoreId,
   isConversationActive,
   onActivateConversation,
-  onFocusConsumed,
   annotationsEnabled = true,
 }: {
   readonly projectId: string
   readonly traceId: string
-  readonly focusAnnotationId?: string | undefined
+  readonly focusScoreId?: string | undefined
   readonly isConversationActive: boolean
   readonly onActivateConversation?: (() => void) | undefined
-  readonly onFocusConsumed?: (() => void) | undefined
   /** Off under a sandbox scope — skips the annotations fetch and focus wiring. */
   readonly annotationsEnabled?: boolean
 }) {
@@ -68,31 +66,21 @@ export function useConversationAnnotationFocus({
   // machine; the effect is the right shape here.
   useEffect(() => {
     // Cleared request → reset the guard so the next one (even the same id) fires.
-    if (!focusAnnotationId) {
+    if (!focusScoreId) {
       focusHandledRef.current = null
       return
     }
-    if (focusHandledRef.current === focusAnnotationId) return
+    if (focusHandledRef.current === focusScoreId) return
     if (!isConversationActive || isDetailLoading || !traceDetail) return
-    const annotation = annotationsData?.items?.find((item) => item.id === focusAnnotationId)
+    const annotation = annotationsData?.items?.find((item) => item.id === focusScoreId)
     if (!annotation) return
-    focusHandledRef.current = focusAnnotationId
+    focusHandledRef.current = focusScoreId
     scrollToAnnotation(annotation)
-    onFocusConsumed?.()
-  }, [
-    focusAnnotationId,
-    isConversationActive,
-    isDetailLoading,
-    traceDetail,
-    annotationsData,
-    scrollToAnnotation,
-    onFocusConsumed,
-  ])
+  }, [focusScoreId, isConversationActive, isDetailLoading, traceDetail, annotationsData, scrollToAnnotation])
 
   return {
     scrollContainerRef,
     textSelectionPopoverControlsRef,
-    scrollToAnnotation,
     traceDetail,
     isDetailLoading,
   }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-conversation-annotation-focus.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-conversation-annotation-focus.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react"
 import { useAnnotationsByTrace } from "../../../../../../../domains/annotations/annotations.collection.ts"
-import { useTraceDetail } from "../../../../../../../domains/traces/traces.collection.ts"
+import { useTraceConversationMessages, useTraceDetail } from "../../../../../../../domains/traces/traces.collection.ts"
 import { useAnnotationNavigation } from "./use-annotation-navigation.ts"
 import type { TextSelectionPopoverControls } from "./use-annotation-popover.ts"
 
@@ -12,10 +12,10 @@ import type { TextSelectionPopoverControls } from "./use-annotation-popover.ts"
  *
  * - `focusScoreId`: the score whose anchor the conversation should focus (the
  *   shareable `scoreId` URL param). Scrolls to its anchored message and opens
- *   its popover. We only fire once the conversation is *active* (so its scroll
- *   container is mounted) AND its messages have *loaded* — otherwise the scroll
- *   target doesn't exist yet and the navigation hook would no-op without retrying.
- *   The hook itself observes the DOM for any remaining render lag.
+ *   its popover. We only fire once the conversation is *active* AND rendered (its
+ *   scroll container only mounts after the first message chunk loads) — otherwise
+ *   the scroll target doesn't exist yet and the navigation hook would no-op
+ *   without retrying. The hook itself observes the DOM for any remaining render lag.
  * - draining a pending scroll queued while the conversation tab was inactive.
  */
 export function useConversationAnnotationFocus({
@@ -44,6 +44,13 @@ export function useConversationAnnotationFocus({
     enabled: annotationsEnabled,
   })
   const { data: traceDetail, isLoading: isDetailLoading } = useTraceDetail({ projectId, traceId })
+  // Same query key the conversation itself uses, so this only mirrors its
+  // loading state instead of adding a fetch.
+  const { isLoading: isConversationLoading } = useTraceConversationMessages({
+    projectId,
+    traceId,
+    enabled: traceDetail != null,
+  })
 
   const { scrollToAnnotation, executePendingScroll } = useAnnotationNavigation({
     scrollContainerRef,
@@ -72,11 +79,23 @@ export function useConversationAnnotationFocus({
     }
     if (focusHandledRef.current === focusScoreId) return
     if (!isConversationActive || isDetailLoading || !traceDetail) return
+    // The conversation renders a skeleton until its first chunk of messages
+    // lands, so the scroll container the navigation pass needs doesn't exist
+    // yet. Marking the request handled before then would swallow it for good.
+    if (isConversationLoading || !scrollContainerRef.current) return
     const annotation = annotationsData?.items?.find((item) => item.id === focusScoreId)
     if (!annotation) return
     focusHandledRef.current = focusScoreId
     scrollToAnnotation(annotation)
-  }, [focusScoreId, isConversationActive, isDetailLoading, traceDetail, annotationsData, scrollToAnnotation])
+  }, [
+    focusScoreId,
+    isConversationActive,
+    isConversationLoading,
+    isDetailLoading,
+    traceDetail,
+    annotationsData,
+    scrollToAnnotation,
+  ])
 
   return {
     scrollContainerRef,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -84,6 +84,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   const [filtersOpen, setFiltersOpen] = useParamState("filtersOpen", false)
   const [activeTraceId, setActiveTraceId] = useParamState("traceId", "")
   const [activeSessionId, setActiveSessionId] = useParamState("sessionId", "")
+  const [, setFocusScoreId] = useParamState("scoreId", "")
   const [, setSelectedSpanId] = useParamState("spanId", "")
   const [, setSelectedSpanTraceId] = useParamState("spanTraceId", "")
   const [rawFilters, setRawFilters] = useParamState("filters", "")
@@ -333,13 +334,15 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
     setActiveTraceId("")
     setSelectedSpanId("")
     setSelectedSpanTraceId("")
-  }, [setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId])
+    setFocusScoreId("")
+  }, [setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId, setFocusScoreId])
 
   const onActiveTraceChange = (traceId: string | undefined) => {
     if (!traceId) {
       closeTraceDrawer()
       return
     }
+    setFocusScoreId("")
     setActiveTraceId(traceId)
   }
 
@@ -352,8 +355,9 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
       setActiveTraceId(traceId ?? "")
       setSelectedSpanId("")
       setSelectedSpanTraceId("")
+      setFocusScoreId("")
     },
-    [setActiveSessionId, setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId],
+    [setActiveSessionId, setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId, setFocusScoreId],
   )
 
   const closeSessionPanel = useCallback(() => {
@@ -361,7 +365,8 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
     setActiveTraceId("")
     setSelectedSpanId("")
     setSelectedSpanTraceId("")
-  }, [setActiveSessionId, setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId])
+    setFocusScoreId("")
+  }, [setActiveSessionId, setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId, setFocusScoreId])
 
   // Submitting a new query invalidates any open drawer context against the new result set.
   // The `savedSearch` slug is intentionally kept so the Save button can surface drift.

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -427,9 +427,9 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
       if (ids.length === 0) return
       const idx = ids.indexOf(activeTraceId)
       const target = idx < 0 ? ids[0] : ids[idx + delta]
-      if (target) setActiveTraceId(target)
+      if (target) onActiveTraceChange(target)
     },
-    [activeTraceId],
+    [activeTraceId, onActiveTraceChange],
   )
 
   const onNextTrace = useCallback(() => navigateTrace(1), [navigateTrace])

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -21,6 +21,31 @@ import { isTraceDetailTab, type TraceDetailTabId, TraceSlot } from "./session-de
 import { useFocusSignalScore } from "./session-detail-drawer/use-focus-signal-score.ts"
 import { useSessionTraces } from "./session-detail-drawer/use-session-traces.ts"
 
+/**
+ * Clears every search param the session panel owns. A caller that reuses the
+ * panel for another session (or closes it) runs this so the previous session's
+ * tab, focused score, or open trace can't leak into the next one.
+ */
+export function useSessionPanelParamReset() {
+  const [, setTraceId] = useParamState("traceId", "")
+  const [, setSignalId] = useParamState("signalId", "")
+  const [, setSessionTab] = useParamState("sessionTab", "")
+  const [, setTraceTab] = useParamState("traceTab", "")
+  const [, setFocusScoreId] = useParamState("scoreId", "")
+  const [, setSelectedSpanId] = useParamState("spanId", "")
+  const [, setSelectedSpanTraceId] = useParamState("spanTraceId", "")
+
+  return () => {
+    setTraceId("")
+    setSignalId("")
+    setSessionTab("")
+    setTraceTab("")
+    setFocusScoreId("")
+    setSelectedSpanId("")
+    setSelectedSpanTraceId("")
+  }
+}
+
 export type OpenTraceOptions = {
   /** Focuses a score's anchor after the trace slot mounts. Implies `conversation` as the default tab. */
   readonly focusScoreId?: string

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -18,11 +18,12 @@ import {
 import { SignalSlot } from "./session-detail-drawer/signal-slot.tsx"
 import { type DetailSlotKind, SlotTransition } from "./session-detail-drawer/slot-transition.tsx"
 import { isTraceDetailTab, type TraceDetailTabId, TraceSlot } from "./session-detail-drawer/trace-slot.tsx"
+import { useFocusSignalScore } from "./session-detail-drawer/use-focus-signal-score.ts"
 import { useSessionTraces } from "./session-detail-drawer/use-session-traces.ts"
 
 export type OpenTraceOptions = {
-  /** Focuses an inline annotation after the trace slot mounts. Implies `conversation` as the default tab. */
-  readonly focusAnnotationId?: string
+  /** Focuses a score's anchor after the trace slot mounts. Implies `conversation` as the default tab. */
+  readonly focusScoreId?: string
   /** Overrides which tab the trace slot lands on. Defaults: `conversation` with focus, otherwise `trace`. */
   readonly targetTab?: TraceDetailTabId
 }
@@ -37,6 +38,7 @@ export function SessionDetailDrawer({
   focusMomentKind,
   focusMomentId,
   focusSpan,
+  focusSignalId,
   defaultTab,
 }: {
   readonly projectId: string
@@ -51,28 +53,34 @@ export function SessionDetailDrawer({
   readonly focusMomentId?: string | undefined
   /** Lands on the Spans tab with this span selected. Remount (re-key) to focus a different span. */
   readonly focusSpan?: { readonly spanId: string; readonly traceId: string } | undefined
+  /** Lands on the anchor of the score this signal recorded in the session, when it has one. */
+  readonly focusSignalId?: string | undefined
   /** Overrides which tab the drawer lands on when no URL param is set. */
   readonly defaultTab?: SessionTabId | undefined
 }) {
   const [traceId, setTraceId] = useParamState("traceId", "")
   const [signalId, setSignalId] = useParamState("signalId", "")
-  const [, setFocusAnnotationId] = useParamState("annotationId", "")
+  const [focusScoreId, setFocusScoreId] = useParamState("scoreId", "")
   const [, setSelectedSpanId] = useParamState("spanId", "")
   const [, setSelectedSpanTraceId] = useParamState("spanTraceId", "")
   const [q] = useParamState("q", "")
-  // Land on the conversation tab when arriving from an active search, so the
-  // conversation tab's search-match autoscroll/highlight has something to scroll to.
+  // Land on the conversation tab when arriving from an active search (so the
+  // conversation tab's search-match autoscroll/highlight has something to scroll
+  // to) or with a focused score, whose anchor only that tab can show.
   const defaultSessionTab =
     defaultTab ??
-    (focusSpan ? "spans" : (searchQuery?.length ?? q.length) > 0 || focusMomentKind ? "conversation" : "session")
+    (focusSpan
+      ? "spans"
+      : (searchQuery?.length ?? q.length) > 0 || focusMomentKind || focusScoreId
+        ? "conversation"
+        : "session")
   const [rawActiveTab, setActiveTab] = useParamState("sessionTab", defaultSessionTab, {
     validate: isSessionTab,
   })
   const activeTab = normalizeSessionTab(rawActiveTab)
   // Owned by `TraceSlot` once it mounts, but written here when sliding into a
-  // trace so the slot lands on the requested tab (Signals → "trace",
-  // Annotations → "conversation"). Kept distinct from `sessionTab` so the two
-  // never collide.
+  // trace so the slot lands on the requested tab (Signals → "trace", Scores →
+  // "conversation"). Kept distinct from `sessionTab` so the two never collide.
   const [, setTraceTab] = useParamState<TraceDetailTabId>("traceTab", "trace", { validate: isTraceDetailTab })
 
   // Seed the span selection when a caller opens the drawer focused on a span.
@@ -135,31 +143,38 @@ export function SessionDetailDrawer({
   const showDetail = detailKind !== null && !isSessionMissing
 
   const openTrace = (nextTraceId: string, options: OpenTraceOptions = {}) => {
-    const { focusAnnotationId, targetTab } = options
+    const { focusScoreId: nextFocusScoreId, targetTab } = options
     setSelectedSpanId("")
     setSelectedSpanTraceId("")
-    setFocusAnnotationId(focusAnnotationId ?? "")
-    setTraceTab(targetTab ?? (focusAnnotationId ? "conversation" : "trace"))
+    setFocusScoreId(nextFocusScoreId ?? "")
+    setTraceTab(targetTab ?? (nextFocusScoreId ? "conversation" : "trace"))
     setTraceId(nextTraceId)
   }
 
   const openSignal = (nextSignalId: string) => {
     setSelectedSpanId("")
     setSelectedSpanTraceId("")
-    setFocusAnnotationId("")
+    setFocusScoreId("")
     setTraceId("")
     setSignalId(nextSignalId)
   }
 
-  const focusAnnotationInConversation = (annotationId: string) => {
-    setFocusAnnotationId(annotationId)
+  const focusScoreInConversation = (scoreId: string) => {
+    setFocusScoreId(scoreId)
     setActiveTab("conversation")
+  }
+
+  // A focused score only makes sense while the Conversation tab is showing it,
+  // so any other tab drops the `scoreId` param rather than stranding it there.
+  const selectTab = (tab: SessionTabId) => {
+    if (tab !== "conversation") setFocusScoreId("")
+    setActiveTab(tab)
   }
 
   const backToSession = () => {
     setSelectedSpanId("")
     setSelectedSpanTraceId("")
-    setFocusAnnotationId("")
+    setFocusScoreId("")
     setTraceId("")
     setSignalId("")
   }
@@ -167,11 +182,24 @@ export function SessionDetailDrawer({
   const handleClose = () => {
     setSelectedSpanId("")
     setSelectedSpanTraceId("")
-    setFocusAnnotationId("")
+    setFocusScoreId("")
     setTraceId("")
     setSignalId("")
     onClose()
   }
+
+  useFocusSignalScore({
+    projectId,
+    signalId: focusSignalId,
+    traceIds: session?.traceIds ?? [],
+    canFocus: !showDetail,
+    onFocus: (score) => {
+      const scoreTraceId = score.traceId ?? ""
+      if (!scoreTraceId) return
+      if (scoreTraceId === session?.latestTraceId) focusScoreInConversation(score.id)
+      else openTrace(scoreTraceId, { focusScoreId: score.id })
+    },
+  })
 
   useHotkeys([
     {
@@ -228,11 +256,11 @@ export function SessionDetailDrawer({
               traces={traces}
               latestTraceId={session.latestTraceId}
               activeTab={activeTab}
-              onActiveTabChange={setActiveTab}
+              onActiveTabChange={selectTab}
               isActive={!showDetail}
               onOpenTrace={openTrace}
               onOpenSignal={openSignal}
-              onOpenInConversation={focusAnnotationInConversation}
+              onOpenInConversation={focusScoreInConversation}
               focusMomentKind={focusMomentKind}
               focusMomentId={focusMomentId}
               {...(searchQuery ? { searchQuery } : {})}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -163,9 +163,9 @@ function MomentLabelBadge({ label, store }: { readonly label: MomentLabelRecord;
  * The session Conversation tab renders the latest ingested trace's
  * conversation (with that trace's inline annotations) by mounting the existing
  * trace ConversationTab against `latestTraceId`. Reusing the full trace keeps
- * inline annotation anchoring (`messageIndex`) exact. When the Annotations tab
- * focuses an annotation on the latest trace (which writes the `annotationId`
- * param and switches here) the conversation scrolls to + opens that annotation.
+ * inline annotation anchoring (`messageIndex`) exact. When the Scores tab
+ * focuses a score on the latest trace (which writes the `scoreId` param and
+ * switches here) the conversation scrolls to + opens that annotation.
  *
  * Detected moment labels from the session analysis render as badges anchored
  * below the exact message that triggered the detection. When opened with a
@@ -215,15 +215,14 @@ export function ConversationTab({
     [moments],
   )
 
-  const [focusAnnotationId, setFocusAnnotationId] = useParamState("annotationId", "")
+  const [focusScoreId] = useParamState("scoreId", "")
   const selectedLabelStore = useSelectedLabelStore()
   const { scrollContainerRef, textSelectionPopoverControlsRef, traceDetail, isDetailLoading } =
     useConversationAnnotationFocus({
       projectId,
       traceId: latestTraceId,
-      focusAnnotationId,
+      focusScoreId,
       isConversationActive: isActive,
-      onFocusConsumed: () => setFocusAnnotationId(""),
       annotationsEnabled,
     })
   const conversation = useTraceConversationMessages({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/scores-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/scores-tab.tsx
@@ -25,7 +25,7 @@ export function ScoresTab({
   readonly traceIds: readonly string[]
   readonly latestTraceId: string
   readonly traceNumberById: ReadonlyMap<string, number>
-  readonly onOpenInConversation: (annotationId: string) => void
+  readonly onOpenInConversation: (scoreId: string) => void
   readonly onOpenTrace: (traceId: string, options?: OpenTraceOptions) => void
 }) {
   const { data, isLoading, isError } = useScoresBySession({ projectId, traceIds })
@@ -70,7 +70,7 @@ export function ScoresTab({
         const traceId = score.traceId ?? ""
         if (!traceId) return
         if (traceId === latestTraceId) onOpenInConversation(score.id)
-        else onOpenTrace(traceId, { focusAnnotationId: score.id })
+        else onOpenTrace(traceId, { focusScoreId: score.id })
       }}
       renderItemAccessory={(score) => {
         const traceNumber = traceNumberById.get(score.traceId ?? "")

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -72,7 +72,7 @@ export function SessionSlot({
   readonly isActive: boolean
   readonly onOpenTrace: (traceId: string, options?: OpenTraceOptions) => void
   readonly onOpenSignal: (signalId: string) => void
-  readonly onOpenInConversation: (annotationId: string) => void
+  readonly onOpenInConversation: (scoreId: string) => void
   readonly searchQuery?: string
   readonly filters?: FilterSet | undefined
   readonly onFiltersChange?: ((filters: FilterSet) => void) | undefined

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/trace-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/trace-slot.tsx
@@ -21,7 +21,7 @@ export function TraceSlot({
 }) {
   const [activeTab, setActiveTab] = useParamState("traceTab", "trace", { validate: isTraceDetailTab })
   const [selectedSpanId, setSelectedSpanId] = useParamState("spanId", "")
-  const [focusAnnotationId] = useParamState("annotationId", "")
+  const [focusScoreId, setFocusScoreId] = useParamState("scoreId", "")
 
   return (
     <TraceDetailBody
@@ -31,7 +31,8 @@ export function TraceSlot({
       onActiveTabChange={setActiveTab}
       selectedSpanId={selectedSpanId}
       onSelectedSpanIdChange={setSelectedSpanId}
-      {...(focusAnnotationId ? { focusAnnotationId } : {})}
+      focusScoreId={focusScoreId}
+      onFocusScoreIdChange={setFocusScoreId}
       {...(searchQuery ? { searchQuery } : {})}
     />
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-focus-signal-score.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-focus-signal-score.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+import type { ScoreRecord } from "../../../../../../domains/scores/scores.functions.ts"
+import { findAnchoredSignalScore } from "./use-focus-signal-score.ts"
+
+function score(overrides: Partial<ScoreRecord> & { readonly id: string }): ScoreRecord {
+  return {
+    organizationId: "org-1",
+    projectId: "project-1",
+    sessionId: "session-1",
+    traceId: "trace-1",
+    spanId: null,
+    source: "annotation",
+    sourceId: "UI",
+    simulationId: null,
+    signalId: "signal-1",
+    evaluationSignalId: null,
+    value: 0,
+    passed: false,
+    feedback: "feedback",
+    metadata: { messageIndex: 3 },
+    error: null,
+    errored: false,
+    duration: 0,
+    tokens: 0,
+    cost: 0,
+    draftedAt: null,
+    annotatorId: "user-1",
+    createdAt: "2026-08-01T10:00:00.000Z",
+    updatedAt: "2026-08-01T10:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("findAnchoredSignalScore", () => {
+  it("picks the newest anchored score the signal recorded", () => {
+    const found = findAnchoredSignalScore({
+      scores: [
+        score({ id: "older", createdAt: "2026-08-01T09:00:00.000Z" }),
+        score({ id: "newer", createdAt: "2026-08-01T11:00:00.000Z" }),
+      ],
+      signalId: "signal-1",
+    })
+
+    expect(found?.id).toBe("newer")
+  })
+
+  it("ignores scores of other signals, other sources, and unanchored scores", () => {
+    const found = findAnchoredSignalScore({
+      scores: [
+        score({ id: "other-signal", signalId: "signal-2" }),
+        score({ id: "evaluation", source: "evaluation", metadata: {} }),
+        score({ id: "conversation-level", metadata: {} }),
+        score({ id: "no-trace", traceId: null }),
+        score({ id: "anchored", createdAt: "2026-08-01T08:00:00.000Z" }),
+      ],
+      signalId: "signal-1",
+    })
+
+    expect(found?.id).toBe("anchored")
+  })
+
+  it("returns null when the signal has no anchored score in the session", () => {
+    expect(
+      findAnchoredSignalScore({
+        scores: [score({ id: "conversation-level", metadata: {} })],
+        signalId: "signal-1",
+      }),
+    ).toBeNull()
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-focus-signal-score.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-focus-signal-score.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react"
+import { useScoresBySession } from "../../../../../../domains/scores/scores.collection.ts"
+import type { ScoreRecord } from "../../../../../../domains/scores/scores.functions.ts"
+
+/**
+ * The signal's newest score in this session that pinpoints a message. Only
+ * annotations carry anchors, so a signal detected purely by an evaluation
+ * resolves to null.
+ */
+export function findAnchoredSignalScore({
+  scores,
+  signalId,
+}: {
+  readonly scores: readonly ScoreRecord[]
+  readonly signalId: string
+}): ScoreRecord | null {
+  return (
+    scores
+      .filter(
+        (score) =>
+          score.source === "annotation" &&
+          score.signalId === signalId &&
+          score.traceId !== null &&
+          score.metadata.messageIndex !== undefined,
+      )
+      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))[0] ?? null
+  )
+}
+
+/**
+ * Focuses the anchored score a signal recorded in the session, once. Used when
+ * the session panel is opened from a signal so it lands where the signal
+ * actually occurred instead of at the top of the conversation.
+ *
+ * `canFocus` is read when the scores land rather than at mount, so a panel that
+ * has meanwhile slid into a trace or signal slot is left where the user put it.
+ */
+export function useFocusSignalScore({
+  projectId,
+  signalId,
+  traceIds,
+  canFocus,
+  onFocus,
+}: {
+  readonly projectId: string
+  readonly signalId: string | undefined
+  readonly traceIds: readonly string[]
+  readonly canFocus: boolean
+  readonly onFocus: (score: ScoreRecord) => void
+}): void {
+  const { data } = useScoresBySession({ projectId, traceIds, enabled: signalId !== undefined })
+  const onFocusRef = useRef(onFocus)
+  onFocusRef.current = onFocus
+  const focusedRef = useRef(false)
+
+  // TODO(frontend-use-effect-policy): the session's scores arrive asynchronously,
+  // long after the drawer mounted, and there is no event at the arrival site.
+  useEffect(() => {
+    if (!signalId || focusedRef.current || !data) return
+    focusedRef.current = true
+    if (!canFocus) return
+    const score = findAnchoredSignalScore({ scores: data.items, signalId })
+    if (score) onFocusRef.current(score)
+  }, [canFocus, data, signalId])
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-focus-signal-score.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-focus-signal-score.ts
@@ -48,13 +48,16 @@ export function useFocusSignalScore({
   readonly canFocus: boolean
   readonly onFocus: (score: ScoreRecord) => void
 }): void {
+  // Callers resolve a signal slug to an id and pass "" until it lands, so an empty
+  // id means "no signal yet" rather than "every signal".
+  const activeSignalId = signalId !== undefined && signalId.length > 0 ? signalId : undefined
   // Scoped to the signal: a session can hold more scores than one page returns,
   // and the anchored one is often not among the newest.
   const { data } = useScoresBySession({
     projectId,
     traceIds,
-    ...(signalId ? { signalId } : {}),
-    enabled: signalId !== undefined,
+    ...(activeSignalId !== undefined ? { signalId: activeSignalId } : {}),
+    enabled: activeSignalId !== undefined,
   })
   const onFocusRef = useRef(onFocus)
   onFocusRef.current = onFocus
@@ -63,10 +66,10 @@ export function useFocusSignalScore({
   // TODO(frontend-use-effect-policy): the session's scores arrive asynchronously,
   // long after the drawer mounted, and there is no event at the arrival site.
   useEffect(() => {
-    if (!signalId || focusedSignalIdRef.current === signalId || !data) return
-    focusedSignalIdRef.current = signalId
+    if (!activeSignalId || focusedSignalIdRef.current === activeSignalId || !data) return
+    focusedSignalIdRef.current = activeSignalId
     if (!canFocus) return
-    const score = findAnchoredSignalScore({ scores: data.items, signalId })
+    const score = findAnchoredSignalScore({ scores: data.items, signalId: activeSignalId })
     if (score) onFocusRef.current(score)
-  }, [canFocus, data, signalId])
+  }, [canFocus, data, activeSignalId])
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-focus-signal-score.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-focus-signal-score.ts
@@ -48,16 +48,23 @@ export function useFocusSignalScore({
   readonly canFocus: boolean
   readonly onFocus: (score: ScoreRecord) => void
 }): void {
-  const { data } = useScoresBySession({ projectId, traceIds, enabled: signalId !== undefined })
+  // Scoped to the signal: a session can hold more scores than one page returns,
+  // and the anchored one is often not among the newest.
+  const { data } = useScoresBySession({
+    projectId,
+    traceIds,
+    ...(signalId ? { signalId } : {}),
+    enabled: signalId !== undefined,
+  })
   const onFocusRef = useRef(onFocus)
   onFocusRef.current = onFocus
-  const focusedRef = useRef(false)
+  const focusedSignalIdRef = useRef<string | null>(null)
 
   // TODO(frontend-use-effect-policy): the session's scores arrive asynchronously,
   // long after the drawer mounted, and there is no event at the arrival site.
   useEffect(() => {
-    if (!signalId || focusedRef.current || !data) return
-    focusedRef.current = true
+    if (!signalId || focusedSignalIdRef.current === signalId || !data) return
+    focusedSignalIdRef.current = signalId
     if (!canFocus) return
     const score = findAnchoredSignalScore({ scores: data.items, signalId })
     if (score) onFocusRef.current(score)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -18,7 +18,6 @@ import { useHotkeys } from "@tanstack/react-hotkeys"
 import { ArrowDownIcon, ArrowUpIcon, GaugeIcon, GroupIcon, ListTreeIcon, MessagesSquareIcon } from "lucide-react"
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
 import { HotkeyBadge } from "../../../../../components/hotkey-badge.tsx"
-import type { AnnotationRecord } from "../../../../../domains/annotations/annotations.functions.ts"
 import { useProjectScope } from "../../../../../domains/projects/project-scope.tsx"
 import { useScoresByTrace } from "../../../../../domains/scores/scores.collection.ts"
 import type { ScoreRecord } from "../../../../../domains/scores/scores.functions.ts"
@@ -27,7 +26,6 @@ import { useTraceDetail } from "../../../../../domains/traces/traces.collection.
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { AddTraceToDatasetAction } from "./add-trace-to-dataset-action.tsx"
-import { isGlobalAnnotation } from "./annotations/hooks/use-annotation-navigation.ts"
 import { useConversationAnnotationFocus } from "./annotations/hooks/use-conversation-annotation-focus.ts"
 import { useTraceTimeline } from "./conversation-timeline/use-trace-timeline.ts"
 import { TraceScoresList } from "./scores/trace-scores-list.tsx"
@@ -148,11 +146,13 @@ function TraceDetailDrawerWithUrlTabs(props: Omit<TraceDetailDrawerProps, "urlSy
     drawerStoreKey,
     ...rest
   } = props
+  const [focusScoreId, setFocusScoreId] = useParamState("scoreId", "")
   // Shared with the session panel via the `detailTab` URL param so Conversation
   // / Annotations carry over when switching between trace and session views.
-  // Default to Conversation when arriving from an active search so the
-  // search-match autoscroll/highlight lands on a hit instead of the trace tab.
-  const defaultTab = (props.searchQuery?.length ?? 0) > 0 ? "conversation" : "trace"
+  // Default to Conversation when arriving from an active search (so the
+  // search-match autoscroll/highlight lands on a hit instead of the trace tab)
+  // or with a focused score, whose anchor only the Conversation tab can show.
+  const defaultTab = (props.searchQuery?.length ?? 0) > 0 || focusScoreId ? "conversation" : "trace"
   const [rawActiveTab, setActiveTab] = useParamState("detailTab", defaultTab, {
     validate: isTraceDetailTab,
   })
@@ -168,6 +168,8 @@ function TraceDetailDrawerWithUrlTabs(props: Omit<TraceDetailDrawerProps, "urlSy
       onActiveTabChange={setActiveTab}
       selectedSpanId={selectedSpanId}
       onSelectedSpanIdChange={setSelectedSpanId}
+      focusScoreId={focusScoreId}
+      onFocusScoreIdChange={setFocusScoreId}
       {...(closeLabel !== undefined ? { closeLabel } : {})}
       {...(drawerStoreKey !== undefined ? { drawerStoreKey } : {})}
     />
@@ -178,6 +180,7 @@ function TraceDetailDrawerWithLocalTabs(props: Omit<TraceDetailDrawerProps, "url
   const { initialTab, initialSpanId, closeLabel, drawerStoreKey, ...rest } = props
   const [activeTab, setActiveTab] = useState<TabId>(normalizeTraceDetailTab(initialTab ?? "trace"))
   const [selectedSpanId, setSelectedSpanId] = useState(initialSpanId ?? "")
+  const [focusScoreId, setFocusScoreId] = useState("")
   return (
     <TraceDetailDrawerShell
       {...(rest as Omit<
@@ -188,6 +191,8 @@ function TraceDetailDrawerWithLocalTabs(props: Omit<TraceDetailDrawerProps, "url
       onActiveTabChange={setActiveTab}
       selectedSpanId={selectedSpanId}
       onSelectedSpanIdChange={setSelectedSpanId}
+      focusScoreId={focusScoreId}
+      onFocusScoreIdChange={setFocusScoreId}
       {...(closeLabel !== undefined ? { closeLabel } : {})}
       {...(drawerStoreKey !== undefined ? { drawerStoreKey } : {})}
     />
@@ -199,6 +204,9 @@ type TraceDetailTabControlProps = {
   readonly onActiveTabChange: (tab: TabId) => void
   readonly selectedSpanId: string
   readonly onSelectedSpanIdChange: (spanId: string) => void
+  /** Score whose anchor the Conversation tab focuses; empty when nothing is focused. */
+  readonly focusScoreId: string
+  readonly onFocusScoreIdChange: (scoreId: string) => void
 }
 
 export type TraceDetailBodyProps = {
@@ -207,7 +215,6 @@ export type TraceDetailBodyProps = {
   readonly projectId: string
   readonly filters?: FilterSet | undefined
   readonly onFiltersChange?: (filters: FilterSet) => void
-  readonly focusAnnotationId?: string
   /** Active search query — drives literal/token highlights in the Conversation tab. */
   readonly searchQuery?: string
 } & TraceDetailTabControlProps
@@ -231,7 +238,8 @@ export function TraceDetailBody({
   onActiveTabChange,
   selectedSpanId,
   onSelectedSpanIdChange,
-  focusAnnotationId,
+  focusScoreId,
+  onFocusScoreIdChange,
   searchQuery,
 }: TraceDetailBodyProps) {
   const isSandbox = useProjectScope().kind === "sandbox"
@@ -287,10 +295,13 @@ export function TraceDetailBody({
   // Stable so the palette contributor's command memo doesn't re-register each render.
   const handleSetActiveTab = useCallback(
     (tab: TabId) => {
+      // The focused score is only meaningful on the Conversation tab, so leaving
+      // it drops the `scoreId` param instead of stranding it in the URL.
+      if (tab !== "conversation") onFocusScoreIdChange("")
       onActiveTabChange(tab)
       setVisitedTabs((prev) => new Set([...prev, tab]))
     },
-    [onActiveTabChange],
+    [onActiveTabChange, onFocusScoreIdChange],
   )
 
   const timeline = useTraceTimeline({
@@ -324,10 +335,10 @@ export function TraceDetailBody({
     },
   ])
 
-  const { scrollContainerRef, textSelectionPopoverControlsRef, scrollToAnnotation } = useConversationAnnotationFocus({
+  const { scrollContainerRef, textSelectionPopoverControlsRef } = useConversationAnnotationFocus({
     projectId,
     traceId,
-    focusAnnotationId,
+    focusScoreId,
     isConversationActive: activeTab === "conversation",
     onActivateConversation: () => handleSetActiveTab("conversation"),
     annotationsEnabled: scoresEnabled,
@@ -337,11 +348,11 @@ export function TraceDetailBody({
     setVisitedTabs((prev) => new Set([...prev, activeTab]))
   }, [activeTab])
 
+  // `ScoreList` only makes anchored annotations clickable; focusing one is a URL
+  // write so the conversation position is shareable.
   function handleScoreClick(score: ScoreRecord) {
-    if (score.source !== "annotation") return
-    const annotation = score as unknown as AnnotationRecord
-    if (isGlobalAnnotation(annotation)) return
-    scrollToAnnotation(annotation)
+    onFocusScoreIdChange(score.id)
+    handleSetActiveTab("conversation")
   }
 
   function navigateToSpan(spanId: string | null) {
@@ -510,6 +521,8 @@ function TraceDetailDrawerShell({
   onActiveTabChange,
   selectedSpanId,
   onSelectedSpanIdChange,
+  focusScoreId,
+  onFocusScoreIdChange,
   closeLabel,
   drawerStoreKey = "trace-detail-drawer-width",
   searchQuery,
@@ -580,6 +593,8 @@ function TraceDetailDrawerShell({
         onActiveTabChange={onActiveTabChange}
         selectedSpanId={selectedSpanId}
         onSelectedSpanIdChange={onSelectedSpanIdChange}
+        focusScoreId={focusScoreId}
+        onFocusScoreIdChange={onFocusScoreIdChange}
         {...(searchQuery ? { searchQuery } : {})}
       />
     </DetailDrawer>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
@@ -11,10 +11,11 @@ import {
   TagList,
   Text,
   Tooltip,
+  useMountEffect,
 } from "@repo/ui"
 import { formatCount, formatDuration, relativeTime } from "@repo/utils"
 import { ArrowDownRightIcon, CheckIcon, DatabaseIcon, TextAlignStartIcon } from "lucide-react"
-import { type ReactNode, useEffect, useMemo, useState } from "react"
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
 import { useProjectAlertIncidentsInRange } from "../../../../../../domains/alerts/alerts.collection.ts"
 import { useShowIncidentsOverlay } from "../../../../../../domains/alerts/use-show-incidents-overlay.ts"
 import {
@@ -27,6 +28,7 @@ import {
   useSignalSessionsCount,
   useSignalSessionsInfiniteScroll,
 } from "../../../../../../domains/signals/signals.collection.ts"
+import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import {
   type BulkSelection,
   EMPTY_SELECTION,
@@ -34,7 +36,7 @@ import {
   useSelectableRows,
 } from "../../../../../../lib/hooks/useSelectableRows.ts"
 import { AddToDatasetModal } from "../../-components/add-to-dataset-modal.tsx"
-import { SessionDetailDrawer } from "../../-components/session-detail-drawer.tsx"
+import { SessionDetailDrawer, useSessionPanelParamReset } from "../../-components/session-detail-drawer.tsx"
 import { SignalDrawerEvaluations } from "./signal-drawer-evaluations.tsx"
 import { formatSeenAgeParts, formatSignalAgeAgoLabel } from "./signal-formatters.ts"
 import { SignalLifecycleStatuses } from "./signal-lifecycle-statuses.tsx"
@@ -47,6 +49,17 @@ import { SignalTrendBar } from "./signal-trend-bar.tsx"
 const SIGNAL_PAGE_PANEL_HEIGHT = "h-72"
 /** Trend chart height inside that panel (leaves room for the panel header + padding). */
 const SIGNAL_PAGE_TREND_CHART_HEIGHT = 200
+
+/**
+ * Which session the Sessions sheet shows. URL-synced on the full-page signal
+ * view so a row is sharable; local state inside the session panel's issue slot,
+ * where `sessionId` already belongs to the panel one level up.
+ */
+function useSignalSessionSheetId(urlSynced: boolean) {
+  const [param, setParam] = useParamState("sessionId", "")
+  const [local, setLocal] = useState("")
+  return urlSynced ? ([param, setParam] as const) : ([local, setLocal] as const)
+}
 
 function SummaryField({ label, value }: { readonly label: string; readonly value: ReactNode }) {
   return (
@@ -170,14 +183,41 @@ export function SignalDetailBody({
     enabled: issue !== null,
   })
   const totalSessionCount = useSignalSessionsCount({ projectId, signalId, enabled: issue !== null })
-  const [sessionSheetSessionId, setSessionSheetSessionId] = useState<string | null>(null)
-  const [sessionSheetOpen, setSessionSheetOpen] = useState(false)
+  // Only the full-page view owns the URL: the drawer variant renders inside the
+  // session panel's issue slot, whose own params live one level up.
+  const urlSyncedSessionSheet = variant === "page"
+  const [sessionSheetSessionId, setSessionSheetSessionId] = useSignalSessionSheetId(urlSyncedSessionSheet)
+  const [sessionSheetOpen, setSessionSheetOpen] = useState(() => sessionSheetSessionId.length > 0)
+  const resetPanelParams = useSessionPanelParamReset()
+  // Nested in the session panel's issue slot those params belong to the panel
+  // above — clearing `signalId` there would close the very slot we render in —
+  // so only the URL-owning page resets them.
+  const resetSessionPanelParams = () => {
+    if (urlSyncedSessionSheet) resetPanelParams()
+  }
+  const sessionsSectionRef = useRef<HTMLDivElement>(null)
+  // Captured at mount so opening a row later never re-triggers the deep-link scroll.
+  const [deepLinkedSessionId] = useState(() => sessionSheetSessionId)
   const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)
   const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
+
+  useMountEffect(() => {
+    if (sessionSheetSessionId.length > 0) onOverlayActiveChange?.(true)
+  })
 
   useEffect(() => {
     setSelectionState(EMPTY_SELECTION)
   }, [signalId])
+
+  const scrolledToDeepLinkRef = useRef(false)
+  // TODO(frontend-use-effect-policy): a shared link lands at the top of the page;
+  // the Sessions section can only be scrolled to once its rows have rendered,
+  // which happens when the sessions query resolves.
+  useEffect(() => {
+    if (deepLinkedSessionId.length === 0 || scrolledToDeepLinkRef.current || sessionsLoading) return
+    scrolledToDeepLinkRef.current = true
+    sessionsSectionRef.current?.scrollIntoView({ block: "start", behavior: "smooth" })
+  }, [deepLinkedSessionId, sessionsLoading])
 
   const sessionIds = useMemo(() => sessions.map((session) => session.sessionId), [sessions])
   const sessionSelection = useSelectableRows<string>({
@@ -230,6 +270,7 @@ export function SignalDetailBody({
     enabled: incidentsFlagEnabled && trendIncidentRange !== null,
   })
   const openSessionSheet = (sessionId: string) => {
+    resetSessionPanelParams()
     setSessionSheetSessionId(sessionId)
     setSessionSheetOpen(true)
     onOverlayActiveChange?.(true)
@@ -457,35 +498,37 @@ export function SignalDetailBody({
 
           {beforeTraces}
 
-          <DetailSection
-            icon={<Icon icon={TextAlignStartIcon} size="sm" />}
-            label="Sessions"
-            defaultOpen
-            className="gap-1"
-            contentClassName="pl-0 pt-0 max-h-none overflow-hidden flex flex-col"
-          >
-            {sessionSelection.selectedCount > 0 ? (
-              <div className="flex items-center gap-2 pb-2">
-                <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
-                  <Icon icon={DatabaseIcon} size="xs" />
-                  Add to dataset ({sessionSelection.selectedCount.toLocaleString()})
-                </Button>
-              </div>
-            ) : null}
-            <InfiniteTable
-              data={sessions}
-              isLoading={sessionsLoading}
-              columns={sessionColumns}
-              getRowKey={(session) => session.sessionId}
-              selection={sessionSelection}
-              onRowClick={(session) => openSessionSheet(session.sessionId)}
-              getRowAriaLabel={(session) => `Open session ${session.sessionId}`}
-              infiniteScroll={infiniteScroll}
-              blankSlate="This issue hasn't shown up on any sessions yet."
-              scrollAreaLayout="intrinsic"
-              className="max-h-[min(28rem,50vh)]"
-            />
-          </DetailSection>
+          <div ref={sessionsSectionRef} className="flex min-w-0 flex-col">
+            <DetailSection
+              icon={<Icon icon={TextAlignStartIcon} size="sm" />}
+              label="Sessions"
+              defaultOpen
+              className="gap-1"
+              contentClassName="pl-0 pt-0 max-h-none overflow-hidden flex flex-col"
+            >
+              {sessionSelection.selectedCount > 0 ? (
+                <div className="flex items-center gap-2 pb-2">
+                  <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
+                    <Icon icon={DatabaseIcon} size="xs" />
+                    Add to dataset ({sessionSelection.selectedCount.toLocaleString()})
+                  </Button>
+                </div>
+              ) : null}
+              <InfiniteTable
+                data={sessions}
+                isLoading={sessionsLoading}
+                columns={sessionColumns}
+                getRowKey={(session) => session.sessionId}
+                selection={sessionSelection}
+                onRowClick={(session) => openSessionSheet(session.sessionId)}
+                getRowAriaLabel={(session) => `Open session ${session.sessionId}`}
+                infiniteScroll={infiniteScroll}
+                blankSlate="This issue hasn't shown up on any sessions yet."
+                scrollAreaLayout="intrinsic"
+                className="max-h-[min(28rem,50vh)]"
+              />
+            </DetailSection>
+          </div>
 
           {append}
         </div>
@@ -494,10 +537,13 @@ export function SignalDetailBody({
       <Sheet
         open={sessionSheetOpen}
         onClose={closeSessionSheet}
-        onClosed={() => setSessionSheetSessionId(null)}
+        onClosed={() => {
+          setSessionSheetSessionId("")
+          resetSessionPanelParams()
+        }}
         closeAriaLabel="Close session panel"
       >
-        {sessionSheetSessionId ? (
+        {sessionSheetSessionId.length > 0 ? (
           <SessionDetailDrawer
             key={sessionSheetSessionId}
             projectId={projectId}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
@@ -504,6 +504,7 @@ export function SignalDetailBody({
             sessionId={sessionSheetSessionId}
             onClose={closeSessionSheet}
             defaultTab="conversation"
+            focusSignalId={signalId}
           />
         ) : null}
       </Sheet>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
@@ -11,7 +11,6 @@ import {
   TagList,
   Text,
   Tooltip,
-  useMountEffect,
 } from "@repo/ui"
 import { formatCount, formatDuration, relativeTime } from "@repo/utils"
 import { ArrowDownRightIcon, CheckIcon, DatabaseIcon, TextAlignStartIcon } from "lucide-react"
@@ -201,13 +200,19 @@ export function SignalDetailBody({
   const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)
   const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
 
-  useMountEffect(() => {
-    if (sessionSheetSessionId.length > 0) onOverlayActiveChange?.(true)
-  })
-
   useEffect(() => {
     setSelectionState(EMPTY_SELECTION)
   }, [signalId])
+
+  // TODO(frontend-use-effect-policy): `useParamState` also tracks history
+  // navigation, so the sheet follows the session id rather than only seeding from
+  // it — otherwise Back leaves an empty sheet open. Our own close sets the open
+  // flag first and clears the id in `onClosed`, so the exit animation still runs.
+  useEffect(() => {
+    const open = sessionSheetSessionId.length > 0
+    setSessionSheetOpen(open)
+    onOverlayActiveChange?.(open)
+  }, [sessionSheetSessionId, onOverlayActiveChange])
 
   const scrolledToDeepLinkRef = useRef(false)
   // TODO(frontend-use-effect-policy): a shared link lands at the top of the page;
@@ -272,8 +277,6 @@ export function SignalDetailBody({
   const openSessionSheet = (sessionId: string) => {
     resetSessionPanelParams()
     setSessionSheetSessionId(sessionId)
-    setSessionSheetOpen(true)
-    onOverlayActiveChange?.(true)
   }
 
   const closeSessionSheet = () => {

--- a/packages/domain/scores/src/ports/score-repository.ts
+++ b/packages/domain/scores/src/ports/score-repository.ts
@@ -89,6 +89,8 @@ export interface ScoreRepositoryShape {
     readonly projectId: ProjectId
     readonly traceIds: readonly TraceId[]
     readonly source?: ScoreSourceType
+    /** Narrows to one signal's scores, so a session with more scores than fit a page still yields them. */
+    readonly signalId?: SignalId
     readonly options?: ScoreListOptions
   }): Effect.Effect<ScoreListPage, RepositoryError, SqlClient>
   /** Per-trace +/- score counts. Omit `source` for all sources; pass `"annotation"` for the public API fields. Signal-less absent evaluation runs are excluded from the negative count. */

--- a/packages/domain/scores/src/use-cases/list-trace-scores.ts
+++ b/packages/domain/scores/src/use-cases/list-trace-scores.ts
@@ -1,4 +1,12 @@
-import { BadRequestError, cuidSchema, ProjectId, type RepositoryError, TraceId, traceIdSchema } from "@domain/shared"
+import {
+  BadRequestError,
+  cuidSchema,
+  ProjectId,
+  type RepositoryError,
+  SignalId,
+  TraceId,
+  traceIdSchema,
+} from "@domain/shared"
 import { Effect } from "effect"
 import { z } from "zod"
 import { ScoreRepository, scoreDraftModeSchema } from "../ports/score-repository.ts"
@@ -29,6 +37,7 @@ export type ListTraceScoresInput = z.input<typeof listTraceScoresInputSchema>
 export const listScoresByTraceIdsInputSchema = z.object({
   projectId: cuidSchema.transform(ProjectId),
   traceIds: z.array(traceIdSchema.transform(TraceId)).max(500),
+  signalId: cuidSchema.transform(SignalId).optional(),
   limit: baseListScoresInputSchema.shape.limit,
   offset: baseListScoresInputSchema.shape.offset,
   draftMode: scoreDraftModeSchema.default("include"),
@@ -87,6 +96,7 @@ export const listScoresByTraceIdsUseCase = Effect.fn("scores.listScoresByTraceId
   return yield* scoreRepository.listByTraceIds({
     projectId: parsed.projectId,
     traceIds: parsed.traceIds,
+    ...(parsed.signalId ? { signalId: parsed.signalId } : {}),
     options: {
       limit: parsed.limit,
       offset: parsed.offset,

--- a/packages/domain/shared/package.json
+++ b/packages/domain/shared/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./seeding": "./src/seeding.ts",
+    "./seed-content/anchored-annotations": "./src/seed-content/anchored-annotations.ts",
     "./seed-content/tau2-trajectories": "./src/seed-content/tau2-trajectories.ts",
     "./seed-content/custom-behavior-qa": "./src/seed-content/custom-behavior-qa.ts",
     "./testing": "./src/testing/index.ts"

--- a/packages/domain/shared/src/seed-content/anchored-annotations.test.ts
+++ b/packages/domain/shared/src/seed-content/anchored-annotations.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { buildSeedAnchoredAnnotations } from "./anchored-annotations.ts"
+import { TAU2_SEED_TRAJECTORIES } from "./tau2-trajectories.ts"
+
+const annotations = buildSeedAnchoredAnnotations()
+const anchored = annotations.filter((annotation) => annotation.anchor !== null)
+const conversationLevel = annotations.filter((annotation) => annotation.anchor === null)
+
+/** Mirrors the drawer: `[system, ...turns up to the last assistant turn]`. */
+function anchoredTurn(annotation: (typeof annotations)[number]) {
+  const trajectory = TAU2_SEED_TRAJECTORIES[annotation.trajectoryIndex]
+  const messageIndex = annotation.anchor?.messageIndex
+  if (!trajectory || messageIndex === undefined) return null
+  const lastAssistantTurn = trajectory.messages.map((message) => message.role).lastIndexOf("assistant")
+  if (messageIndex - 1 > lastAssistantTurn) return null
+  return trajectory.messages[messageIndex - 1] ?? null
+}
+
+describe("buildSeedAnchoredAnnotations", () => {
+  it("covers every named signal with an anchored and a conversation-level occurrence", () => {
+    expect(anchored).toHaveLength(8)
+    expect(conversationLevel.length).toBeGreaterThan(0)
+    expect(new Set(annotations.map((annotation) => annotation.key)).size).toBe(annotations.length)
+  })
+
+  it("anchors on an assistant turn that carries text", () => {
+    for (const annotation of anchored) {
+      const message = anchoredTurn(annotation)
+      expect(message, annotation.key).not.toBeNull()
+      expect(message?.role, annotation.key).toBe("assistant")
+      expect((message?.role === "assistant" ? (message.content ?? "") : "").trim(), annotation.key).not.toBe("")
+    }
+  })
+
+  it("keeps anchors inside the conversation's first loaded chunk", () => {
+    for (const annotation of anchored) {
+      expect(annotation.anchor?.messageIndex, annotation.key).toBeLessThan(25)
+    }
+  })
+
+  it("keeps substring offsets inside the anchored text part", () => {
+    const substring = anchored.filter((annotation) => annotation.anchor?.startOffset !== undefined)
+    expect(substring.length).toBeGreaterThan(0)
+
+    for (const annotation of substring) {
+      const message = anchoredTurn(annotation)
+      const text = message?.role === "assistant" ? (message.content ?? "") : ""
+      const { partIndex, startOffset = 0, endOffset = 0 } = annotation.anchor ?? {}
+      expect(partIndex, annotation.key).toBe(0)
+      expect(startOffset, annotation.key).toBeLessThan(endOffset)
+      expect(endOffset, annotation.key).toBeLessThanOrEqual(text.length)
+    }
+  })
+
+  it("puts a signal's conversation-level occurrence on a different session than its anchored one", () => {
+    for (const annotation of conversationLevel) {
+      const anchoredSibling = anchored.find((candidate) => candidate.signalIndex === annotation.signalIndex)
+      expect(annotation.trajectoryIndex, annotation.key).not.toBe(anchoredSibling?.trajectoryIndex)
+    }
+  })
+})

--- a/packages/domain/shared/src/seed-content/anchored-annotations.ts
+++ b/packages/domain/shared/src/seed-content/anchored-annotations.ts
@@ -1,0 +1,170 @@
+/**
+ * Flagger annotations that pinpoint where a signal manifests in a seeded
+ * conversation, so the Scores tab's "click a score → scroll to its anchor"
+ * flow, the shareable `?scoreId=` link, and the signal → session auto-focus all
+ * have something to land on.
+ *
+ * Every signal gets one anchored occurrence plus one conversation-level one, so
+ * both branches are reachable from the same signal: the anchored session scrolls
+ * to a message, the unanchored one opens the conversation from the top.
+ */
+
+import { SEED_SIGNAL_FIXTURES } from "./issues.ts"
+import {
+  TAU2_SEED_TRAJECTORIES,
+  type Tau2SeedTrajectory,
+  tau2TrajectoryIndexForSignalOccurrence,
+} from "./tau2-trajectories.ts"
+
+/**
+ * The conversation drawer pages messages in as the reader scrolls, and the
+ * scroll-to-anchor pass only waits for a render — not for another chunk. An
+ * anchor past the first chunk would have no DOM node to find, so seeded anchors
+ * stay inside it. Mirrors `CONVERSATION_CHUNK_SIZE` in the web app.
+ */
+const CONVERSATION_FIRST_CHUNK_MESSAGES = 25
+
+/** Named signal fixtures, the ones the demo tours; the generated tail stays unannotated. */
+const ANNOTATED_SIGNAL_COUNT = 8
+
+/** Substring anchors cover a clause, not a wall of text. */
+const SUBSTRING_ANCHOR_MAX_LENGTH = 160
+const SUBSTRING_ANCHOR_MIN_LENGTH = 32
+
+/** Flaggers that plausibly author these support failures, rotated per signal. */
+const ANNOTATION_FLAGGER_SLUGS = ["bluffing", "incompletion", "forgetting"] as const
+
+export type SeedAnnotationAnchor = {
+  readonly messageIndex: number
+  /** Set together with the offsets for a substring anchor; absent for a whole-message one. */
+  readonly partIndex?: number
+  readonly startOffset?: number
+  readonly endOffset?: number
+}
+
+export type SeedAnchoredAnnotation = {
+  /** Suffix of the deterministic score id, unique across the fixture set. */
+  readonly key: string
+  /** Index into `SEED_SIGNAL_FIXTURES`; the seeders resolve it to their scoped signal id. */
+  readonly signalIndex: number
+  /** Index into `TAU2_SEED_TRAJECTORIES`; the seeders resolve it to the `tau2-trajectory` trace. */
+  readonly trajectoryIndex: number
+  readonly feedback: string
+  readonly rawFeedback: string
+  readonly flaggerSlug: string
+  /** Null for a conversation-level annotation, which has no message to scroll to. */
+  readonly anchor: SeedAnnotationAnchor | null
+  readonly daysAgo: number
+  readonly hour: number
+  readonly minute: number
+}
+
+/**
+ * Assistant turns that can carry an anchor: they have text to highlight, they
+ * are inside the conversation the drawer renders (which stops at the last
+ * assistant turn), and they land in its first chunk. The rendered conversation
+ * is `[system, ...turns]`, so every turn shifts one index down.
+ */
+function anchorableAssistantTurns(trajectory: Tau2SeedTrajectory) {
+  const lastAssistantTurn = trajectory.messages.map((message) => message.role).lastIndexOf("assistant")
+  const turns: { readonly messageIndex: number; readonly text: string }[] = []
+
+  for (let turn = 0; turn <= lastAssistantTurn; turn++) {
+    const messageIndex = turn + 1
+    if (messageIndex >= CONVERSATION_FIRST_CHUNK_MESSAGES) break
+    const message = trajectory.messages[turn]
+    if (!message || message.role !== "assistant") continue
+    const text = message.content ?? ""
+    if (text.trim().length === 0) continue
+    turns.push({ messageIndex, text })
+  }
+
+  return turns
+}
+
+/**
+ * Offsets covering the turn's opening claim. Stops at the first line break so
+ * the highlight stays inside one rendered block instead of bleeding across a
+ * markdown list, and returns null when nothing long enough fits — the caller
+ * then anchors the whole turn instead.
+ */
+function openingClaimOffsets(text: string): { readonly startOffset: number; readonly endOffset: number } | null {
+  const lineBreak = text.indexOf("\n")
+  const cap = Math.min(text.length, lineBreak === -1 ? text.length : lineBreak, SUBSTRING_ANCHOR_MAX_LENGTH)
+  if (cap < SUBSTRING_ANCHOR_MIN_LENGTH) return null
+
+  const sentenceEnd = text.slice(0, cap).search(/[.!?](\s|$)/)
+  const endOffset = sentenceEnd >= SUBSTRING_ANCHOR_MIN_LENGTH ? sentenceEnd + 1 : text.lastIndexOf(" ", cap)
+  return endOffset >= SUBSTRING_ANCHOR_MIN_LENGTH ? { startOffset: 0, endOffset } : null
+}
+
+function anchoredAnnotation(signalIndex: number, maxTrajectories: number): SeedAnchoredAnnotation | null {
+  const signal = SEED_SIGNAL_FIXTURES[signalIndex]
+  const trajectoryIndex = tau2TrajectoryIndexForSignalOccurrence({ signalIndex, occurrenceIndex: 0, maxTrajectories })
+  const trajectory = TAU2_SEED_TRAJECTORIES[trajectoryIndex]
+  if (!signal || !trajectory) return null
+
+  const turns = anchorableAssistantTurns(trajectory)
+  const turn = turns[turns.length - 1]
+  if (!turn) return null
+
+  // Odd signals pinpoint a substring so the text-selection highlight is covered
+  // too; even ones anchor the whole turn.
+  const offsets = signalIndex % 2 === 1 ? openingClaimOffsets(turn.text) : null
+  const rawFeedback = offsets
+    ? "This exact claim is not backed by the tool results."
+    : "This turn is where the agent commits to an outcome the tools never confirmed."
+
+  return {
+    key: `anchored:${signalIndex}`,
+    signalIndex,
+    trajectoryIndex,
+    feedback: `${signal.name}: ${rawFeedback} (tau2 ${trajectory.domain} task ${trajectory.taskId}, reward ${trajectory.reward})`,
+    rawFeedback,
+    flaggerSlug: ANNOTATION_FLAGGER_SLUGS[signalIndex % ANNOTATION_FLAGGER_SLUGS.length] ?? "bluffing",
+    anchor: { messageIndex: turn.messageIndex, ...(offsets ? { partIndex: 0, ...offsets } : {}) },
+    daysAgo: signalIndex % 7,
+    hour: (signalIndex * 5 + 9) % 24,
+    minute: (signalIndex * 13) % 60,
+  }
+}
+
+function conversationLevelAnnotation(signalIndex: number, maxTrajectories: number): SeedAnchoredAnnotation | null {
+  const signal = SEED_SIGNAL_FIXTURES[signalIndex]
+  const trajectoryIndex = tau2TrajectoryIndexForSignalOccurrence({ signalIndex, occurrenceIndex: 1, maxTrajectories })
+  const trajectory = TAU2_SEED_TRAJECTORIES[trajectoryIndex]
+  if (!signal || !trajectory) return null
+  // Same trajectory as the anchored occurrence would put both annotations on one
+  // session, hiding the difference between them.
+  if (
+    trajectoryIndex === tau2TrajectoryIndexForSignalOccurrence({ signalIndex, occurrenceIndex: 0, maxTrajectories })
+  ) {
+    return null
+  }
+
+  const rawFeedback = "The whole conversation ends without meeting the customer's goal, and no single turn is at fault."
+
+  return {
+    key: `conversation:${signalIndex}`,
+    signalIndex,
+    trajectoryIndex,
+    feedback: `${signal.name}: ${rawFeedback} (tau2 ${trajectory.domain} task ${trajectory.taskId}, reward ${trajectory.reward})`,
+    rawFeedback,
+    flaggerSlug: ANNOTATION_FLAGGER_SLUGS[(signalIndex + 1) % ANNOTATION_FLAGGER_SLUGS.length] ?? "incompletion",
+    anchor: null,
+    daysAgo: (signalIndex + 3) % 7,
+    hour: (signalIndex * 5 + 14) % 24,
+    minute: (signalIndex * 17) % 60,
+  }
+}
+
+export function buildSeedAnchoredAnnotations(
+  maxTrajectories = TAU2_SEED_TRAJECTORIES.length,
+): readonly SeedAnchoredAnnotation[] {
+  return Array.from({ length: ANNOTATED_SIGNAL_COUNT }, (_, signalIndex) => signalIndex).flatMap((signalIndex) =>
+    [
+      anchoredAnnotation(signalIndex, maxTrajectories),
+      conversationLevelAnnotation(signalIndex, maxTrajectories),
+    ].filter((annotation): annotation is SeedAnchoredAnnotation => annotation !== null),
+  )
+}

--- a/packages/domain/shared/src/seed-content/tau2-trajectories.ts
+++ b/packages/domain/shared/src/seed-content/tau2-trajectories.ts
@@ -149,3 +149,56 @@ export function classifyTau2SeedTrajectory(trajectory: Tau2SeedTrajectory): Tau2
 
   return "tool-result-grounding"
 }
+
+/**
+ * Failed-trajectory indexes per signal family, memoized per `maxTrajectories`
+ * because classification runs regexes over every trajectory and the seeders ask
+ * for hundreds of occurrences per run. A family with no failed trajectory of its
+ * own falls back to every failed trajectory.
+ */
+const failedTrajectoryIndexesByFamilyCache = new Map<number, ReadonlyMap<string, readonly number[]>>()
+
+function failedTrajectoryIndexesByFamily(maxTrajectories: number): ReadonlyMap<string, readonly number[]> {
+  const cached = failedTrajectoryIndexesByFamilyCache.get(maxTrajectories)
+  if (cached) return cached
+
+  const considered = TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories)
+  const allFailed = considered.flatMap((trajectory, index) =>
+    trajectory.outcome === "failure" || trajectory.reward < 1 ? [index] : [],
+  )
+  const matched = new Map<string, number[]>()
+  considered.forEach((trajectory, index) => {
+    const family = classifyTau2SeedTrajectory(trajectory)
+    if (family === null) return
+    const indexes = matched.get(family) ?? []
+    indexes.push(index)
+    matched.set(family, indexes)
+  })
+
+  const resolved = new Map<string, readonly number[]>(
+    TAU2_SEED_SIGNAL_FAMILIES.map((family) => [family.key, matched.get(family.key) ?? allFailed]),
+  )
+  failedTrajectoryIndexesByFamilyCache.set(maxTrajectories, resolved)
+  return resolved
+}
+
+/**
+ * Trajectory the seeded occurrence `(signalIndex, occurrenceIndex)` lands on.
+ * Signals cycle through the tau2 signal families and each occurrence walks that
+ * family's failed trajectories, so every session listed under a signal fails the
+ * way the signal describes.
+ */
+export function tau2TrajectoryIndexForSignalOccurrence({
+  signalIndex,
+  occurrenceIndex,
+  maxTrajectories = TAU2_SEED_TRAJECTORIES.length,
+}: {
+  readonly signalIndex: number
+  readonly occurrenceIndex: number
+  readonly maxTrajectories?: number
+}): number {
+  const family = TAU2_SEED_SIGNAL_FAMILIES[signalIndex % TAU2_SEED_SIGNAL_FAMILIES.length]
+  const candidates = (family && failedTrajectoryIndexesByFamily(maxTrajectories).get(family.key)) ?? []
+  if (candidates.length === 0) return 0
+  return candidates[(signalIndex + occurrenceIndex) % candidates.length] ?? 0
+}

--- a/packages/domain/shared/src/seed-content/tau2-trajectories.ts
+++ b/packages/domain/shared/src/seed-content/tau2-trajectories.ts
@@ -163,8 +163,10 @@ function failedTrajectoryIndexesByFamily(maxTrajectories: number): ReadonlyMap<s
   if (cached) return cached
 
   const considered = TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories)
+  // Same exclusion `classifyTau2SeedTrajectory` applies, so the fallback can't
+  // hand a family a trajectory the classifier would have rejected.
   const allFailed = considered.flatMap((trajectory, index) =>
-    trajectory.outcome === "failure" || trajectory.reward < 1 ? [index] : [],
+    trajectory.outcome === "failure" && trajectory.reward < 1 ? [index] : [],
   )
   const matched = new Map<string, number[]>()
   considered.forEach((trajectory, index) => {

--- a/packages/platform/db-clickhouse/src/seeds/scores/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/scores/index.ts
@@ -1,8 +1,8 @@
 import { EvaluationId, ScoreId, SignalId } from "@domain/shared"
+import { buildSeedAnchoredAnnotations } from "@domain/shared/seed-content/anchored-annotations"
 import {
-  classifyTau2SeedTrajectory,
-  TAU2_SEED_SIGNAL_FAMILIES,
   TAU2_SEED_TRAJECTORIES,
+  tau2TrajectoryIndexForSignalOccurrence,
 } from "@domain/shared/seed-content/tau2-trajectories"
 import { SEED_SIGNAL_FIXTURES, type SeedScope } from "@domain/shared/seeding"
 import { Effect } from "effect"
@@ -36,37 +36,15 @@ function createdAtForTau2Signal(scope: SeedScope, signalIndex: number, occurrenc
   )
 }
 
-function buildFailedTrajectoryIndexesByFamily(maxTrajectories = TAU2_SEED_TRAJECTORIES.length) {
-  const byFamily = new Map<(typeof TAU2_SEED_SIGNAL_FAMILIES)[number]["key"], number[]>()
-
-  TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories).forEach((trajectory, trajectoryIndex) => {
-    const family = classifyTau2SeedTrajectory(trajectory)
-    if (family === null) return
-
-    const indexes = byFamily.get(family) ?? []
-    indexes.push(trajectoryIndex)
-    byFamily.set(family, indexes)
-  })
-
-  return byFamily
-}
-
 function buildTau2SignalAnalyticsRows(scope: SeedScope, maxTrajectories = TAU2_SEED_TRAJECTORIES.length) {
   const orgId = scope.organizationId
   const projectId = scope.projectId
-  const familyKeys = TAU2_SEED_SIGNAL_FAMILIES.map((family) => family.key)
-  const failedByFamily = buildFailedTrajectoryIndexesByFamily(maxTrajectories)
-  const allFailedTrajectoryIndexes = TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories).flatMap((trajectory, index) =>
-    trajectory.outcome === "failure" || trajectory.reward < 1 ? [index] : [],
-  )
 
   return SEED_SIGNAL_FIXTURES.flatMap((_, signalIndex) => {
-    const family = familyKeys[signalIndex % familyKeys.length]!
-    const candidateIndexes = failedByFamily.get(family) ?? allFailedTrajectoryIndexes
     const occurrenceCount = signalIndex < 8 ? 12 : 3
 
     return Array.from({ length: occurrenceCount }, (_, occurrenceIndex) => {
-      const trajectoryIndex = candidateIndexes[(signalIndex + occurrenceIndex) % candidateIndexes.length] ?? 0
+      const trajectoryIndex = tau2TrajectoryIndexForSignalOccurrence({ signalIndex, occurrenceIndex, maxTrajectories })
       const traceId = scope.traceHex("tau2-trajectory", trajectoryIndex)
       return {
         id: ScoreId(scope.cuid(`score:tau2-issue:${signalIndex}:${occurrenceIndex}`)),
@@ -180,6 +158,40 @@ export function buildLifecycleAnalyticsRows(scope: SeedScope) {
   ]
 }
 
+/**
+ * Analytics mirror of the seeded flagger annotations. The anchor itself only
+ * exists in Postgres (ClickHouse scores carry no metadata); these rows are what
+ * put their sessions under the signal in the Sessions list.
+ */
+function buildAnchoredAnnotationAnalyticsRows(scope: SeedScope, maxTrajectories?: number) {
+  const orgId = scope.organizationId
+  const projectId = scope.projectId
+
+  return buildSeedAnchoredAnnotations(maxTrajectories).map((annotation) => {
+    const traceId = scope.traceHex("tau2-trajectory", annotation.trajectoryIndex)
+
+    return {
+      id: ScoreId(scope.cuid(`score:tau2-annotation:${annotation.key}`)),
+      organization_id: orgId,
+      project_id: projectId,
+      session_id: traceId,
+      trace_id: traceId,
+      span_id: "",
+      source: "annotation",
+      source_id: "SYSTEM",
+      simulation_id: "",
+      signal_id: scopedSignalIdByFixtureIndex(scope, annotation.signalIndex),
+      value: 0,
+      passed: false,
+      errored: false,
+      duration: 0,
+      tokens: 0,
+      cost: 0,
+      created_at: scope.timestampDaysAgo(annotation.daysAgo, annotation.hour, annotation.minute),
+    }
+  })
+}
+
 function buildAllAnalyticsRows(scope: SeedScope, maxTau2Trajectories?: number) {
   const lifecycleAnalyticsRows = buildLifecycleAnalyticsRows(scope)
   const tau2SignalAnalyticsRows = buildTau2SignalAnalyticsRows(scope, maxTau2Trajectories)
@@ -212,4 +224,24 @@ const seedScores: Seeder = {
     }),
 }
 
-export const scoreSeeders: readonly Seeder[] = [seedScores]
+// Separate seeder (and sentinel) from `seedScores`: `scores` has no row-level
+// dedup, so a database seeded before the annotations existed must be able to
+// pick them up without re-inserting every tau2 occurrence row.
+const seedAnchoredAnnotations: Seeder = {
+  name: "scores/tau2-flagger-annotations",
+  run: (ctx) =>
+    Effect.gen(function* () {
+      const rows = buildAnchoredAnnotationAnalyticsRows(ctx.scope, ctx.maxTau2Trajectories)
+      const sentinel = rows[0]?.id
+      if (sentinel === undefined) return
+      const present = yield* isSentinelPresent(ctx.client, "scores", "id = {sentinel:String}", { sentinel })
+      if (present) {
+        if (!ctx.quiet) console.log("  -> scores/tau2-flagger-annotations: already seeded, skipping")
+        return
+      }
+      yield* insertJsonEachRow(ctx.client, "scores", rows)
+      if (!ctx.quiet) console.log(`  -> scores: ${rows.length} flagger annotation analytics rows`)
+    }),
+}
+
+export const scoreSeeders: readonly Seeder[] = [seedScores, seedAnchoredAnnotations]

--- a/packages/platform/db-postgres/src/repositories/score-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.ts
@@ -477,11 +477,13 @@ export const ScoreRepositoryLive = Layer.effect(
         projectId,
         traceIds,
         source,
+        signalId,
         options,
       }: {
         readonly projectId: ProjectId
         readonly traceIds: readonly TraceId[]
         readonly source?: ScoreSourceType
+        readonly signalId?: SignalId
         readonly options?: ScoreListOptions
       }) => {
         if (traceIds.length === 0) {
@@ -493,14 +495,12 @@ export const ScoreRepositoryLive = Layer.effect(
           })
         }
         const traceIdValues = traceIds.map((traceId) => String(traceId))
-        const combined =
-          source !== undefined
-            ? and(
-                eq(scores.projectId, projectId),
-                inArray(scores.traceId, traceIdValues),
-                eq(scores.sourceType, source),
-              )
-            : and(eq(scores.projectId, projectId), inArray(scores.traceId, traceIdValues))
+        const combined = and(
+          eq(scores.projectId, projectId),
+          inArray(scores.traceId, traceIdValues),
+          ...(source !== undefined ? [eq(scores.sourceType, source)] : []),
+          ...(signalId !== undefined ? [eq(scores.signalId, signalId)] : []),
+        )
         return list({
           baseWhere: combined ?? eq(scores.projectId, projectId),
           options,

--- a/packages/platform/db-postgres/src/seeds/scores/index.test.ts
+++ b/packages/platform/db-postgres/src/seeds/scores/index.test.ts
@@ -1,0 +1,37 @@
+import { scoreSchema } from "@domain/scores"
+import { createSeedScope, SEED_API_KEY_ID, SEED_ORG_ID, SEED_PROJECT_ID } from "@domain/shared/seeding"
+import { describe, expect, it } from "vitest"
+import { buildAnchoredAnnotationScoreRows } from "./index.ts"
+
+const scope = createSeedScope({
+  organizationId: SEED_ORG_ID,
+  projectId: SEED_PROJECT_ID,
+  timelineAnchor: new Date("2026-06-16T12:00:00.000Z"),
+  apiKeyId: SEED_API_KEY_ID,
+})
+
+describe("buildAnchoredAnnotationScoreRows", () => {
+  const rows = buildAnchoredAnnotationScoreRows(scope)
+
+  // The repository parses every row it reads back through `scoreSchema`, so a
+  // seeded annotation missing `rawFeedback` would only fail once the UI asks for it.
+  it("writes rows the score repository can read back", () => {
+    for (const row of rows) {
+      const parsed = scoreSchema.safeParse({ ...row, sessionId: row.sessionId ?? null })
+      expect(parsed.error?.message ?? "valid", row.id).toBe("valid")
+    }
+  })
+
+  it("links every row to a signal and publishes it", () => {
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of rows) {
+      expect(row.signalId, row.id).not.toBeNull()
+      expect(row.draftedAt, row.id).toBeNull()
+      expect(row.sourceType, row.id).toBe("annotation")
+    }
+  })
+
+  it("keeps ids deterministic across builds", () => {
+    expect(buildAnchoredAnnotationScoreRows(scope).map((row) => row.id)).toEqual(rows.map((row) => row.id))
+  })
+})

--- a/packages/platform/db-postgres/src/seeds/scores/index.ts
+++ b/packages/platform/db-postgres/src/seeds/scores/index.ts
@@ -1,9 +1,10 @@
 import { ScoreId, SignalId } from "@domain/shared"
+import { buildSeedAnchoredAnnotations } from "@domain/shared/seed-content/anchored-annotations"
 import {
-  classifyTau2SeedTrajectory,
   TAU2_SEED_SIGNAL_FAMILIES,
   TAU2_SEED_TRAJECTORIES,
   type Tau2SeedTrajectory,
+  tau2TrajectoryIndexForSignalOccurrence,
 } from "@domain/shared/seed-content/tau2-trajectories"
 import { SEED_SIGNAL_FIXTURES, type SeedScope } from "@domain/shared/seeding"
 import { Effect } from "effect"
@@ -36,21 +37,6 @@ function createdAtForTau2Signal(scope: SeedScope, signalIndex: number, occurrenc
   )
 }
 
-function buildFailedTrajectoryIndexesByFamily(maxTrajectories = TAU2_SEED_TRAJECTORIES.length) {
-  const byFamily = new Map<(typeof TAU2_SEED_SIGNAL_FAMILIES)[number]["key"], number[]>()
-
-  TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories).forEach((trajectory, trajectoryIndex) => {
-    const family = classifyTau2SeedTrajectory(trajectory)
-    if (family === null) return
-
-    const indexes = byFamily.get(family) ?? []
-    indexes.push(trajectoryIndex)
-    byFamily.set(family, indexes)
-  })
-
-  return byFamily
-}
-
 function buildTau2Feedback(signalName: string, trajectory: Tau2SeedTrajectory): string {
   return (
     `${signalName}: tau2 ${trajectory.domain} task ${trajectory.taskId} failed benchmark reward ${trajectory.reward}. ` +
@@ -61,19 +47,13 @@ function buildTau2Feedback(signalName: string, trajectory: Tau2SeedTrajectory): 
 function buildTau2SignalScoreRows(scope: SeedScope, maxTrajectories = TAU2_SEED_TRAJECTORIES.length) {
   const orgId = scope.organizationId
   const projectId = scope.projectId
-  const familyKeys = TAU2_SEED_SIGNAL_FAMILIES.map((family) => family.key)
-  const failedByFamily = buildFailedTrajectoryIndexesByFamily(maxTrajectories)
-  const allFailedTrajectoryIndexes = TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories).flatMap((trajectory, index) =>
-    trajectory.outcome === "failure" || trajectory.reward < 1 ? [index] : [],
-  )
 
   return SEED_SIGNAL_FIXTURES.flatMap((issue, signalIndex) => {
-    const family = familyKeys[signalIndex % familyKeys.length]!
-    const candidateIndexes = failedByFamily.get(family) ?? allFailedTrajectoryIndexes
+    const family = TAU2_SEED_SIGNAL_FAMILIES[signalIndex % TAU2_SEED_SIGNAL_FAMILIES.length]!
     const occurrenceCount = signalIndex < 8 ? 12 : 3
 
     return Array.from({ length: occurrenceCount }, (_, occurrenceIndex) => {
-      const trajectoryIndex = candidateIndexes[(signalIndex + occurrenceIndex) % candidateIndexes.length] ?? 0
+      const trajectoryIndex = tau2TrajectoryIndexForSignalOccurrence({ signalIndex, occurrenceIndex, maxTrajectories })
       const trajectory = TAU2_SEED_TRAJECTORIES[trajectoryIndex]!
       const createdAt = createdAtForTau2Signal(scope, signalIndex, occurrenceIndex)
 
@@ -98,7 +78,7 @@ function buildTau2SignalScoreRows(scope: SeedScope, maxTrajectories = TAU2_SEED_
           taskId: trajectory.taskId,
           outcome: trajectory.outcome,
           reward: String(trajectory.reward),
-          signalFamily: family,
+          signalFamily: family.key,
           trajectoryIndex: String(trajectoryIndex),
         },
         error: null,
@@ -160,14 +140,60 @@ function buildTau2ControlScoreRows(scope: SeedScope, maxTrajectories = TAU2_SEED
   })
 }
 
+/**
+ * Published flagger annotations for the named signals. The anchored ones carry a
+ * `messageIndex` (and sometimes a substring range), which is what lets the
+ * Conversation tab scroll to the flagged turn.
+ */
+export function buildAnchoredAnnotationScoreRows(scope: SeedScope, maxTrajectories?: number) {
+  const orgId = scope.organizationId
+  const projectId = scope.projectId
+
+  return buildSeedAnchoredAnnotations(maxTrajectories).map((annotation) => {
+    const createdAt = scope.dateDaysAgo(annotation.daysAgo, annotation.hour, annotation.minute)
+
+    return {
+      id: ScoreId(scope.cuid(`score:tau2-annotation:${annotation.key}`)),
+      organizationId: orgId,
+      projectId,
+      sessionId: null,
+      traceId: scope.traceHex("tau2-trajectory", annotation.trajectoryIndex),
+      spanId: null,
+      sourceType: "annotation" as const,
+      sourceId: "SYSTEM",
+      simulationId: null,
+      signalId: scopedSignalIdByFixtureIndex(scope, annotation.signalIndex),
+      value: 0,
+      passed: false,
+      feedback: annotation.feedback,
+      metadata: {
+        rawFeedback: annotation.rawFeedback,
+        flaggerSlug: annotation.flaggerSlug,
+        ...(annotation.anchor ?? {}),
+      },
+      error: null,
+      errored: false,
+      duration: 0,
+      tokens: 0,
+      cost: 0,
+      draftedAt: null,
+      annotatorId: null,
+      createdAt,
+      updatedAt: createdAt,
+    }
+  })
+}
+
 function buildAllScoreRows(scope: SeedScope, maxTau2Trajectories?: number) {
   const tau2ControlScoreRows = buildTau2ControlScoreRows(scope, maxTau2Trajectories)
   const tau2SignalScoreRows = buildTau2SignalScoreRows(scope, maxTau2Trajectories)
+  const anchoredAnnotationScoreRows = buildAnchoredAnnotationScoreRows(scope, maxTau2Trajectories)
 
   return {
     tau2ControlScoreRows,
     tau2SignalScoreRows,
-    all: [...tau2ControlScoreRows, ...tau2SignalScoreRows],
+    anchoredAnnotationScoreRows,
+    all: [...tau2ControlScoreRows, ...tau2SignalScoreRows, ...anchoredAnnotationScoreRows],
   }
 }
 
@@ -176,10 +202,12 @@ function buildAllScoreRows(scope: SeedScope, maxTau2Trajectories?: number) {
  * draft state — consumed by the signals seeder to derive issue centroids
  * from feedback embeddings.
  */
-export const buildSignalLinkedScoreSeedRows = (scope: SeedScope) =>
-  buildAllScoreRows(scope).tau2SignalScoreRows.filter(
+export const buildSignalLinkedScoreSeedRows = (scope: SeedScope) => {
+  const built = buildAllScoreRows(scope)
+  return [...built.tau2SignalScoreRows, ...built.anchoredAnnotationScoreRows].filter(
     (row): row is typeof row & { signalId: string } => row.signalId !== null && row.draftedAt === null,
   )
+}
 
 const seedScores: Seeder = {
   name: "scores/tau2-support-score-graph",
@@ -197,7 +225,7 @@ const seedScores: Seeder = {
         }
 
         console.log(
-          `  -> scores: ${allScoreRows.length} total (${built.tau2SignalScoreRows.length} tau2 issue-linked, ${built.tau2ControlScoreRows.length} tau2 controls)`,
+          `  -> scores: ${allScoreRows.length} total (${built.tau2SignalScoreRows.length} tau2 issue-linked, ${built.tau2ControlScoreRows.length} tau2 controls, ${built.anchoredAnnotationScoreRows.length} flagger annotations)`,
         )
       },
       catch: (error) => new SeedError({ reason: "Failed to seed scores", cause: error }),


### PR DESCRIPTION
## What

Clicking a score with an anchor already scrolled the Conversation tab to the message it points at and highlighted it. Two things were missing: the resulting position couldn't be shared, and opening a session from a signal dropped you at the top of the conversation even when the signal had pinpointed a message.

### 1. The focused score lives in the URL

The session panel used to write `?annotationId=<id>` and then wipe it the instant the scroll landed (`onFocusConsumed`), and the standalone trace drawer scrolled imperatively without touching the URL at all. Neither position survived a copy-paste.

The focus now lives in a `scoreId` search param that persists, so `?sessionId=…&sessionTab=conversation&scoreId=…` reproduces the scroll and the highlight on load.

Keeping the param honest:

- Both drawers drop `scoreId` when the user leaves the Conversation tab, so it never coexists with another tab.
- A present `scoreId` makes Conversation the default tab, so the invariant holds on load no matter which other params survived the paste.
- The project explorer clears it when switching or closing a session or trace (next to where it already clears `spanId`), so a stale id can't trail into a different entity.

### 2. Signals land on their own anchor

`SessionDetailDrawer` takes a new `focusSignalId`, passed from the signal's Sessions section. `useFocusSignalScore` resolves the newest anchored annotation the signal recorded in that session and focuses it once:

- score on the session's latest trace → Conversation tab, scrolled and highlighted;
- score on another trace → slides into that trace's Conversation, mirroring what the Scores tab does;
- no anchored score (a signal detected only by an evaluation, since evaluation scores carry no anchor) → plain Conversation, exactly as before.

It reads the scores the Scores tab already fetches, so there's no new server function and no extra request in the common path. It also stands down if the panel has meanwhile slid into a trace or signal slot, so it can't yank a user who has already navigated.

## Notable refactor

`TraceDetailBody` gained `focusScoreId` / `onFocusScoreIdChange` alongside its existing `activeTab` and `selectedSpanId` controls: URL-backed in the standalone drawer and the session's trace slot, local state in the nested (`urlSyncedTabs={false}`) mount. That let the imperative `scrollToAnnotation` call in the Scores tab handler go away, so both drawers now reach the conversation through the same param-driven path.

## Verification

- `pnpm --filter web typecheck`, `check`, `format` clean. The 7 remaining biome warnings are pre-existing in `build-record-tree.test.ts`.
- `pnpm knip` clean.
- `pnpm --filter web test`: 932 tests pass, including 3 new ones covering the anchored-score resolution.

Not verified in a browser (no local stack here), so two things are worth a click-through on review: re-clicking the same score after a tab round-trip should still re-scroll, and the signal to session hop when the anchored score sits on a non-latest trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added score-based navigation for focusing conversation annotations from URLs and session details.
  * Selecting a score opens the Conversation tab and focuses its location.
  * Signal-related sessions automatically focus the newest matching anchored score.
  * Deep-linked sessions open automatically and scroll to the relevant section.
  * Added anchored score data to seeded project content.
  * Score focus clears when switching tabs, traces, or session views.

* **Bug Fixes**
  * Improved navigation reliability while messages and content are loading.
  * Prevented premature focus attempts while signal information is resolving.

* **Tests**
  * Added coverage for anchored score selection, filtering, and delayed scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->