### PR TITLE
fix: reject metadata.* filters on scores/behaviors/moments analytics streams

### DIFF
--- a/apps/api/src/routes/analytics.test.ts
+++ b/apps/api/src/routes/analytics.test.ts
@@ -64,6 +64,37 @@ describe("Analytics Routes Integration", () => {
           range: RANGE,
         },
       },
+      // Regression: scores/behaviors/moments back onto tables with no `metadata`
+      // column (session_moment_labels/session_semantic_moments/taxonomy_observations/
+      // scores) — a metadata.* filter previously reached ClickHouse unresolved and
+      // 500'd with "Unknown expression or function identifier `metadata`".
+      {
+        name: "metadata.* filter on the scores stream",
+        body: {
+          stream: "scores",
+          metric: { kind: "count" },
+          filters: { "metadata.agentVersion": [{ op: "eq", value: "2" }] },
+          range: RANGE,
+        },
+      },
+      {
+        name: "metadata.* filter on the behaviors stream",
+        body: {
+          stream: "behaviors",
+          metric: { kind: "count" },
+          filters: { "metadata.agentVersion": [{ op: "eq", value: "2" }] },
+          range: RANGE,
+        },
+      },
+      {
+        name: "metadata.* filter on the moments stream",
+        body: {
+          stream: "moments",
+          metric: { kind: "count" },
+          filters: { "metadata.agentVersion": [{ op: "eq", value: "2" }] },
+          range: RANGE,
+        },
+      },
       {
         name: "inverted range",
         body: { stream: "traces", metric: { kind: "count" }, range: { fromIso: RANGE.toIso, toIso: RANGE.fromIso } },
@@ -97,6 +128,25 @@ describe("Analytics Routes Integration", () => {
           stream: "traces",
           metric: { kind: "count" },
           filters: { duration: [{ op: "gtePercentile", value: 90 }] },
+          range: RANGE,
+        },
+        tenant.apiKeyToken,
+      )
+      expect(res.status).not.toBe(400)
+    })
+
+    it<ApiTestContext>("accepts a metadata.* filter on the traces stream (its table carries metadata)", async ({
+      app,
+      database,
+    }) => {
+      const tenant = await createTenantSetup(database)
+      const res = await post(
+        app,
+        "any-project",
+        {
+          stream: "traces",
+          metric: { kind: "count" },
+          filters: { "metadata.agentVersion": [{ op: "eq", value: "2" }] },
           range: RANGE,
         },
         tenant.apiKeyToken,

--- a/packages/domain/shared/src/analytics-query.test.ts
+++ b/packages/domain/shared/src/analytics-query.test.ts
@@ -219,6 +219,34 @@ describe("analyticsQuerySchema", () => {
     ).toBe(false)
   })
 
+  it("accepts a metadata.* filter on the streams whose backing table carries a metadata column", () => {
+    for (const stream of ["traces", "sessions", "spans"] as const) {
+      const result = analyticsQuerySchema.safeParse({
+        stream,
+        metric: { kind: "count" },
+        filters: { "metadata.agentVersion": [{ op: "eq", value: "2" }] },
+        range,
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it("rejects a metadata.* filter on scores/behaviors/moments (their backing tables carry no metadata column)", () => {
+    // Regression: previously this reached the ClickHouse filter builder unresolved,
+    // producing "Unknown expression or function identifier `metadata`" (a 500), since
+    // session_moment_labels/session_semantic_moments/taxonomy_observations/scores
+    // have no `metadata` column to index into.
+    for (const stream of ["scores", "behaviors", "moments"] as const) {
+      const result = analyticsQuerySchema.safeParse({
+        stream,
+        metric: { kind: "count" },
+        filters: { "metadata.agentVersion": [{ op: "eq", value: "2" }] },
+        range,
+      })
+      expect(result.success).toBe(false)
+    }
+  })
+
   it("caps the limit", () => {
     const result = analyticsQuerySchema.safeParse({
       stream: "traces",

--- a/packages/domain/shared/src/analytics-query.ts
+++ b/packages/domain/shared/src/analytics-query.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 import { type MonitorMetric, monitorMetricSchema } from "./alert-incident-condition.ts"
-import { filterSetSchema, spanRowFilterSetSchema } from "./filter.ts"
+import { filterSetSchema, noMetadataFilterSetSchema, spanRowFilterSetSchema } from "./filter.ts"
 
 /**
  * Breakdown dimensions per stream — logical names the API accepts, mapped to
@@ -204,6 +204,11 @@ export const analyticsQuerySchema = z.discriminatedUnion("stream", [
         "The metric: `count`, `passRate`, `errorRate` (over the pass/error flags), or `{avg|min|max|median}` of the 0–1 score `value`.",
       ),
       ...commonFields,
+      filters: noMetadataFilterSetSchema
+        .optional()
+        .describe(
+          "Structured filter set applied to the stream (same DSL as `listTraces`). `metadata.*` filters are not supported on this stream.",
+        ),
     })
     .strict(),
   z
@@ -219,6 +224,11 @@ export const analyticsQuerySchema = z.discriminatedUnion("stream", [
         "The metric: `count`, or `{avg|min|max|median}` of the 0–1 assignment `confidence`.",
       ),
       ...commonFields,
+      filters: noMetadataFilterSetSchema
+        .optional()
+        .describe(
+          "Structured filter set applied to the stream (same DSL as `listTraces`). `metadata.*` filters are not supported on this stream.",
+        ),
     })
     .strict(),
   z
@@ -234,6 +244,11 @@ export const analyticsQuerySchema = z.discriminatedUnion("stream", [
         "The metric: `count`, or `{avg|min|max|median}` of the 0–1 label `confidence` or moment `coherence`.",
       ),
       ...commonFields,
+      filters: noMetadataFilterSetSchema
+        .optional()
+        .describe(
+          "Structured filter set applied to the stream (same DSL as `listTraces`). `metadata.*` filters are not supported on this stream.",
+        ),
     })
     .strict(),
 ])

--- a/packages/domain/shared/src/filter.test.ts
+++ b/packages/domain/shared/src/filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { filterSetSchema, spanRowFilterSetSchema, traceFilterSetSchema } from "./filter.ts"
+import { filterSetSchema, noMetadataFilterSetSchema, spanRowFilterSetSchema, traceFilterSetSchema } from "./filter.ts"
 
 describe("filterSetSchema", () => {
   it("parses a valid filter set", () => {
@@ -164,5 +164,32 @@ describe("traceFilterSetSchema", () => {
   it("accepts absolute thresholds on non-percentile-eligible fields", () => {
     const result = traceFilterSetSchema.safeParse({ tokensInput: [{ op: "gte", value: 100 }] })
     expect(result.success).toBe(true)
+  })
+})
+
+describe("noMetadataFilterSetSchema", () => {
+  it("rejects a metadata.* filter key", () => {
+    const result = noMetadataFilterSetSchema.safeParse({ "metadata.agentVersion": [{ op: "eq", value: "2" }] })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain("metadata.* filters are not supported")
+    }
+  })
+
+  it("rejects a nested metadata.* filter key", () => {
+    const result = noMetadataFilterSetSchema.safeParse({ "metadata.runtime.env": [{ op: "eq", value: "prod" }] })
+    expect(result.success).toBe(false)
+  })
+
+  it("accepts non-metadata filter fields", () => {
+    const result = noMetadataFilterSetSchema.safeParse({
+      kind: [{ op: "eq", value: "escalation" }],
+      confidence: [{ op: "gte", value: 0.5 }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts an empty filter set", () => {
+    expect(noMetadataFilterSetSchema.safeParse({}).success).toBe(true)
   })
 })

--- a/packages/domain/shared/src/filter.ts
+++ b/packages/domain/shared/src/filter.ts
@@ -171,3 +171,23 @@ export const traceFilterSetSchema: z.ZodType<FilterSet> = filterSetSchema.superR
     })
   }
 })
+
+export const NO_METADATA_FILTER_MESSAGE =
+  'metadata.* filters are not supported on this stream — its backing table carries no metadata column. Use stream "traces", "sessions", or "spans" for metadata filters.'
+
+/**
+ * Rejects `metadata.*` filter keys at the boundary. For streams whose backing table
+ * carries no `metadata` column (the analytics `scores`/`behaviors`/`moments` streams),
+ * a `metadata.*` filter would otherwise reach the ClickHouse filter builder unresolved
+ * and fail with an "Unknown expression or function identifier `metadata`" 500.
+ */
+export const noMetadataFilterSetSchema: z.ZodType<FilterSet> = filterSetSchema.superRefine((filters, ctx) => {
+  for (const field of Object.keys(filters)) {
+    if (!field.startsWith("metadata.")) continue
+    ctx.addIssue({
+      code: "custom",
+      message: NO_METADATA_FILTER_MESSAGE,
+      path: [field],
+    })
+  }
+})


### PR DESCRIPTION
## What does this PR do?

Fixes a production 500 in the analytics query endpoint (`POST /v1/projects/:projectSlug/analytics/query`).

**Datadog issue:** [`RepositoryError: Unknown expression or function identifier \`metadata\``](https://app.datadoghq.eu/error-tracking/issue/06b7eeec-9d76-11f1-8227-da7ad0900005) (`06b7eeec-9d76-11f1-8227-da7ad0900005`), 1 occurrence, first seen 2026-08-21 — a new, previously-untriaged issue found via the scheduled Datadog error-tracking sweep.

**Root cause:** The shared `filterSetSchema` (`packages/domain/shared/src/filter.ts`) accepts `metadata.*` filter keys unconditionally, and `buildClickHouseWhere` (`packages/platform/db-clickhouse/src/filter-builder.ts:96-115`) always compiles them to a bare `metadata[key]` SQL expression, regardless of the stream. That's correct for the `traces`/`sessions`/`spans` analytics streams, whose backing ClickHouse tables all carry a real `metadata` column — but the `scores`, `behaviors`, and `moments` streams query tables (`scores`, `session_moment_labels`/`session_semantic_moments`, `taxonomy_observations`) that have **no `metadata` column at all**. Any `metadata.*` filter on those three streams sends ClickHouse an unresolved identifier and 500s.

This generalizes the one observed occurrence (a `moments`-stream query filtering on `metadata['agentVersion']`) to all three affected streams, since none of their tables carry a `metadata` column.

**Fix:** Added `noMetadataFilterSetSchema` in `filter.ts`, following the exact pattern the codebase already uses for the analogous `gtePercentile` boundary restriction (`traceFilterSetSchema`/`spanRowFilterSetSchema`) — reject the unsupported shape at the Zod validation boundary with a clear message, rather than let it reach the query builder. Applied it to the `scores`/`behaviors`/`moments` variants of `analyticsQuerySchema` (`packages/domain/shared/src/analytics-query.ts`), which is what `apps/api`'s `queryAnalytics` handler re-validates `input.body` against before building the query. The OpenAPI/SDK-facing schema (`packages/operations/src/openapi/entities/analytics.ts`) is intentionally left permissive, mirroring the existing `gtePercentile` precedent — the domain schema is the actual enforcement point.

`traces`/`sessions`/`spans` are unaffected and continue to accept `metadata.*` filters.

## Related issue (if applicable)

N/A — found via scheduled Datadog error-tracking triage, not a filed issue.

## How was this tested?

- Added unit tests in `packages/domain/shared/src/filter.test.ts` and `analytics-query.test.ts` covering: `metadata.*` rejected on `scores`/`behaviors`/`moments`, still accepted on `traces`/`sessions`/`spans`, nested metadata paths, and non-metadata fields passing through unaffected.
- Added HTTP-level regression cases to `apps/api/src/routes/analytics.test.ts`'s existing `validation (400)` table for all three affected streams, plus a positive case confirming `traces` still accepts `metadata.*`.
- Verified fail-without-fix / pass-with-fix by `git stash`-ing the source changes (keeping the new tests) and confirming the new tests fail with the pre-fix code, then pass after restoring the fix.
- `pnpm --filter @domain/shared test` (233/233 passing), `pnpm --filter @domain/shared typecheck` (tsgo, clean), `pnpm --filter @app/api typecheck` (tsgo, clean), `pnpm exec biome check` on all changed files (clean).
- Could not run the `apps/api` HTTP integration suite end-to-end in this sandbox — it's blocked by a pre-existing, unrelated environment issue (missing prebuilt native binary for the `chdb` test-ClickHouse dependency, affecting every route test file, not just this change).

**Verification after deploy:** occurrences of Datadog issue `06b7eeec-9d76-11f1-8227-da7ad0900005` should stay at zero; a `metadata.*` filter against `stream: "scores"`/`"behaviors"`/`"moments"` should now return a `400` instead of a `500`.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_012V4sVj7Kz6hSd5rwyfVi9P)_