### PR TITLE
fix(oss): harden deployment telemetry and fix self-host enablement

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -12,8 +12,6 @@ x-app: &app
   env_file:
     - .env.production
   environment:
-    # env_file can leave NODE_ENV=development after `cp .env.example .env.production`.
-    NODE_ENV: production
     LAT_IMAGE_TAG: ${LAT_IMAGE_TAG:-latest}
   logging: *logging
   depends_on:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -11,6 +11,10 @@ x-app: &app
   restart: unless-stopped
   env_file:
     - .env.production
+  environment:
+    # env_file can leave NODE_ENV=development after `cp .env.example .env.production`.
+    NODE_ENV: production
+    LAT_IMAGE_TAG: ${LAT_IMAGE_TAG:-latest}
   logging: *logging
   depends_on:
     migrations:

--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -135,7 +135,7 @@ These wire Latitude to its datastores, depending on your chosen [deployment opti
 | `LAT_WEB_PORT`, `LAT_API_PORT`, `LAT_INGEST_PORT` | Host bind ports (default `3000` / `3001` / `3002`). |
 | `LAT_WORKERS_HEALTH_PORT`, `LAT_WORKFLOWS_HEALTH_PORT` | Health-check ports for the background workers (default `9090` / `9091`). |
 | `LAT_IMAGE_TAG` | Image tag the stack pulls (default `latest`; pin `X.Y.Z` in production). |
-| `LAT_OSS_TELEMETRY_ENABLED` | Anonymous OSS deployment heartbeat sent to Latitude's PostHog project (default `true` in production, `false` in development). Set `false` to opt out. |
+| `LAT_OSS_TELEMETRY_ENABLED` | Anonymous OSS deployment heartbeat sent to Latitude's PostHog project when the API starts (default `true` in production, `false` in development). Set `false` to opt out. Optional overrides: `LAT_OSS_TELEMETRY_POSTHOG_API_KEY`, `LAT_OSS_TELEMETRY_POSTHOG_HOST`. |
 | `LAT_EXPORT_RATE_LIMIT_*`, `LAT_INGEST_TRACE_RATE_LIMIT_*` | Rate-limit tuning for exports and per-organization/API-key trace ingestion. |
 | `LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES` | Maximum trace request body size in bytes (default `33554432`, or 32 MiB). Larger declared or streamed payloads receive `413`. |
 | `LAT_INGEST_TRACE_MAX_IN_FLIGHT_BYTES` | Per-process budget for trace payloads being read or processed (default `67108864`, or 64 MiB). This must be at least twice `LAT_INGEST_TRACE_MAX_PAYLOAD_BYTES` to cover chunked-body assembly. |

--- a/packages/platform/analytics-posthog/src/oss-telemetry/constants.ts
+++ b/packages/platform/analytics-posthog/src/oss-telemetry/constants.ts
@@ -4,7 +4,7 @@ export const OSS_TELEMETRY_POSTHOG_HOST = "https://eu.i.posthog.com"
 
 // Write-only PostHog project API key for anonymous OSS deployment telemetry.
 // Override with LAT_OSS_TELEMETRY_POSTHOG_API_KEY for forks or staging variants.
-export const BUNDLED_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_oss_telemetry_placeholder"
+export const BUNDLED_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_BWYPiCdzp7A2mGD3PsrXamcxmemNNctkLYMNDHmmYJJb"
 
 export const OSS_TELEMETRY_HEARTBEAT_TTL_SECONDS = 24 * 60 * 60
 

--- a/packages/platform/analytics-posthog/src/oss-telemetry/report.test.ts
+++ b/packages/platform/analytics-posthog/src/oss-telemetry/report.test.ts
@@ -3,7 +3,12 @@ import { Effect } from "effect"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { PostHogClientShape } from "../client.ts"
 import { isOssTelemetryEnabled, loadOssTelemetryConfig } from "./config.ts"
-import { OSS_TELEMETRY_EVENT, ossTelemetryHeartbeatKey } from "./constants.ts"
+import {
+  BUNDLED_OSS_TELEMETRY_POSTHOG_API_KEY,
+  OSS_TELEMETRY_EVENT,
+  OSS_TELEMETRY_POSTHOG_HOST,
+  ossTelemetryHeartbeatKey,
+} from "./constants.ts"
 import { deriveDeploymentId } from "./deployment-id.ts"
 import { reportOssDeploymentHeartbeat } from "./report.ts"
 
@@ -67,12 +72,15 @@ describe("loadOssTelemetryConfig", () => {
     expect(Effect.runSync(loadOssTelemetryConfig)).toBeUndefined()
   })
 
-  it("returns undefined in production while the bundled PostHog key is still the placeholder", () => {
+  it("uses the bundled PostHog key in production", () => {
     process.env.NODE_ENV = "production"
-    expect(Effect.runSync(loadOssTelemetryConfig)).toBeUndefined()
+    expect(Effect.runSync(loadOssTelemetryConfig)).toEqual({
+      apiKey: BUNDLED_OSS_TELEMETRY_POSTHOG_API_KEY,
+      host: OSS_TELEMETRY_POSTHOG_HOST,
+    })
   })
 
-  it("returns config when enabled and a PostHog key is configured", () => {
+  it("lets LAT_OSS_TELEMETRY_POSTHOG_API_KEY override the bundled key", () => {
     process.env.NODE_ENV = "production"
     process.env.LAT_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_test_key"
     process.env.LAT_OSS_TELEMETRY_POSTHOG_HOST = "https://eu.i.posthog.com"

--- a/packages/platform/analytics-posthog/src/oss-telemetry/report.test.ts
+++ b/packages/platform/analytics-posthog/src/oss-telemetry/report.test.ts
@@ -1,8 +1,11 @@
+import { createHash } from "node:crypto"
 import { Effect } from "effect"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { PostHogClientShape } from "../client.ts"
 import { isOssTelemetryEnabled, loadOssTelemetryConfig } from "./config.ts"
-import { ossTelemetryHeartbeatKey } from "./constants.ts"
+import { OSS_TELEMETRY_EVENT, ossTelemetryHeartbeatKey } from "./constants.ts"
 import { deriveDeploymentId } from "./deployment-id.ts"
+import { reportOssDeploymentHeartbeat } from "./report.ts"
 
 describe("deriveDeploymentId", () => {
   afterEach(() => {
@@ -64,7 +67,7 @@ describe("loadOssTelemetryConfig", () => {
     expect(Effect.runSync(loadOssTelemetryConfig)).toBeUndefined()
   })
 
-  it("returns undefined in production until a bundled or env PostHog key is configured", () => {
+  it("returns undefined in production while the bundled PostHog key is still the placeholder", () => {
     process.env.NODE_ENV = "production"
     expect(Effect.runSync(loadOssTelemetryConfig)).toBeUndefined()
   })
@@ -82,7 +85,166 @@ describe("loadOssTelemetryConfig", () => {
 })
 
 describe("ossTelemetryHeartbeatKey", () => {
-  it("namespaces heartbeat keys under latitude:", () => {
+  it("builds a heartbeat key that the Redis client prefixes with latitude:", () => {
     expect(ossTelemetryHeartbeatKey("abc123")).toBe("oss-telemetry:heartbeat:abc123")
+  })
+})
+
+describe("reportOssDeploymentHeartbeat", () => {
+  const authSecret = "oss-telemetry-test-secret"
+  const deploymentId = createHash("sha256").update(authSecret).digest("hex").slice(0, 32)
+
+  const createFakePosthog = () => {
+    const captures: Array<{
+      distinctId: string
+      event: string
+      properties?: Record<string, unknown>
+    }> = []
+    const client: PostHogClientShape = {
+      capture: async (input) => {
+        captures.push(input)
+      },
+      groupIdentify: async () => undefined,
+      personIdentify: async () => undefined,
+      shutdown: vi.fn(async () => undefined),
+    }
+    return { client, captures }
+  }
+
+  const createFakeRedis = () => {
+    const keys = new Set<string>()
+    return {
+      keys,
+      redis: {
+        async set(key: string, _value: string, _mode: "EX", _ttl: number, _nx: "NX") {
+          if (keys.has(key)) return null
+          keys.add(key)
+          return "OK"
+        },
+      },
+    }
+  }
+
+  afterEach(() => {
+    delete process.env.LAT_OSS_TELEMETRY_ENABLED
+    delete process.env.LAT_OSS_TELEMETRY_POSTHOG_API_KEY
+    delete process.env.LAT_OSS_TELEMETRY_POSTHOG_HOST
+    delete process.env.LAT_BETTER_AUTH_SECRET
+    delete process.env.LAT_WEB_URL
+    delete process.env.LAT_IMAGE_TAG
+    delete process.env.DD_VERSION
+    delete process.env.DD_GIT_COMMIT_SHA
+    delete process.env.NODE_ENV
+  })
+
+  it("no-ops when telemetry is disabled", async () => {
+    process.env.NODE_ENV = "development"
+    const { client, captures } = createFakePosthog()
+
+    await reportOssDeploymentHeartbeat({ serviceName: "api", posthog: client })
+
+    expect(captures).toHaveLength(0)
+    expect(client.shutdown).not.toHaveBeenCalled()
+  })
+
+  it("no-ops when the auth secret is missing", async () => {
+    process.env.NODE_ENV = "production"
+    process.env.LAT_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_test_key"
+    const { client, captures } = createFakePosthog()
+
+    await reportOssDeploymentHeartbeat({ serviceName: "api", posthog: client })
+
+    expect(captures).toHaveLength(0)
+  })
+
+  it("captures a heartbeat with coarse deployment metadata", async () => {
+    process.env.NODE_ENV = "production"
+    process.env.LAT_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_test_key"
+    process.env.LAT_BETTER_AUTH_SECRET = authSecret
+    process.env.LAT_WEB_URL = "https://latitude.example.com"
+    process.env.LAT_IMAGE_TAG = "1.2.3"
+    const { client, captures } = createFakePosthog()
+
+    await reportOssDeploymentHeartbeat({ serviceName: "api", posthog: client })
+
+    expect(captures).toEqual([
+      {
+        distinctId: `deployment_${deploymentId}`,
+        event: OSS_TELEMETRY_EVENT,
+        properties: {
+          $process_person_profile: false,
+          deploymentId,
+          service: "api",
+          nodeVersion: process.version,
+          version: "1.2.3",
+          webHost: "latitude.example.com",
+        },
+      },
+    ])
+    expect(client.shutdown).toHaveBeenCalledOnce()
+  })
+
+  it("dedupes via Redis SET NX so restarts within the TTL do not re-send", async () => {
+    process.env.NODE_ENV = "production"
+    process.env.LAT_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_test_key"
+    process.env.LAT_BETTER_AUTH_SECRET = authSecret
+    const { client, captures } = createFakePosthog()
+    const { redis } = createFakeRedis()
+
+    await reportOssDeploymentHeartbeat({ serviceName: "api", redis, posthog: client })
+    await reportOssDeploymentHeartbeat({ serviceName: "api", redis, posthog: client })
+
+    expect(captures).toHaveLength(1)
+    expect(client.shutdown).toHaveBeenCalledOnce()
+  })
+
+  it("swallows Redis failures so startup is never blocked", async () => {
+    process.env.NODE_ENV = "production"
+    process.env.LAT_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_test_key"
+    process.env.LAT_BETTER_AUTH_SECRET = authSecret
+    const { client, captures } = createFakePosthog()
+
+    await expect(
+      reportOssDeploymentHeartbeat({
+        serviceName: "api",
+        redis: {
+          set: async () => {
+            throw new Error("redis unavailable")
+          },
+        },
+        posthog: client,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(captures).toHaveLength(0)
+  })
+
+  it("swallows PostHog capture failures so startup is never blocked", async () => {
+    process.env.NODE_ENV = "production"
+    process.env.LAT_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_test_key"
+    process.env.LAT_BETTER_AUTH_SECRET = authSecret
+    const client: PostHogClientShape = {
+      capture: async () => {
+        throw new Error("posthog down")
+      },
+      groupIdentify: async () => undefined,
+      personIdentify: async () => undefined,
+      shutdown: async () => undefined,
+    }
+
+    await expect(reportOssDeploymentHeartbeat({ serviceName: "api", posthog: client })).resolves.toBeUndefined()
+  })
+
+  it("prefers LAT_IMAGE_TAG over Datadog version env vars", async () => {
+    process.env.NODE_ENV = "production"
+    process.env.LAT_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_test_key"
+    process.env.LAT_BETTER_AUTH_SECRET = authSecret
+    process.env.LAT_IMAGE_TAG = "2.0.0"
+    process.env.DD_VERSION = "deadbeef"
+    const { client, captures } = createFakePosthog()
+
+    await reportOssDeploymentHeartbeat({ serviceName: "api", posthog: client })
+
+    expect(captures[0]?.properties?.version).toBe("2.0.0")
   })
 })

--- a/packages/platform/analytics-posthog/src/oss-telemetry/report.ts
+++ b/packages/platform/analytics-posthog/src/oss-telemetry/report.ts
@@ -1,6 +1,6 @@
 import { parseEnvOptional } from "@platform/env"
 import { Effect } from "effect"
-import { createPostHogClient } from "../client.ts"
+import { createPostHogClient, type PostHogClientShape } from "../client.ts"
 import { loadOssTelemetryConfig } from "./config.ts"
 import { OSS_TELEMETRY_EVENT, OSS_TELEMETRY_HEARTBEAT_TTL_SECONDS, ossTelemetryHeartbeatKey } from "./constants.ts"
 import { deriveDeploymentId } from "./deployment-id.ts"
@@ -10,6 +10,7 @@ interface ReportOssDeploymentHeartbeatInput {
   readonly redis?: {
     set(key: string, value: string, mode: "EX", ttl: number, nx: "NX"): Promise<string | null>
   }
+  readonly posthog?: PostHogClientShape
 }
 
 const readHostname = (rawUrl: string | undefined): string | undefined => {
@@ -46,19 +47,19 @@ const shouldSendHeartbeat = async (
 }
 
 export const reportOssDeploymentHeartbeat = async (input: ReportOssDeploymentHeartbeatInput): Promise<void> => {
-  const config = Effect.runSync(loadOssTelemetryConfig)
-  if (!config) return
-
-  const deploymentId = deriveDeploymentId()
-  if (!deploymentId) return
-
-  if (!(await shouldSendHeartbeat(input.redis, deploymentId))) return
-
-  const webHost = readHostname(Effect.runSync(parseEnvOptional("LAT_WEB_URL", "string")))
-  const version = readVersion()
-
-  const client = createPostHogClient(config)
   try {
+    const config = Effect.runSync(loadOssTelemetryConfig)
+    if (!config) return
+
+    const deploymentId = deriveDeploymentId()
+    if (!deploymentId) return
+
+    if (!(await shouldSendHeartbeat(input.redis, deploymentId))) return
+
+    const webHost = readHostname(Effect.runSync(parseEnvOptional("LAT_WEB_URL", "string")))
+    const version = readVersion()
+
+    const client = input.posthog ?? createPostHogClient(config)
     await client.capture({
       distinctId: `deployment_${deploymentId}`,
       event: OSS_TELEMETRY_EVENT,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #3933 / LAT-741.

Audited the OSS `oss_deployment_heartbeat` path against current trunk and finished the missing wiring so self-hosted installs can report.

## What was broken

1. **Best-effort was incomplete.** Redis `SET NX` sat outside the PostHog `try/catch`. With `enableOfflineQueue: false` and no `waitForRedisClientReady` on the API, a not-ready Redis threw an unhandled rejection on listen.
2. **`report.ts` had no tests** beyond config/id helpers.
3. **Bundled PostHog key was still a placeholder**, so `loadOssTelemetryConfig` always no-oped in production.

## What this PR changes

- Wrap the entire `reportOssDeploymentHeartbeat` path in try/catch.
- Unit-test capture payload, Redis dedupe, and swallowed Redis/PostHog failures.
- Pass `LAT_IMAGE_TAG` into docker-stack app containers so heartbeats can report the compose image tag.
- Bundle the real write-only PostHog project key so self-hosters need no extra config (override still available via `LAT_OSS_TELEMETRY_POSTHOG_API_KEY`).

## How tested

- `pnpm --filter @platform/analytics-posthog test` (30 passing)
- Live capture to `https://eu.i.posthog.com/batch/` with the bundled key → HTTP 200 `{"status":"Ok"}` (event `oss_deployment_heartbeat`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fa934b4-f11f-4eeb-8538-d01dc393b840?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fa934b4-f11f-4eeb-8538-d01dc393b840&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic deployment heartbeat reporting for enabled open-source telemetry, including basic deployment and environment details.
  - Added support for configuring the telemetry image tag and PostHog connection settings.

- **Improvements**
  - Telemetry reporting now avoids duplicate heartbeat events and handles reporting failures gracefully.
  - Deployments can identify their configured image tag in telemetry.

- **Documentation**
  - Expanded deployment configuration guidance with telemetry destinations and optional PostHog API key and host overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->