### PR TITLE
Up to date flagger docs

### DIFF
--- a/docs/annotations/flaggers.mdx
+++ b/docs/annotations/flaggers.mdx
@@ -9,16 +9,6 @@ Flaggers are Latitude's built-in automatic annotators. They inspect completed se
 
 Use flaggers when you want project-wide coverage of failure patterns you already know about, without reviewing every conversation by hand. They are useful for cases that are easy to miss in manual review: low-volume safety failures, recurring frustration, or behavior that only becomes visible across a long session.
 
-## How a flagger runs
-
-Every project starts with all flaggers provisioned. Detection happens in two passes.
-
-**Screening** runs on 100% of sessions and costs nothing. It gathers cheap evidence from the session (tool errors, error spans, repeated tool loops, latency and cost outliers, conversation moments, text patterns) and runs the checks that need no model. Deterministic matches are written straight away.
-
-**LLM classification** runs for one session and one flagger at a time. A classifier reads the conversation together with the screening evidence, and a second model pass reviews the proposed annotation before it is saved. This pass is billed by AI usage.
-
-Latitude waits for a session to settle before screening it. Sessions re-screen as new turns arrive, and at most one annotation is published per flagger per distinct piece of flagged content, so a growing conversation does not accumulate copies of the same finding.
-
 ## Available flaggers
 
 The settings page groups flaggers the same way this page does. The first two groups are deterministic, free, and always run on every eligible session. The last two use an LLM and are sampled.
@@ -95,6 +85,16 @@ LLM checks on failure modes in your agent's own output.
   </Accordion>
 </AccordionGroup>
 
+### Cost and efficiency
+
+Deterministic checks on token waste. Free, and run on every eligible session.
+
+<AccordionGroup>
+  <Accordion title="Low cache hit rate">
+    Large multi-turn sessions where prompt caching is active but fewer than 30% of input tokens were served from cache, which usually means caching is broken.
+  </Accordion>
+</AccordionGroup>
+
 ### Response validity
 
 Deterministic checks on the shape of the response. Free, and run on every eligible session.
@@ -113,15 +113,15 @@ Deterministic checks on the shape of the response. Free, and run on every eligib
   </Accordion>
 </AccordionGroup>
 
-### Cost and efficiency
+## How a flagger runs
 
-Deterministic checks on token waste. Free, and run on every eligible session.
+Every project starts with all flaggers provisioned. Detection happens in two passes.
 
-<AccordionGroup>
-  <Accordion title="Low cache hit rate">
-    Large multi-turn sessions where prompt caching is active but fewer than 30% of input tokens were served from cache, which usually means caching is broken.
-  </Accordion>
-</AccordionGroup>
+**Screening** runs on 100% of sessions and costs nothing. It gathers cheap evidence from the session (tool errors, error spans, repeated tool loops, latency and cost outliers, conversation moments, text patterns) and runs the checks that need no model. Deterministic matches are written straight away.
+
+**LLM classification** runs for one session and one flagger at a time. A classifier reads the conversation together with the screening evidence, and a second model pass reviews the proposed annotation before it is saved. This pass is billed by AI usage.
+
+Latitude waits for a session to settle before screening it. Sessions re-screen as new turns arrive, and at most one annotation is published per flagger per distinct piece of flagged content, so a growing conversation does not accumulate copies of the same finding.
 
 ## Sampling
 
@@ -130,15 +130,6 @@ Sampling applies only to the LLM flaggers, and it defaults to 10%. Deterministic
 Sampling is not the whole story on coverage. When screening finds evidence pointing at a specific category, that flagger's LLM pass runs regardless of the sampling rate. Sampling governs the sessions where nothing in particular stood out. This is why lowering sampling reduces volume but does not silence a flagger that keeps matching on real evidence.
 
 Sampling never affects search, filtering, or manual investigation. Every session stays fully queryable.
-
-## Suppression
-
-Some categories overlap, and a match on one makes another misleading. Latitude skips the second flagger in those cases:
-
-- **Refusal** is skipped when jailbreaking or NSFW fired, because refusing an adversarial or toxic request is the correct behavior.
-- **Laziness** is skipped when thrashing found a tool loop, because being stuck in a loop is a different failure from punting work back to the user.
-
-A suppressed flagger produces no annotation for that session, which explains gaps you might otherwise read as a miss.
 
 ## Configure flaggers
 
@@ -159,6 +150,16 @@ Run a project for a week with the defaults before changing anything, then look a
 - If a flagger's matches are mostly wrong for your domain, lower its sampling.
 - If you keep annotating cases by hand that a flagger should have caught, raise its sampling.
 - If a flagger is wrong for your product right now, for example NSFW on a creative-writing assistant, turn it off and revisit when the product changes.
+
+## Suppression
+
+Some categories overlap, and a match on one makes another misleading. Latitude skips the second flagger in those cases:
+
+- **Refusal** is skipped when jailbreaking or NSFW fired, because refusing an adversarial or toxic request is the correct behavior.
+- **Laziness** is skipped when thrashing found a tool loop, because being stuck in a loop is a different failure from punting work back to the user.
+
+A suppressed flagger produces no annotation for that session, which explains gaps you might otherwise read as a miss.
+
 
 ## Flaggers, search, and manual annotations
 

--- a/docs/annotations/flaggers.mdx
+++ b/docs/annotations/flaggers.mdx
@@ -1,17 +1,19 @@
 ---
 title: Flaggers
-description: Built-in automatic annotators that inspect every session for known failure categories
+description: Built-in automatic annotators that surface common failure categories in every session
 ---
 
 # Flaggers
 
-Flaggers are Latitude's built-in automatic annotators. They inspect completed sessions for known failure categories and write an annotation when they find one. Those annotations are attributed to Latitude rather than to a person, and they feed signal discovery, evaluation alignment, and score analytics exactly like human feedback.
+Flaggers are Latitude's built-in automatic annotators. They inspect completed sessions for common failure categories and write an annotation when they find one. Those annotations are attributed to Latitude rather than to a person, and they feed signal discovery, evaluation alignment, and score analytics exactly like human feedback.
 
 Use flaggers when you want project-wide coverage of failure patterns you already know about, without reviewing every conversation by hand. They are useful for cases that are easy to miss in manual review: low-volume safety failures, recurring frustration, or behavior that only becomes visible across a long session.
 
+Flaggers work on [sessions](../getting-started/concepts#sessions), the unit Latitude reviews: the whole conversation your agent had, across every trace it produced. A trace that arrives without a session id becomes a single-trace session, so nothing goes unscreened.
+
 ## Available flaggers
 
-The settings page groups flaggers the same way this page does. The first two groups are deterministic, free, and always run on every eligible session. The last two use an LLM and are sampled.
+Flaggers come in four groups, the same ones the settings page uses. **User-side signals** and **Agent behavior** use an LLM, so they are sampled and billed by AI usage. **Cost and efficiency** and **Response validity** are deterministic: they cost nothing and run on every eligible session while they are enabled.
 
 ### User-side signals
 
@@ -87,7 +89,7 @@ LLM checks on failure modes in your agent's own output.
 
 ### Cost and efficiency
 
-Deterministic checks on token waste. Free, and run on every eligible session.
+Deterministic checks on token waste. Free, and run on every eligible session while enabled.
 
 <AccordionGroup>
   <Accordion title="Low cache hit rate">
@@ -97,7 +99,7 @@ Deterministic checks on token waste. Free, and run on every eligible session.
 
 ### Response validity
 
-Deterministic checks on the shape of the response. Free, and run on every eligible session.
+Deterministic checks on the shape of the response. Free, and run on every eligible session while enabled.
 
 <AccordionGroup>
   <Accordion title="Empty response">
@@ -117,7 +119,7 @@ Deterministic checks on the shape of the response. Free, and run on every eligib
 
 Every project starts with all flaggers provisioned. Detection happens in two passes.
 
-**Screening** runs on 100% of sessions and costs nothing. It gathers cheap evidence from the session (tool errors, error spans, repeated tool loops, latency and cost outliers, conversation moments, text patterns) and runs the checks that need no model. Deterministic matches are written straight away.
+**Screening** runs on 100% of sessions and costs nothing. It gathers cheap evidence from the session (tool errors, error spans, repeated tool loops, latency and cost outliers, conversation moments, text patterns) and runs every enabled check that needs no model. Deterministic matches are written straight away.
 
 **LLM classification** runs for one session and one flagger at a time. A classifier reads the conversation together with the screening evidence, and a second model pass reviews the proposed annotation before it is saved. This pass is billed by AI usage.
 
@@ -125,7 +127,7 @@ Latitude waits for a session to settle before screening it. Sessions re-screen a
 
 ## Sampling
 
-Sampling applies only to the LLM flaggers, and it defaults to 10%. Deterministic flaggers have no sampling control: they are free, so they always run.
+Sampling applies only to the LLM flaggers, and it defaults to 10%. Deterministic flaggers have no sampling control: they are free, so an enabled one runs on every eligible session. Turning a flagger off stops it either way.
 
 Sampling is not the whole story on coverage. When screening finds evidence pointing at a specific category, that flagger's LLM pass runs regardless of the sampling rate. Sampling governs the sessions where nothing in particular stood out. This is why lowering sampling reduces volume but does not silence a flagger that keeps matching on real evidence.
 
@@ -137,7 +139,7 @@ Open **Project Settings → Flaggers** to manage a project. Each row has an on/o
 
 **Use-case presets** turn on a sensible set in one click. They cover support agents, coding agents, sales agents, tool workflow agents, knowledge-base agents, structured extraction, and safety-sensitive agents. Picking a preset replaces the current selection and leaves sampling rates alone. The same presets appear during project onboarding.
 
-You can also toggle flaggers through the API with `PATCH /projects/{id}`, passing flagger slugs to booleans in the `flaggers` field. The API controls enablement only; sampling is set from the settings page.
+You can also toggle flaggers through the API with `PATCH /v1/projects/{projectSlug}`, passing flagger slugs to booleans in the `flaggers` field. The API controls enablement only; sampling is set from the settings page.
 
 <Note>
   Flagger categories are defined by Latitude. You choose which ones run and how aggressively the LLM ones sample, not the underlying category definition. To detect something specific to your product, use an [evaluation](../evaluations/overview) or a [saved search](../search/saved-searches) instead.
@@ -153,13 +155,12 @@ Run a project for a week with the defaults before changing anything, then look a
 
 ## Suppression
 
-Some categories overlap, and a match on one makes another misleading. Latitude skips the second flagger in those cases:
+Some categories overlap, and one of them firing makes the other misleading. Latitude skips the second flagger in those cases:
 
-- **Refusal** is skipped when jailbreaking or NSFW fired, because refusing an adversarial or toxic request is the correct behavior.
+- **Refusal** is skipped when jailbreaking or NSFW is in play, because refusing an adversarial or toxic request is the correct behavior.
 - **Laziness** is skipped when thrashing found a tool loop, because being stuck in a loop is a different failure from punting work back to the user.
 
-A suppressed flagger produces no annotation for that session, which explains gaps you might otherwise read as a miss.
-
+Suppression happens during screening, so it does not wait for the suppressing flagger to confirm a match. Evidence pointing at jailbreaking is enough to skip refusal for that session, even if the jailbreaking classifier later decides there was nothing there. A suppressed flagger writes no annotation, which explains gaps you might otherwise read as a miss.
 
 ## Flaggers, search, and manual annotations
 
@@ -167,13 +168,13 @@ A suppressed flagger produces no annotation for that session, which explains gap
 | --- | --- |
 | **Flaggers** | Automatic detection of known failure categories across a project. |
 | **[Search](../search/overview)** | Investigating custom cohorts or patterns no built-in flagger covers. |
-| **[Inline annotations](./inline-annotations)** | Adding human judgment to specific traces. |
+| **[Inline annotations](./inline-annotations)** | Adding human judgment to specific sessions. |
 
 These work together: flaggers generate signal automatically, search scopes investigation, and manual annotations add the judgment neither can produce.
 
 ## Related
 
 - [Annotations Overview](./overview): How annotations connect to scores, signals, and evaluations
-- [Inline Annotations](./inline-annotations): Leave human feedback on traces
+- [Inline Annotations](./inline-annotations): Leave human feedback on sessions
 - [Search](../search/overview): Investigate patterns flaggers do not cover
 - [Signals](../signals/overview): How annotations become trackable failure patterns

--- a/docs/annotations/flaggers.mdx
+++ b/docs/annotations/flaggers.mdx
@@ -5,11 +5,11 @@ description: Built-in automatic annotators that surface common failure categorie
 
 # Flaggers
 
-Flaggers are Latitude's built-in automatic annotators. They inspect completed sessions for common failure categories and write an annotation when they find one. Those annotations are attributed to Latitude rather than to a person, and they feed signal discovery, evaluation alignment, and score analytics exactly like human feedback.
+Flaggers are Latitude's built-in automatic annotators. They inspect completed sessions for common failure categories and annotate the trace where the problem shows up when they find one. Those annotations are attributed to Latitude rather than to a person, and they feed signal discovery, evaluation alignment, and score analytics exactly like human feedback.
 
 Use flaggers when you want project-wide coverage of failure patterns you already know about, without reviewing every conversation by hand. They are useful for cases that are easy to miss in manual review: low-volume safety failures, recurring frustration, or behavior that only becomes visible across a long session.
 
-Flaggers work on [sessions](../getting-started/concepts#sessions), the unit Latitude reviews: the whole conversation your agent had, across every trace it produced. A trace that arrives without a session id becomes a single-trace session, so nothing goes unscreened.
+Detection is session-wide. A flagger reads the whole [session](../getting-started/concepts#sessions), the conversation your agent had across every trace it produced, because most of these failures only make sense in the context of the turns around them. The annotation itself lands on one trace inside that session, anchored to the message that shows the issue, so it appears in trace-level views and analytics like any other annotation. A trace that arrives without a session id becomes a single-trace session, so nothing goes unscreened.
 
 ## Available flaggers
 
@@ -168,13 +168,13 @@ Suppression happens during screening, so it does not wait for the suppressing fl
 | --- | --- |
 | **Flaggers** | Automatic detection of known failure categories across a project. |
 | **[Search](../search/overview)** | Investigating custom cohorts or patterns no built-in flagger covers. |
-| **[Inline annotations](./inline-annotations)** | Adding human judgment to specific sessions. |
+| **[Inline annotations](./inline-annotations)** | Adding human judgment to a specific trace. |
 
 These work together: flaggers generate signal automatically, search scopes investigation, and manual annotations add the judgment neither can produce.
 
 ## Related
 
 - [Annotations Overview](./overview): How annotations connect to scores, signals, and evaluations
-- [Inline Annotations](./inline-annotations): Leave human feedback on sessions
+- [Inline Annotations](./inline-annotations): Leave human feedback on a trace
 - [Search](../search/overview): Investigate patterns flaggers do not cover
 - [Signals](../signals/overview): How annotations become trackable failure patterns

--- a/docs/annotations/flaggers.mdx
+++ b/docs/annotations/flaggers.mdx
@@ -1,92 +1,178 @@
 ---
 title: Flaggers
-description: Automatic annotators that surface common failure categories on every trace
+description: Built-in automatic annotators that inspect every session for known failure categories
 ---
 
 # Flaggers
 
-Flaggers are Latitude's built-in automatic annotators. They check completed traces for common failure categories and add annotations when they find a match.
+Flaggers are Latitude's built-in automatic annotators. They inspect completed sessions for known failure categories and write an annotation when they find one. Those annotations are attributed to Latitude rather than to a person, and they feed signal discovery, evaluation alignment, and score analytics exactly like human feedback.
 
-Use flaggers when you want project-wide coverage for known failure patterns without manually reviewing every trace. Flagger annotations feed signal discovery, evaluation alignment, score analytics, and trace-level review.
+Use flaggers when you want project-wide coverage of failure patterns you already know about, without reviewing every conversation by hand. They are useful for cases that are easy to miss in manual review: low-volume safety failures, recurring frustration, or behavior that only becomes visible across a long session.
+
+## How a flagger runs
+
+Every project starts with all flaggers provisioned. Detection happens in two passes.
+
+**Screening** runs on 100% of sessions and costs nothing. It gathers cheap evidence from the session (tool errors, error spans, repeated tool loops, latency and cost outliers, conversation moments, text patterns) and runs the checks that need no model. Deterministic matches are written straight away.
+
+**LLM classification** runs for one session and one flagger at a time. A classifier reads the conversation together with the screening evidence, and a second model pass reviews the proposed annotation before it is saved. This pass is billed by AI usage.
+
+Latitude waits for a session to settle before screening it. Sessions re-screen as new turns arrive, and at most one annotation is published per flagger per distinct piece of flagged content, so a growing conversation does not accumulate copies of the same finding.
 
 ## Available flaggers
 
-Each project starts with flaggers for common reliability and safety categories:
+The settings page groups flaggers the same way this page does. The first two groups are deterministic, free, and always run on every eligible session. The last two use an LLM and are sampled.
+
+### User-side signals
+
+LLM checks on what the person on the other side of the conversation is doing.
 
 <AccordionGroup>
+  <Accordion title="Frustration">
+    The user shows annoyance, disappointment, loss of trust, or has to restate themselves because the agent is not helping.
+
+    Not flagged: neutral clarifying questions, or an isolated terse reply with no other evidence of frustration.
+  </Accordion>
+
   <Accordion title="Jailbreaking">
-    Attempts to bypass safety constraints, system instructions, tool boundaries, or the assistant's intended role.
+    Prompt injection, instruction-hierarchy attacks, policy evasion, tool abuse aimed at bypassing guardrails, role escape attempts, or the agent actually following one of those attempts.
+
+    Not flagged: harmless roleplay, or an ordinary unsafe request that the agent correctly refuses.
   </Accordion>
 
   <Accordion title="NSFW">
-    Sexual or otherwise not-safe-for-work content that should be reviewed.
-  </Accordion>
+    Workplace-inappropriate or toxic content: explicit profanity, sexual content, abusive harassment, hate speech, identity-based slurs, or graphic violent language.
 
-  <Accordion title="Refusal">
-    Cases where the assistant refuses, deflects, or over-restricts a request it should be able to handle.
-  </Accordion>
-
-  <Accordion title="Frustration">
-    Clear user dissatisfaction, repeated correction, annoyance, or loss of trust.
-  </Accordion>
-
-  <Accordion title="Forgetting">
-    Cases where the assistant loses relevant earlier context from the same conversation.
-  </Accordion>
-
-  <Accordion title="Laziness">
-    Cases where the assistant avoids doing the requested work, gives a shallow answer, or pushes work back to the user without a good reason.
-  </Accordion>
-
-  <Accordion title="Thrashing">
-    Agent behavior that cycles through tools or repeated actions without making progress.
-  </Accordion>
-
-  <Accordion title="Tool Call Errors">
-    Failed or errored tool invocations visible in the trace.
-  </Accordion>
-
-  <Accordion title="Output Schema Validation">
-    Structured-output responses that do not conform to the declared schema.
-  </Accordion>
-
-  <Accordion title="Empty Response">
-    Empty, whitespace-only, or otherwise degenerate assistant responses when a substantive answer was expected.
+    Not flagged: benign anatomy or health discussion, mild romance, neutral policy discussion about unsafe content, or colloquial language with no real toxicity.
   </Accordion>
 </AccordionGroup>
 
-## How flaggers appear in Latitude
+### Agent behavior
 
-When a flagger matches a trace, Latitude adds an annotation to that trace. You can review it from the trace detail view, see it in score analytics, and use it as input for signals and evaluations.
+LLM checks on failure modes in your agent's own output.
 
-Flaggers are especially useful for patterns that are easy to miss in manual review, such as low-volume safety failures, recurring frustration, or behavior that appears only across long sessions.
+<AccordionGroup>
+  <Accordion title="Refusal">
+    The agent declines, deflects, or over-restricts a request that is allowed and answerable within its policy and capabilities.
+
+    Not flagged: a correct refusal, where the request is unsafe, unsupported, or missing context the agent needs.
+  </Accordion>
+
+  <Accordion title="Laziness">
+    The agent gives a shallow partial answer, stops early without justification, skips context it was handed, or pushes work back onto the user that it should have done itself.
+
+    Not flagged: work genuinely blocked by missing access, missing context, or policy.
+  </Accordion>
+
+  <Accordion title="Forgetting">
+    The agent loses relevant context from earlier in the same conversation: it repeats settled questions, contradicts established facts, or ignores constraints the user already gave.
+
+    Not flagged: ambiguity that was never resolved, or context the user never provided.
+  </Accordion>
+
+  <Accordion title="Incompletion">
+    A task the user or the system prompt assigned was not completed, and the user's later messages show it by demanding a retry, repeating the request, or pointing at what is missing.
+
+    Only closed episodes are judged. The agent's latest response is not flaggable until the user has reacted to it, so this flagger fires on a later screening pass rather than immediately.
+  </Accordion>
+
+  <Accordion title="Thrashing">
+    The agent cycles through the same tools or tool sequences, oscillates between states, or piles up tool calls without moving toward the goal. Three or more identical calls match deterministically for free; the ambiguous cases go to the LLM pass.
+
+    Not flagged: legitimate retries after a transient error, or iterative refinement that is visibly converging.
+  </Accordion>
+
+  <Accordion title="Bluffing">
+    The agent ignores a failed tool call and confidently continues, presenting results the call never returned, narrating the action as done, or answering from fabricated data.
+
+    Not flagged: acknowledging the failure, retrying, hedging, or answering from other evidence actually present in the conversation.
+  </Accordion>
+
+  <Accordion title="PII leakage">
+    The agent's output exposes personal identifiers (emails, phone numbers, card or government numbers, personal records) belonging to a third party or that the user never supplied.
+
+    Not flagged: the user's own data echoed back, placeholder or fictional examples, masked identifiers, or public business contact details.
+  </Accordion>
+</AccordionGroup>
+
+### Response validity
+
+Deterministic checks on the shape of the response. Free, and run on every eligible session.
+
+<AccordionGroup>
+  <Accordion title="Empty response">
+    Empty, whitespace-only, or otherwise degenerate assistant responses where a substantive answer was expected.
+  </Accordion>
+
+  <Accordion title="Tool call errors">
+    Tool responses that are malformed, duplicated, explicitly failed, or that call a tool the agent never declared.
+  </Accordion>
+
+  <Accordion title="Output schema validation">
+    Structured output that is truncated or cannot be parsed as JSON.
+  </Accordion>
+</AccordionGroup>
+
+### Cost and efficiency
+
+Deterministic checks on token waste. Free, and run on every eligible session.
+
+<AccordionGroup>
+  <Accordion title="Low cache hit rate">
+    Large multi-turn sessions where prompt caching is active but fewer than 30% of input tokens were served from cache, which usually means caching is broken.
+  </Accordion>
+</AccordionGroup>
+
+## Sampling
+
+Sampling applies only to the LLM flaggers, and it defaults to 10%. Deterministic flaggers have no sampling control: they are free, so they always run.
+
+Sampling is not the whole story on coverage. When screening finds evidence pointing at a specific category, that flagger's LLM pass runs regardless of the sampling rate. Sampling governs the sessions where nothing in particular stood out. This is why lowering sampling reduces volume but does not silence a flagger that keeps matching on real evidence.
+
+Sampling never affects search, filtering, or manual investigation. Every session stays fully queryable.
+
+## Suppression
+
+Some categories overlap, and a match on one makes another misleading. Latitude skips the second flagger in those cases:
+
+- **Refusal** is skipped when jailbreaking or NSFW fired, because refusing an adversarial or toxic request is the correct behavior.
+- **Laziness** is skipped when thrashing found a tool loop, because being stuck in a loop is a different failure from punting work back to the user.
+
+A suppressed flagger produces no annotation for that session, which explains gaps you might otherwise read as a miss.
 
 ## Configure flaggers
 
-Open **Project Settings** to manage flaggers for a project. For each flagger you can adjust:
+Open **Project Settings → Flaggers** to manage a project. Each row has an on/off switch, and LLM rows also have a sampling slider showing whether they are free or billed by AI usage.
 
-- **Enabled**: Turn the flagger on or off.
-- **Sampling**: Control how aggressively Latitude checks traces for that category.
+**Use-case presets** turn on a sensible set in one click. They cover support agents, coding agents, sales agents, tool workflow agents, knowledge-base agents, structured extraction, and safety-sensitive agents. Picking a preset replaces the current selection and leaves sampling rates alone. The same presets appear during project onboarding.
 
-Use higher sampling for more coverage and lower sampling to reduce noise or processing volume.
+You can also toggle flaggers through the API with `PATCH /projects/{id}`, passing flagger slugs to booleans in the `flaggers` field. The API controls enablement only; sampling is set from the settings page.
 
 <Note>
-  Flagger categories are defined by Latitude. You can configure whether each flagger runs and how aggressively it samples, but not the underlying category definition.
+  Flagger categories are defined by Latitude. You choose which ones run and how aggressively the LLM ones sample, not the underlying category definition. To detect something specific to your product, use an [evaluation](../evaluations/overview) or a [saved search](../search/saved-searches) instead.
 </Note>
+
+## Tuning advice
+
+Run a project for a week with the defaults before changing anything, then look at what each flagger actually caught.
+
+- If a flagger's matches are mostly wrong for your domain, lower its sampling.
+- If you keep annotating cases by hand that a flagger should have caught, raise its sampling.
+- If a flagger is wrong for your product right now, for example NSFW on a creative-writing assistant, turn it off and revisit when the product changes.
 
 ## Flaggers, search, and manual annotations
 
 | Surface | Best for |
 | --- | --- |
-| **Flaggers** | Automatic detection of known failure categories across your project. |
-| **[Search](../search/overview)** | Investigating custom cohorts or patterns not covered by a built-in flagger. |
-| **[Inline annotations](./inline-annotations)** | Adding human feedback to specific traces. |
+| **Flaggers** | Automatic detection of known failure categories across a project. |
+| **[Search](../search/overview)** | Investigating custom cohorts or patterns no built-in flagger covers. |
+| **[Inline annotations](./inline-annotations)** | Adding human judgment to specific traces. |
 
-These surfaces complement each other: flaggers create automatic signal, search scopes investigation, and manual annotations add human judgment.
+These work together: flaggers generate signal automatically, search scopes investigation, and manual annotations add the judgment neither can produce.
 
 ## Related
 
 - [Annotations Overview](./overview): How annotations connect to scores, signals, and evaluations
 - [Inline Annotations](./inline-annotations): Leave human feedback on traces
-- [Search](../search/overview): Investigate patterns that flaggers do not cover
+- [Search](../search/overview): Investigate patterns flaggers do not cover
 - [Signals](../signals/overview): How annotations become trackable failure patterns

--- a/docs/annotations/guides/annotate-effectively.mdx
+++ b/docs/annotations/guides/annotate-effectively.mdx
@@ -1,9 +1,9 @@
 ---
-title: Annotate sessions effectively
+title: Annotate traces effectively
 description: Practical habits for human annotation that keep signal discovery and evaluation alignment accurate.
 ---
 
-# Annotate sessions effectively
+# Annotate traces effectively
 
 Annotations feed [signal discovery](../../signals/overview), [evaluation alignment](../../evaluations/alignment), and the rest of what Latitude does with your feedback. A thumbs-up or thumbs-down alone is rarely enough, so add a short sentence of context, especially on failures. The habits below help that sentence stay useful for you and for automated evaluations.
 

--- a/docs/annotations/guides/annotate-effectively.mdx
+++ b/docs/annotations/guides/annotate-effectively.mdx
@@ -1,9 +1,9 @@
 ---
-title: Annotate traces effectively
+title: Annotate sessions effectively
 description: Practical habits for human annotation that keep signal discovery and evaluation alignment accurate.
 ---
 
-# Annotate traces effectively
+# Annotate sessions effectively
 
 Annotations feed [signal discovery](../../signals/overview), [evaluation alignment](../../evaluations/alignment), and the rest of what Latitude does with your feedback. A thumbs-up or thumbs-down alone is rarely enough, so add a short sentence of context, especially on failures. The habits below help that sentence stay useful for you and for automated evaluations.
 
@@ -14,7 +14,7 @@ For how annotations work, see [Annotations Overview](../overview). For automatic
 The single biggest predictor of annotation value is consistency.
 
 - **Annotate continuously, in small batches.** Fifteen minutes every couple of days beats a four-hour marathon once a quarter. You want the range of issues your product sees over time, not whatever happened in one day of use.
-- **Diversity beats volume.** Twenty varied traces tell you more about your agent than two hundred near-duplicates. If a saved search keeps returning the same conversation shape, broaden it or move on. Don't waste time annotating problems you've already identified and are monitoring.
+- **Diversity beats volume.** Twenty varied sessions tell you more about your agent than two hundred near-duplicates. If a saved search keeps returning the same conversation shape, broaden it or move on. Don't waste time annotating problems you've already identified and are monitoring.
 
 <Tip>
   Marathon sessions cause reviewer fatigue, and tired reviewers produce noisier
@@ -35,8 +35,8 @@ A few rules of thumb:
 
 - **Say what happened, not just pass/fail.** One short sentence about what the agent did is enough.
 - **Note what set it off.** What in the user's message or earlier turns led to the problem? That helps similar cases group together.
-- **Skip boilerplate and fluff.** No need for "annotation:" prefixes or "this trace shows…". Treat it like a Slack note to a teammate. Padding waste time and reduces automatic signal detection accuracy.
-- **Don't pad obvious passes.** If a trace is fine, a thumbs-up with no feedback (or skipping the annotation entirely) is fine. On a thumbs-down, empty feedback won't help you find or fix issues later.
+- **Skip boilerplate and fluff.** No need for "annotation:" prefixes or "this session shows…". Treat it like a Slack note to a teammate. Padding waste time and reduces automatic signal detection accuracy.
+- **Don't pad obvious passes.** If a session is fine, a thumbs-up with no feedback (or skipping the annotation entirely) is fine. On a thumbs-down, empty feedback won't help you find or fix issues later.
 
 ## Pick the right scope
 
@@ -55,9 +55,9 @@ Every annotation can be **conversation-level**, **message-level**, or **text-ran
 
 ## Review through a saved search
 
-A [saved search](../../search/saved-searches) is a query plus filters that define which traces to review, saved so you can come back to them. Random spot-checking won't tell you when you're done; a saved search will, if you've scoped it well. See [Search and review effectively](../../search/guides/search-and-review-effectively) for query design and sizing. The review loop:
+A [saved search](../../search/saved-searches) is a query plus filters that define which sessions to review, saved so you can come back to them. Random spot-checking won't tell you when you're done; a saved search will, if you've scoped it well. See [Search and review effectively](../../search/guides/search-and-review-effectively) for query design and sizing. The review loop:
 
-1. Open the saved search and work matches from the trace detail view, annotating as you go.
+1. Open the saved search and work matches from the session detail view, annotating as you go.
 2. Mix thumbs-up and thumbs-down while you go. Don't only annotate failures.
 3. When your team agrees the saved search is reviewed, leave it in place. To learn if the issue returns, point a [monitor](../../monitors/overview) at the saved search.
 
@@ -66,11 +66,11 @@ A [saved search](../../search/saved-searches) is a query plus filters that defin
 [Flaggers](../flaggers) add annotations automatically for common failure categories. Work with them by adjusting sampling rather than treating every match as noise.
 
 - **Start with defaults.** Run a project for a week with flaggers on. Look at what each flagger catches before changing anything.
-- **Lower sampling when noisy.** If a flagger's annotations are mostly false positives in your domain, drop its sampling. This applies to the LLM-based flaggers only; the deterministic ones are free and always run.
+- **Lower sampling when noisy.** If a flagger's annotations are mostly false positives in your domain, drop its sampling. This applies to the LLM-based flaggers only; the deterministic ones are free and run whenever they are enabled.
 - **Raise sampling when missing real cases.** If you keep manually annotating cases that the flagger should have caught, raise sampling so it runs on more sessions.
 - **Disable temporarily, never permanently.** If a flagger is wrong for your product right now (e.g. you _expect_ NSFW content for a creative-writing assistant), turn it off, but revisit when the product changes.
 
-Flagger annotations feed [signal discovery](../../signals/overview) and [alignment](../../evaluations/alignment) the same way yours do. If a flagger already annotated a trace, you can usually skip it.
+Flagger annotations feed [signal discovery](../../signals/overview) and [alignment](../../evaluations/alignment) the same way yours do. If a flagger already annotated a session, you can usually skip it.
 
 ## When to link a signal manually
 
@@ -85,13 +85,13 @@ Annotations age. The product changes, the model changes, the prompts change.
 
 - **Re-review after a fix.** After you fix a signal, annotate a few recent matches of its watch evaluation to confirm the fix held.
 - **Watch alignment.** If an evaluation's alignment score drops, add a few fresh annotations and realign from the evaluation dashboard.
-- **Prune stale saved searches.** If reopening one turns up no recent matches, the traces may be gone or the query needs updating.
+- **Prune stale saved searches.** If reopening one turns up no recent matches, the sessions may be gone or the query needs updating.
 
 ## What teams often do
 
 - **A weekly review slot.** Whoever owns a saved search clears recent matches; everyone else spot-checks during normal work.
 - **Delegated saved searches.** Domain-specific saved searches owned in practice by the engineer or PM who knows that surface area.
-- **Annotation during dogfood.** Engineers shipping changes annotate a handful of traces from their own staging. This catches regressions before they reach a user.
+- **Annotation during dogfood.** Engineers shipping changes annotate a handful of sessions from their own staging. This catches regressions before they reach a user.
 
 ## Recommended pattern
 

--- a/docs/annotations/guides/annotate-effectively.mdx
+++ b/docs/annotations/guides/annotate-effectively.mdx
@@ -66,8 +66,8 @@ A [saved search](../../search/saved-searches) is a query plus filters that defin
 [Flaggers](../flaggers) add annotations automatically for common failure categories. Work with them by adjusting sampling rather than treating every match as noise.
 
 - **Start with defaults.** Run a project for a week with flaggers on. Look at what each flagger catches before changing anything.
-- **Lower sampling when noisy.** If a flagger's annotations are mostly false positives in your domain, drop its sampling.
-- **Raise sampling when missing real cases.** If you keep manually annotating traces that the flagger should have caught, raise sampling so it runs on more traces.
+- **Lower sampling when noisy.** If a flagger's annotations are mostly false positives in your domain, drop its sampling. This applies to the LLM-based flaggers only; the deterministic ones are free and always run.
+- **Raise sampling when missing real cases.** If you keep manually annotating cases that the flagger should have caught, raise sampling so it runs on more sessions.
 - **Disable temporarily, never permanently.** If a flagger is wrong for your product right now (e.g. you _expect_ NSFW content for a creative-writing assistant), turn it off, but revisit when the product changes.
 
 Flagger annotations feed [signal discovery](../../signals/overview) and [alignment](../../evaluations/alignment) the same way yours do. If a flagger already annotated a trace, you can usually skip it.

--- a/docs/annotations/inline-annotations.md
+++ b/docs/annotations/inline-annotations.md
@@ -1,17 +1,17 @@
 ---
 title: Inline Annotations
-description: Annotate any trace directly from its detail view
+description: Annotate any session directly from its detail view
 ---
 
 # Inline Annotations
 
-Inline annotations are the main way to leave human feedback on a trace. Any trace you can open has an annotation panel, whether you reached it from the Traces page, Signals, or a saved search.
+Inline annotations are the main way to leave human feedback on a session. Any session you can open has an annotation panel, whether you reached it from the Sessions page, Signals, or a saved search. A single trace opened on its own has the same panel, scoped to that trace.
 
 ## How Inline Annotations Work
 
-When viewing a trace:
+When viewing a session:
 
-1. Open the trace detail view.
+1. Open the session detail view.
 2. Use the annotation panel on the right.
 3. Choose a scope:
    - **Conversation-level**: assess the whole interaction.
@@ -27,8 +27,8 @@ Annotations save as drafts while you edit. Once finalized, they feed analytics, 
 For batch review, start from [search](../search/overview) or a [saved search](../search/saved-searches):
 
 1. Run or open a search for the cohort you want to review, such as _"failed payments last week"_ or _"checkout flows over 5 steps"_.
-2. Open a matching trace.
-3. Read the conversation, annotate it, and move to the next trace.
+2. Open a matching session.
+3. Read the conversation, annotate it, and move to the next session.
 4. Reopen the saved search from the **Saved searches** dropdown whenever you want to pick the cohort back up.
 
 For shared review work, saved searches are visible to everyone in the project, so a teammate can open the same cohort from the **Saved searches** dropdown.
@@ -37,11 +37,11 @@ For shared review work, saved searches are visible to everyone in the project, s
 
 Use inline annotations for:
 
-- Systematic review of a trace cohort
-- Ad-hoc spot checks while browsing traces
+- Systematic review of a session cohort
+- Ad-hoc spot checks while browsing sessions
 - Signal investigation
 - Team review and coaching
-- Extra context on traces that already have scores or flagger annotations
+- Extra context on sessions that already have scores or flagger annotations
 
 If you want detection without human review for a fixed set of known failure categories, use [flaggers](./flaggers).
 
@@ -57,5 +57,5 @@ Message-level and text-range annotations leave highlights in the conversation vi
 
 - [Annotations Overview](./overview): How the annotation system works
 - [Flaggers](./flaggers): Automatic annotators for common failure categories
-- [Search](../search/overview): Find traces to annotate
+- [Search](../search/overview): Find sessions to annotate
 - [Signals](../signals/overview): How annotations connect to signal tracking

--- a/docs/annotations/inline-annotations.md
+++ b/docs/annotations/inline-annotations.md
@@ -1,11 +1,11 @@
 ---
 title: Inline Annotations
-description: Annotate any session directly from its detail view
+description: Annotate any trace directly from the session detail view
 ---
 
 # Inline Annotations
 
-Inline annotations are the main way to leave human feedback on a session. Any session you can open has an annotation panel, whether you reached it from the Sessions page, Signals, or a saved search. A single trace opened on its own has the same panel, scoped to that trace.
+Inline annotations are the main way to leave human feedback on a trace. You open the session, read the whole conversation, and annotate the trace that shows the behavior you want to call out. Any session you can open has an annotation panel, whether you reached it from the Sessions page, Signals, or a saved search, and a trace opened on its own has the same panel.
 
 ## How Inline Annotations Work
 
@@ -41,7 +41,7 @@ Use inline annotations for:
 - Ad-hoc spot checks while browsing sessions
 - Signal investigation
 - Team review and coaching
-- Extra context on sessions that already have scores or flagger annotations
+- Extra context on traces that already have scores or flagger annotations
 
 If you want detection without human review for a fixed set of known failure categories, use [flaggers](./flaggers).
 

--- a/docs/annotations/overview.md
+++ b/docs/annotations/overview.md
@@ -14,7 +14,7 @@ Finalized annotations become scores. They feed analytics, signal discovery, and 
 Annotations can come from:
 
 1. **Inline review** from any trace detail view. See [Inline Annotations](./inline-annotations).
-2. **Flaggers** when a trace matches a known failure category such as _jailbreaking_, _frustration_, or _tool call errors_. See [Flaggers](./flaggers).
+2. **Flaggers** when a session matches a known failure category such as _jailbreaking_, _frustration_, _incompletion_, or _tool call errors_. See [Flaggers](./flaggers).
 3. **Your own systems** through the [Annotations API](../scores/api).
 
 ## How to Annotate

--- a/docs/annotations/overview.md
+++ b/docs/annotations/overview.md
@@ -5,7 +5,7 @@ description: Review your agent's interactions and provide human feedback
 
 # Annotations
 
-Annotations are verdicts on individual traces. A human reviewer, a Latitude flagger, or an external system can attach a thumbs-up or thumbs-down verdict with feedback to a conversation, message, or text range.
+Annotations are verdicts on a session, the conversation your agent had from start to finish. A human reviewer, a Latitude flagger, or an external system can attach a thumbs-up or thumbs-down verdict with feedback to the whole conversation, one message, or a text range inside it.
 
 Finalized annotations become scores. They feed analytics, signal discovery, and evaluation alignment the same way regardless of where they came from.
 
@@ -13,9 +13,9 @@ Finalized annotations become scores. They feed analytics, signal discovery, and 
 
 Annotations can come from:
 
-1. **Inline review** from any trace detail view. See [Inline Annotations](./inline-annotations).
-2. **Flaggers** when a session matches a known failure category such as _jailbreaking_, _frustration_, _incompletion_, or _tool call errors_. See [Flaggers](./flaggers).
-3. **Your own systems** through the [Annotations API](../scores/api).
+1. **Inline review** from any session detail view. See [Inline Annotations](./inline-annotations).
+2. **Flaggers** when a completed session matches a known failure category such as _jailbreaking_, _frustration_, _incompletion_, or _tool call errors_. See [Flaggers](./flaggers).
+3. **Your own systems** through the [Annotations API](../scores/api), which pins the annotation to one trace inside the session.
 
 ## How to Annotate
 
@@ -30,7 +30,7 @@ Human annotations save as drafts while you edit. Once finalized, they become par
 
 ## Where to Annotate
 
-Open any trace detail view—from Traces, Search, Signals, or Sessions—and use the annotation panel on the right. For batch review, start with a [saved search](../search/saved-searches), then work through the matching traces one at a time.
+Open any session, whether you got there from Sessions, Search, or Signals, and use the annotation panel on the right. For batch review, start with a [saved search](../search/saved-searches), then work through the matching sessions one at a time.
 
 If you want automatic coverage for known failure categories, use [flaggers](./flaggers). If you are building your own feedback UI, submit annotations through the [Annotations API](../scores/api).
 
@@ -49,12 +49,12 @@ Annotations are the foundation of Latitude's reliability loop. They help you:
 | **[Scores](../scores/overview)** | Each finalized annotation becomes a score for analytics and dashboards. |
 | **[Signals](../signals/overview)** | Failed annotations can cluster into trackable signals. |
 | **[Evaluations](../evaluations/overview)** | Annotations provide ground truth for measuring evaluation accuracy. |
-| **[Search](../search/overview)** | Search and saved searches help you find trace cohorts to review. |
+| **[Search](../search/overview)** | Search and saved searches help you find session cohorts to review. |
 | **[Flaggers](./flaggers)** | Flaggers create automatic annotations for common failure categories. |
 
 ## Next Steps
 
-- [Inline Annotations](./inline-annotations): Annotate directly from trace views
+- [Inline Annotations](./inline-annotations): Annotate directly from session views
 - [Flaggers](./flaggers): Automatic annotators for common failure categories
 - [Search](../search/overview): Build cohorts to annotate
 - [Evaluation Alignment](../evaluations/alignment): See how annotations calibrate evaluations

--- a/docs/annotations/overview.md
+++ b/docs/annotations/overview.md
@@ -5,7 +5,7 @@ description: Review your agent's interactions and provide human feedback
 
 # Annotations
 
-Annotations are verdicts on a session, the conversation your agent had from start to finish. A human reviewer, a Latitude flagger, or an external system can attach a thumbs-up or thumbs-down verdict with feedback to the whole conversation, one message, or a text range inside it.
+Annotations are verdicts on a trace. You read the session it belongs to, the full conversation, and attach a thumbs-up or thumbs-down verdict with feedback to the trace where the behavior happened, scoped to the whole conversation, one message, or a text range inside it. A human reviewer, a Latitude flagger, or an external system can all create one.
 
 Finalized annotations become scores. They feed analytics, signal discovery, and evaluation alignment the same way regardless of where they came from.
 
@@ -14,8 +14,8 @@ Finalized annotations become scores. They feed analytics, signal discovery, and 
 Annotations can come from:
 
 1. **Inline review** from any session detail view. See [Inline Annotations](./inline-annotations).
-2. **Flaggers** when a completed session matches a known failure category such as _jailbreaking_, _frustration_, _incompletion_, or _tool call errors_. See [Flaggers](./flaggers).
-3. **Your own systems** through the [Annotations API](../scores/api), which pins the annotation to one trace inside the session.
+2. **Flaggers** when a completed session matches a known failure category such as _jailbreaking_, _frustration_, _incompletion_, or _tool call errors_. The flagger reads the session and annotates the trace where the issue appeared. See [Flaggers](./flaggers).
+3. **Your own systems** through the [Annotations API](../scores/api), which targets the trace by id or by a filter set matching exactly one.
 
 ## How to Annotate
 

--- a/docs/getting-started/quick-start-pm.md
+++ b/docs/getting-started/quick-start-pm.md
@@ -45,20 +45,35 @@ When a search is one you'll come back to, click **Save search** and give it a na
 
 ## Automatic Detection with Flaggers
 
-Some failure categories are common enough that Latitude detects them for you. Every project starts with a set of built-in **flaggers** running on every completed trace:
+Some failure categories are common enough that Latitude detects them for you. Every project starts with a set of built-in **flaggers** that inspect completed sessions. They come in four groups:
 
-- **Jailbreaking**: Attempts to bypass safety constraints
-- **NSFW**: Sexual or otherwise inappropriate content
-- **Refusal**: The agent refuses requests it should handle
-- **Frustration**: Clear user dissatisfaction
-- **Forgetting**: The agent loses conversation context
+**User-side signals** (LLM-based)
+
+- **Jailbreaking**: Attempts to bypass safety constraints or system instructions
+- **NSFW**: Workplace-inappropriate or toxic content
+- **Frustration**: Clear user dissatisfaction or loss of trust
+
+**Agent behavior** (LLM-based)
+
+- **Refusal**: The agent refuses a request it should handle
 - **Laziness**: The agent avoids doing the requested work
+- **Forgetting**: The agent loses context from earlier in the conversation
+- **Incompletion**: A task was left undone and the user had to follow up
 - **Thrashing**: The agent cycles between tools without making progress
-- **Tool Call Errors**: Failed tool invocations
-- **Output Schema Validation**: Structured output didn't conform to the declared schema
-- **Empty Response**: The assistant returned an empty or degenerate response
+- **Bluffing**: The agent continues past a failed tool call as if it succeeded
+- **PII leakage**: The agent's output exposes personal data it should not have surfaced
 
-When a flagger matches, it writes an annotation directly on the trace. That annotation feeds into [signal discovery](../signals/overview), [scores analytics](../scores/analytics), and [evaluation alignment](../evaluations/alignment) the same way a human annotation would. You can adjust which flaggers are enabled and how aggressively they sample under **Project Settings**. See [Flaggers](../annotations/flaggers) for the full list.
+**Response validity** (deterministic, free, runs on everything)
+
+- **Empty response**: The agent returned an empty or degenerate response
+- **Tool call errors**: Malformed, duplicated, failed, or undeclared tool calls
+- **Output schema validation**: Structured output was truncated or unparseable
+
+**Cost and efficiency** (deterministic, free, runs on everything)
+
+- **Low cache hit rate**: Caching is on but most input tokens are missing the cache
+
+When a flagger matches, it writes an annotation on the session's trace. That annotation feeds into [signal discovery](../signals/overview), [scores analytics](../scores/analytics), and [evaluation alignment](../evaluations/alignment) the same way a human annotation would. Under **Project Settings** you can toggle each flagger, apply a use-case preset, and set how aggressively the LLM ones sample. See [Flaggers](../annotations/flaggers) for what each one detects.
 
 ## Reviewing Traces
 

--- a/docs/getting-started/quick-start-pm.md
+++ b/docs/getting-started/quick-start-pm.md
@@ -73,11 +73,11 @@ Some failure categories are common enough that Latitude detects them for you. Ev
 
 - **Low cache hit rate**: Caching is on but most input tokens are missing the cache
 
-When a flagger matches, it writes an annotation on the session. That annotation feeds into [signal discovery](../signals/overview), [scores analytics](../scores/analytics), and [evaluation alignment](../evaluations/alignment) the same way a human annotation would. Under **Project Settings** you can toggle each flagger, apply a use-case preset, and set how aggressively the LLM ones sample. See [Flaggers](../annotations/flaggers) for what each one detects.
+When a flagger matches, it annotates the trace inside the session where the issue appeared. That annotation feeds into [signal discovery](../signals/overview), [scores analytics](../scores/analytics), and [evaluation alignment](../evaluations/alignment) the same way a human annotation would. Under **Project Settings** you can toggle each flagger, apply a use-case preset, and set how aggressively the LLM ones sample. See [Flaggers](../annotations/flaggers) for what each one detects.
 
 ## Reviewing Sessions
 
-To leave human feedback on a session, open it from any list (Sessions, Search, a signal's logs) and use the annotation panel on the right:
+To leave human feedback, open a session from any list (Sessions, Search, a signal's logs) and use the annotation panel on the right. Your verdict attaches to the trace you are looking at:
 
 - Click anywhere in the conversation to create a message-level annotation, or use the button for a conversation-level one.
 - Mark it as positive (thumbs up) or negative (thumbs down).

--- a/docs/getting-started/quick-start-pm.md
+++ b/docs/getting-started/quick-start-pm.md
@@ -45,7 +45,7 @@ When a search is one you'll come back to, click **Save search** and give it a na
 
 ## Automatic Detection with Flaggers
 
-Some failure categories are common enough that Latitude detects them for you. Every project starts with a set of built-in **flaggers** that inspect completed sessions. They come in four groups:
+Some failure categories are common enough that Latitude detects them for you. Every project starts with a set of built-in **flaggers** that inspect every completed session. They come in four groups:
 
 **User-side signals** (LLM-based)
 
@@ -63,28 +63,28 @@ Some failure categories are common enough that Latitude detects them for you. Ev
 - **Bluffing**: The agent continues past a failed tool call as if it succeeded
 - **PII leakage**: The agent's output exposes personal data it should not have surfaced
 
-**Response validity** (deterministic, free, runs on everything)
+**Response validity** (deterministic, free, runs on every session while enabled)
 
 - **Empty response**: The agent returned an empty or degenerate response
 - **Tool call errors**: Malformed, duplicated, failed, or undeclared tool calls
 - **Output schema validation**: Structured output was truncated or unparseable
 
-**Cost and efficiency** (deterministic, free, runs on everything)
+**Cost and efficiency** (deterministic, free, runs on every session while enabled)
 
 - **Low cache hit rate**: Caching is on but most input tokens are missing the cache
 
-When a flagger matches, it writes an annotation on the session's trace. That annotation feeds into [signal discovery](../signals/overview), [scores analytics](../scores/analytics), and [evaluation alignment](../evaluations/alignment) the same way a human annotation would. Under **Project Settings** you can toggle each flagger, apply a use-case preset, and set how aggressively the LLM ones sample. See [Flaggers](../annotations/flaggers) for what each one detects.
+When a flagger matches, it writes an annotation on the session. That annotation feeds into [signal discovery](../signals/overview), [scores analytics](../scores/analytics), and [evaluation alignment](../evaluations/alignment) the same way a human annotation would. Under **Project Settings** you can toggle each flagger, apply a use-case preset, and set how aggressively the LLM ones sample. See [Flaggers](../annotations/flaggers) for what each one detects.
 
-## Reviewing Traces
+## Reviewing Sessions
 
-To leave human feedback on a trace, open it from any list (Search, Traces, a signal's logs) and use the annotation panel on the right:
+To leave human feedback on a session, open it from any list (Sessions, Search, a signal's logs) and use the annotation panel on the right:
 
 - Click anywhere in the conversation to create a message-level annotation, or use the button for a conversation-level one.
 - Mark it as positive (thumbs up) or negative (thumbs down).
 - Write feedback describing what you observed.
 - Optionally link it to an existing signal, or leave the assignment automatic.
 
-A typical review session combines saved searches and inline annotations: open the saved search you're responsible for, click the first trace, annotate, move on. The saved search's Annotated count goes up as you work.
+A typical review slot combines saved searches and inline annotations: open the saved search you're responsible for, click the first session, annotate, move on. The saved search's Annotated count goes up as you work.
 
 ## Understanding Signals
 

--- a/docs/observability/features/sampling.mdx
+++ b/docs/observability/features/sampling.mdx
@@ -23,7 +23,9 @@ A sampling rate of `0%` pauses the evaluation.
 
 ### Flagger sampling
 
-Flaggers can sample how aggressively Latitude runs additional automated checks for a category. This balances detection coverage with processing volume.
+The LLM-based flaggers sample how aggressively Latitude runs their model-backed checks, which balances detection coverage against AI usage. The deterministic flaggers (empty response, tool call errors, output schema validation, low cache hit rate) have no sampling control: they are free and always run.
+
+When screening finds evidence pointing at a specific category, that flagger runs regardless of its sampling rate. Sampling governs the sessions where nothing stood out.
 
 Flagger sampling does not remove traces from search, filtering, or manual signal investigation.
 

--- a/docs/observability/features/sampling.mdx
+++ b/docs/observability/features/sampling.mdx
@@ -23,7 +23,9 @@ A sampling rate of `0%` pauses the evaluation.
 
 ### Flagger sampling
 
-The LLM-based flaggers sample how aggressively Latitude runs their model-backed checks, which balances detection coverage against AI usage. The deterministic flaggers (empty response, tool call errors, output schema validation, low cache hit rate) have no sampling control: they are free and always run.
+Flaggers evaluate whole sessions, so their sampling rate counts sessions rather than individual traces.
+
+The LLM-based flaggers sample how aggressively Latitude runs their model-backed checks, which balances detection coverage against AI usage. The deterministic flaggers (empty response, tool call errors, output schema validation, low cache hit rate) have no sampling control: they are free, so an enabled one runs on everything it is eligible for.
 
 When screening finds evidence pointing at a specific category, that flagger runs regardless of its sampling rate. Sampling governs the sessions where nothing stood out.
 

--- a/docs/signals/overview.mdx
+++ b/docs/signals/overview.mdx
@@ -36,7 +36,7 @@ Your telemetry sends real user and agent interactions into Latitude as traces. T
 Latitude uses several signal sources to decide whether a trace represents good or bad behavior:
 
 - **Annotations**: Human feedback left on traces during review.
-- **Flaggers**: Built-in automatic annotators for categories such as frustration, refusal, jailbreaking, tool errors, and empty responses.
+- **Flaggers**: Built-in automatic annotators for categories such as frustration, refusal, jailbreaking, incompletion, bluffing, PII leakage, tool call errors, and empty responses.
 - **Evaluations**: Automated monitors that track signal patterns across incoming traces.
 - **Custom scores**: Domain-specific verdicts you submit from your own systems.
 


### PR DESCRIPTION
## What does this PR do?

## Bring the public flagger docs back in sync with the registry

The docs under `docs/` described 10 flaggers. The strategy registry has 14, and several of the descriptions no longer matched what the strategies actually detect. This updates the public docs to the current code and restructures the reference page around the same grouping the settings UI uses.

### Added the four missing flaggers

Bluffing, PII leakage, Incompletion, and Low cache hit rate shipped without ever reaching the docs. Descriptions come from `FLAGGER_DISPLAY` in `packages/domain/flaggers/src/flagger-strategies/display.ts`.

### Corrected stale descriptions

- **NSFW** was described as sexual content only. The strategy also covers profanity, abusive harassment, hate speech, slurs, and graphic violence.
- **Output schema validation** claimed to check conformance against a declared schema. It detects truncated or unparseable JSON.
- **Tool call errors** listed only failed invocations. It also flags malformed, duplicated, and undeclared-tool calls.
- **Thrashing** is a hybrid: three or more identical calls match deterministically, the rest go to the LLM pass.

### Fixed conceptual drift

- **Traces vs sessions.** Screening runs per settled session, not per trace. Corrected throughout.
- **Sampling is LLM-only.** The docs told users every flagger has a sampling knob. Deterministic flaggers are free and always run, so the settings page shows no slider for them.
- **Hint evidence bypasses sampling.** When screening finds evidence for a category, that flagger's LLM pass runs regardless of the rate. This is why lowering sampling does not silence a flagger that keeps matching, and it was previously undocumented.
- **Suppression was undocumented.** Refusal is skipped when jailbreaking or NSFW fired; laziness is skipped when thrashing found a tool loop. Users reading a gap as a miss had no way to know.
- **Use-case presets were undocumented.** Seven presets exist in both project settings and onboarding.
- **Re-screening dedup.** Sessions re-screen as they grow; at most one annotation is published per flagger per distinct piece of flagged content.

### Restructured the reference page around the UI grouping

`docs/annotations/flaggers.mdx` now uses the four groups from `apps/web/src/domains/flaggers/presets.ts`: user-side signals, agent behavior, response validity, cost and efficiency. That ordering carries the free/deterministic vs billed/LLM split for free, which is what a reader needs before touching sampling. `FLAGGER_GROUPS` has a compile-time exhaustiveness assert, so a new strategy cannot ship without landing in a group, which makes it the least drift-prone structure to mirror.

Each LLM entry also carries a short "Not flagged" line taken from the strategy's own negative guidance, since that is the part most often mistaken for a bug.

### Files

| File | Change |
| --- | --- |
| `docs/annotations/flaggers.mdx` | Rewritten: all 14 flaggers, grouped, plus sampling / suppression / presets / API sections |
| `docs/getting-started/quick-start-pm.md` | Duplicated 10-item list replaced with the grouped 14 |
| `docs/observability/features/sampling.mdx` | Deterministic flaggers have no sampling; hinted sessions run regardless |
| `docs/annotations/guides/annotate-effectively.mdx` | Tuning advice scoped to LLM flaggers |
| `docs/signals/overview.mdx` | Category examples refreshed |
| `docs/annotations/overview.md` | Session wording, added incompletion |

### Deliberately out of scope

`dev-docs/flaggers.md` is already accurate against the registry and is unchanged. The hint catalog, rate-limit buckets, and reflag internals stay out of the public docs: they are operational detail with no user-facing control.

Docs only, no code or behavior changes.

## Related issue (if applicable)

<!-- If this PR resolves an issue, link it so it auto-closes on merge, e.g. Closes #123 -->

Closes #

## How was this tested?

<!-- Describe the tests you ran or the steps to verify the change. -->

## Checklist

- [ ] Lint, type-checking, and tests pass locally
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reworked flagger guidance around session-wide detection, trace anchoring, screening, rescreening, and annotation deduplication.
  - Added coverage for incompletion, bluffing, PII leakage, and low cache hit rate.
  - Clarified sampling behavior: deterministic flaggers evaluate every eligible completed session, while LLM-based flaggers follow sampling rates.
  - Updated annotation, review, inline annotation, signals, and quick-start guidance to consistently use session terminology.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->