### PR TITLE
Keep the comments added in #4478 to one line

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.test.ts
@@ -114,8 +114,7 @@ describe("useAnnotationNavigation", () => {
       result.current.scrollToAnnotation(annotation)
     })
 
-    // The conversation is still laying out right after the request, so the scroll
-    // waits for it to settle instead of landing short of the anchor.
+    // Still laying out right after the request, so the scroll waits instead of landing short of the anchor.
     expect(textElement.scrollIntoView).not.toHaveBeenCalled()
 
     act(() => {
@@ -156,8 +155,7 @@ describe("useAnnotationNavigation", () => {
       result.current.scrollToAnnotation(annotation)
     })
 
-    // Messages laying out above the anchor keep pushing it down, so each change
-    // restarts the wait rather than scrolling against a stale layout.
+    // Messages above the anchor keep pushing it down, so each change restarts the wait.
     for (let step = 0; step < 6; step++) {
       scrollHeight += 100
       act(() => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.ts
@@ -337,12 +337,7 @@ export function useAnnotationNavigation({
         return { element: messageElement, clickTarget: triggerElement, annotation }
       }
 
-      // The target renders asynchronously (the conversation chunk has to land and,
-      // for a substring anchor, its highlight spans have to be painted), and even
-      // once it exists the messages above it keep laying out, pushing it further
-      // down — scrolling before that settles lands short of the anchor. Sampling
-      // the scroll height covers node insertions and pure reflows alike; scroll
-      // once it holds steady.
+      // The anchor renders late and keeps moving while messages lay out; a steady scroll height covers reflows too.
       let elapsed = 0
       let quietFor = 0
       let lastScrollHeight = -1

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-conversation-annotation-focus.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-conversation-annotation-focus.ts
@@ -44,8 +44,7 @@ export function useConversationAnnotationFocus({
     enabled: annotationsEnabled,
   })
   const { data: traceDetail, isLoading: isDetailLoading } = useTraceDetail({ projectId, traceId })
-  // Same query key the conversation itself uses, so this only mirrors its
-  // loading state instead of adding a fetch.
+  // Same query key the conversation uses, so this mirrors its loading state without adding a fetch.
   const { isLoading: isConversationLoading } = useTraceConversationMessages({
     projectId,
     traceId,
@@ -79,9 +78,7 @@ export function useConversationAnnotationFocus({
     }
     if (focusHandledRef.current === focusScoreId) return
     if (!isConversationActive || isDetailLoading || !traceDetail) return
-    // The conversation renders a skeleton until its first chunk of messages
-    // lands, so the scroll container the navigation pass needs doesn't exist
-    // yet. Marking the request handled before then would swallow it for good.
+    // No scroll container exists until the first chunk lands, and marking it handled here would swallow the request.
     if (isConversationLoading || !scrollContainerRef.current) return
     const annotation = annotationsData?.items?.find((item) => item.id === focusScoreId)
     if (!annotation) return

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -89,7 +89,7 @@ export function SessionDetailDrawer({
   const [, setSelectedSpanId] = useParamState("spanId", "")
   const [, setSelectedSpanTraceId] = useParamState("spanTraceId", "")
   const [q] = useParamState("q", "")
-  // Land on Conversation when a search match or a focused score needs that tab to scroll to something.
+  // Land on Conversation when a search match, moment label, or score needs that tab to scroll to something.
   const defaultSessionTab =
     defaultTab ??
     (focusSpan

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -89,9 +89,7 @@ export function SessionDetailDrawer({
   const [, setSelectedSpanId] = useParamState("spanId", "")
   const [, setSelectedSpanTraceId] = useParamState("spanTraceId", "")
   const [q] = useParamState("q", "")
-  // Land on the conversation tab when arriving from an active search (so the
-  // conversation tab's search-match autoscroll/highlight has something to scroll
-  // to) or with a focused score, whose anchor only that tab can show.
+  // Land on Conversation when a search match or a focused score needs that tab to scroll to something.
   const defaultSessionTab =
     defaultTab ??
     (focusSpan
@@ -189,8 +187,7 @@ export function SessionDetailDrawer({
     setActiveTab("conversation")
   }
 
-  // A focused score only makes sense while the Conversation tab is showing it,
-  // so any other tab drops the `scoreId` param rather than stranding it there.
+  // A focused score only means anything on the Conversation tab, so any other tab drops the param.
   const selectTab = (tab: SessionTabId) => {
     if (tab !== "conversation") setFocusScoreId("")
     setActiveTab(tab)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-focus-signal-score.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-focus-signal-score.ts
@@ -48,11 +48,9 @@ export function useFocusSignalScore({
   readonly canFocus: boolean
   readonly onFocus: (score: ScoreRecord) => void
 }): void {
-  // Callers resolve a signal slug to an id and pass "" until it lands, so an empty
-  // id means "no signal yet" rather than "every signal".
+  // An empty id is a slug still resolving, not a request for every signal's scores.
   const activeSignalId = signalId !== undefined && signalId.length > 0 ? signalId : undefined
-  // Scoped to the signal: a session can hold more scores than one page returns,
-  // and the anchored one is often not among the newest.
+  // Scoped to the signal: the newest page of a busy session can omit the anchored score.
   const { data } = useScoresBySession({
     projectId,
     traceIds,
@@ -63,8 +61,7 @@ export function useFocusSignalScore({
   onFocusRef.current = onFocus
   const focusedSignalIdRef = useRef<string | null>(null)
 
-  // TODO(frontend-use-effect-policy): the session's scores arrive asynchronously,
-  // long after the drawer mounted, and there is no event at the arrival site.
+  // TODO(frontend-use-effect-policy): the scores land asynchronously, with no event at the arrival site.
   useEffect(() => {
     if (!activeSignalId || focusedSignalIdRef.current === activeSignalId || !data) return
     focusedSignalIdRef.current = activeSignalId

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -149,9 +149,7 @@ function TraceDetailDrawerWithUrlTabs(props: Omit<TraceDetailDrawerProps, "urlSy
   const [focusScoreId, setFocusScoreId] = useParamState("scoreId", "")
   // Shared with the session panel via the `detailTab` URL param so Conversation
   // / Annotations carry over when switching between trace and session views.
-  // Default to Conversation when arriving from an active search (so the
-  // search-match autoscroll/highlight lands on a hit instead of the trace tab)
-  // or with a focused score, whose anchor only the Conversation tab can show.
+  // Default to Conversation when a search match or a focused score needs that tab to scroll to something.
   const defaultTab = (props.searchQuery?.length ?? 0) > 0 || focusScoreId ? "conversation" : "trace"
   const [rawActiveTab, setActiveTab] = useParamState("detailTab", defaultTab, {
     validate: isTraceDetailTab,
@@ -295,8 +293,7 @@ export function TraceDetailBody({
   // Stable so the palette contributor's command memo doesn't re-register each render.
   const handleSetActiveTab = useCallback(
     (tab: TabId) => {
-      // The focused score is only meaningful on the Conversation tab, so leaving
-      // it drops the `scoreId` param instead of stranding it in the URL.
+      // The focused score only means anything on the Conversation tab, so leaving it drops the param.
       if (tab !== "conversation") onFocusScoreIdChange("")
       onActiveTabChange(tab)
       setVisitedTabs((prev) => new Set([...prev, tab]))
@@ -348,8 +345,7 @@ export function TraceDetailBody({
     setVisitedTabs((prev) => new Set([...prev, activeTab]))
   }, [activeTab])
 
-  // `ScoreList` only makes anchored annotations clickable; focusing one is a URL
-  // write so the conversation position is shareable.
+  // `ScoreList` only makes anchored annotations clickable; the URL write is what makes the position shareable.
   function handleScoreClick(score: ScoreRecord) {
     onFocusScoreIdChange(score.id)
     handleSetActiveTab("conversation")

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
@@ -271,6 +271,7 @@ export function SignalDetailBody({
     setSessionSheetSessionId(sessionId)
   }
 
+  // Drops the flag here and clears the id in `onClosed`, so the exit animation runs before the sync effect sees it.
   const closeSessionSheet = () => {
     setSessionSheetOpen(false)
     onOverlayActiveChange?.(false)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
@@ -182,15 +182,12 @@ export function SignalDetailBody({
     enabled: issue !== null,
   })
   const totalSessionCount = useSignalSessionsCount({ projectId, signalId, enabled: issue !== null })
-  // Only the full-page view owns the URL: the drawer variant renders inside the
-  // session panel's issue slot, whose own params live one level up.
+  // Only the full-page view owns the URL; the drawer variant's params live one level up.
   const urlSyncedSessionSheet = variant === "page"
   const [sessionSheetSessionId, setSessionSheetSessionId] = useSignalSessionSheetId(urlSyncedSessionSheet)
   const [sessionSheetOpen, setSessionSheetOpen] = useState(() => sessionSheetSessionId.length > 0)
   const resetPanelParams = useSessionPanelParamReset()
-  // Nested in the session panel's issue slot those params belong to the panel
-  // above — clearing `signalId` there would close the very slot we render in —
-  // so only the URL-owning page resets them.
+  // Nested, clearing `signalId` would close the very slot we render in, so only the URL-owning page resets.
   const resetSessionPanelParams = () => {
     if (urlSyncedSessionSheet) resetPanelParams()
   }
@@ -204,10 +201,7 @@ export function SignalDetailBody({
     setSelectionState(EMPTY_SELECTION)
   }, [signalId])
 
-  // TODO(frontend-use-effect-policy): `useParamState` also tracks history
-  // navigation, so the sheet follows the session id rather than only seeding from
-  // it — otherwise Back leaves an empty sheet open. Our own close sets the open
-  // flag first and clears the id in `onClosed`, so the exit animation still runs.
+  // TODO(frontend-use-effect-policy): follows the param so history navigation can't leave an empty sheet open.
   useEffect(() => {
     const open = sessionSheetSessionId.length > 0
     setSessionSheetOpen(open)
@@ -215,9 +209,7 @@ export function SignalDetailBody({
   }, [sessionSheetSessionId, onOverlayActiveChange])
 
   const scrolledToDeepLinkRef = useRef(false)
-  // TODO(frontend-use-effect-policy): a shared link lands at the top of the page;
-  // the Sessions section can only be scrolled to once its rows have rendered,
-  // which happens when the sessions query resolves.
+  // TODO(frontend-use-effect-policy): the section can only be scrolled to once the sessions query resolves.
   useEffect(() => {
     if (deepLinkedSessionId.length === 0 || scrolledToDeepLinkRef.current || sessionsLoading) return
     scrolledToDeepLinkRef.current = true

--- a/packages/domain/shared/src/seed-content/anchored-annotations.ts
+++ b/packages/domain/shared/src/seed-content/anchored-annotations.ts
@@ -108,8 +108,7 @@ function anchoredAnnotation(signalIndex: number, maxTrajectories: number): SeedA
   const turn = turns[turns.length - 1]
   if (!turn) return null
 
-  // Odd signals pinpoint a substring so the text-selection highlight is covered
-  // too; even ones anchor the whole turn.
+  // Odd signals pinpoint a substring so the text-selection highlight is covered too.
   const offsets = signalIndex % 2 === 1 ? openingClaimOffsets(turn.text) : null
   const rawFeedback = offsets
     ? "This exact claim is not backed by the tool results."
@@ -134,8 +133,7 @@ function conversationLevelAnnotation(signalIndex: number, maxTrajectories: numbe
   const trajectoryIndex = tau2TrajectoryIndexForSignalOccurrence({ signalIndex, occurrenceIndex: 1, maxTrajectories })
   const trajectory = TAU2_SEED_TRAJECTORIES[trajectoryIndex]
   if (!signal || !trajectory) return null
-  // Same trajectory as the anchored occurrence would put both annotations on one
-  // session, hiding the difference between them.
+  // One session carrying both annotations would hide the difference between them.
   if (
     trajectoryIndex === tau2TrajectoryIndexForSignalOccurrence({ signalIndex, occurrenceIndex: 0, maxTrajectories })
   ) {

--- a/packages/domain/shared/src/seed-content/tau2-trajectories.ts
+++ b/packages/domain/shared/src/seed-content/tau2-trajectories.ts
@@ -163,8 +163,7 @@ function failedTrajectoryIndexesByFamily(maxTrajectories: number): ReadonlyMap<s
   if (cached) return cached
 
   const considered = TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories)
-  // Same exclusion `classifyTau2SeedTrajectory` applies, so the fallback can't
-  // hand a family a trajectory the classifier would have rejected.
+  // Same exclusion `classifyTau2SeedTrajectory` applies, so the fallback can't contradict it.
   const allFailed = considered.flatMap((trajectory, index) =>
     trajectory.outcome === "failure" && trajectory.reward < 1 ? [index] : [],
   )

--- a/packages/platform/db-clickhouse/src/seeds/scores/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/scores/index.ts
@@ -224,9 +224,7 @@ const seedScores: Seeder = {
     }),
 }
 
-// Separate seeder (and sentinel) from `seedScores`: `scores` has no row-level
-// dedup, so a database seeded before the annotations existed must be able to
-// pick them up without re-inserting every tau2 occurrence row.
+// Own sentinel: `scores` has no row-level dedup, so picking these up must not re-insert the tau2 rows.
 const seedAnchoredAnnotations: Seeder = {
   name: "scores/tau2-flagger-annotations",
   run: (ctx) =>

--- a/packages/platform/db-postgres/src/seeds/scores/index.test.ts
+++ b/packages/platform/db-postgres/src/seeds/scores/index.test.ts
@@ -13,8 +13,7 @@ const scope = createSeedScope({
 describe("buildAnchoredAnnotationScoreRows", () => {
   const rows = buildAnchoredAnnotationScoreRows(scope)
 
-  // The repository parses every row it reads back through `scoreSchema`, so a
-  // seeded annotation missing `rawFeedback` would only fail once the UI asks for it.
+  // The repository parses every row through `scoreSchema`, so a missing `rawFeedback` only fails in the UI.
   it("writes rows the score repository can read back", () => {
     for (const row of rows) {
       const parsed = scoreSchema.safeParse({ ...row, sessionId: row.sessionId ?? null })


### PR DESCRIPTION
Follow-up to #4478, which merged while I was applying this.

CodeRabbit flagged one file for breaking the repo's comment guideline (rare, and one line when they exist). The same slip was in eleven files across that PR, so this sweeps all of them rather than leaving the code inconsistent — 22 lines of comment where there were 56.

Comment text only: no statement changed, and `git show` of the commit has no non-comment `+`/`-` line.

One multi-line comment is deliberately left alone — the `traceTab` block in `session-detail-drawer.tsx` predates the branch, and #4478 only changed a word inside it.

## Verification

`pnpm --filter web typecheck` clean. The suites were green on the same content before the cherry-pick: web 933, `@domain/shared` 227, `@platform/db-postgres` 371, `knip` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified internal comments across annotation navigation, conversation focus, session and trace drawers, signal details, seed content, and score handling.
  * Improved explanations of asynchronous loading, URL synchronization, scrolling, focus behavior, and annotation seeding.

* **Tests**
  * Simplified test descriptions without changing test behavior or assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->