### PR TITLE
fix(workers): stop the billing test falling out of the partition window

### DIFF
--- a/apps/workers/src/workers/billing.test.ts
+++ b/apps/workers/src/workers/billing.test.ts
@@ -63,6 +63,7 @@ const provideAtomicReservation = Effect.provideService(
 const NOW = new Date()
 const BILLING_PERIOD_START = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth(), 1))
 const BILLING_PERIOD_END = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() + 1, 1))
+const BILLING_PERIOD_MIDPOINT = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth(), 15, 12))
 
 describe("billing runtime integration", () => {
   beforeEach(() => {
@@ -528,7 +529,7 @@ describe("billing runtime integration", () => {
 
     vi.useFakeTimers()
     try {
-      vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z"))
+      vi.setSystemTime(BILLING_PERIOD_MIDPOINT)
 
       await pg.db.insert(organizations).values([
         {
@@ -547,14 +548,14 @@ describe("billing runtime integration", () => {
         id: generateId(),
         organizationId: freeOrgId,
         planSlug: "free",
-        periodStart: new Date("2026-06-01T00:00:00.000Z"),
-        periodEnd: new Date("2026-07-01T00:00:00.000Z"),
+        periodStart: BILLING_PERIOD_START,
+        periodEnd: BILLING_PERIOD_END,
         includedCredits: PLAN_CONFIGS.free.includedCredits,
         consumedCredits: PLAN_CONFIGS.free.includedCredits,
         overageCredits: 0,
         reportedOverageCredits: 0,
         overageAmountMills: 0,
-        updatedAt: new Date("2026-06-15T12:00:00.000Z"),
+        updatedAt: BILLING_PERIOD_MIDPOINT,
       })
 
       await pg.db.insert(subscriptions).values({
@@ -564,21 +565,21 @@ describe("billing runtime integration", () => {
         stripeCustomerId: "cus_overage",
         stripeSubscriptionId: "sub_overage",
         status: "active",
-        periodStart: new Date("2026-06-01T00:00:00.000Z"),
-        periodEnd: new Date("2026-07-01T00:00:00.000Z"),
+        periodStart: BILLING_PERIOD_START,
+        periodEnd: BILLING_PERIOD_END,
       })
       await pg.db.insert(billingUsagePeriods).values({
         id: generateId(),
         organizationId: proOrgId,
         planSlug: "pro",
-        periodStart: new Date("2026-06-01T00:00:00.000Z"),
-        periodEnd: new Date("2026-07-01T00:00:00.000Z"),
+        periodStart: BILLING_PERIOD_START,
+        periodEnd: BILLING_PERIOD_END,
         includedCredits: PLAN_CONFIGS.pro.includedCredits,
         consumedCredits: PLAN_CONFIGS.pro.includedCredits,
         overageCredits: 0,
         reportedOverageCredits: 0,
         overageAmountMills: 0,
-        updatedAt: new Date("2026-06-15T12:00:00.000Z"),
+        updatedAt: BILLING_PERIOD_MIDPOINT,
       })
 
       const freeResult = await Effect.runPromise(
@@ -632,14 +633,14 @@ describe("billing runtime integration", () => {
         context: {
           planSlug: "free",
           planSource: "free-fallback",
-          periodStart: new Date("2026-06-01T00:00:00.000Z"),
-          periodEnd: new Date("2026-07-01T00:00:00.000Z"),
+          periodStart: BILLING_PERIOD_START,
+          periodEnd: BILLING_PERIOD_END,
           includedCredits: PLAN_CONFIGS.free.includedCredits,
           overageAllowed: false,
         },
         period: {
-          start: new Date("2026-06-01T00:00:00.000Z"),
-          end: new Date("2026-07-01T00:00:00.000Z"),
+          start: BILLING_PERIOD_START,
+          end: BILLING_PERIOD_END,
           includedCredits: PLAN_CONFIGS.free.includedCredits,
           consumedCredits: PLAN_CONFIGS.free.includedCredits,
           overageCredits: 0,


### PR DESCRIPTION
`test-integration` has been failing on every PR since this morning:

```
RepositoryError: Repository query failed
Caused by: no partition of relation "billing_usage_events" found for row
  billing_period_start: 2026-06-01
```

`billing_usage_events` is partitioned by month, and `ensure_billing_usage_events_partitions` creates partitions for `now() - 2 months` through `now() + 3 months` off **Postgres's** clock. The failing test pins itself to June 2026 with `vi.setSystemTime`, which only moves **JS** time — Postgres still sees the real date. From 2026-09-01 the window became 2026-07 … 2026-12, June dropped out of it, and the insert had nowhere to land.

Nothing changed in the code. The test armed itself on the first of the month.

The file already defines `NOW`-relative constants for exactly this reason, with a comment naming the trap — the other tests use them and this one didn't. It now does, via a matching `BILLING_PERIOD_MIDPOINT`.

Only that one test changes. The spending-cap test keeps its fixed July dates because it writes to `subscriptions` and `billing_usage_periods`, neither of which is partitioned, so the window doesn't apply to it.

Worth noting for later: any test that hardcodes a date and writes to a partitioned table has the same fuse, and `months_back = 2` is how long it takes to burn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790842217&installation_model_id=435055&pr_number=4522&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4522&signature=14b85f174c6b7a3bf05e9e21290d8163c4ebb461b511fd2ec2d285ac2bd89935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated billing integration tests to calculate billing periods dynamically based on the current UTC month.
  * Improved test reliability across different calendar dates and execution times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->