### PR TITLE
fix(analytics): reject unresolvable gtePercentile filters on queryAnalytics

### DIFF
--- a/packages/domain/shared/src/analytics-query.test.ts
+++ b/packages/domain/shared/src/analytics-query.test.ts
@@ -233,4 +233,46 @@ describe("analyticsQuerySchema", () => {
     expect(isValidAnalyticsRange(range)).toBe(true)
     expect(isValidAnalyticsRange({ fromIso: range.toIso, toIso: range.fromIso })).toBe(false)
   })
+
+  it("accepts gtePercentile on duration/ttft/cost for traces and sessions", () => {
+    for (const stream of ["traces", "sessions"] as const) {
+      for (const field of ["duration", "ttft", "cost"] as const) {
+        const result = analyticsQuerySchema.safeParse({
+          stream,
+          metric: { kind: "count" },
+          filters: { [field]: [{ op: "gtePercentile", value: 90 }] },
+          range,
+        })
+        expect(result.success).toBe(true)
+      }
+    }
+  })
+
+  it("rejects gtePercentile on a non-percentile-eligible field for traces and sessions", () => {
+    // These fields would otherwise reach `buildTraceFilterClauses`/`buildSessionFilterClauses`
+    // unresolved and throw an unhandled 500 instead of a validation 400.
+    for (const stream of ["traces", "sessions"] as const) {
+      const result = analyticsQuerySchema.safeParse({
+        stream,
+        metric: { kind: "count" },
+        filters: { tokensInput: [{ op: "gtePercentile", value: 90 }] },
+        range,
+      })
+      expect(result.success).toBe(false)
+    }
+  })
+
+  it("rejects gtePercentile on scores/behaviors/moments filters (no percentile resolution step)", () => {
+    // scores/behaviors/moments never resolve `gtePercentile` into an absolute threshold, so any
+    // field would otherwise reach `buildClickHouseWhere` unresolved and throw an unhandled 500.
+    for (const stream of ["scores", "behaviors", "moments"] as const) {
+      const result = analyticsQuerySchema.safeParse({
+        stream,
+        metric: { kind: "count" },
+        filters: { duration: [{ op: "gtePercentile", value: 90 }] },
+        range,
+      })
+      expect(result.success).toBe(false)
+    }
+  })
 })

--- a/packages/domain/shared/src/analytics-query.ts
+++ b/packages/domain/shared/src/analytics-query.ts
@@ -1,6 +1,11 @@
 import { z } from "zod"
 import { type MonitorMetric, monitorMetricSchema } from "./alert-incident-condition.ts"
-import { filterSetSchema, spanRowFilterSetSchema } from "./filter.ts"
+import {
+  rejectGtePercentileFilterSetSchema,
+  sessionFilterSetSchema,
+  spanRowFilterSetSchema,
+  traceFilterSetSchema,
+} from "./filter.ts"
 
 /**
  * Breakdown dimensions per stream — logical names the API accepts, mapped to
@@ -112,11 +117,10 @@ const rangeSchema = z
   })
   .describe("The time window.")
 
-// Fields common to every stream (metric is per-stream, added on each variant).
+// Fields common to every stream (metric and filters are per-stream, added on each variant —
+// each stream's filter builder resolves/rejects `gtePercentile` differently, so a shared
+// permissive schema here would let unsupported operators reach the filter builder and 500).
 const commonFields = {
-  filters: filterSetSchema
-    .optional()
-    .describe("Structured filter set applied to the stream (same DSL as `listTraces`)."),
   timeBucket: analyticsTimeBucketSchema
     .optional()
     .describe("Bucket the metric over time. Omit for a single aggregate."),
@@ -159,6 +163,9 @@ export const analyticsQuerySchema = z.discriminatedUnion("stream", [
       query: semanticQuery.optional(),
       breakdown: z.enum(TRACE_BREAKDOWN_FIELDS).optional().describe("Dimension to group by, one row per value."),
       metric: traceFamilyMetric,
+      filters: traceFilterSetSchema
+        .optional()
+        .describe("Structured filter set applied to the stream (same DSL as `listTraces`)."),
       ...commonFields,
     })
     .strict(),
@@ -168,6 +175,9 @@ export const analyticsQuerySchema = z.discriminatedUnion("stream", [
       query: semanticQuery.optional(),
       breakdown: z.enum(SESSION_BREAKDOWN_FIELDS).optional().describe("Dimension to group by, one row per value."),
       metric: traceFamilyMetric,
+      filters: sessionFilterSetSchema
+        .optional()
+        .describe("Structured filter set applied to the stream (same DSL as `listTraces`)."),
       ...commonFields,
     })
     .strict(),
@@ -203,6 +213,11 @@ export const analyticsQuerySchema = z.discriminatedUnion("stream", [
       metric: scoreMetricSchema.describe(
         "The metric: `count`, `passRate`, `errorRate` (over the pass/error flags), or `{avg|min|max|median}` of the 0–1 score `value`.",
       ),
+      filters: rejectGtePercentileFilterSetSchema("scores")
+        .optional()
+        .describe(
+          "Structured filter set applied to the stream (same DSL as `listTraces`). `gtePercentile` is not supported — use absolute thresholds.",
+        ),
       ...commonFields,
     })
     .strict(),
@@ -218,6 +233,11 @@ export const analyticsQuerySchema = z.discriminatedUnion("stream", [
       metric: behaviorMetricSchema.describe(
         "The metric: `count`, or `{avg|min|max|median}` of the 0–1 assignment `confidence`.",
       ),
+      filters: rejectGtePercentileFilterSetSchema("behaviors")
+        .optional()
+        .describe(
+          "Structured filter set applied to the stream (same DSL as `listTraces`). `gtePercentile` is not supported — use absolute thresholds.",
+        ),
       ...commonFields,
     })
     .strict(),
@@ -233,6 +253,11 @@ export const analyticsQuerySchema = z.discriminatedUnion("stream", [
       metric: momentMetricSchema.describe(
         "The metric: `count`, or `{avg|min|max|median}` of the 0–1 label `confidence` or moment `coherence`.",
       ),
+      filters: rejectGtePercentileFilterSetSchema("moments")
+        .optional()
+        .describe(
+          "Structured filter set applied to the stream (same DSL as `listTraces`). `gtePercentile` is not supported — use absolute thresholds.",
+        ),
       ...commonFields,
     })
     .strict(),

--- a/packages/domain/shared/src/filter.ts
+++ b/packages/domain/shared/src/filter.ts
@@ -1,5 +1,10 @@
 import { z } from "zod"
-import { isPercentileTraceFilterField, PERCENTILE_TRACE_FILTER_FIELDS } from "./trace-filter-fields.ts"
+import {
+  isPercentileSessionFilterField,
+  isPercentileTraceFilterField,
+  PERCENTILE_SESSION_FILTER_FIELDS,
+  PERCENTILE_TRACE_FILTER_FIELDS,
+} from "./trace-filter-fields.ts"
 
 // ---------------------------------------------------------------------------
 // Operators
@@ -171,3 +176,42 @@ export const traceFilterSetSchema: z.ZodType<FilterSet> = filterSetSchema.superR
     })
   }
 })
+
+export const sessionFilterGtePercentileMessage = (field: string): string =>
+  `gtePercentile is only supported on ${PERCENTILE_SESSION_FILTER_FIELDS.join("/")}; not on '${field}'. Use absolute gte/lte thresholds instead.`
+
+/** Session filters allow `gtePercentile` only on duration/ttft/cost — other fields would reach the filter builder unresolved and 500. */
+export const sessionFilterSetSchema: z.ZodType<FilterSet> = filterSetSchema.superRefine((filters, ctx) => {
+  for (const [field, conditions] of Object.entries(filters)) {
+    if (isPercentileSessionFilterField(field)) continue
+    conditions.forEach((cond, index) => {
+      if (cond.op === "gtePercentile") {
+        ctx.addIssue({
+          code: "custom",
+          message: sessionFilterGtePercentileMessage(field),
+          path: [field, index, "op"],
+        })
+      }
+    })
+  }
+})
+
+/**
+ * Streams whose filter builder never resolves `gtePercentile` into an absolute threshold (scores,
+ * behaviors, moments) must reject the operator outright at the boundary — same rationale as
+ * `spanRowFilterSetSchema`, generalized so each stream gets an accurate error message.
+ */
+export const rejectGtePercentileFilterSetSchema = (streamLabel: string): z.ZodType<FilterSet> =>
+  filterSetSchema.superRefine((filters, ctx) => {
+    for (const [field, conditions] of Object.entries(filters)) {
+      conditions.forEach((cond, index) => {
+        if (cond.op === "gtePercentile") {
+          ctx.addIssue({
+            code: "custom",
+            message: `gtePercentile is not supported on ${streamLabel} filters; not on '${field}'. Use absolute gte/lte thresholds instead.`,
+            path: [field, index, "op"],
+          })
+        }
+      })
+    }
+  })


### PR DESCRIPTION
## What does this PR do?

Fixes an unhandled 500 in `queryAnalytics` (`POST /v1/projects/:projectSlug/analytics/query`) when a caller sends a `gtePercentile` filter on a field the stream can't resolve it for.

**Datadog issue addressed:** [`bb657964-773c-11f1-b715-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/bb657964-773c-11f1-b715-da7ad0900005) — `Error: Unsupported filter operator: gtePercentile` (`api`, `packages/platform/db-clickhouse/src/filter-builder.ts:201`). Regressed on 2026-08-18 after a prior fix (#3839) had resolved a *different* call site; over the last 7 days this fired from `POST /v1/projects/:projectSlug/analytics/query` (`stream: "sessions"`) via `buildSessionFilterClauses` (`session-repository.ts:376`).

**Root cause:** `gtePercentile` is only meaningful when the filter builder resolves it into an absolute threshold first:
- `traces`/`sessions` streams resolve it, but only for `duration`/`ttft`/`cost` (`resolvePercentileFilters`) — any other field falls through unresolved.
- `scores`/`behaviors`/`moments` streams never resolve it at all.

Either way, an unresolved `gtePercentile` reaches `buildClause` in `filter-builder.ts`, which throws a plain `Error("Unsupported filter operator: gtePercentile")` — an unhandled 500 instead of a 400.

This exact class of bug was already fixed for `querySpans`/analytics `stream: "spans"` (#3839, `spanRowFilterSetSchema`) and for the `traces` domain elsewhere (#4086, `traceFilterSetSchema`) — but `queryAnalytics`'s own schema (`analyticsQuerySchema` in `packages/domain/shared/src/analytics-query.ts`) never adopted either hardened schema. All non-span streams shared one permissive `filterSetSchema` for `filters`, so the gap silently generalized to `sessions` (the one that fired in production), plus `traces`, `scores`, `behaviors`, and `moments`.

**Fix:**
- `packages/domain/shared/src/filter.ts`: add `sessionFilterSetSchema` (mirrors `traceFilterSetSchema`, restricting `gtePercentile` to `duration`/`ttft`/`cost`) and a `rejectGtePercentileFilterSetSchema(streamLabel)` factory for streams with no percentile-resolution step at all.
- `packages/domain/shared/src/analytics-query.ts`: give each stream variant of `analyticsQuerySchema` its own `filters` schema matching what its filter builder actually supports (`traceFilterSetSchema` for `traces`, `sessionFilterSetSchema` for `sessions`, existing `spanRowFilterSetSchema` for `spans`, `rejectGtePercentileFilterSetSchema` for `scores`/`behaviors`/`moments`) instead of one shared permissive schema.

Handler-side, `packages/operations/src/operations/analytics.ts` already re-validates the request body through `analyticsQuerySchema` before it reaches the filter builder, so this alone is enough to turn the crash into a clean `400` — no handler changes needed.

## Related issue (if applicable)

N/A — found via Datadog Error Tracking triage, not a filed issue.

## How was this tested?

Added regression tests to `packages/domain/shared/src/analytics-query.test.ts`:
- `gtePercentile` on `duration`/`ttft`/`cost` still succeeds for `traces` and `sessions`.
- `gtePercentile` on a non-percentile-eligible field (e.g. `tokensInput`) is now rejected for `traces` and `sessions`.
- `gtePercentile` on any field is now rejected for `scores`, `behaviors`, and `moments`.

Confirmed the new tests fail without the fix (reproducing the exact unhandled-500 codepath) by temporarily stashing the `filter.ts`/`analytics-query.ts` changes and re-running — both new assertions failed as expected — then restored the fix and re-ran to green.

```
pnpm --filter @domain/shared test        # 225/225 passing
pnpm --filter @domain/shared typecheck    # clean (tsgo)
pnpm --filter @repo/operations typecheck  # clean (tsgo)
pnpm --filter @platform/db-clickhouse typecheck  # clean (tsgo)
pnpm exec biome check <changed files>     # clean
```

**Verification in production:** after deploy, occurrences of Datadog issue `bb657964-773c-11f1-b715-da7ad0900005` should stop (any further `gtePercentile` misuse on these streams now returns a `400` from the `queryAnalytics` handler instead of a `500`).

**Remaining risk:** the OpenAPI/SDK-facing mirror schema (`AnalyticsQueryBodySchema` in `packages/operations/src/openapi/entities/analytics.ts`) still documents `filters` with the generic, unrestricted shape for `sessions`/`scores`/`behaviors`/`moments` — its code comment notes it's a Fern-generator-friendly mirror and that "domain filter constraints are re-checked in the handler via the domain schema," which this PR relies on. The runtime behavior is now correct (400 instead of 500), but SDK-generated types/docs for these streams don't yet reflect the `gtePercentile` restriction. Left out of this PR to keep the fix minimal and low-risk; flagging as a good follow-up for API-docs accuracy.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoYZKJTkZD8NVBhpYkYfi1)_