### PR TITLE
chore(deps): bump rosetta-ai to 2.3.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ catalogs:
       specifier: 19.2.5
       version: 19.2.5
     rosetta-ai:
-      specifier: 2.2.0
-      version: 2.2.0
+      specifier: 2.3.0
+      version: 2.3.0
     tsdown:
       specifier: 0.21.9
       version: 0.21.9
@@ -664,7 +664,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       rosetta-ai:
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.3.0
       satori:
         specifier: 0.26.0
         version: 0.26.0
@@ -1140,7 +1140,7 @@ importers:
         version: 4.0.0-beta.57
       rosetta-ai:
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.3.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1173,7 +1173,7 @@ importers:
         version: 4.0.0-beta.57
       rosetta-ai:
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.3.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1488,7 +1488,7 @@ importers:
         version: 4.0.0-beta.57
       rosetta-ai:
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.3.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -2051,7 +2051,7 @@ importers:
         version: 8.6.0
       rosetta-ai:
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.3.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -2576,7 +2576,7 @@ importers:
         version: 4.0.0-beta.57
       rosetta-ai:
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.3.0
     devDependencies:
       '@platform/testkit':
         specifier: workspace:*
@@ -3527,7 +3527,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       rosetta-ai:
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.3.0
       tailwindcss:
         specifier: 4.2.4
         version: 4.2.4
@@ -12974,8 +12974,8 @@ packages:
       rollup:
         optional: true
 
-  rosetta-ai@2.2.0:
-    resolution: {integrity: sha512-tJzXJWc5KBmTdYs6D9nAZfmqutWNUK61nrkVY+x//j+HUobL34juK88SYiYiLZhwuo2tYyQsdoQtgqJz+uBIgQ==}
+  rosetta-ai@2.3.0:
+    resolution: {integrity: sha512-xaR2TC0nS2f+WUKrD1EMlp2lhLJ5lVkdvAHEuZH2SSgnxlaJZ0oZtq7Q7TM97Ah3bNq1XoPHJ10bnwTTJkDFVw==}
     engines: {node: '>=20.0.0'}
 
   rou3@0.7.12:
@@ -25661,7 +25661,7 @@ snapshots:
     optionalDependencies:
       rolldown: 1.0.3
 
-  rosetta-ai@2.2.0:
+  rosetta-ai@2.3.0:
     dependencies:
       zod: 4.4.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ publicHoistPattern:
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - "@temporalio/*"
+  - "rosetta-ai"
 
 # Disable npm `pre*` / `post*` lifecycle scripts (defense in depth on top of
 # pnpm-workspace.yaml `onlyBuiltDependencies` allowlist). Mini Shai-Hulud
@@ -74,7 +75,7 @@ catalog:
   quickjs-emscripten: 0.32.0
   react: 19.2.5
   react-dom: 19.2.5
-  rosetta-ai: 2.2.0
+  rosetta-ai: 2.3.0
   protobufjs: 8.6.6
   tsdown: 0.21.9
   tsx: 4.21.0


### PR DESCRIPTION
Bumps the `rosetta-ai` catalog entry from 2.2.0 to 2.3.0. All seven consumers (`apps/web`, `packages/ui`, `@platform/db-clickhouse`, `@domain/spans`, `@domain/annotations`, `@domain/ai`, `@domain/flaggers`) resolve it through `catalog:`, so the bump is one line plus the lockfile.

## what 2.3.0 adds

The release is additive — no exports were removed, no dependency or engine changes (still `zod@4` and Node >=20):

- `GenAIServerToolCallRequestPart` / `GenAIServerToolCallResponsePart` / `GenAIServerToolDetails` — provider-executed tool calls (`web_search`, `code_interpreter`, and friends), where only the `type` discriminator is known and the rest of the payload is passed through as-is
- `GenAICompactionPart`, plus `compaction` as a finish reason
- `document` as a content type

The new parts join the `GenAIPartSchema` union, which is the part worth a second look: our OTLP content mappers in `packages/domain/spans/src/otlp/content/` and the message normalizers switch on `part.type`, so these arrive as unhandled members and fall through to the existing generic-part handling rather than being mapped to anything specific. That's the same behavior as before the bump — nothing regresses — but wiring server tool calls and compaction parts into the span mappers and the conversation UI is follow-up work, not part of this PR.

## release-age exclusion

`minimumReleaseAge` is 7 days, and 2.3.0 published the same day, so `pnpm install` refused it with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`. This adds `rosetta-ai` to `minimumReleaseAgeExclude` alongside `@temporalio/*`.

The guard exists to let the registry yank malicious releases before they reach our lockfile. `rosetta-ai` is a first-party package published from our own npm account, so the supply-chain risk the delay buys down doesn't apply the way it does for third-party deps — we control the publish. Worth flagging explicitly since it does permanently opt one package out of the delay; a one-off `--config.minimumReleaseAge=0` was the alternative, but it would leave every other clean install hitting the same wall.

## validation

`typecheck` clean on all seven consumers. Tests pass on every package that touches rosetta-ai: `@domain/spans` (2164), `@platform/import-sources` (274), `@domain/flaggers` (354), `@domain/annotations` (77), `@domain/ai` (23).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `rosetta-ai` package to version 2.3.0.
  * Adjusted package release-age handling for the updated package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->