### PR TITLE
docs: point product links at console.latitude.so

### DIFF
--- a/apps/api/src/routes/well-known.ts
+++ b/apps/api/src/routes/well-known.ts
@@ -4,7 +4,7 @@
  * RFC 9728 (OAuth Protected Resource Metadata) lets a protected resource
  * advertise the authorization server(s) trusted to issue tokens for it. Our
  * authorization server is the web app's Better Auth `mcp` plugin, which lives
- * on a different origin (typical: `app.latitude.so` vs `api.latitude.so`).
+ * on a different origin (typical: `console.latitude.so` vs `api.latitude.so`).
  * RFC 9728 explicitly allows the AS to live on a different origin than the
  * protected resource — the AS just has to be listed here so MCP clients know
  * where to start the OAuth dance.

--- a/dev-docs/mcp.md
+++ b/dev-docs/mcp.md
@@ -44,7 +44,7 @@ The MCP server is the protected resource; the web app is the authorization serve
 
 ```
 ┌──────────────────────────────────────┐      ┌────────────────────────────────────┐
-│ apps/web — app.latitude.so           │      │ apps/api — api.latitude.so         │
+│ apps/web — console.latitude.so       │      │ apps/api — api.latitude.so         │
 │ (TanStack Start)                     │      │ (Hono / OpenAPIHono)               │
 │                                      │      │                                    │
 │  /login              sign-in UI      │      │  /v1/...   REST + ApiKey/OAuth     │
@@ -53,7 +53,7 @@ The MCP server is the protected resource; the web app is the authorization serve
 │  /api/auth/*         BA handler      │      │  /.well-known/oauth-protected-     │
 │    (incl. mcp/authorize, mcp/token,  │      │     resource                       │
 │     mcp/register, oauth2/consent,    │      │     → static JSON pointing at      │
-│     .well-known/*)                   │      │       app.latitude.so/api/auth     │
+│     .well-known/*)                   │      │       console.latitude.so/api/auth │
 │                                      │      │                                    │
 │  getBetterAuth() ◄───────────────────┼─┐    │  no Better Auth here               │
 └──────────────────────────────────────┘ │    │                                    │
@@ -78,13 +78,13 @@ The MCP server is the protected resource; the web app is the authorization serve
 ### Discovery flow (RFC 9728 + RFC 8414)
 
 1. MCP client → `api.latitude.so/v1/mcp` with no token → `401` + `WWW-Authenticate: Bearer resource_metadata="https://api.latitude.so/.well-known/oauth-protected-resource"`.
-2. MCP client → `api.latitude.so/.well-known/oauth-protected-resource` → `{ "resource": "https://api.latitude.so", "authorization_servers": ["https://app.latitude.so/api/auth"] }`.
-3. MCP client → `app.latitude.so/api/auth/.well-known/oauth-authorization-server` → Better Auth's AS metadata listing the authorize/token/register endpoints (all on the web origin).
-4. MCP client opens the browser at `app.latitude.so/api/auth/mcp/authorize?…`. Same origin as the existing session cookie — Better Auth reads it directly. If no session, BA redirects to `/login`, user signs in, BA continues the authorize step.
-5. BA mints a `consent_code` and redirects to `app.latitude.so/auth/consent?consent_code=…&client_id=…`. Still same origin.
+2. MCP client → `api.latitude.so/.well-known/oauth-protected-resource` → `{ "resource": "https://api.latitude.so", "authorization_servers": ["https://console.latitude.so/api/auth"] }`.
+3. MCP client → `console.latitude.so/api/auth/.well-known/oauth-authorization-server` → Better Auth's AS metadata listing the authorize/token/register endpoints (all on the web origin).
+4. MCP client opens the browser at `console.latitude.so/api/auth/mcp/authorize?…`. Same origin as the existing session cookie — Better Auth reads it directly. If no session, BA redirects to `/login`, user signs in, BA continues the authorize step.
+5. BA mints a `consent_code` and redirects to `console.latitude.so/auth/consent?consent_code=…&client_id=…`. Still same origin.
 6. User picks an org and approves. The web server fn (a) validates membership, (b) writes the chosen org id to `oauth_applications.organization_id` for the matching `client_id`, (c) calls `betterAuth.api.oauth2Consent({ accept: true, consent_code })` in-process.
 7. BA returns the auth code to the MCP client's redirect URI.
-8. MCP client → `POST app.latitude.so/api/auth/mcp/token` → opaque access token.
+8. MCP client → `POST console.latitude.so/api/auth/mcp/token` → opaque access token.
 9. MCP client → `api.latitude.so/v1/mcp` with `Authorization: Bearer …`. The API's middleware validates the token (Drizzle SELECT, joins to `oauth_applications.organization_id`) and sets `c.var.auth` / `c.var.organization`. Tool dispatch proceeds.
 
 The browser never crosses origins — the session cookie stays on the web app. The MCP client (a CLI agent) crosses origins for the token call and the protected-resource call, but those are header-bearer requests, not cookie requests, so CORS and `SameSite` don't apply.

--- a/docs/agent-dispatch/webhooks.mdx
+++ b/docs/agent-dispatch/webhooks.mdx
@@ -28,7 +28,7 @@ Latitude sends JSON with the trigger, the dispatch context, and the prompt text 
     "organizationName": "Acme Inc.",
     "projectName": "Checkout API",
     "projectSlug": "checkout-api",
-    "deepLinkUrl": "https://app.latitude.so/projects/checkout-api/signals/sig_123",
+    "deepLinkUrl": "https://console.latitude.so/projects/checkout-api/signals/sig_123",
     "signal": {
       "id": "sig_123",
       "name": "Payment timeout spike"

--- a/docs/getting-started/quick-start-dev.md
+++ b/docs/getting-started/quick-start-dev.md
@@ -9,7 +9,7 @@ This guide walks you through connecting an existing AI agent to Latitude. By the
 
 ## Prerequisites
 
-- A Latitude account (sign up at [latitude.so](https://latitude.so))
+- A Latitude account (sign up at [console.latitude.so](https://console.latitude.so/login))
 - An existing AI-powered application using a supported provider or framework
 
 ## Step 1: Create a Project

--- a/docs/getting-started/quick-start-pm.md
+++ b/docs/getting-started/quick-start-pm.md
@@ -9,7 +9,7 @@ This guide walks you through the Latitude web interface. You'll learn how to nav
 
 ## Prerequisites
 
-- A Latitude account (sign up at [latitude.so](https://latitude.so))
+- A Latitude account (sign up at [console.latitude.so](https://console.latitude.so/login))
 - A project with telemetry already connected (ask your development team to set this up using the [Developer Quick Start](./quick-start-dev))
 
 ## Understanding the Dashboard

--- a/docs/more/partners.mdx
+++ b/docs/more/partners.mdx
@@ -48,16 +48,16 @@ This is the plain OAuth 2.1 authorization code flow with PKCE, the same one the 
 
 <Steps>
   <Step title="Register a client for this account">
-    `POST https://app.latitude.so/api/auth/mcp/register` with your `client_name` and `redirect_uris`. Use `"token_endpoint_auth_method": "none"` for a public client. Store the `client_id` you get back **with this account** — registration is unauthenticated and instant, and each connected account needs its own client (see [Your client_id](#your-client_id)).
+    `POST https://console.latitude.so/api/auth/mcp/register` with your `client_name` and `redirect_uris`. Use `"token_endpoint_auth_method": "none"` for a public client. Store the `client_id` you get back **with this account** — registration is unauthenticated and instant, and each connected account needs its own client (see [Your client_id](#your-client_id)).
   </Step>
   <Step title="Send the user to authorize">
-    Open `https://app.latitude.so/api/auth/mcp/authorize` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=openid offline_access`, a `state`, and a PKCE `code_challenge` (S256).
+    Open `https://console.latitude.so/api/auth/mcp/authorize` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=openid offline_access`, a `state`, and a PKCE `code_challenge` (S256).
   </Step>
   <Step title="They sign in and consent">
     Latitude asks them to pick which organization to connect and to approve your access.
   </Step>
   <Step title="Exchange the code">
-    They come back to your `redirect_uri` with `?code`. Exchange it at `POST https://app.latitude.so/api/auth/mcp/token` with `grant_type=authorization_code`, the `code`, your `client_id`, and the `code_verifier`.
+    They come back to your `redirect_uri` with `?code`. Exchange it at `POST https://console.latitude.so/api/auth/mcp/token` with `grant_type=authorization_code`, the `code`, your `client_id`, and the `code_verifier`.
   </Step>
 </Steps>
 
@@ -306,7 +306,7 @@ Hand that API key to your telemetry setup and traces start flowing. See [Start t
 Access tokens last **1 hour**, refresh tokens **7 days**. Refresh at the same token endpoint both paths use. Your client is public, so no secret is involved:
 
 ```bash
-curl -X POST https://app.latitude.so/api/auth/mcp/token \
+curl -X POST https://console.latitude.so/api/auth/mcp/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=refresh_token" \
   -d "client_id={client_id}" \
@@ -317,7 +317,7 @@ You get a fresh pair back. Store the new refresh token — the old one is spent.
 
 ## What your users experience
 
-- **They can sign in immediately.** Latitude uses email magic links, so there is no password to set. They go to [app.latitude.so](https://app.latitude.so), enter the email you provisioned, and they are in as the **owner** of their new organization.
+- **They can sign in immediately.** Latitude uses email magic links, so there is no password to set. They go to [console.latitude.so](https://console.latitude.so), enter the email you provisioned, and they are in as the **owner** of their new organization.
 - **They skip our onboarding questionnaire.** Latitude records your platform as where the account came from, so we don't ask them again. This is why the profile fields above are worth sending.
 - **They see you.** Your name and icon appear under **Settings → Keys → OAuth Keys**, with the date they connected.
 - **They can revoke you.** One click, and your tokens stop working within seconds. Handle a sudden `401` on the public API as "this user disconnected us" and stop retrying.

--- a/docs/security/pii-redaction.mdx
+++ b/docs/security/pii-redaction.mdx
@@ -59,7 +59,7 @@ When a value is redacted that should not have been, the fix is to turn off the c
 **API** — `settings.redaction` on `PATCH /v1/projects/{projectSlug}`, also available through the SDKs and the `latitude` CLI.
 
 ```bash
-curl -X PATCH https://gateway.latitude.so/v1/projects/my-project \
+curl -X PATCH https://api.latitude.so/v1/projects/my-project \
   -H "Authorization: Bearer $LATITUDE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"settings":{"redaction":{"mode":"enforce","entities":["email","credit_card"]}}}'

--- a/packages/operations/src/operations/oauth-keys.ts
+++ b/packages/operations/src/operations/oauth-keys.ts
@@ -17,7 +17,7 @@ import type { OrganizationScopedEnv } from "../types.ts"
 
 // OAuth keys are the `(client, user)` connections users grant to OAuth /
 // MCP clients (Claude Code, Cursor, Codex…) via the consent flow at
-// `app.latitude.so/auth/consent`. The API exposes read + revoke surfaces;
+// `console.latitude.so/auth/consent`. The API exposes read + revoke surfaces;
 // creation is impossible by design (rows are minted by the consent UX).
 //
 // **Response contract**: never expose `access_token`, `refresh_token`,


### PR DESCRIPTION
`app.latitude.so` is v1. The v2 web origin is `console.latitude.so` (`infra/config.ts:182`), so several docs were sending readers to the wrong app.

## Public docs

| File | Fix |
| --- | --- |
| `docs/more/partners.mdx` | 6 × `app.latitude.so` → `console.latitude.so`: the OAuth `register` / `authorize` / `token` endpoints, and the sign-in link partners hand to provisioned users |
| `docs/agent-dispatch/webhooks.mdx` | `deepLinkUrl` in the payload example |
| `docs/security/pii-redaction.mdx` | `gateway.latitude.so` → `api.latitude.so` in the `PATCH /v1/projects/{slug}` curl. That was a v1 host; every other API example in the docs uses `api.latitude.so` |
| `docs/getting-started/quick-start-{pm,dev}.md` | "sign up at latitude.so" now points at `console.latitude.so/login`, matching the five telemetry pages that already link accounts that way |

The partners endpoint change is right on substance, not just hostname: Better Auth serves the authorization server on the web origin, per `dev-docs/mcp.md`.

## Internal

- `dev-docs/mcp.md` — the cross-origin diagram and OAuth flow steps 2-5 and 8. This is the source the partners guide was written from, so leaving it stale would re-seed the error. `console.latitude.so` is 4 characters longer, so padding was reclaimed inside each affected cell; box widths stay at 84 and border columns are still aligned.
- `packages/operations/src/operations/oauth-keys.ts` and `apps/api/src/routes/well-known.ts` — comment-only, no code touched.

## Deliberately unchanged

- `apps/web/src/routes/login.tsx:192` — the "Latitude V1 is still available" link, which should stay on `app.latitude.so`.
- `packages/telemetry/claude-code/CHANGELOG.md:88` — a historical entry recording this same fix in that package.
- Three test files using `https://app.latitude.so` as an arbitrary origin fixture.
- `https://latitude.so` in `docs/deployment/overview.mdx` and the `docs.json` logo href, which point at the marketing site correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790854194&installation_model_id=435055&pr_number=4528&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4528&signature=96bdb0dbf16870879fe242c3a7173e4c86842d5c1a630c3effd79ade1e27738e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->