### PR TITLE
fix(infra): enable billing enforcement on Latitude Cloud

### DIFF
--- a/infra/lib/ecs.ts
+++ b/infra/lib/ecs.ts
@@ -482,6 +482,7 @@ function createTaskDefinition(
           { name: "LAT_OBSERVABILITY_ENABLED", value: "true" },
           { name: "LAT_OBSERVABILITY_OTLP_TRACES_ENDPOINT", value: "http://localhost:4318/v1/traces" },
           { name: "LAT_OSS_TELEMETRY_ENABLED", value: "false" },
+          { name: "LAT_BILLING_ENABLED", value: "true" },
           { name: "LAT_POSTHOG_HOST", value: "https://eu.i.posthog.com" },
         ]
 


### PR DESCRIPTION
Adds `LAT_BILLING_ENABLED=true` to `baseEnvironment` in `infra/lib/ecs.ts`. One line.

Depends on #4515 — merge and deploy this **before or with** it.

## Why

#4515 makes billing enforcement opt-in. `LAT_BILLING_ENABLED` defaults to `false`, and when it is not `true` every organization resolves to the new `self-hosted` plan: unbounded credits, no ingest cap, no plan-driven retention.

That is the right default for self-hosters running our public images. It is wrong for Latitude Cloud — without it, Cloud stops enforcing free-plan credit caps (ingest never returns 402) and stops stamping plan retention on telemetry.

## Coverage

`createTaskDefinition` is called inside the loop over `config.ecs.services`, so this single entry reaches all five services — `web`, `api`, `ingest`, `workers`, `workflows`. Each resolves billing plans in process, so a partial rollout would leave some paths enforcing and others not; this avoids that.

`createMigrationTaskDefinition` builds its own environment array, so the one-shot migrations task is correctly unaffected — it does not need the flag.

## Staging

`baseEnvironment` is shared by both stacks, so staging enforces too. That is deliberate: it keeps the enforced path exercised before it reaches production, instead of leaving staging unmetered and unable to reproduce credit-cap or retention behaviour. Staging has few organizations, so any that need headroom can take an enterprise billing override in the backoffice — the per-org overhead that makes overrides a poor answer for self-hosters is not a problem at that scale.

## Value format

Literal string `"true"`. `packages/domain/billing/src/config.ts:10` parses it via `parseEnv("LAT_BILLING_ENABLED", "boolean", false)`, which accepts only `true`/`false`; anything else raises `BillingConfigurationError`. The value is a constant with no templating, so there is no path that can yield an empty string (which would silently mean `false`).

`LAT_TELEMETRY_RETENTION_DAYS` is deliberately left unset — it is the self-host retention knob and is ignored when billing is enabled. Retention on Cloud comes from each organization's plan.

## Verification after deploy

1. Open `/backoffice/organizations/<id>` for any Cloud organization. The billing card's "Source" must read `subscription`, `override`, or `free-fallback`. `self-hosted` means the variable did not reach that service.
2. Confirm a free-plan organization still shows its 20,000 included credits and a 30-day retention entitlement.

## Rollback

Remove the line and redeploy. Services return to the unmetered `self-hosted` plan. No crash, no data loss, no migration to undo.

## Checks

- `pnpm typecheck` in `infra/` passes.
- `pulumi preview` not run — needs stack credentials.
- No guardrail added: `infra/` has no tests, values schema, or required-env list to extend. Worth considering separately, since a missing value here fails silently — no crash, no alert, enforcement just stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled billing functionality across ECS task containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->