### PR TITLE
fix(web): classify rejected inputValidator requests as 400, not 500

### DIFF
--- a/apps/web/src/middlewares/server-fn-error.test.ts
+++ b/apps/web/src/middlewares/server-fn-error.test.ts
@@ -66,6 +66,32 @@ describe("recordServerFnError", () => {
     expect(info.status).toBe(500)
   })
 
+  it("does NOT report a rejected inputValidator (zod) request as 500", () => {
+    // What TanStack's `execValidator` throws when a Standard Schema
+    // `inputValidator` rejects the input: `new Error(JSON.stringify(issues))`.
+    const validationError = new Error(
+      JSON.stringify([{ code: "too_small", minimum: 1, path: ["organizationName"], message: "Please enter a name" }]),
+    )
+    const span = fakeSpan()
+    const info = recordServerFnError(span, validationError)
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(span.setStatus).not.toHaveBeenCalled()
+    expect(info.isClientError).toBe(true)
+    expect(info.status).toBe(400)
+    // The message must stay the raw issues array so `extractFieldErrors` on the client can still parse it.
+    expect(JSON.parse(JSON.parse(info.error.message).message)).toEqual(JSON.parse(validationError.message))
+  })
+
+  it("still reports a JSON-array error message that isn't a validator issues shape", () => {
+    const span = fakeSpan()
+    const info = recordServerFnError(span, new Error(JSON.stringify([{ unrelated: "shape" }])))
+
+    expect(span.recordException).toHaveBeenCalledTimes(1)
+    expect(info.isClientError).toBe(false)
+    expect(info.status).toBe(500)
+  })
+
   it("re-throwable error carries the serialized payload and original stack", () => {
     const original = new UnauthorizedError({ message: "No user in session" })
     const info = recordServerFnError(fakeSpan(), original)

--- a/apps/web/src/middlewares/server-fn-error.ts
+++ b/apps/web/src/middlewares/server-fn-error.ts
@@ -19,10 +19,38 @@ type ServerFnErrorInfo = {
 const errorTag = (e: unknown): string | undefined =>
   typeof e === "object" && e !== null && "_tag" in (e as DomainError) ? (e as DomainError)._tag : undefined
 
+interface StandardSchemaIssue {
+  readonly message: string
+  readonly path?: readonly unknown[]
+}
+
+const isStandardSchemaIssue = (issue: unknown): issue is StandardSchemaIssue =>
+  typeof issue === "object" &&
+  issue !== null &&
+  typeof (issue as StandardSchemaIssue).message === "string" &&
+  Array.isArray((issue as StandardSchemaIssue).path)
+
+/**
+ * TanStack's `execValidator` throws a plain `Error` whose message is the
+ * JSON-encoded Standard Schema issues array when an `inputValidator` (e.g.
+ * zod) rejects the request — rejected input, not a server fault, so it must
+ * be duck-typed from the message shape rather than an exception type.
+ */
+const isInputValidationError = (e: unknown): boolean => {
+  if (!(e instanceof Error)) return false
+  try {
+    const parsed = JSON.parse(e.message)
+    return Array.isArray(parsed) && parsed.length > 0 && parsed.every(isStandardSchemaIssue)
+  } catch {
+    return false
+  }
+}
+
 const errorStatus = (e: unknown): number => {
   if (isHttpError(e)) return e.httpStatus
   // Stale-tab server-fn hashes after a deploy — expected 404, not a 500.
   if (isMissingServerFnError(e)) return 404
+  if (isInputValidationError(e)) return 400
   return 500
 }
 
@@ -91,7 +119,7 @@ export const recordServerFnError = (span: Span, e: unknown): ServerFnErrorInfo =
   const httpError = isHttpError(e)
   const tag = errorTag(e)
   const message = httpError ? e.httpMessage : e instanceof Error ? e.message : "Unknown error occurred"
-  const status = httpError ? e.httpStatus : 500
+  const status = errorStatus(e)
   const isClientError = isExpectedClientError(status)
 
   if (!isClientError) {


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive noise source in Datadog Error Tracking: server functions that reject via `.inputValidator()` (zod) were being recorded as `500` server faults instead of expected `400` client errors.

**Datadog issue addressed:** [`786d9ad4-8069-11f1-ab43-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/786d9ad4-8069-11f1-ab43-da7ad0900005) — `web` service, error type `Error`, 74 occurrences over the last 7 days, first seen ~36 days ago (`issue.first_seen_version f5f2519`). Sampled from `completeOnboarding`'s `organizationName` validation failing with `"Please enter an organization name"`.

**Root cause:** `apps/web/src/middlewares/server-fn-error.ts` has a deliberate `isExpectedClientError` filter so 4xx-class errors (bad input, no access, not logged in) are excluded from Error Tracking, keeping the signal focused on real 5xx bugs. It classifies via `errorStatus()`, which only recognizes `HttpError`-shaped exceptions (objects with `httpStatus`/`httpMessage`).

TanStack Start's `execValidator` (`@tanstack/start-client-core`) does not throw an `HttpError` or even a `ZodError` when a Standard Schema `inputValidator` rejects input — it throws a **plain `Error`** whose message is `JSON.stringify(issues)`:

```js
if (result.issues) throw new Error(JSON.stringify(result.issues, void 0, 2));
```

`errorStatus()` doesn't recognize this shape, so it falls through to the `500` default, and every rejected `.inputValidator()` call across the app (315+ call sites) gets recorded into Datadog as a false server fault — exactly the noise the filter was built to prevent. The client already handles this gracefully via `extractFieldErrors`/`createFormSubmitHandler` (inline field errors, no raw error surfaced to the user), so this was purely an observability bug, not a user-facing one.

**Fix:** duck-type the Standard Schema issues array shape (`{ message: string, path: array }[]`) in `errorStatus()` and classify it as `400`, the same way `NotFoundError`/`UnauthorizedError` are already excluded. Also fixed `recordServerFnError` to call the shared `errorStatus()` helper instead of a narrower inline `httpError ? e.httpStatus : 500` check, so both call sites (`recordServerFnError` and `recordRequestError`) stay in sync.

No behavior change for users: the client-bound error message is untouched, so `extractFieldErrors` continues to parse field errors identically. This only changes what gets reported to Datadog (skipped) and the log level (`warn` instead of `error`).

## Root cause generalization

This bug isn't specific to `completeOnboarding` — `errorStatus()` is the single shared classification point for every server function using `.inputValidator()`, so the fix resolves the false-positive for all of them, not just the observed one.

## How was this tested?

- Added two unit tests to `server-fn-error.test.ts`:
  - A rejected-validator-shaped `Error` is classified `400`/`isClientError: true` and **not** recorded to the span, while the client-bound message still round-trips correctly for `extractFieldErrors`.
  - A JSON-array error message that doesn't match the Standard Schema issue shape is still correctly reported as `500` (no over-broad matching).
- Confirmed the new test fails without the fix and passes with it.
- `pnpm --filter web test` — full suite green (2 pre-existing, unrelated failures in `phone-countries.test.ts` due to ICU timezone data differences in this sandbox; untouched by this change).
- `pnpm --filter web typecheck` (tsgo) — clean.
- `pnpm exec biome check` on changed files — clean.

**Verification after deploy:** occurrences of issue `786d9ad4-8069-11f1-ab43-da7ad0900005` (and the equivalent pattern on any other `.inputValidator()`-guarded server function) should stop appearing in Error Tracking going forward, since new occurrences will be classified as `400` at ingestion.

## Related issue (if applicable)

N/A — found via scheduled Datadog Error Tracking triage, not a filed issue.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gq5vU7xMK8MMmrsTqXpnS8)_