### PR TITLE
Add Latitude v1 shutdown banner (Oct 31, 2026)

### DIFF
--- a/apps/web/src/app/(public)/invitations/[token]/page.tsx
+++ b/apps/web/src/app/(public)/invitations/[token]/page.tsx
@@ -5,6 +5,7 @@ import buildMetatags from '$/app/_lib/buildMetatags'
 import { FocusLayout } from '$/components/layouts'
 import { ShutdownBanner } from '$/components/ShutdownBanner'
 import { ROUTES } from '$/services/routes'
+import { env } from '@latitude-data/env'
 import { redirect } from 'next/navigation'
 
 import AuthFooter from '../../_components/Footer'
@@ -47,7 +48,7 @@ export default async function InvitationPage({
 
   return (
     <FocusLayout
-      banner={<ShutdownBanner />}
+      banner={env.LATITUDE_CLOUD ? <ShutdownBanner /> : null}
       header={
         <FocusHeader
           title={`You've been invited`}

--- a/apps/web/src/app/(public)/invitations/[token]/page.tsx
+++ b/apps/web/src/app/(public)/invitations/[token]/page.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from '@latitude-data/web-ui/atoms/Card'
 import { FocusHeader } from '@latitude-data/web-ui/molecules/FocusHeader'
 import buildMetatags from '$/app/_lib/buildMetatags'
 import { FocusLayout } from '$/components/layouts'
+import { ShutdownBanner } from '$/components/ShutdownBanner'
 import { ROUTES } from '$/services/routes'
 import { redirect } from 'next/navigation'
 
@@ -46,6 +47,7 @@ export default async function InvitationPage({
 
   return (
     <FocusLayout
+      banner={<ShutdownBanner />}
       header={
         <FocusHeader
           title={`You've been invited`}

--- a/apps/web/src/app/(public)/login/page.tsx
+++ b/apps/web/src/app/(public)/login/page.tsx
@@ -6,6 +6,7 @@ import { ShutdownBanner } from '$/components/ShutdownBanner'
 import { getDataFromSession } from '$/data-access'
 import { ROUTES } from '$/services/routes'
 import { isLatitudeUrl } from '@latitude-data/constants'
+import { env } from '@latitude-data/env'
 import { Card, CardContent } from '@latitude-data/web-ui/atoms/Card'
 import { FocusHeader } from '@latitude-data/web-ui/molecules/FocusHeader'
 import { redirect } from 'next/navigation'
@@ -39,7 +40,7 @@ export default async function LoginPage({
 
   return (
     <FocusLayout
-      banner={<ShutdownBanner />}
+      banner={env.LATITUDE_CLOUD ? <ShutdownBanner /> : null}
       header={<FocusHeader title='Welcome to Latitude' />}
       footer={<LoginFooter returnTo={returnTo} />}
     >

--- a/apps/web/src/app/(public)/login/page.tsx
+++ b/apps/web/src/app/(public)/login/page.tsx
@@ -2,6 +2,7 @@ import AuthFooter from '$/app/(public)/_components/Footer'
 import LoginFooter from '$/app/(public)/login/_components/LoginFooter'
 import buildMetatags from '$/app/_lib/buildMetatags'
 import FocusLayout from '$/components/layouts/FocusLayout'
+import { ShutdownBanner } from '$/components/ShutdownBanner'
 import { getDataFromSession } from '$/data-access'
 import { ROUTES } from '$/services/routes'
 import { isLatitudeUrl } from '@latitude-data/constants'
@@ -38,6 +39,7 @@ export default async function LoginPage({
 
   return (
     <FocusLayout
+      banner={<ShutdownBanner />}
       header={<FocusHeader title='Welcome to Latitude' />}
       footer={<LoginFooter returnTo={returnTo} />}
     >

--- a/apps/web/src/app/(public)/magic-links/confirm/[token]/ConfirmMagicLink.tsx
+++ b/apps/web/src/app/(public)/magic-links/confirm/[token]/ConfirmMagicLink.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { use } from 'react'
+
+import { useOnce } from '$/hooks/useMount'
+import { confirmMagicLinkTokenAction } from '$/actions/magicLinkTokens/confirm'
+import { FocusLayout } from '$/components/layouts'
+import { ShutdownBanner } from '$/components/ShutdownBanner'
+import useLatitudeAction from '$/hooks/useLatitudeAction'
+import { FocusHeader } from '@latitude-data/web-ui/molecules/FocusHeader'
+
+export default function ConfirmMagicLink({
+  params,
+  searchParams,
+  isCloud,
+}: {
+  params: Promise<{ token: string }>
+  searchParams: Promise<{ returnTo?: string }>
+  isCloud: boolean
+}) {
+  const { token } = use(params)
+  const { returnTo } = use(searchParams)
+  const { execute } = useLatitudeAction(confirmMagicLinkTokenAction, {
+    onSuccess: () => {}, // We don't want the default toast message in this case
+  })
+
+  useOnce(() => {
+    setTimeout(() => execute({ token, returnTo }), 1000)
+  })
+
+  return (
+    <FocusLayout
+      banner={isCloud ? <ShutdownBanner /> : null}
+      header={
+        <FocusHeader
+          title='You are in!'
+          description='In a few seconds you will be redirected to your workspace.'
+        />
+      }
+    />
+  )
+}

--- a/apps/web/src/app/(public)/magic-links/confirm/[token]/page.tsx
+++ b/apps/web/src/app/(public)/magic-links/confirm/[token]/page.tsx
@@ -1,40 +1,19 @@
-'use client'
+import { env } from '@latitude-data/env'
 
-import { use } from 'react'
+import ConfirmMagicLink from './ConfirmMagicLink'
 
-import { useOnce } from '$/hooks/useMount'
-import { confirmMagicLinkTokenAction } from '$/actions/magicLinkTokens/confirm'
-import { FocusLayout } from '$/components/layouts'
-import { ShutdownBanner } from '$/components/ShutdownBanner'
-import useLatitudeAction from '$/hooks/useLatitudeAction'
-import { FocusHeader } from '@latitude-data/web-ui/molecules/FocusHeader'
-
-export default function ConfirmMagicLink({
+export default function ConfirmMagicLinkPage({
   params,
   searchParams,
 }: {
   params: Promise<{ token: string }>
   searchParams: Promise<{ returnTo?: string }>
 }) {
-  const { token } = use(params)
-  const { returnTo } = use(searchParams)
-  const { execute } = useLatitudeAction(confirmMagicLinkTokenAction, {
-    onSuccess: () => {}, // We don't want the default toast message in this case
-  })
-
-  useOnce(() => {
-    setTimeout(() => execute({ token, returnTo }), 1000)
-  })
-
   return (
-    <FocusLayout
-      banner={<ShutdownBanner />}
-      header={
-        <FocusHeader
-          title='You are in!'
-          description='In a few seconds you will be redirected to your workspace.'
-        />
-      }
+    <ConfirmMagicLink
+      params={params}
+      searchParams={searchParams}
+      isCloud={!!env.LATITUDE_CLOUD}
     />
   )
 }

--- a/apps/web/src/app/(public)/magic-links/confirm/[token]/page.tsx
+++ b/apps/web/src/app/(public)/magic-links/confirm/[token]/page.tsx
@@ -5,6 +5,7 @@ import { use } from 'react'
 import { useOnce } from '$/hooks/useMount'
 import { confirmMagicLinkTokenAction } from '$/actions/magicLinkTokens/confirm'
 import { FocusLayout } from '$/components/layouts'
+import { ShutdownBanner } from '$/components/ShutdownBanner'
 import useLatitudeAction from '$/hooks/useLatitudeAction'
 import { FocusHeader } from '@latitude-data/web-ui/molecules/FocusHeader'
 
@@ -27,6 +28,7 @@ export default function ConfirmMagicLink({
 
   return (
     <FocusLayout
+      banner={<ShutdownBanner />}
       header={
         <FocusHeader
           title='You are in!'

--- a/apps/web/src/app/(public)/magic-links/sent/page.tsx
+++ b/apps/web/src/app/(public)/magic-links/sent/page.tsx
@@ -3,6 +3,7 @@ import buildMetatags from '$/app/_lib/buildMetatags'
 import { FocusLayout } from '$/components/layouts'
 import { ShutdownBanner } from '$/components/ShutdownBanner'
 import { ROUTES } from '$/services/routes'
+import { env } from '@latitude-data/env'
 import { redirect } from 'next/navigation'
 
 export const metadata = buildMetatags({
@@ -19,7 +20,7 @@ export default async function MagicLinkSent({
 
   return (
     <FocusLayout
-      banner={<ShutdownBanner />}
+      banner={env.LATITUDE_CLOUD ? <ShutdownBanner /> : null}
       header={
         <FocusHeader
           title="You've got mail!"

--- a/apps/web/src/app/(public)/magic-links/sent/page.tsx
+++ b/apps/web/src/app/(public)/magic-links/sent/page.tsx
@@ -1,6 +1,7 @@
 import { FocusHeader } from '@latitude-data/web-ui/molecules/FocusHeader'
 import buildMetatags from '$/app/_lib/buildMetatags'
 import { FocusLayout } from '$/components/layouts'
+import { ShutdownBanner } from '$/components/ShutdownBanner'
 import { ROUTES } from '$/services/routes'
 import { redirect } from 'next/navigation'
 
@@ -18,6 +19,7 @@ export default async function MagicLinkSent({
 
   return (
     <FocusLayout
+      banner={<ShutdownBanner />}
       header={
         <FocusHeader
           title="You've got mail!"

--- a/apps/web/src/app/(public)/setup/page.tsx
+++ b/apps/web/src/app/(public)/setup/page.tsx
@@ -1,6 +1,7 @@
 import AuthFooter from '$/app/(public)/_components/Footer'
 import buildMetatags from '$/app/_lib/buildMetatags'
 import { FocusLayout } from '$/components/layouts'
+import { ShutdownBanner } from '$/components/ShutdownBanner'
 import { GoogleTagManager } from '$/components/Providers/GoogleTagManager'
 import { env } from '@latitude-data/env'
 import { Card, CardContent } from '@latitude-data/web-ui/atoms/Card'
@@ -35,6 +36,7 @@ export default async function SetupPage({
     <>
       <GoogleTagManager />
       <FocusLayout
+        banner={<ShutdownBanner />}
         header={
           <FocusHeader
             title='Create your Latitude account'

--- a/apps/web/src/app/(public)/setup/page.tsx
+++ b/apps/web/src/app/(public)/setup/page.tsx
@@ -36,7 +36,7 @@ export default async function SetupPage({
     <>
       <GoogleTagManager />
       <FocusLayout
-        banner={<ShutdownBanner />}
+        banner={env.LATITUDE_CLOUD ? <ShutdownBanner /> : null}
         header={
           <FocusHeader
             title='Create your Latitude account'

--- a/apps/web/src/app/no-workspace/page.tsx
+++ b/apps/web/src/app/no-workspace/page.tsx
@@ -1,5 +1,6 @@
 import { createSupportUserIdentity } from '$/app/(private)/_lib/createSupportUserIdentity'
 import { IntercomProvider } from '$/components/IntercomSupportChat'
+import { ShutdownBanner } from '$/components/ShutdownBanner'
 import { getCurrentUserOrRedirect } from '$/services/auth/getCurrentUser'
 import { ROUTES } from '$/services/routes'
 import { Alert } from '@latitude-data/web-ui/atoms/Alert'
@@ -12,18 +13,21 @@ export default async function NoWorkspace() {
 
   return (
     <IntercomProvider identity={supportIdentity}>
-      <div className='flex items-center justify-center p-4 h-screen'>
-        <div className='max-w-xl flex flex-col items-center justify-center gap-y-2'>
-          <Alert
-            variant='destructive'
-            title='No workspace found'
-            description={`It looks like the email ${user.email} is not associated with any workspace. Please contact support if you believe this is a mistake.`}
-          />
-          <Link href={ROUTES.dashboard.root}>
-            <Button fancy variant='outline'>
-              Go to Dashboard
-            </Button>
-          </Link>
+      <div className='flex flex-col h-screen'>
+        <ShutdownBanner />
+        <div className='flex flex-1 items-center justify-center p-4 min-h-0'>
+          <div className='max-w-xl flex flex-col items-center justify-center gap-y-2'>
+            <Alert
+              variant='destructive'
+              title='No workspace found'
+              description={`It looks like the email ${user.email} is not associated with any workspace. Please contact support if you believe this is a mistake.`}
+            />
+            <Link href={ROUTES.dashboard.root}>
+              <Button fancy variant='outline'>
+                Go to Dashboard
+              </Button>
+            </Link>
+          </div>
         </div>
       </div>
     </IntercomProvider>

--- a/apps/web/src/app/no-workspace/page.tsx
+++ b/apps/web/src/app/no-workspace/page.tsx
@@ -3,6 +3,7 @@ import { IntercomProvider } from '$/components/IntercomSupportChat'
 import { ShutdownBanner } from '$/components/ShutdownBanner'
 import { getCurrentUserOrRedirect } from '$/services/auth/getCurrentUser'
 import { ROUTES } from '$/services/routes'
+import { env } from '@latitude-data/env'
 import { Alert } from '@latitude-data/web-ui/atoms/Alert'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import Link from 'next/link'
@@ -14,7 +15,7 @@ export default async function NoWorkspace() {
   return (
     <IntercomProvider identity={supportIdentity}>
       <div className='flex flex-col h-screen'>
-        <ShutdownBanner />
+        {env.LATITUDE_CLOUD ? <ShutdownBanner /> : null}
         <div className='flex flex-1 items-center justify-center p-4 min-h-0'>
           <div className='max-w-xl flex flex-col items-center justify-center gap-y-2'>
             <Alert

--- a/apps/web/src/components/ShutdownBanner/index.tsx
+++ b/apps/web/src/components/ShutdownBanner/index.tsx
@@ -1,0 +1,31 @@
+import {
+  LATITUDE_EMAIL,
+  LATITUDE_V2_URL,
+} from '@latitude-data/core/constants'
+import { Alert } from '@latitude-data/web-ui/atoms/Alert'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+
+export function ShutdownBanner() {
+  return (
+    <Alert
+      variant='warning'
+      className='shrink-0 rounded-none border-x-0 border-t-0'
+      title='Latitude v1 is shutting down'
+      description={
+        <span>
+          Latitude v1 will shut down on October 31, 2026. Please{' '}
+          <Text.H5 asChild underline color='warningMutedForeground'>
+            <a href={LATITUDE_V2_URL} target='_blank' rel='noreferrer'>
+              migrate to Latitude v2
+            </a>
+          </Text.H5>
+          , or{' '}
+          <Text.H5 asChild underline color='warningMutedForeground'>
+            <a href={`mailto:${LATITUDE_EMAIL}`}>contact support</a>
+          </Text.H5>{' '}
+          for more information.
+        </span>
+      }
+    />
+  )
+}

--- a/apps/web/src/components/ShutdownBanner/index.tsx
+++ b/apps/web/src/components/ShutdownBanner/index.tsx
@@ -10,17 +10,17 @@ export function ShutdownBanner() {
       title='Latitude v1 is shutting down'
       description={
         <span>
-          Latitude v1 will shut down on October 31, 2026. Please{' '}
+          Latitude v1 will shut down on October 31, 2026.{' '}
           <Text.H5 asChild underline color='warningMutedForeground'>
             <a href={LATITUDE_V2_URL} target='_blank' rel='noreferrer'>
-              migrate to Latitude v2
+              Migrate to Latitude v2
             </a>
           </Text.H5>
           , or{' '}
           <Text.H5 asChild underline color='warningMutedForeground'>
             <a href={`mailto:${LATITUDE_EMAIL}`}>contact support</a>
-          </Text.H5>{' '}
-          for more information.
+          </Text.H5>
+          .
         </span>
       }
     />

--- a/apps/web/src/components/ShutdownBanner/index.tsx
+++ b/apps/web/src/components/ShutdownBanner/index.tsx
@@ -1,7 +1,4 @@
-import {
-  LATITUDE_EMAIL,
-  LATITUDE_V2_URL,
-} from '@latitude-data/core/constants'
+import { LATITUDE_EMAIL, LATITUDE_V2_URL } from '@latitude-data/core/constants'
 import { Alert } from '@latitude-data/web-ui/atoms/Alert'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 

--- a/apps/web/src/components/layouts/AppLayout/index.tsx
+++ b/apps/web/src/components/layouts/AppLayout/index.tsx
@@ -27,7 +27,7 @@ export default function AppLayout({
         'overflow-y-auto custom-scrollbar': scrollable,
       })}
     >
-      <ShutdownBanner />
+      {isCloud ? <ShutdownBanner /> : null}
       <DocumentationProvider>
         <AppHeader
           currentUser={currentUser}

--- a/apps/web/src/components/layouts/AppLayout/index.tsx
+++ b/apps/web/src/components/layouts/AppLayout/index.tsx
@@ -6,6 +6,7 @@ import AppHeader, { AppHeaderProps } from './Header'
 
 import DocumentationSidebarLayout from './DocumentationSidebarLayout'
 import { DocumentationProvider } from '$/components/Documentation/Provider'
+import { ShutdownBanner } from '$/components/ShutdownBanner'
 
 export type AppLayoutProps = AppHeaderProps & {
   children: ReactNode
@@ -26,17 +27,20 @@ export default function AppLayout({
         'overflow-y-auto custom-scrollbar': scrollable,
       })}
     >
+      <ShutdownBanner />
       <DocumentationProvider>
         <AppHeader
           currentUser={currentUser}
           cloudInfo={cloudInfo}
           isCloud={isCloud}
         />
-        <DocumentationSidebarLayout>
-          <main className='w-full flex-grow min-h-0 h-full relative'>
-            {children}
-          </main>
-        </DocumentationSidebarLayout>
+        <div className='flex-1 min-h-0 overflow-hidden'>
+          <DocumentationSidebarLayout>
+            <main className='w-full flex-grow min-h-0 h-full relative'>
+              {children}
+            </main>
+          </DocumentationSidebarLayout>
+        </div>
       </DocumentationProvider>
     </div>
   )

--- a/apps/web/src/components/layouts/FocusLayout.tsx
+++ b/apps/web/src/components/layouts/FocusLayout.tsx
@@ -3,22 +3,27 @@ import type { ReactNode } from 'react'
 export default function FocusLayout({
   header,
   footer,
+  banner,
   children,
 }: {
   header?: ReactNode
   footer?: ReactNode
+  banner?: ReactNode
   children?: ReactNode
 }) {
   return (
-    <div className='flex flex-col items-center justify-center h-screen'>
-      <div className='flex flex-col gap-y-6 max-w-[22rem]'>
-        {header ? <div>{header}</div> : null}
-        {children}
-        {footer && (
-          <div className='flex flex-col items-center justify-center gap-y-6'>
-            {footer}
-          </div>
-        )}
+    <div className='flex flex-col h-screen'>
+      {banner}
+      <div className='flex flex-1 flex-col items-center justify-center min-h-0'>
+        <div className='flex flex-col gap-y-6 max-w-[22rem]'>
+          {header ? <div>{header}</div> : null}
+          {children}
+          {footer && (
+            <div className='flex flex-col items-center justify-center gap-y-6'>
+              {footer}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -60,6 +60,7 @@ export * from '@latitude-data/constants/tracing'
 export const LATITUDE_EVENT = 'latitudeEventsChannel'
 export const LATITUDE_DOCS_URL = 'https://docs.latitude.so'
 export const LATITUDE_EMAIL = 'hello@latitude.so'
+export const LATITUDE_V2_URL = 'https://latitude.so'
 export const LATITUDE_SLACK_URL =
   'https://join.slack.com/t/trylatitude/shared_invite/zt-35wu2h9es-N419qlptPMhyOeIpj3vjzw'
 export const DEFAULT_PROVIDER_MAX_FREE_RUNS = 100


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Latitude v1 (app.latitude.so) needs a visible notice that the product shuts down on October 31, 2026, so people can migrate to v2 or contact support.

## What changed

Persistent warning banner in the logged-in app shell and on auth screens. It is not dismissible.

**Cloud-only:** the banner renders only when `LATITUDE_CLOUD` is true (same flag AppLayout already uses as `isCloud`). Self-hosted v1 does not see it.

Copy:
- Title: **Latitude v1 is shutting down**
- Body: Latitude v1 will shut down on October 31, 2026. Migrate to Latitude v2, or contact support.

Links:
- Latitude v2 → https://latitude.so (`LATITUDE_V2_URL`)
- Support → mailto:hello@latitude.so (`LATITUDE_EMAIL`)

## Where it is mounted (cloud only)

- **Logged-in pages:** `AppLayout`, above the header, gated on the existing `isCloud` prop (`!!env.LATITUDE_CLOUD` in the private layout).
- **Auth pages:** `FocusLayout` `banner` prop, passed only when `env.LATITUDE_CLOUD` is true (login, signup, invitations, magic-link sent). Magic-link confirm is a client page, so a server wrapper threads `isCloud`.
- **No-workspace:** same `env.LATITUDE_CLOUD` gate.

## Testing

- Self-hosted (`LATITUDE_CLOUD` unset): `/login` has no shutdown banner
- Cloud (`LATITUDE_CLOUD=true`): `/login` and `/setup` show the banner with the updated copy and working links

[Cloud login shows shutdown banner](https://cursor.com/agents/bc-4547b478-9c4e-4ccd-a1b1-973bb3350b0a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_banner_cloud.webp)
[Self-hosted login has no shutdown banner](https://cursor.com/agents/bc-4547b478-9c4e-4ccd-a1b1-973bb3350b0a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_banner_selfhost.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4547b478-9c4e-4ccd-a1b1-973bb3350b0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4547b478-9c4e-4ccd-a1b1-973bb3350b0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790842082&installation_model_id=435055&pr_number=4521&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4521&signature=ff5f2d3d3d2cab92daa84e8e75f7f766e97b8864272a10f727ae46d7e38db981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->