### PR TITLE
feat(telemetry): propagate traces and flush reliably across Durable Objects

### DIFF
--- a/dev-docs/telemetry-sdk.md
+++ b/dev-docs/telemetry-sdk.md
@@ -82,6 +82,18 @@ Python mirrors the same helpers on `latitude_telemetry.sdk.tracer` (`get_latitud
 
 Spans carrying `latitude.*` attributes directly are indistinguishable from `capture()`-scoped spans on ingest. This matters on edge runtimes where ambient OTel context cannot be entered across async boundaries.
 
+## Cross-boundary propagation
+
+`injectTraceContext(context?)` and `extractTraceContext()` / `withTraceContext()` carry the active span and Latitude context across a boundary that has no ambient OpenTelemetry context: a Durable Object RPC call, a service binding, a queue message. The carrier is keyed by HTTP header names, so the same object works as an argument and as `fetch` headers. `withParentContext(tracer, context)` is the lower-level piece: it makes a framework-owned tracer attach its first span to a remote parent while leaving its own nesting intact. See [`trace-correlation.md`](trace-correlation.md) for the contract these share with the Hermes and Claude Code emitters.
+
+## Cloudflare helpers
+
+`@latitude-data/telemetry/cloudflare` holds the runtime-specific helpers, which are deliberately absent from the root import:
+
+- `createCodemodeTelemetry()` — nests codemode-internal tool spans under the outer `execute` span.
+- `createDurableObjectTelemetry()` — flushing for a runtime that evicts without warning. Exports are serialized and coalesced, a caller arriving mid-export gets a later one, in-flight exports register with `ctx.waitUntil()`, and a failed export is reported rather than thrown into the work being traced. Durable Objects must flush at each unit of work because the batch processor's timer is not a scheduler the runtime keeps alive.
+- The propagation helpers above, re-exported for discoverability.
+
 ## Project scoping
 
 Project routing uses three layers, highest precedence first:

--- a/dev-docs/trace-correlation.md
+++ b/dev-docs/trace-correlation.md
@@ -59,6 +59,37 @@ Both record `latitude.parent.trace_id` and `latitude.parent.span_id` as metadata
 
 A harness launching another one always does so non-interactively. For Claude Code that means `claude -p`, where Claude Code exits before spawning an `async` Stop hook — so before this contract could work at all, the emitter had to register a synchronous `SessionEnd` hook as well. See [`claude-code-telemetry.md`](claude-code-telemetry.md). Any other harness we add to this contract needs the same question asked of it: does its exporter actually run when it is driven headlessly?
 
+## Carrying it without an environment
+
+Environment variables only reach a child that is a *process*. A second agent in a Cloudflare Durable Object has the same problem — its own isolate, no shared memory, no ambient OpenTelemetry context — but is reached over an RPC call, so there is nothing to inherit. `@latitude-data/telemetry` carries the same contract as an argument.
+
+`injectTraceContext(context?)` returns a carrier keyed by HTTP header names, so one object serves both as an RPC argument and as `fetch` headers:
+
+| Key | Counterpart |
+| --- | --- |
+| `traceparent` | `TRACEPARENT` |
+| `tracestate` | Vendor sampling state, preserved as-is so a host SDK's propagation survives the hop. |
+| `x-latitude-context` | `LATITUDE_SESSION_ID` and `LATITUDE_PROJECT`, plus the rest of `ContextOptions`, as JSON with non-Latin-1 characters escaped — an unescaped accent in metadata would throw when the carrier is spread into `fetch` headers. |
+
+`extractTraceContext()` and `withTraceContext()` reinstall it. Parsing follows the same W3C rules as the Python side, with the same failure posture: malformed means root.
+
+Two deliberate departures from the variables:
+
+- **No scoped second name.** `LATITUDE_TRACEPARENT` exists because a repo's environment may already carry an unrelated `TRACEPARENT`. An argument constructed at the call site cannot collide with anything, so there is nothing to opt out of.
+- **The capture `name` and the SDK's default `project` stay behind.** `name` labels one capture root, so carrying it would relabel every span the callee emits. The default project is per-instance configuration each side already has; an explicit `ContextOptions.project` *is* carried, and has to be set when the two agents are configured for different projects — otherwise this is exactly the silent split the `LATITUDE_PROJECT` row above warns about.
+
+The shape matches, anchored on the tool span for the same reason:
+
+```
+Orchestrator Durable Object
+└── ai.streamText (turn)
+     └── ai.toolCall draftItinerary      ← the causal boundary
+          └── ai.generateText            ← the planner's Durable Object
+               └── ai.generateText.doGenerate
+```
+
+The cap in [Bounds](#bounds) has no counterpart on this path. A carrier anchors on the span active at the call site, which is already scoped to one turn, so a long-lived Durable Object starts a new trace each turn instead of growing one forever.
+
 ## Bounds
 
 An inherited trace grows for as long as the child keeps running, and Latitude reloads the whole trace on every late span (`TracesIngested` → debounced per-trace `trace-end`, which calls `loadTraceForTraceEndUseCase`). An all-day interactive session would make that reload an ever-growing read.
@@ -78,4 +109,4 @@ Span ids on the owned-trace path are unchanged, which keeps a session that is mi
 
 ## Late and out-of-order arrival
 
-A child process routinely ships after the parent turn has closed, and sometimes before it. Traces are not immutable: late spans re-fire the debounced `trace-end` job for that trace id, which recomputes from ClickHouse. `packages/domain/spans/src/otlp/cross-harness-correlation.test.ts` covers both orders producing the same tree.
+A child process routinely ships after the parent turn has closed, and sometimes before it. Traces are not immutable: late spans re-fire the debounced `trace-end` job for that trace id, which recomputes from ClickHouse. `packages/domain/spans/src/otlp/cross-harness-correlation.test.ts` covers both orders producing the same tree, for the environment path and for the Durable Object one.

--- a/docs/telemetry/frameworks/cloudflare-think.mdx
+++ b/docs/telemetry/frameworks/cloudflare-think.mdx
@@ -386,8 +386,10 @@ agents are configured for different Latitude projects, or their spans will split
 and the trace will break in half.
 
 <Note>
-  An absent or malformed carrier is not an error. The callee simply starts its own trace, which is
-  the same thing it did before you added propagation.
+  The carrier overrides, it does not replace. What it holds wins over whatever the callee already
+  has; what it leaves out the callee keeps. So an absent or malformed carrier is not an error and
+  not a reset either — the callee behaves exactly as it did before you added propagation, starting
+  its own trace in a plain handler and staying inside an enclosing `capture()` where you have one.
 </Note>
 
 ---

--- a/docs/telemetry/frameworks/cloudflare-think.mdx
+++ b/docs/telemetry/frameworks/cloudflare-think.mdx
@@ -177,8 +177,6 @@ This is the recommended setup for most Think apps.
 
 ## Codemode Internal Tools
 
-Requires `@latitude-data/telemetry` 3.6.0 or newer.
-
 Think's codemode `execute` tool appears as a normal AI SDK tool span. Tools
 called from inside codemode run outside the active AI SDK tool-call context, so
 wrap both the internal tool set and the outer `execute` tool with
@@ -274,8 +272,6 @@ const codemode = createCodemodeTelemetry({
 ---
 
 ## Multiple Agents Across Durable Objects
-
-Requires `@latitude-data/telemetry` 4.1.0 or newer.
 
 A second agent in its own Durable Object gets a fresh isolate: no shared memory, no ambient
 OpenTelemetry context. Its spans start a trace of their own, so the planner or researcher you

--- a/docs/telemetry/frameworks/cloudflare-think.mdx
+++ b/docs/telemetry/frameworks/cloudflare-think.mdx
@@ -273,6 +273,169 @@ const codemode = createCodemodeTelemetry({
 
 ---
 
+## Multiple Agents Across Durable Objects
+
+Requires `@latitude-data/telemetry` 4.1.0 or newer.
+
+A second agent in its own Durable Object gets a fresh isolate: no shared memory, no ambient
+OpenTelemetry context. Its spans start a trace of their own, so the planner or researcher you
+delegated to lands in a separate trace from the turn that called it.
+
+Hand the active span over with the call. `injectTraceContext()` serializes it into a carrier, and
+the callee reinstalls it with `withTraceContext()`.
+
+<Steps>
+  <Step title="Send the context with the call">
+    Call `injectTraceContext()` from inside the tool's `execute`. It anchors on whichever span is
+    active, so the second agent parents on that specific tool call.
+
+    ```ts
+    import { injectTraceContext } from "@latitude-data/telemetry/cloudflare"
+    import { getAgentByName } from "agents"
+    import { tool } from "ai"
+    import { z } from "zod"
+
+    export class MyAgent extends Think<Env> {
+      private context: ContextOptions | undefined
+
+      getTools() {
+        return {
+          draftItinerary: tool({
+            description: "Ask the planner agent for a two-day itinerary.",
+            inputSchema: z.object({ goal: z.string() }),
+            execute: async ({ goal }) => {
+              const planner = await getAgentByName(this.env.Planner, this.name)
+              return planner.draftItinerary(goal, injectTraceContext(this.context))
+            },
+          }),
+        }
+      }
+    }
+    ```
+  </Step>
+
+  <Step title="Join the trace on the other side">
+    `withTraceContext()` runs the callee's work inside the caller's trace. It also hands you the
+    extracted context, so a framework that wants a tracer instead of an ambient context can get one
+    from `remote.getTracer()`.
+
+    ```ts
+    import { createDurableObjectTelemetry, type TraceContextCarrier, withTraceContext } from "@latitude-data/telemetry/cloudflare"
+    import { Agent } from "agents"
+    import { generateText } from "ai"
+
+    export class Planner extends Agent<Env> {
+      private telemetry = createDurableObjectTelemetry({ latitude: getLatitude(this.env), ctx: this.ctx })
+
+      async draftItinerary(goal: string, trace?: TraceContextCarrier) {
+        return this.telemetry.run(() =>
+          withTraceContext(trace, async (remote) => {
+            const result = await generateText({
+              model: getModel(this.env),
+              prompt: `Draft a two-day itinerary. Goal: ${goal}`,
+              experimental_telemetry: {
+                isEnabled: true,
+                tracer: remote.getTracer(getLatitude(this.env), "cloudflare-planner"),
+                functionId: "planner-turn",
+              },
+            })
+
+            return result.text
+          }),
+        )
+      }
+    }
+    ```
+  </Step>
+</Steps>
+
+Both agents now report one trace, and Latitude renders the second agent as a subagent of the tool
+call that invoked it:
+
+```text
+ai.streamText
+  ai.toolCall draftItinerary
+    ai.generateText          ← the planner's Durable Object
+      ai.generateText.doGenerate
+```
+
+The carrier keys are HTTP header names, so the same object works over `fetch` and over a service
+binding:
+
+```ts
+await fetch(url, {
+  headers: { "content-type": "application/json", ...injectTraceContext(this.context) },
+})
+```
+
+On the receiving side, `withTraceContext()` reads a `Request` or a `Headers` directly:
+
+```ts
+export default {
+  async fetch(request: Request, env: Env) {
+    return withTraceContext(request, async (remote) => handle(request, env, remote))
+  },
+}
+```
+
+The carrier moves the trace and the Latitude context: session id, user id, user email, tags, and
+metadata. Two things stay behind. A `capture()` name is not carried, because it labels one capture
+root and would relabel every span the callee emits. The SDK's default `project` is not carried
+either, since each side applies its own — pass `project` in the context explicitly when the two
+agents are configured for different Latitude projects, or their spans will split into two projects
+and the trace will break in half.
+
+<Note>
+  An absent or malformed carrier is not an error. The callee simply starts its own trace, which is
+  the same thing it did before you added propagation.
+</Note>
+
+---
+
+## Flushing Before Eviction
+
+A Durable Object is evicted whenever it goes idle, and nothing runs first. Spans still sitting in
+the batch processor at that moment are lost: the batch timer is not a scheduler the Workers runtime
+keeps alive on your behalf.
+
+The fix is to flush at the end of every unit of work the object performs — a turn, an RPC method, a
+`fetch`, an alarm. `createDurableObjectTelemetry()` makes that cheap enough to do every time.
+
+```ts
+import { createDurableObjectTelemetry } from "@latitude-data/telemetry/cloudflare"
+
+export class MyAgent extends Think<Env> {
+  private telemetry = createDurableObjectTelemetry({ latitude: getLatitude(this.env), ctx: this.ctx })
+
+  async onChatResponse() {
+    await this.telemetry.flush()
+  }
+
+  onChatError(error: unknown) {
+    this.telemetry.flushSoon()
+    return error
+  }
+}
+```
+
+- `run(work)` runs a unit of work and flushes once it settles, whether it resolved or threw.
+- `flush()` exports everything buffered so far. Callers arriving together share one export, and a
+  caller arriving mid-export gets a later one rather than the in-flight one, which would miss the
+  spans it is waiting on.
+- `flushSoon()` does not wait. It registers the export with `ctx.waitUntil()` so the runtime keeps
+  the object alive for it.
+
+A failed export goes to `onError` (`console.error` by default) instead of failing the work being
+traced.
+
+<Warning>
+  Keep batching on. `disableBatch: true` sends one HTTP request per span and nothing waits for
+  them, which is worse on Workers, not better. Batching plus one flush per unit of work is a single
+  request per turn.
+</Warning>
+
+---
+
 ## Programmatic Turns
 
 If your app starts Think turns with your own `runTurn()` call, wrap that call
@@ -352,9 +515,10 @@ separate parent `cloudflare-think-turn` span.
 
 The Latitude repository includes a runnable Think example at
 [`examples/cloudflare-think-app`](https://github.com/latitude-dev/latitude-llm/tree/development/packages/telemetry/typescript/examples/cloudflare-think-app).
-It includes an `execute` codemode tool backed by several demo tools, a small QA
-page, and a local verifier that checks model spans, codemode tool spans,
-`userId`, and `sessionId` against local Latitude.
+It includes an `execute` codemode tool backed by several demo tools, a second
+`Planner` agent in its own Durable Object reached over RPC, a small QA page, and
+a local verifier that checks model spans, codemode tool spans, `userId`,
+`sessionId`, and that the planner's turn joins the orchestrator's trace.
 
 ---
 

--- a/docs/telemetry/hermes.md
+++ b/docs/telemetry/hermes.md
@@ -95,11 +95,11 @@ passing `-U`:
 
 <CodeGroup>
 ```bash Official installer
-~/.hermes/bin/uv pip install --python ~/.hermes/hermes-agent/venv/bin/python latitude-telemetry-hermes==0.1.2
+~/.hermes/bin/uv pip install --python ~/.hermes/hermes-agent/venv/bin/python latitude-telemetry-hermes==<version>
 ```
 
 ```bash Your own environment
-pip install latitude-telemetry-hermes==0.1.2
+pip install latitude-telemetry-hermes==<version>
 ```
 </CodeGroup>
 

--- a/docs/telemetry/project-scoping.md
+++ b/docs/telemetry/project-scoping.md
@@ -24,10 +24,9 @@ For every span Latitude ingests, the server applies this order (highest priority
    Acts as the per-batch default.
 
 <Note>
-  The SDK option was renamed from `projectSlug` / `project_slug` to `project` in
-  `@latitude-data/telemetry` ≥ `3.0.0-alpha.12` and `latitude-telemetry` ≥ `3.0.0a8`. The old
-  names still work but log a deprecation warning — see each SDK's CHANGELOG for the migration
-  diff. The `X-Latitude-Project` header name and the `latitude.project` span attribute are
+  The SDK option was renamed from `projectSlug` / `project_slug` to `project`. The old names
+  still work but log a deprecation warning — see each SDK's CHANGELOG for the migration diff.
+  The `X-Latitude-Project` header name and the `latitude.project` span attribute are
   unchanged.
 </Note>
 

--- a/packages/domain/spans/src/otlp/cross-harness-correlation.test.ts
+++ b/packages/domain/spans/src/otlp/cross-harness-correlation.test.ts
@@ -195,3 +195,89 @@ describe("cross-harness trace correlation", () => {
     expect(buildAgentGraph({ spans: graphInput(spans) }).roots.length).toBeGreaterThan(1)
   })
 })
+
+// Two Cloudflare Durable Objects, two isolates with no shared memory: the orchestrator hands the
+// active tool span over its RPC call and the planner emits against it from its own Latitude SDK.
+// Same contract as above, over an argument instead of the environment.
+const DO_TOOL_SPAN = "5555555555555555"
+const DO_PLANNER_SPAN = "6666666666666666"
+const DO_SESSION_ID = "cloudflare-session-1"
+const DO_TOOL_CALL_ID = "call_plan_01"
+
+const DO_TURN_SPAN = "7777777777777777"
+const DO_ORCHESTRATOR_MODEL_SPAN = "8888888888888888"
+const DO_PLANNER_MODEL_SPAN = "9999999999999999"
+
+const orchestratorBatch = batch("orchestrator-agent", "so.latitude.instrumentation.cloudflare-think", [
+  span({
+    spanId: DO_TURN_SPAN,
+    name: "ai.streamText",
+    attributes: [str("ai.operationId", "ai.streamText"), str("session.id", DO_SESSION_ID)],
+  }),
+  span({
+    spanId: DO_ORCHESTRATOR_MODEL_SPAN,
+    parentSpanId: DO_TURN_SPAN,
+    name: "ai.streamText.doStream",
+    attributes: [
+      str("ai.operationId", "ai.streamText.doStream"),
+      str("ai.model.provider", "anthropic.messages"),
+      str("ai.model.id", "claude-sonnet-4-5"),
+      str("session.id", DO_SESSION_ID),
+    ],
+  }),
+  span({
+    spanId: DO_TOOL_SPAN,
+    parentSpanId: DO_ORCHESTRATOR_MODEL_SPAN,
+    name: "ai.toolCall",
+    attributes: [
+      str("ai.operationId", "ai.toolCall"),
+      str("ai.toolCall.name", "plan"),
+      str("ai.toolCall.id", DO_TOOL_CALL_ID),
+      str("session.id", DO_SESSION_ID),
+    ],
+  }),
+])
+
+const plannerBatch = batch("planner-agent", "so.latitude.instrumentation.planner", [
+  span({
+    spanId: DO_PLANNER_SPAN,
+    parentSpanId: DO_TOOL_SPAN,
+    name: "ai.generateText",
+    attributes: [str("ai.operationId", "ai.generateText"), str("session.id", DO_SESSION_ID)],
+  }),
+  span({
+    spanId: DO_PLANNER_MODEL_SPAN,
+    parentSpanId: DO_PLANNER_SPAN,
+    name: "ai.generateText.doGenerate",
+    attributes: [
+      str("ai.operationId", "ai.generateText.doGenerate"),
+      str("ai.model.provider", "anthropic.messages"),
+      str("ai.model.id", "claude-sonnet-4-5"),
+      str("session.id", DO_SESSION_ID),
+    ],
+  }),
+])
+
+describe("Durable Object trace correlation", () => {
+  it("resolves the second agent as a subagent of the tool call that invoked it", () => {
+    const spans = ingest(orchestratorBatch, plannerBatch)
+    const graph = buildAgentGraph({ spans: graphInput(spans) })
+    const planner = flatten(graph.roots).find((n) => n.trigger.type === "tool" && n.trigger.toolName === "plan")
+
+    expect(new Set(spans.map((s) => s.traceId)).size).toBe(1)
+    expect(graph.roots).toHaveLength(1)
+    expect(planner?.kind).toBe("subagent")
+    expect(planner?.parentId).toBe(graph.roots[0]?.id)
+    expect(planner?.ownGenerationCount).toBe(1)
+    expect(planner?.trigger).toEqual({ type: "tool", toolName: "plan", toolCallId: DO_TOOL_CALL_ID })
+  })
+
+  it("merges the same way when the evicted object's batch arrives first", () => {
+    // Either object can be evicted mid-turn and flush after the other has already shipped.
+    const reversed = buildAgentGraph({ spans: graphInput(ingest(plannerBatch, orchestratorBatch)) })
+    const forward = buildAgentGraph({ spans: graphInput(ingest(orchestratorBatch, plannerBatch)) })
+
+    expect(reversed.roots).toHaveLength(1)
+    expect(flatten(reversed.roots).map((n) => n.trigger)).toEqual(flatten(forward.roots).map((n) => n.trigger))
+  })
+})

--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -5,10 +5,29 @@ All notable changes to the TypeScript Telemetry SDK will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.1.0] - 2026-09-01
+
+### Added
+
+- `injectTraceContext()` / `extractTraceContext()` / `withTraceContext()` carry the active span and
+  Latitude context across a boundary with no ambient OpenTelemetry context, so a second agent in its
+  own Cloudflare Durable Object joins the caller's trace instead of orphaning one. Injecting from
+  inside a tool's `execute` parents the callee on that tool call, which is what makes it render as a
+  subagent. The carrier is keyed by HTTP header names, so one object serves an RPC argument and
+  `fetch` headers, and an absent or malformed carrier leaves the callee a root rather than failing.
+- `withParentContext(tracer, context)` attaches a framework-owned tracer's first span to a remote
+  parent while leaving nested spans on their real parents.
+- `createDurableObjectTelemetry()` flushes at each unit of work, which is the only reliable point on
+  a runtime that evicts without warning. Exports are serialized and coalesced, a caller arriving
+  mid-export gets a later one, in-flight exports register with `ctx.waitUntil()`, and a failed
+  export is reported instead of failing the turn.
+- The Cloudflare Think guide and runnable example cover multi-agent propagation and eviction-safe
+  flushing, including a second `Planner` agent in its own Durable Object.
 
 ### Fixed
 
+- Constructing `Latitude` no longer assumes `process.once` exists, so it works on runtimes without
+  Node signal handling.
 - Smart filter now promotes ancestors of kept spans (including already-ended parents held briefly
   after a drop) so exported traces stay connected when only a descendant independently passed the
   filter — e.g. a stamped `tcp.connect` no longer ships without its parent.

--- a/packages/telemetry/typescript/examples/cloudflare-think-app/README.md
+++ b/packages/telemetry/typescript/examples/cloudflare-think-app/README.md
@@ -70,10 +70,10 @@ npm run verify:local
 
 The verifier uses AI SDK's mock model, forces an `execute` tool call and a
 `draftItinerary` tool call, sends spans with
-`latitude.getTracer("cloudflare-think", context)`, then runs the planner turn
-from the carrier alone after the orchestrator turn has closed — the same late,
-out-of-order arrival an evicted Durable Object produces. It flushes the Latitude
-SDK and polls local ClickHouse for the generated session. It exits non-zero if
+`latitude.getTracer("cloudflare-think", context)`, and runs the planner turn
+from a root OpenTelemetry context so the carrier is the only thing that can
+reattach it — the position a second Durable Object is in. It flushes the
+Latitude SDK and polls local ClickHouse for the generated session. It exits non-zero if
 spans do not arrive, if no `execute` tool span is stored, if any span misses the
 expected user/session context, or if the planner's spans did not join the
 orchestrator's trace under the `draftItinerary` tool span.

--- a/packages/telemetry/typescript/examples/cloudflare-think-app/README.md
+++ b/packages/telemetry/typescript/examples/cloudflare-think-app/README.md
@@ -8,11 +8,23 @@ The React page uses Think's default WebSocket chat path through
 the user/session context to `latitude.getTracer("cloudflare-think", context)`,
 so model and tool spans are stored with `user_id` and `session_id`.
 
-`MyAgent` exposes a single codemode `execute` tool. Inside codemode, the model can
-call three deterministic demo tools: `getWeather`, `estimateTripBudget`, and
-`listCityHighlights`. The example uses `createCodemodeTelemetry()` to wrap the
-codemode tool set and outer `execute` tool, so internal tool spans are parented
-under `execute` and Latitude shows the full codemode waterfall in one trace.
+`MyAgent` exposes a codemode `execute` tool and a `draftItinerary` tool. Inside
+codemode, the model can call three deterministic demo tools: `getWeather`,
+`estimateTripBudget`, and `listCityHighlights`. The example uses
+`createCodemodeTelemetry()` to wrap the codemode tool set and outer `execute`
+tool, so internal tool spans are parented under `execute` and Latitude shows the
+full codemode waterfall in one trace.
+
+`draftItinerary` calls `Planner`, a second agent living in its own Durable
+Object, over RPC. That object is a separate isolate with no shared memory, so
+`MyAgent` hands the active tool span over with `injectTraceContext()` and
+`Planner` rejoins it with `withTraceContext()`. Both agents report one trace, and
+the planner shows up as a subagent of the tool call that invoked it.
+
+Both agents flush through `createDurableObjectTelemetry()`. A Durable Object is
+evicted whenever it goes idle with no hook that runs first, so anything still
+buffered in the batch processor is lost; the helper flushes at the end of each
+turn and coalesces concurrent callers onto one export.
 
 ## Run locally
 
@@ -56,8 +68,12 @@ LATITUDE_PROJECT_SLUG=cloudflare-think-test \
 npm run verify:local
 ```
 
-The verifier uses AI SDK's mock model, forces an `execute` tool call, sends spans
-with `latitude.getTracer("cloudflare-think", context)`, flushes the Latitude SDK,
-and polls local ClickHouse for the generated session. It exits non-zero if spans
-do not arrive, if no `execute` tool span is stored, or if any span misses the
-expected user/session context.
+The verifier uses AI SDK's mock model, forces an `execute` tool call and a
+`draftItinerary` tool call, sends spans with
+`latitude.getTracer("cloudflare-think", context)`, then runs the planner turn
+from the carrier alone after the orchestrator turn has closed — the same late,
+out-of-order arrival an evicted Durable Object produces. It flushes the Latitude
+SDK and polls local ClickHouse for the generated session. It exits non-zero if
+spans do not arrive, if no `execute` tool span is stored, if any span misses the
+expected user/session context, or if the planner's spans did not join the
+orchestrator's trace under the `draftItinerary` tool span.

--- a/packages/telemetry/typescript/examples/cloudflare-think-app/scripts/verify-local.mjs
+++ b/packages/telemetry/typescript/examples/cloudflare-think-app/scripts/verify-local.mjs
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto"
 import { setTimeout as sleep } from "node:timers/promises"
-import { stepCountIs, streamText, tool } from "ai"
+import { generateText, stepCountIs, streamText, tool } from "ai"
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test"
 import { z } from "zod"
+import { injectTraceContext, withTraceContext } from "../../../dist/cloudflare.js"
 import { Latitude } from "../../../dist/index.js"
 
 const ingestUrl = process.env.LATITUDE_TELEMETRY_URL ?? "http://localhost:3002"
@@ -60,23 +61,44 @@ function makeThinkModel() {
                 usage: { inputTokens: 18, outputTokens: 8, totalTokens: 26 },
               },
             ]
-          : [
-              { type: "stream-start", warnings: [] },
-              {
-                type: "response-metadata",
-                id: `resp_${randomUUID()}`,
-                modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
-                timestamp: new Date(),
-              },
-              { type: "text-start", id: "text-1" },
-              {
-                type: "text-delta",
-                id: "text-1",
-                delta: "Barcelona is sunny, estimated at 190 EUR, with three local highlights.",
-              },
-              { type: "text-end", id: "text-1" },
-              { type: "finish", finishReason: "stop", usage: { inputTokens: 30, outputTokens: 12, totalTokens: 42 } },
-            ]
+          : calls === 2
+            ? [
+                { type: "stream-start", warnings: [] },
+                {
+                  type: "response-metadata",
+                  id: `resp_${randomUUID()}`,
+                  modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
+                  timestamp: new Date(),
+                },
+                {
+                  type: "tool-call",
+                  toolCallId: "call_draft_itinerary",
+                  toolName: "draftItinerary",
+                  input: JSON.stringify({ goal: "a sunny weekend in Barcelona" }),
+                },
+                {
+                  type: "finish",
+                  finishReason: "tool-calls",
+                  usage: { inputTokens: 22, outputTokens: 9, totalTokens: 31 },
+                },
+              ]
+            : [
+                { type: "stream-start", warnings: [] },
+                {
+                  type: "response-metadata",
+                  id: `resp_${randomUUID()}`,
+                  modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
+                  timestamp: new Date(),
+                },
+                { type: "text-start", id: "text-1" },
+                {
+                  type: "text-delta",
+                  id: "text-1",
+                  delta: "Barcelona is sunny, estimated at 190 EUR, with three local highlights.",
+                },
+                { type: "text-end", id: "text-1" },
+                { type: "finish", finishReason: "stop", usage: { inputTokens: 30, outputTokens: 12, totalTokens: 42 } },
+              ]
 
       return {
         stream: simulateReadableStream({ chunks }),
@@ -138,28 +160,71 @@ const execute = tool({
   },
 })
 
+function makePlannerModel() {
+  return new MockLanguageModelV3({
+    provider: "cloudflare-workers-ai",
+    modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
+    doGenerate: async () => ({
+      finishReason: "stop",
+      usage: { inputTokens: 24, outputTokens: 40, totalTokens: 64 },
+      content: [{ type: "text", text: "Day 1: old town walk. Day 2: market and sunset viewpoint." }],
+      warnings: [],
+    }),
+  })
+}
+
+// The planner runs in a second Durable Object with no shared memory, so all it gets is the carrier
+// the orchestrator handed over its RPC call. Running it after the turn closed also exercises the
+// late-arrival path an evicted object produces.
+async function runPlannerTurn(carrier) {
+  return withTraceContext(carrier, async (remote) => {
+    const result = await generateText({
+      model: makePlannerModel(),
+      prompt: "Draft a two-day itinerary for a sunny weekend in Barcelona.",
+      experimental_telemetry: {
+        isEnabled: true,
+        tracer: remote.getTracer(latitude, "cloudflare-planner"),
+        functionId: "planner-turn",
+      },
+    })
+
+    return result.text
+  })
+}
+
 async function runThinkTurn() {
   const sessionId = `cloudflare-think-local-${randomUUID()}`
+  const context = {
+    userId: "local-think-user",
+    sessionId,
+    tags: ["cloudflare-think", "local-e2e"],
+    metadata: {
+      verifier: "cloudflare-think-app",
+      continuation: false,
+      messageCount: 1,
+      codemode: true,
+    },
+  }
+  let plannerCarrier
+
+  const draftItinerary = tool({
+    description: "Ask the planner agent, running in its own Durable Object, for a two-day itinerary.",
+    inputSchema: z.object({ goal: z.string() }),
+    execute: async ({ goal }) => {
+      plannerCarrier = injectTraceContext(context)
+      return { goal, delegatedTo: "planner-durable-object" }
+    },
+  })
 
   try {
     const result = streamText({
       model: makeThinkModel(),
       messages: [{ role: "user", content: "Use codemode and tools to plan a sunny weekend in Barcelona." }],
-      tools: { execute },
-      stopWhen: stepCountIs(2),
+      tools: { execute, draftItinerary },
+      stopWhen: stepCountIs(3),
       experimental_telemetry: {
         isEnabled: true,
-        tracer: latitude.getTracer("cloudflare-think", {
-          userId: "local-think-user",
-          sessionId,
-          tags: ["cloudflare-think", "local-e2e"],
-          metadata: {
-            verifier: "cloudflare-think-app",
-            continuation: false,
-            messageCount: 1,
-            codemode: true,
-          },
-        }),
+        tracer: latitude.getTracer("cloudflare-think", context),
         functionId: "think-turn",
         metadata: { framework: "cloudflare-think", verifier: "local-e2e" },
       },
@@ -168,7 +233,7 @@ async function runThinkTurn() {
     let text = ""
     for await (const delta of result.textStream) text += delta
 
-    return { sessionId, text }
+    return { sessionId, text, plannerCarrier }
   } finally {
     await latitude.flush()
   }
@@ -233,13 +298,66 @@ async function waitForSpans(sessionId) {
   throw new Error(`Expected identified model and codemode tool spans in ClickHouse for session ${sessionId}`)
 }
 
-const { sessionId, text } = await runThinkTurn()
+async function waitForPlannerTrace(sessionId) {
+  const escaped = sessionId.replaceAll("'", "''")
+  const sql = `
+    SELECT span_id, parent_span_id, trace_id, name, tool_name
+    FROM spans
+    WHERE session_id = '${escaped}'
+    FORMAT TabSeparated
+  `
+
+  for (let attempt = 1; attempt <= 20; attempt += 1) {
+    const rows = (await queryClickHouse(sql))
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const [spanId, parentSpanId, traceId, name, toolName] = line.split("\t")
+        return { spanId, parentSpanId, traceId, name, toolName }
+      })
+
+    const toolSpan = rows.find((row) => row.toolName === "draftItinerary")
+    const plannerSpans = rows.filter((row) => row.name.startsWith("ai.generateText"))
+    const plannerRoot = plannerSpans.find((row) => row.parentSpanId === toolSpan?.spanId)
+    const traceIds = new Set(rows.map((row) => row.traceId))
+
+    if (toolSpan && plannerRoot && traceIds.size === 1) {
+      return { traceId: plannerRoot.traceId, plannerSpanCount: plannerSpans.length }
+    }
+    await sleep(500)
+  }
+
+  throw new Error(`Expected the planner turn to join the orchestrator trace for session ${sessionId}`)
+}
+
+const { sessionId, text, plannerCarrier } = await runThinkTurn()
+
+if (!plannerCarrier?.traceparent) {
+  throw new Error("Expected the orchestrator to hand a traceparent to the planner")
+}
+
+const itinerary = await runPlannerTurn(plannerCarrier)
+await latitude.flush()
+
 const { spanCount, toolSpanCount, codemodeSpanCount, identifiedSpanCount, providerSpanCount } =
   await waitForSpans(sessionId)
+const { traceId, plannerSpanCount } = await waitForPlannerTrace(sessionId)
 
 console.log(
   JSON.stringify(
-    { ok: true, sessionId, text, spanCount, toolSpanCount, codemodeSpanCount, identifiedSpanCount, providerSpanCount },
+    {
+      ok: true,
+      sessionId,
+      traceId,
+      text,
+      itinerary,
+      spanCount,
+      toolSpanCount,
+      codemodeSpanCount,
+      identifiedSpanCount,
+      providerSpanCount,
+      plannerSpanCount,
+    },
     null,
     2,
   ),

--- a/packages/telemetry/typescript/examples/cloudflare-think-app/scripts/verify-local.mjs
+++ b/packages/telemetry/typescript/examples/cloudflare-think-app/scripts/verify-local.mjs
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto"
 import { setTimeout as sleep } from "node:timers/promises"
+import { context as otelContext, ROOT_CONTEXT } from "@opentelemetry/api"
 import { generateText, stepCountIs, streamText, tool } from "ai"
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test"
 import { z } from "zod"
@@ -94,7 +95,8 @@ function makeThinkModel() {
                 {
                   type: "text-delta",
                   id: "text-1",
-                  delta: "Barcelona is sunny, estimated at 190 EUR, with three local highlights.",
+                  delta:
+                    "Barcelona is sunny and about 190 EUR for two days. The planner suggests: Day 1 old town walk, Day 2 market and sunset viewpoint.",
                 },
                 { type: "text-end", id: "text-1" },
                 { type: "finish", finishReason: "stop", usage: { inputTokens: 30, outputTokens: 12, totalTokens: 42 } },
@@ -173,23 +175,25 @@ function makePlannerModel() {
   })
 }
 
-// The planner runs in a second Durable Object with no shared memory, so all it gets is the carrier
-// the orchestrator handed over its RPC call. Running it after the turn closed also exercises the
-// late-arrival path an evicted object produces.
+// The planner runs in a second Durable Object, so the only thing tying it to the caller is the
+// carrier. `ROOT_CONTEXT` stands in for that isolate: it strips the ambient context this process
+// happens to have, so nothing but the carrier can reattach the turn.
 async function runPlannerTurn(carrier) {
-  return withTraceContext(carrier, async (remote) => {
-    const result = await generateText({
-      model: makePlannerModel(),
-      prompt: "Draft a two-day itinerary for a sunny weekend in Barcelona.",
-      experimental_telemetry: {
-        isEnabled: true,
-        tracer: remote.getTracer(latitude, "cloudflare-planner"),
-        functionId: "planner-turn",
-      },
-    })
+  return otelContext.with(ROOT_CONTEXT, () =>
+    withTraceContext(carrier, async (remote) => {
+      const result = await generateText({
+        model: makePlannerModel(),
+        prompt: "Draft a two-day itinerary for a sunny weekend in Barcelona.",
+        experimental_telemetry: {
+          isEnabled: true,
+          tracer: remote.getTracer(latitude, "cloudflare-planner"),
+          functionId: "planner-turn",
+        },
+      })
 
-    return result.text
-  })
+      return result.text
+    }),
+  )
 }
 
 async function runThinkTurn() {
@@ -211,8 +215,10 @@ async function runThinkTurn() {
     description: "Ask the planner agent, running in its own Durable Object, for a two-day itinerary.",
     inputSchema: z.object({ goal: z.string() }),
     execute: async ({ goal }) => {
+      // Stands in for `planner.draftItinerary(goal, injectTraceContext(...))` over Durable Object
+      // RPC: the carrier is the whole handover, and the caller awaits the answer.
       plannerCarrier = injectTraceContext(context)
-      return { goal, delegatedTo: "planner-durable-object" }
+      return { goal, itinerary: await runPlannerTurn(plannerCarrier) }
     },
   })
 
@@ -336,9 +342,6 @@ if (!plannerCarrier?.traceparent) {
   throw new Error("Expected the orchestrator to hand a traceparent to the planner")
 }
 
-const itinerary = await runPlannerTurn(plannerCarrier)
-await latitude.flush()
-
 const { spanCount, toolSpanCount, codemodeSpanCount, identifiedSpanCount, providerSpanCount } =
   await waitForSpans(sessionId)
 const { traceId, plannerSpanCount } = await waitForPlannerTrace(sessionId)
@@ -350,7 +353,6 @@ console.log(
       sessionId,
       traceId,
       text,
-      itinerary,
       spanCount,
       toolSpanCount,
       codemodeSpanCount,

--- a/packages/telemetry/typescript/examples/cloudflare-think-app/src/worker.ts
+++ b/packages/telemetry/typescript/examples/cloudflare-think-app/src/worker.ts
@@ -3,9 +3,15 @@ import { CodemodeRuntime } from "@cloudflare/codemode"
 import { Think, type TurnConfig, type TurnContext } from "@cloudflare/think"
 import { createExecuteTool } from "@cloudflare/think/tools/execute"
 import { type ContextOptions, Latitude } from "@latitude-data/telemetry"
-import { createCodemodeTelemetry } from "@latitude-data/telemetry/cloudflare"
-import { routeAgentRequest } from "agents"
-import { tool } from "ai"
+import {
+  createCodemodeTelemetry,
+  createDurableObjectTelemetry,
+  injectTraceContext,
+  type TraceContextCarrier,
+  withTraceContext,
+} from "@latitude-data/telemetry/cloudflare"
+import { Agent, getAgentByName, routeAgentRequest } from "agents"
+import { generateText, tool } from "ai"
 import { z } from "zod"
 
 export { CodemodeRuntime }
@@ -13,6 +19,7 @@ export { CodemodeRuntime }
 type Env = {
   LOADER: WorkerLoader
   MyAgent: DurableObjectNamespace<MyAgent>
+  Planner: DurableObjectNamespace<Planner>
   LATITUDE_API_KEY: string
   LATITUDE_PROJECT_SLUG: string
   LATITUDE_TELEMETRY_URL?: string
@@ -31,6 +38,10 @@ function getLatitude(env: Env) {
   })
 
   return latitude
+}
+
+function getModel(env: Env) {
+  return createAnthropic({ apiKey: env.ANTHROPIC_API_KEY })("claude-sonnet-4-5")
 }
 
 function latitudeContext(env: Env, ctx: TurnContext): ContextOptions {
@@ -67,11 +78,35 @@ const travelTools = {
   }),
 }
 
+/** A second agent in its own Durable Object: separate isolate, separate memory, separate turn. */
+export class Planner extends Agent<Env> {
+  private telemetry = createDurableObjectTelemetry({ latitude: getLatitude(this.env), ctx: this.ctx })
+
+  async draftItinerary(goal: string, trace?: TraceContextCarrier) {
+    return this.telemetry.run(() =>
+      withTraceContext(trace, async (remote) => {
+        const result = await generateText({
+          model: getModel(this.env),
+          prompt: `Draft a two-day itinerary. Keep it to four lines. Goal: ${goal}`,
+          experimental_telemetry: {
+            isEnabled: true,
+            tracer: remote.getTracer(getLatitude(this.env), "cloudflare-planner"),
+            functionId: "planner-turn",
+          },
+        })
+
+        return result.text
+      }),
+    )
+  }
+}
+
 export class MyAgent extends Think<Env> {
   private context: ContextOptions | undefined
+  private telemetry = createDurableObjectTelemetry({ latitude: getLatitude(this.env), ctx: this.ctx })
 
   getModel() {
-    return createAnthropic({ apiKey: this.env.ANTHROPIC_API_KEY })("claude-sonnet-4-5")
+    return getModel(this.env)
   }
 
   getSystemPrompt() {
@@ -79,7 +114,7 @@ export class MyAgent extends Think<Env> {
       "Use execute once for travel planning.",
       "Do not inspect tool signatures.",
       "Inside execute, call tools.getWeather({ city }), tools.estimateTripBudget({ city, days, travelers }), and tools.listCityHighlights({ city }).",
-      "Return one object with those results, then summarize it briefly.",
+      "Then call draftItinerary once with the trip goal, and summarize both results briefly.",
     ].join(" ")
   }
 
@@ -96,6 +131,16 @@ export class MyAgent extends Think<Env> {
           tools: codemode.traceToolSet(travelTools),
         }),
       ),
+      draftItinerary: tool({
+        description: "Ask the planner agent for a two-day itinerary.",
+        inputSchema: z.object({ goal: z.string() }),
+        execute: async ({ goal }) => {
+          const planner = await getAgentByName(this.env.Planner, this.name)
+          // Called from inside the tool's `execute`, so the planner's turn parents on this tool
+          // call rather than starting a trace of its own.
+          return planner.draftItinerary(goal, injectTraceContext(this.context))
+        },
+      }),
     }
   }
 
@@ -103,7 +148,7 @@ export class MyAgent extends Think<Env> {
     this.context = latitudeContext(this.env, ctx)
 
     return {
-      maxSteps: 4,
+      maxSteps: 6,
       experimental_telemetry: {
         isEnabled: true,
         tracer: getLatitude(this.env).getTracer("cloudflare-think", this.context),
@@ -113,11 +158,11 @@ export class MyAgent extends Think<Env> {
   }
 
   async onChatResponse() {
-    await getLatitude(this.env).flush()
+    await this.telemetry.flush()
   }
 
   onChatError(error: unknown) {
-    this.ctx.waitUntil(getLatitude(this.env).flush())
+    this.telemetry.flushSoon()
     return error
   }
 }

--- a/packages/telemetry/typescript/examples/cloudflare-think-app/wrangler.jsonc
+++ b/packages/telemetry/typescript/examples/cloudflare-think-app/wrangler.jsonc
@@ -18,6 +18,10 @@
       {
         "name": "MyAgent",
         "class_name": "MyAgent"
+      },
+      {
+        "name": "Planner",
+        "class_name": "Planner"
       }
     ]
   },
@@ -25,6 +29,10 @@
     {
       "tag": "v1",
       "new_sqlite_classes": ["MyAgent"]
+    },
+    {
+      "tag": "v2",
+      "new_sqlite_classes": ["Planner"]
     }
   ],
   "vars": {

--- a/packages/telemetry/typescript/package.json
+++ b/packages/telemetry/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/telemetry",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Latitude Telemetry for TypeScript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/typescript/src/cloudflare.ts
+++ b/packages/telemetry/typescript/src/cloudflare.ts
@@ -1,1 +1,15 @@
 export { type CodemodeTelemetry, type CodemodeTelemetryOptions, createCodemodeTelemetry } from "./sdk/codemode.ts"
+export {
+  createDurableObjectTelemetry,
+  type DurableObjectLifecycle,
+  type DurableObjectTelemetry,
+  type DurableObjectTelemetryOptions,
+} from "./sdk/durable-objects.ts"
+export {
+  extractTraceContext,
+  injectTraceContext,
+  type RemoteTraceContext,
+  type RemoteTraceParent,
+  type TraceContextCarrier,
+  withTraceContext,
+} from "./sdk/trace-context.ts"

--- a/packages/telemetry/typescript/src/sdk/context.ts
+++ b/packages/telemetry/typescript/src/sdk/context.ts
@@ -94,27 +94,35 @@ function getCaptureScope(ctx: Context): CaptureScopeInternal | undefined {
   return isCaptureScope(scope) ? scope : undefined
 }
 
+/**
+ * Merges Latitude context into the value the span processor stamps spans from. Nesting rules match
+ * `capture()`: tags accumulate and dedupe, metadata shallow-merges, scalars are last-write-wins.
+ */
+export function setLatitudeContext(ctx: Context, options: ContextOptions): Context {
+  const existingData = getLatitudeContext(ctx)
+
+  const mergedData: LatitudeContextData = {
+    name: options.name ?? existingData?.name,
+    tags: mergeArrays(existingData?.tags, options.tags),
+    metadata: { ...existingData?.metadata, ...options.metadata },
+    sessionId: options.sessionId ?? existingData?.sessionId,
+    userId: options.userId ?? existingData?.userId,
+    userEmail: options.userEmail ?? existingData?.userEmail,
+    project: options.project ?? options.projectSlug ?? existingData?.project,
+  }
+
+  return ctx.setValue(LATITUDE_CONTEXT_KEY, mergedData)
+}
+
 function buildCaptureContext(name: string, currentContext: Context, options: ContextOptions): Context {
-  const existingData = getLatitudeContext(currentContext)
   const shouldReuseTrace = shouldReuseActiveLatitudeTrace(currentContext)
   const parentContext = shouldReuseTrace ? currentContext : trace.deleteSpan(currentContext)
 
   if (options.project === undefined && options.projectSlug !== undefined) {
     warnProjectSlugDeprecated("capture")
   }
-  const projectFromOptions = options.project ?? options.projectSlug
 
-  const mergedData: LatitudeContextData = {
-    name: options.name ?? name,
-    tags: mergeArrays(existingData?.tags, options.tags),
-    metadata: { ...existingData?.metadata, ...options.metadata },
-    sessionId: options.sessionId ?? existingData?.sessionId,
-    userId: options.userId ?? existingData?.userId,
-    userEmail: options.userEmail ?? existingData?.userEmail,
-    project: projectFromOptions ?? existingData?.project,
-  }
-
-  return parentContext.setValue(LATITUDE_CONTEXT_KEY, mergedData)
+  return setLatitudeContext(parentContext, { ...options, name: options.name ?? name })
 }
 
 function startCaptureScope(name: string, options: ContextOptions = {}): CaptureScope {

--- a/packages/telemetry/typescript/src/sdk/durable-objects.test.ts
+++ b/packages/telemetry/typescript/src/sdk/durable-objects.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest"
+import { createDurableObjectTelemetry } from "./durable-objects.ts"
+
+function deferred() {
+  let resolve!: () => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe("createDurableObjectTelemetry", () => {
+  it("flushes after the work resolves", async () => {
+    const order: string[] = []
+    const latitude = {
+      flush: async () => {
+        order.push("flush")
+      },
+    }
+    const telemetry = createDurableObjectTelemetry({ latitude })
+
+    const result = await telemetry.run(async () => {
+      order.push("work")
+      return "done"
+    })
+
+    expect(result).toBe("done")
+    expect(order).toEqual(["work", "flush"])
+  })
+
+  it("flushes and rethrows when the work fails", async () => {
+    const flush = vi.fn(async () => {})
+    const telemetry = createDurableObjectTelemetry({ latitude: { flush } })
+
+    await expect(
+      telemetry.run(async () => {
+        throw new Error("turn failed")
+      }),
+    ).rejects.toThrow("turn failed")
+    expect(flush).toHaveBeenCalledTimes(1)
+  })
+
+  it("collapses callers that arrive while a flush is queued onto one export", async () => {
+    const flush = vi.fn(async () => {})
+    const telemetry = createDurableObjectTelemetry({ latitude: { flush } })
+
+    await Promise.all([telemetry.flush(), telemetry.flush(), telemetry.flush()])
+
+    expect(flush).toHaveBeenCalledTimes(1)
+  })
+
+  it("gives a caller that arrives mid-export a later one", async () => {
+    const gate = deferred()
+    const flush = vi.fn(() => gate.promise)
+    const telemetry = createDurableObjectTelemetry({ latitude: { flush } })
+
+    const first = telemetry.flush()
+    await Promise.resolve()
+    // This caller's spans ended after the in-flight export started, so sharing it would drop them.
+    const second = telemetry.flush()
+    gate.resolve()
+    await Promise.all([first, second])
+
+    expect(flush).toHaveBeenCalledTimes(2)
+  })
+
+  it("never runs two exports at once", async () => {
+    let active = 0
+    let peak = 0
+    const telemetry = createDurableObjectTelemetry({
+      latitude: {
+        flush: async () => {
+          active += 1
+          peak = Math.max(peak, active)
+          await Promise.resolve()
+          active -= 1
+        },
+      },
+    })
+
+    const flushes = Array.from({ length: 5 }, async () => {
+      await telemetry.flush()
+    })
+    await Promise.all(flushes)
+
+    expect(peak).toBe(1)
+  })
+
+  it("reports an export failure instead of failing the work being traced", async () => {
+    const onError = vi.fn()
+    const error = new Error("exporter unreachable")
+    const telemetry = createDurableObjectTelemetry({
+      latitude: { flush: async () => Promise.reject(error) },
+      onError,
+    })
+
+    await expect(telemetry.run(async () => "done")).resolves.toBe("done")
+    expect(onError).toHaveBeenCalledWith(error)
+  })
+
+  it("keeps flushing after a failed export", async () => {
+    const flush = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("exporter unreachable"))
+      .mockResolvedValue(undefined)
+    const telemetry = createDurableObjectTelemetry({ latitude: { flush }, onError: () => {} })
+
+    await telemetry.flush()
+    await telemetry.flush()
+
+    expect(flush).toHaveBeenCalledTimes(2)
+  })
+
+  it("hands the export to waitUntil so the runtime waits for it", async () => {
+    const pending: Promise<unknown>[] = []
+    const flush = vi.fn(async () => {})
+    const telemetry = createDurableObjectTelemetry({
+      latitude: { flush },
+      ctx: { waitUntil: (promise) => pending.push(promise) },
+    })
+
+    telemetry.flushSoon()
+    await Promise.all(pending)
+
+    expect(pending).toHaveLength(1)
+    expect(flush).toHaveBeenCalledTimes(1)
+  })
+
+  it("still exports when waitUntil rejects the registration", async () => {
+    const flush = vi.fn(async () => {})
+    const telemetry = createDurableObjectTelemetry({
+      latitude: { flush },
+      ctx: {
+        waitUntil: () => {
+          throw new Error("Cannot perform I/O on behalf of a different request")
+        },
+      },
+    })
+
+    await telemetry.flush()
+
+    expect(flush).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/telemetry/typescript/src/sdk/durable-objects.ts
+++ b/packages/telemetry/typescript/src/sdk/durable-objects.ts
@@ -1,0 +1,83 @@
+/**
+ * Flushing for agents that live in a Durable Object.
+ *
+ * A Durable Object is evicted whenever it goes idle, with no hook to run first, and the batch span
+ * processor's timer is not a scheduler the runtime keeps alive — a batch still queued when the
+ * object goes away is simply lost. The only reliable discipline is to flush at the end of every
+ * unit of work the object performs: a turn, an RPC method, a `fetch`, an alarm.
+ *
+ * That makes flushing frequent, so it has to be cheap and safe to call: flushes are serialized,
+ * concurrent callers collapse onto one export, and a failing export never surfaces into the work
+ * being traced.
+ */
+
+import type { Latitude } from "./init.ts"
+
+/**
+ * The slice of `DurableObjectState` / `ExecutionContext` this helper uses, structurally typed so
+ * the SDK carries no dependency on `@cloudflare/workers-types`.
+ */
+export type DurableObjectLifecycle = {
+  waitUntil?: (promise: Promise<unknown>) => void
+}
+
+export type DurableObjectTelemetryOptions = {
+  readonly latitude: Pick<Latitude, "flush">
+  /** `this.ctx` of the Durable Object. Registers in-flight exports so the runtime waits for them. */
+  readonly ctx?: DurableObjectLifecycle
+  /** Defaults to `console.error`. An export failure must not fail the work being traced. */
+  readonly onError?: (error: unknown) => void
+}
+
+export type DurableObjectTelemetry = {
+  /** Runs a unit of work and flushes once it settles, whether it resolved or threw. */
+  readonly run: <T>(work: () => T | Promise<T>) => Promise<T>
+  /** Exports everything buffered so far. Concurrent callers share one export. */
+  readonly flush: () => Promise<void>
+  /** Flushes without waiting, handing the export to `ctx.waitUntil()` when one was supplied. */
+  readonly flushSoon: () => void
+}
+
+export function createDurableObjectTelemetry(options: DurableObjectTelemetryOptions): DurableObjectTelemetry {
+  const onError = options.onError ?? ((error: unknown) => console.error("[Latitude] Failed to flush spans:", error))
+
+  let chain: Promise<void> = Promise.resolve()
+  let queued = false
+
+  const flush = (): Promise<void> => {
+    // A caller arriving while an export is in flight needs a later one: spans that ended after it
+    // started are not in it. A caller arriving while one is merely queued can share that queued run.
+    if (queued) return chain
+
+    queued = true
+    chain = chain.then(async () => {
+      queued = false
+      try {
+        await options.latitude.flush()
+      } catch (error) {
+        onError(error)
+      }
+    })
+
+    const pending = chain
+    // `waitUntil` throws once the request that owns the context has finished. The export still runs
+    // to completion either way; registering it only asks the runtime to wait when it still can.
+    try {
+      options.ctx?.waitUntil?.(pending)
+    } catch {}
+
+    return pending
+  }
+
+  return {
+    flush,
+    flushSoon: () => void flush(),
+    run: async (work) => {
+      try {
+        return await work()
+      } finally {
+        await flush()
+      }
+    },
+  }
+}

--- a/packages/telemetry/typescript/src/sdk/index.ts
+++ b/packages/telemetry/typescript/src/sdk/index.ts
@@ -26,5 +26,13 @@ export {
   isLatitudeInstrumentationSpan,
   RedactThenExportSpanProcessor,
 } from "./span-filter.ts"
-export { getLatitudeTracer } from "./tracer.ts"
+export {
+  extractTraceContext,
+  injectTraceContext,
+  type RemoteTraceContext,
+  type RemoteTraceParent,
+  type TraceContextCarrier,
+  withTraceContext,
+} from "./trace-context.ts"
+export { getLatitudeTracer, withParentContext } from "./tracer.ts"
 export type { ContextOptions, InitLatitudeOptions, LatitudeOptions, LatitudeSpanProcessorOptions } from "./types.ts"

--- a/packages/telemetry/typescript/src/sdk/init.ts
+++ b/packages/telemetry/typescript/src/sdk/init.ts
@@ -159,7 +159,8 @@ export class Latitude {
       console.error("[Latitude] Failed to register instrumentations:", err)
     })
 
-    if (!shutdownHandlersRegistered) {
+    // Workers never delivers these signals and may not expose `process`; it flushes at work boundaries.
+    if (!shutdownHandlersRegistered && typeof process !== "undefined" && typeof process.once === "function") {
       process.once("SIGTERM", () => void this.handleShutdown())
       process.once("SIGINT", () => void this.handleShutdown())
       shutdownHandlersRegistered = true

--- a/packages/telemetry/typescript/src/sdk/trace-context.test.ts
+++ b/packages/telemetry/typescript/src/sdk/trace-context.test.ts
@@ -223,6 +223,76 @@ describe("extractTraceContext", () => {
     expect(extractTraceContext(carrier).parent).toBeUndefined()
   })
 
+  it("stays inside an enclosing capture when no carrier arrived", async () => {
+    const exporter = new InMemorySpanExporter()
+    const latitude = newLatitude(exporter)
+
+    // Resetting to a clean context on an absent carrier would tear this work out of its own capture.
+    await capture(
+      "planner-turn",
+      async () => {
+        await withTraceContext(undefined, async () => {
+          latitude.getTracer("planner").startSpan("work").end()
+        })
+      },
+      { sessionId: "local-session" },
+    )
+    await latitude.flush()
+
+    const spans = exporter.getFinishedSpans()
+    const root = find(spans, "planner-turn")
+    const work = find(spans, "work")
+
+    expect(work?.spanContext().traceId).toBe(root?.spanContext().traceId)
+    expect(work?.parentSpanContext?.spanId).toBe(root?.spanContext().spanId)
+    expect(work?.attributes["session.id"]).toBe("local-session")
+
+    await latitude.shutdown()
+  })
+
+  it("overrides the receiver's context with what the carrier holds and keeps the rest", async () => {
+    const exporter = new InMemorySpanExporter()
+    const latitude = newLatitude(exporter)
+    const carrier = {
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01",
+      "x-latitude-context": JSON.stringify({ sessionId: "caller-session" }),
+    }
+
+    await capture(
+      "planner-turn",
+      async () => {
+        await withTraceContext(carrier, async () => {
+          latitude.getTracer("planner").startSpan("work").end()
+        })
+      },
+      { sessionId: "local-session", userId: "local-user" },
+    )
+    await latitude.flush()
+
+    const work = find(exporter.getFinishedSpans(), "work")
+    expect(work?.parentSpanContext?.spanId).toBe("2222222222222222")
+    expect(work?.attributes["session.id"]).toBe("caller-session")
+    expect(work?.attributes["user.id"]).toBe("local-user")
+
+    await latitude.shutdown()
+  })
+
+  it("leaves baggage the host SDK set in place", async () => {
+    const latitude = newLatitude(new InMemorySpanExporter())
+    const tenant = propagation.setBaggage(context.active(), propagation.createBaggage({ tenant: { value: "acme" } }))
+
+    const seen = context.with(tenant, () =>
+      withTraceContext(
+        { traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01" },
+        () => propagation.getBaggage(context.active())?.getEntry("tenant")?.value,
+      ),
+    )
+
+    expect(seen).toBe("acme")
+
+    await latitude.shutdown()
+  })
+
   it("survives a malformed Latitude context without dropping the trace", () => {
     const carrier = {
       traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01",

--- a/packages/telemetry/typescript/src/sdk/trace-context.test.ts
+++ b/packages/telemetry/typescript/src/sdk/trace-context.test.ts
@@ -1,0 +1,263 @@
+import { context, propagation, trace } from "@opentelemetry/api"
+import { InMemorySpanExporter, type ReadableSpan } from "@opentelemetry/sdk-trace-node"
+import { afterEach, describe, expect, it } from "vitest"
+import { capture } from "./context.ts"
+import { Latitude } from "./init.ts"
+import { extractTraceContext, injectTraceContext, withTraceContext } from "./trace-context.ts"
+
+function newLatitude(exporter: InMemorySpanExporter) {
+  return new Latitude({ apiKey: "test-key", project: "test-project", exporter, disableBatch: true })
+}
+
+function find(spans: readonly ReadableSpan[], name: string) {
+  return spans.find((span) => span.name === name)
+}
+
+describe("injectTraceContext", () => {
+  afterEach(() => {
+    trace.disable()
+    context.disable()
+    propagation.disable()
+  })
+
+  it("carries the active span and the ambient Latitude context", async () => {
+    const exporter = new InMemorySpanExporter()
+    const latitude = newLatitude(exporter)
+    let carrier: Record<string, string> = {}
+
+    await capture(
+      "orchestrator-turn",
+      async () => {
+        await latitude.getTracer("orchestrator").startActiveSpan("ai.toolCall plan", async (span) => {
+          carrier = injectTraceContext()
+          span.end()
+        })
+      },
+      { sessionId: "sess-1", userId: "user-1", project: "acme", tags: ["orchestrator"], metadata: { plan: "pro" } },
+    )
+    await latitude.flush()
+
+    const toolSpan = find(exporter.getFinishedSpans(), "ai.toolCall plan")
+    expect(carrier.traceparent).toBe(`00-${toolSpan?.spanContext().traceId}-${toolSpan?.spanContext().spanId}-01`)
+    expect(JSON.parse(carrier["x-latitude-context"] ?? "{}")).toEqual({
+      sessionId: "sess-1",
+      userId: "user-1",
+      project: "acme",
+      tags: ["orchestrator"],
+      metadata: { plan: "pro" },
+    })
+
+    await latitude.shutdown()
+  })
+
+  it("leaves out the SDK's default project, which each side applies from its own configuration", async () => {
+    const exporter = new InMemorySpanExporter()
+    const latitude = newLatitude(exporter)
+
+    const carrier = await capture("orchestrator-turn", async () => injectTraceContext(), { sessionId: "sess-1" })
+
+    expect(JSON.parse(carrier["x-latitude-context"] ?? "{}")).not.toHaveProperty("project")
+
+    await latitude.shutdown()
+  })
+
+  it("leaves out the capture name so the callee's spans are not relabelled", async () => {
+    const exporter = new InMemorySpanExporter()
+    const latitude = newLatitude(exporter)
+    let carrier: Record<string, string> = {}
+
+    await capture("orchestrator-turn", async () => {
+      carrier = injectTraceContext()
+    })
+
+    expect(JSON.parse(carrier["x-latitude-context"] ?? "{}")).not.toHaveProperty("name")
+
+    await latitude.shutdown()
+  })
+
+  it("escapes non-Latin-1 metadata so the carrier survives fetch headers", () => {
+    const carrier = injectTraceContext({ metadata: { city: "Málaga 🌤" } })
+    const encoded = carrier["x-latitude-context"] ?? ""
+
+    expect([...encoded].every((char) => char.charCodeAt(0) <= 0xff)).toBe(true)
+    expect(JSON.parse(encoded)).toEqual({ metadata: { city: "Málaga 🌤" } })
+  })
+
+  it("carries context only when no span is active, leaving the callee a root", () => {
+    const carrier = injectTraceContext({ sessionId: "sess-1" })
+
+    expect(carrier).not.toHaveProperty("traceparent")
+    expect(extractTraceContext(carrier).parent).toBeUndefined()
+  })
+
+  it("writes into a caller-supplied carrier so it can be spread into headers", async () => {
+    const exporter = new InMemorySpanExporter()
+    const latitude = newLatitude(exporter)
+
+    const headers = await latitude.getTracer("orchestrator").startActiveSpan("ai.toolCall plan", async (span) => {
+      const out = injectTraceContext({ sessionId: "sess-1" }, { "content-type": "application/json" })
+      span.end()
+      return out
+    })
+
+    expect(headers["content-type"]).toBe("application/json")
+    expect(headers.traceparent).toBeDefined()
+
+    await latitude.shutdown()
+  })
+})
+
+describe("extractTraceContext", () => {
+  afterEach(() => {
+    trace.disable()
+    context.disable()
+    propagation.disable()
+  })
+
+  it("parents the callee's spans on the caller's tool span across two SDK instances", async () => {
+    const callerExporter = new InMemorySpanExporter()
+    const caller = newLatitude(callerExporter)
+
+    const carrier = await caller.getTracer("orchestrator").startActiveSpan("ai.toolCall plan", async (span) => {
+      const out = injectTraceContext({ sessionId: "sess-1", userId: "user-1", project: "acme" })
+      span.end()
+      return out
+    })
+    await caller.flush()
+    const toolSpan = find(callerExporter.getFinishedSpans(), "ai.toolCall plan")
+
+    // A second Durable Object: its own SDK instance, its own exporter, no shared memory.
+    const calleeExporter = new InMemorySpanExporter()
+    const callee = new Latitude({
+      apiKey: "test-key",
+      project: "test-project",
+      exporter: calleeExporter,
+      disableBatch: true,
+      tracerProvider: caller.provider,
+    })
+
+    await withTraceContext(carrier, async (remote) => {
+      await remote.getTracer(callee, "planner").startActiveSpan("ai.generateText", async (span) => {
+        span.end()
+      })
+    })
+    await callee.flush()
+
+    const plannerSpan = find(calleeExporter.getFinishedSpans(), "ai.generateText")
+    expect(plannerSpan?.spanContext().traceId).toBe(toolSpan?.spanContext().traceId)
+    expect(plannerSpan?.parentSpanContext?.spanId).toBe(toolSpan?.spanContext().spanId)
+    expect(plannerSpan?.attributes["session.id"]).toBe("sess-1")
+    expect(plannerSpan?.attributes["user.id"]).toBe("user-1")
+    expect(plannerSpan?.attributes["latitude.project"]).toBe("acme")
+
+    await callee.shutdown()
+  })
+
+  it("parents a framework-owned tracer with no ambient context", async () => {
+    const exporter = new InMemorySpanExporter()
+    const latitude = newLatitude(exporter)
+    const carrier = {
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01",
+      "x-latitude-context": JSON.stringify({ sessionId: "sess-1" }),
+    }
+
+    // Cloudflare Think hands the tracer back from `beforeTurn()` and starts the turn later, outside
+    // any context this side could have entered.
+    const tracer = extractTraceContext(carrier).getTracer(latitude, "planner")
+    await tracer.startActiveSpan("ai.generateText", async (span) => {
+      await tracer.startActiveSpan("ai.toolCall lookup", async (child) => child.end())
+      span.end()
+    })
+    await latitude.flush()
+
+    const spans = exporter.getFinishedSpans()
+    const turn = find(spans, "ai.generateText")
+    const tool = find(spans, "ai.toolCall lookup")
+
+    expect(turn?.spanContext().traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736")
+    expect(turn?.parentSpanContext?.spanId).toBe("2222222222222222")
+    expect(turn?.attributes["session.id"]).toBe("sess-1")
+    // A nested span keeps its real parent: the remote parent only stands in for a missing one.
+    expect(tool?.parentSpanContext?.spanId).toBe(turn?.spanContext().spanId)
+
+    await latitude.shutdown()
+  })
+
+  it("reads a Request and a Headers as carriers", () => {
+    const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01"
+    const headers = new Headers({ traceparent })
+
+    expect(extractTraceContext(headers).parent?.spanId).toBe("2222222222222222")
+    expect(extractTraceContext(new Request("https://example.com", { headers })).parent?.spanId).toBe("2222222222222222")
+  })
+
+  it("reads carrier keys case-insensitively", () => {
+    const carrier = { TraceParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01" }
+
+    expect(extractTraceContext(carrier).parent?.traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736")
+  })
+
+  it("keeps the sampled flag out of a non-sampled handover", () => {
+    const carrier = { traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-00" }
+
+    expect(extractTraceContext(carrier).parent?.sampled).toBe(false)
+  })
+
+  it("ignores trailing fields of a future traceparent version", () => {
+    const carrier = { traceparent: "01-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01-extra" }
+
+    expect(extractTraceContext(carrier).parent?.spanId).toBe("2222222222222222")
+  })
+
+  it.each([
+    ["absent", undefined],
+    ["empty", {}],
+    ["truncated", { traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222" }],
+    ["version ff", { traceparent: "ff-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01" }],
+    ["all-zero trace id", { traceparent: `00-${"0".repeat(32)}-2222222222222222-01` }],
+    ["all-zero span id", { traceparent: `00-4bf92f3577b34da6a3ce929d0e0e4736-${"0".repeat(16)}-01` }],
+    ["over-long version 00", { traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01-extra" }],
+    ["non-hex", { traceparent: "00-zzf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01" }],
+    ["newline-split", { traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-2222\n222222222222-01" }],
+  ])("makes the callee a root when the traceparent is %s", (_case, carrier) => {
+    expect(extractTraceContext(carrier).parent).toBeUndefined()
+  })
+
+  it("survives a malformed Latitude context without dropping the trace", () => {
+    const carrier = {
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-01",
+      "x-latitude-context": "{not json",
+    }
+    const remote = extractTraceContext(carrier)
+
+    expect(remote.parent?.spanId).toBe("2222222222222222")
+    expect(remote.context).toEqual({})
+  })
+
+  it("drops context fields that are not the type they claim", () => {
+    const carrier = {
+      "x-latitude-context": JSON.stringify({ sessionId: 42, tags: ["ok", 7], metadata: ["nope"] }),
+    }
+
+    expect(extractTraceContext(carrier).context).toEqual({ tags: ["ok"] })
+  })
+
+  it("lets the callee override carried context without losing the rest", () => {
+    const exporter = new InMemorySpanExporter()
+    const latitude = newLatitude(exporter)
+    const carrier = injectTraceContext({ sessionId: "sess-1", tags: ["orchestrator"], project: "caller-project" })
+    const remote = extractTraceContext(carrier)
+
+    remote
+      .getTracer(latitude, "planner", { tags: ["planner"], project: "callee-project" })
+      .startSpan("x")
+      .end()
+
+    const span = find(exporter.getFinishedSpans(), "x")
+    expect(span?.attributes["session.id"]).toBe("sess-1")
+    expect(span?.attributes["latitude.project"]).toBe("callee-project")
+    expect(JSON.parse(String(span?.attributes["latitude.tags"]))).toEqual(["orchestrator", "planner"])
+
+    return latitude.shutdown()
+  })
+})

--- a/packages/telemetry/typescript/src/sdk/trace-context.ts
+++ b/packages/telemetry/typescript/src/sdk/trace-context.ts
@@ -219,7 +219,13 @@ export function injectTraceContext(context?: ContextOptions, carrier: TraceConte
 
 /**
  * Reads a carrier produced by `injectTraceContext()`. Accepts a plain carrier, a `Headers`, or a
- * `Request`. Always returns a usable result: an absent or malformed carrier yields a root.
+ * `Request`.
+ *
+ * The carrier overrides, it does not replace. A parent it holds wins over the receiver's active
+ * span and the fields it holds win over the receiver's, but whatever it leaves out stays as the
+ * receiver had it — so an absent or malformed carrier is a no-op, and the callee roots its own
+ * trace exactly where it would have anyway. Deliberately not a reset to a clean context: that
+ * would pull the work out of an enclosing `capture()` and drop baggage the host SDK set.
  */
 export function extractTraceContext(source?: CarrierSource): RemoteTraceContext {
   const read = toReader(source)

--- a/packages/telemetry/typescript/src/sdk/trace-context.ts
+++ b/packages/telemetry/typescript/src/sdk/trace-context.ts
@@ -1,0 +1,266 @@
+/**
+ * W3C Trace Context across a call boundary that carries no ambient context.
+ *
+ * Two agents in separate Durable Objects share no memory and no OpenTelemetry context: the callee
+ * roots its own trace unless the caller hands the active span over as data. `injectTraceContext()`
+ * serializes it, `extractTraceContext()` / `withTraceContext()` reinstall it on the other side.
+ *
+ * The contract is the one the Hermes and Claude Code emitters already use across processes, only
+ * with an argument instead of the environment: a valid traceparent means "you are a child of this
+ * span", its absence means "you are a root". A malformed one makes the callee a root, never a
+ * failure.
+ *
+ * Carrier keys are HTTP header names, so the same object works as an RPC argument and as `fetch`
+ * headers.
+ */
+
+import {
+  createTraceState,
+  isSpanContextValid,
+  type Context as OtelContext,
+  context as otelContext,
+  TraceFlags,
+  type Tracer,
+  trace,
+} from "@opentelemetry/api"
+import { getLatitudeContext, setLatitudeContext } from "./context.ts"
+import type { Latitude } from "./init.ts"
+import { withParentContext } from "./tracer.ts"
+import type { ContextOptions } from "./types.ts"
+
+const TRACEPARENT = "traceparent"
+const TRACESTATE = "tracestate"
+const LATITUDE_CONTEXT = "x-latitude-context"
+
+const TRACE_ID_RE = /^[0-9a-f]{32}$/
+const SPAN_ID_RE = /^[0-9a-f]{16}$/
+const HEX_BYTE_RE = /^[0-9a-f]{2}$/
+const NON_LATIN1_RE = /[\u0080-\uffff]/g
+
+export type TraceContextCarrier = Record<string, string>
+
+type HeadersLike = { get(name: string): string | null }
+type RequestLike = { headers: HeadersLike }
+type CarrierSource = TraceContextCarrier | HeadersLike | RequestLike | null | undefined
+
+export type RemoteTraceParent = {
+  readonly traceId: string
+  readonly spanId: string
+  readonly sampled: boolean
+}
+
+export type RemoteTraceContext = {
+  /** The span the caller handed over, or `undefined` when this side is a root. */
+  readonly parent: RemoteTraceParent | undefined
+  /** Session, user, project, tags and metadata the caller carried over. */
+  readonly context: ContextOptions
+  /** OpenTelemetry context with the remote parent and the Latitude context installed. */
+  readonly otelContext: OtelContext
+  /** Runs `work` with that context active, so spans started inside join the caller's trace. */
+  readonly run: <T>(work: () => T) => T
+  /**
+   * A tracer whose spans join the caller's trace and carry its Latitude context, for frameworks
+   * that own the model call and take a tracer instead of running inside a callback — Cloudflare
+   * Think's `beforeTurn()`, the AI SDK's `experimental_telemetry`.
+   */
+  readonly getTracer: (latitude: Pick<Latitude, "getTracer">, scope: string, overrides?: ContextOptions) => Tracer
+}
+
+function isHeadersLike(value: object): value is HeadersLike {
+  return typeof (value as HeadersLike).get === "function"
+}
+
+function isRequestLike(value: object): value is RequestLike {
+  const headers = (value as RequestLike).headers
+  return typeof headers === "object" && headers !== null && isHeadersLike(headers)
+}
+
+function toReader(source: CarrierSource): (key: string) => string | undefined {
+  if (!source || typeof source !== "object") return () => undefined
+
+  const headers = isHeadersLike(source) ? source : isRequestLike(source) ? source.headers : undefined
+  if (headers) return (key) => headers.get(key) ?? undefined
+
+  const lowered = new Map<string, string>()
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof value === "string") lowered.set(key.toLowerCase(), value)
+  }
+  return (key) => lowered.get(key)
+}
+
+function parseTraceparent(raw: string | undefined): RemoteTraceParent | undefined {
+  const value = (raw ?? "").trim().toLowerCase()
+  if (!value) return undefined
+
+  const parts = value.split("-")
+  if (parts.length < 4) return undefined
+
+  const [version, traceId, spanId, flags] = parts as [string, string, string, string]
+  if (!HEX_BYTE_RE.test(version) || version === "ff") return undefined
+  // Version 00 is exactly four fields; a later version may append more, which this version must
+  // ignore rather than reject (W3C forward-compatibility rule).
+  if (version === "00" && parts.length !== 4) return undefined
+  if (!TRACE_ID_RE.test(traceId) || !SPAN_ID_RE.test(spanId) || !HEX_BYTE_RE.test(flags)) return undefined
+  if (traceId === "0".repeat(32) || spanId === "0".repeat(16)) return undefined
+
+  return { traceId, spanId, sampled: (Number.parseInt(flags, 16) & TraceFlags.SAMPLED) !== 0 }
+}
+
+function formatTraceparent(traceId: string, spanId: string, sampled: boolean): string {
+  return `00-${traceId}-${spanId}-${sampled ? "01" : "00"}`
+}
+
+function toContextOptions(source: {
+  name?: string | undefined
+  tags?: readonly string[] | undefined
+  metadata?: Record<string, unknown> | undefined
+  sessionId?: string | undefined
+  userId?: string | undefined
+  userEmail?: string | undefined
+  project?: string | undefined
+}): ContextOptions {
+  return {
+    ...(source.name ? { name: source.name } : {}),
+    ...(source.tags && source.tags.length > 0 ? { tags: [...source.tags] } : {}),
+    ...(source.metadata && Object.keys(source.metadata).length > 0 ? { metadata: source.metadata } : {}),
+    ...(source.sessionId ? { sessionId: source.sessionId } : {}),
+    ...(source.userId ? { userId: source.userId } : {}),
+    ...(source.userEmail ? { userEmail: source.userEmail } : {}),
+    ...(source.project ? { project: source.project } : {}),
+  }
+}
+
+function mergeContextOptions(base: ContextOptions, overrides: ContextOptions | undefined): ContextOptions {
+  if (!overrides) return base
+
+  return toContextOptions({
+    name: overrides.name ?? base.name,
+    tags: overrides.tags ? [...new Set([...(base.tags ?? []), ...overrides.tags])] : base.tags,
+    metadata: overrides.metadata ? { ...base.metadata, ...overrides.metadata } : base.metadata,
+    sessionId: overrides.sessionId ?? base.sessionId,
+    userId: overrides.userId ?? base.userId,
+    userEmail: overrides.userEmail ?? base.userEmail,
+    project: overrides.project ?? overrides.projectSlug ?? base.project ?? base.projectSlug,
+  })
+}
+
+// Header values must be Latin-1, so metadata holding an accent or an emoji would throw when the
+// carrier is spread into `fetch` headers. `JSON.parse` reads the escapes back natively.
+function toAsciiJson(value: unknown): string {
+  return JSON.stringify(value).replace(
+    NON_LATIN1_RE,
+    (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  )
+}
+
+function encodeLatitudeContext(context: ContextOptions): string | undefined {
+  // `name` labels one capture root, so carrying it over would relabel every span the callee emits.
+  const { name: _name, projectSlug: _projectSlug, ...carried } = context
+  if (Object.keys(carried).length === 0) return undefined
+  return toAsciiJson(carried)
+}
+
+function decodeLatitudeContext(raw: string | undefined): ContextOptions {
+  if (!raw) return {}
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {}
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {}
+
+  const value = parsed as Record<string, unknown>
+  const tags = value.tags
+  const metadata = value.metadata
+
+  return toContextOptions({
+    tags: Array.isArray(tags) ? tags.filter((tag): tag is string => typeof tag === "string") : undefined,
+    metadata:
+      typeof metadata === "object" && metadata !== null && !Array.isArray(metadata)
+        ? (metadata as Record<string, unknown>)
+        : undefined,
+    sessionId: typeof value.sessionId === "string" ? value.sessionId : undefined,
+    userId: typeof value.userId === "string" ? value.userId : undefined,
+    userEmail: typeof value.userEmail === "string" ? value.userEmail : undefined,
+    project: typeof value.project === "string" ? value.project : undefined,
+  })
+}
+
+/**
+ * Serializes the active span and Latitude context into a carrier the callee can join.
+ *
+ * Anchors on whichever span is active, so calling it from inside a tool's `execute` makes the
+ * callee a child of that tool call — the edge that distinguishes "this agent was launched by that
+ * specific tool call" from "both ran during the same turn". With no active span it carries context
+ * only, and the callee roots its own trace.
+ */
+export function injectTraceContext(context?: ContextOptions, carrier: TraceContextCarrier = {}): TraceContextCarrier {
+  const active = otelContext.active()
+  const spanContext = trace.getSpanContext(active)
+
+  if (spanContext && isSpanContextValid(spanContext)) {
+    carrier[TRACEPARENT] = formatTraceparent(
+      spanContext.traceId,
+      spanContext.spanId,
+      (spanContext.traceFlags & TraceFlags.SAMPLED) !== 0,
+    )
+    const traceState = spanContext.traceState?.serialize()
+    if (traceState) carrier[TRACESTATE] = traceState
+  }
+
+  const ambient = getLatitudeContext(active)
+  const encoded = encodeLatitudeContext(mergeContextOptions(ambient ? toContextOptions(ambient) : {}, context))
+  if (encoded) carrier[LATITUDE_CONTEXT] = encoded
+
+  return carrier
+}
+
+/**
+ * Reads a carrier produced by `injectTraceContext()`. Accepts a plain carrier, a `Headers`, or a
+ * `Request`. Always returns a usable result: an absent or malformed carrier yields a root.
+ */
+export function extractTraceContext(source?: CarrierSource): RemoteTraceContext {
+  const read = toReader(source)
+  const parent = parseTraceparent(read(TRACEPARENT))
+  const context = decodeLatitudeContext(read(LATITUDE_CONTEXT))
+
+  let resolved = otelContext.active()
+
+  if (parent) {
+    const rawTraceState = read(TRACESTATE)
+    const traceState = rawTraceState ? createTraceState(rawTraceState) : undefined
+    resolved = trace.setSpanContext(resolved, {
+      traceId: parent.traceId,
+      spanId: parent.spanId,
+      traceFlags: parent.sampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
+      isRemote: true,
+      ...(traceState ? { traceState } : {}),
+    })
+  }
+
+  if (Object.keys(context).length > 0) {
+    resolved = setLatitudeContext(resolved, context)
+  }
+
+  return {
+    parent,
+    context,
+    otelContext: resolved,
+    run: (work) => otelContext.with(resolved, work),
+    getTracer: (latitude, scope, overrides) => {
+      const tracer = latitude.getTracer(scope, mergeContextOptions(context, overrides))
+      return parent ? withParentContext(tracer, resolved) : tracer
+    },
+  }
+}
+
+/**
+ * Runs `work` inside the caller's trace and Latitude context. The extracted context is handed to
+ * `work` so a framework that needs a tracer rather than an ambient context can reach `getTracer()`.
+ */
+export function withTraceContext<T>(source: CarrierSource, work: (remote: RemoteTraceContext) => T): T {
+  const remote = extractTraceContext(source)
+  return remote.run(() => work(remote))
+}

--- a/packages/telemetry/typescript/src/sdk/tracer.ts
+++ b/packages/telemetry/typescript/src/sdk/tracer.ts
@@ -1,4 +1,12 @@
-import { type Attributes, type Context, type Span, type SpanOptions, type Tracer, trace } from "@opentelemetry/api"
+import {
+  type Attributes,
+  type Context,
+  context as otelContext,
+  type Span,
+  type SpanOptions,
+  type Tracer,
+  trace,
+} from "@opentelemetry/api"
 import { ATTRIBUTES } from "../constants/attributes.ts"
 import { SCOPE_LATITUDE } from "../constants/scope.ts"
 import type { ContextOptions } from "./types.ts"
@@ -73,4 +81,40 @@ export function withLatitudeAttributes(tracer: Tracer, attributes: Attributes): 
   }
 
   return wrapper
+}
+
+/**
+ * Wraps a tracer so a span it starts outside any active span attaches to `parent` — the span a
+ * caller in another process handed over — instead of rooting a fresh trace. Once one of its spans
+ * is active, descendants nest under that span as usual: re-parenting everything on the remote span
+ * would flatten the framework's own nesting into one level.
+ */
+export function withParentContext(tracer: Tracer, parent: Context): Tracer {
+  const resolve = (explicit?: Context): Context => {
+    if (explicit) return explicit
+    const active = otelContext.active()
+    return trace.getSpan(active) ? active : parent
+  }
+
+  const startActive = tracer.startActiveSpan.bind(tracer) as (name: string, ...rest: unknown[]) => unknown
+
+  return {
+    startSpan(name: string, options?: SpanOptions, context?: Context): Span {
+      return tracer.startSpan(name, options, resolve(context))
+    },
+    startActiveSpan<F extends (span: Span) => unknown>(
+      name: string,
+      arg1: F | SpanOptions,
+      arg2?: F | Context,
+      arg3?: F,
+    ): ReturnType<F> {
+      if (typeof arg1 === "function") {
+        return startActive(name, {}, resolve(), arg1) as ReturnType<F>
+      }
+      if (typeof arg2 === "function") {
+        return startActive(name, arg1, resolve(), arg2) as ReturnType<F>
+      }
+      return startActive(name, arg1, resolve(arg2 as Context), arg3) as ReturnType<F>
+    },
+  }
 }


### PR DESCRIPTION
A user on Cloudflare Workers + Durable Objects (Agents SDK, `@cloudflare/think`, AI SDK v6) reported two gaps and hand-rolled both workarounds: passing `traceparent` manually across an RPC call so a second agent joins the trace, and force-flushing spans in every agent before the object disappears. This makes the SDK handle both.

Neither is a new problem. `dev-docs/trace-correlation.md` already defines the contract for it — *a valid traceparent means "you are a child of this span", its absence means "you are a root"* — for Hermes launching Claude Code across processes. A Durable Object is the same situation with a different transport: its own isolate, no shared memory, no ambient OpenTelemetry context, but reached over an RPC call rather than spawned, so there is no environment to inherit. This carries the same contract over an argument.

## propagation

`injectTraceContext(context?)` serializes the active span plus the Latitude context into a carrier. `extractTraceContext()` and `withTraceContext()` reinstall it on the other side.

```ts
// orchestrator
execute: async ({ goal }) => {
  const planner = await getAgentByName(this.env.Planner, this.name)
  return planner.draftItinerary(goal, injectTraceContext(this.context))
}

// planner, in its own Durable Object
async draftItinerary(goal: string, trace?: TraceContextCarrier) {
  return withTraceContext(trace, async (remote) =>
    generateText({
      model: getModel(this.env),
      prompt: `Draft a two-day itinerary. Goal: ${goal}`,
      experimental_telemetry: {
        isEnabled: true,
        tracer: remote.getTracer(getLatitude(this.env), "cloudflare-planner"),
      },
    }),
  )
}
```

Injecting from inside a tool's `execute` anchors on that tool span, which is the edge that makes the callee render as a **subagent of that specific call** instead of something that happened to run during the same turn.

The carrier is keyed by HTTP header names (`traceparent`, `tracestate`, `x-latitude-context`), so one object serves an RPC argument and `fetch` headers; the extract side also accepts a `Request` or a `Headers`. Parsing follows the same W3C rules as the Python side — version `ff`, all-zero ids, over-long v00, forward-compatible trailing fields — with the same posture: malformed means root, never a throw.

Two things deliberately don't cross. A `capture()` name labels one capture root and would relabel every span the callee emits. The SDK's *default* project is per-instance configuration each side already has; an explicit `ContextOptions.project` is carried, and has to be set when the two agents ship to different projects, or the trace splits in half with no error anywhere.

`withParentContext(tracer, context)` is the piece that makes this work for frameworks that hand back a tracer instead of running inside a callback, like Think's `beforeTurn()`. It attaches the tracer's first span to the remote parent and leaves nested spans on their real parents — re-parenting everything would flatten the AI SDK's own nesting into one level.

## flushing

There is no eviction hook to wait for, and the batch processor's timer is not a scheduler the Workers runtime keeps alive, so a batch still queued when the object goes idle is simply gone. The only reliable point is the end of each unit of work — a turn, an RPC method, a `fetch`, an alarm. That makes flushing frequent, so `createDurableObjectTelemetry()` makes it cheap and safe to call constantly:

- exports are serialized and coalesced
- a caller arriving mid-export gets a *later* one, since an in-flight export cannot contain spans that ended after it started
- in-flight exports register with `ctx.waitUntil()`, guarded because it throws once the owning request has finished
- a failed export goes to `onError` rather than into the work being traced

`run()` wraps a unit of work and flushes when it settles either way; `flush()` and `flushSoon()` are there for framework hooks like `onChatResponse` / `onChatError`.

Also guards `process.once` in the constructor, which Workers may not expose.

## validation

Ingest needed no changes. The Durable Object case added to `cross-harness-correlation.test.ts` resolves the planner as a subagent under the tool call in either arrival order — worth having separately from the Hermes case, since the AI SDK's attribute shape reaches the graph by a different route. That test initially failed until the planner got its inner `doGenerate` span: `ai.generateText` alone maps to `agent_step`, not a generation, so the tool span was never a boundary. It now mirrors what the SDK actually emits, verified against a real AI SDK v6 run rather than assumed.

20 unit tests across `trace-context.test.ts` and `durable-objects.test.ts`. The runnable example gains a real second Durable Object reached over RPC, and its local verifier now runs the planner turn *after* the orchestrator turn closes — the late, out-of-order arrival an evicted object produces — then asserts in ClickHouse that both landed on one trace under the `draftItinerary` tool span.

Verified end to end against a local Latitude instance. The stored trace:

```
ai.streamText                        invoke_agent   c753ac33
├── ai.streamText.doStream           chat           ee3ea998
│   └── ai.toolCall execute          execute_tool   6fef7e00
├── ai.streamText.doStream           chat           b188124b
│   └── ai.toolCall draftItinerary   execute_tool   2ab0969c   ← the causal boundary
│       └── ai.generateText          agent_step     213551db   ← the second Durable Object
│           └── ai.generateText.doGenerate  chat    74e8f1be
└── ai.streamText.doStream           chat           864705ed
```

One trace id across both emitters, session and user on all eight spans, and the planner parented on the tool call that invoked it — emitted after the orchestrator turn had already closed, from the carrier alone.

Releases as 4.1.0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790864453&installation_model_id=435055&pr_number=4529&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4529&signature=24c500ae4ddd39c6f6fc60ce0663af68dd2a527120cf7fe88f5653d5eb035cea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
