### PR TITLE
fix(signals): no-op lifecycle on unpromoted candidates

### DIFF
--- a/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.test.ts
+++ b/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.test.ts
@@ -153,4 +153,27 @@ describe("requestSignalDiscoveredNotificationsUseCase", () => {
 
     expect(result).toEqual({ status: "skipped", reason: "user-origin-signal" })
   })
+
+  it("skips ignored, resolved, and muted signals so a back-door lifecycle does not notify on promotion", async () => {
+    const ignored = await Effect.runPromise(
+      requestSignalDiscoveredNotificationsUseCase(input).pipe(
+        Effect.provide(makeLayer({ signal: makeSignal({ ignoredAt: new Date("2026-06-16T00:00:00.000Z") }) })),
+      ),
+    )
+    expect(ignored).toEqual({ status: "skipped", reason: "signal-ignored" })
+
+    const resolved = await Effect.runPromise(
+      requestSignalDiscoveredNotificationsUseCase(input).pipe(
+        Effect.provide(makeLayer({ signal: makeSignal({ resolvedAt: new Date("2026-06-16T00:00:00.000Z") }) })),
+      ),
+    )
+    expect(resolved).toEqual({ status: "skipped", reason: "signal-resolved" })
+
+    const muted = await Effect.runPromise(
+      requestSignalDiscoveredNotificationsUseCase(input).pipe(
+        Effect.provide(makeLayer({ signal: makeSignal({ mutedAt: new Date("2026-06-16T00:00:00.000Z") }) })),
+      ),
+    )
+    expect(muted).toEqual({ status: "skipped", reason: "signal-muted" })
+  })
 })

--- a/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.ts
+++ b/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.ts
@@ -34,7 +34,16 @@ export interface SignalDiscoveredNotificationRequest {
 }
 
 export type RequestSignalDiscoveredNotificationsResult =
-  | { readonly status: "skipped"; readonly reason: "signal-not-found" | "user-origin-signal" | "no-recipients" }
+  | {
+      readonly status: "skipped"
+      readonly reason:
+        | "signal-not-found"
+        | "user-origin-signal"
+        | "signal-muted"
+        | "signal-ignored"
+        | "signal-resolved"
+        | "no-recipients"
+    }
   | { readonly status: "ok"; readonly requests: readonly SignalDiscoveredNotificationRequest[] }
 
 export type RequestSignalDiscoveredNotificationsError = RepositoryError
@@ -54,6 +63,18 @@ export const requestSignalDiscoveredNotificationsUseCase = (input: RequestSignal
     if (signal.origin === "user") {
       yield* Effect.annotateCurrentSpan("skipped", "user-origin-signal")
       return { status: "skipped", reason: "user-origin-signal" } as const
+    }
+    if (signal.mutedAt !== null) {
+      yield* Effect.annotateCurrentSpan("skipped", "signal-muted")
+      return { status: "skipped", reason: "signal-muted" } as const
+    }
+    if (signal.ignoredAt !== null) {
+      yield* Effect.annotateCurrentSpan("skipped", "signal-ignored")
+      return { status: "skipped", reason: "signal-ignored" } as const
+    }
+    if (signal.resolvedAt !== null) {
+      yield* Effect.annotateCurrentSpan("skipped", "signal-resolved")
+      return { status: "skipped", reason: "signal-resolved" } as const
     }
 
     const hasSignalAssignee = Boolean(signal.assigneeId)

--- a/packages/domain/signals/src/use-cases/apply-signal-lifecycle-command.test.ts
+++ b/packages/domain/signals/src/use-cases/apply-signal-lifecycle-command.test.ts
@@ -346,28 +346,32 @@ describe("applySignalLifecycleCommandUseCase", () => {
       expect(events).toHaveLength(1)
     })
 
-    it.each(["resolve", "unresolve", "ignore", "unignore", "mute", "unmute"] as const)(
-      "treats an unpromoted candidate as not found on %s",
-      async (command) => {
-        const candidate = makeSignal("c".repeat(24), { promotedAt: null })
-        const { effect, issues, events, softDeletedSignalIds } = run({
-          signals: [candidate],
-          command,
-        })
+    it.each([
+      "resolve",
+      "unresolve",
+      "ignore",
+      "unignore",
+      "mute",
+      "unmute",
+    ] as const)("treats an unpromoted candidate as not found on %s", async (command) => {
+      const candidate = makeSignal("c".repeat(24), { promotedAt: null })
+      const { effect, issues, events, softDeletedSignalIds } = run({
+        signals: [candidate],
+        command,
+      })
 
-        await expect(Effect.runPromise(effect)).rejects.toMatchObject({
-          _tag: "NotFoundError",
-          entity: "Signal",
-          id: candidate.id,
-        })
-        expect(issues.get(candidate.id)).toMatchObject({
-          resolvedAt: null,
-          ignoredAt: null,
-          mutedAt: null,
-        })
-        expect(events).toEqual([])
-        expect(softDeletedSignalIds).toEqual([])
-      },
-    )
+      await expect(Effect.runPromise(effect)).rejects.toMatchObject({
+        _tag: "NotFoundError",
+        entity: "Signal",
+        id: candidate.id,
+      })
+      expect(issues.get(candidate.id)).toMatchObject({
+        resolvedAt: null,
+        ignoredAt: null,
+        mutedAt: null,
+      })
+      expect(events).toEqual([])
+      expect(softDeletedSignalIds).toEqual([])
+    })
   })
 })

--- a/packages/domain/signals/src/use-cases/apply-signal-lifecycle-command.test.ts
+++ b/packages/domain/signals/src/use-cases/apply-signal-lifecycle-command.test.ts
@@ -43,7 +43,7 @@ const makeSignal = (id: string, overrides: Partial<Signal> = {}): Signal => ({
   priority: null,
   centroid: null,
   clusteredAt: null,
-  promotedAt: null,
+  promotedAt: earlier,
   resolvedAt: null,
   ignoredAt: null,
   regressedAt: null,
@@ -345,5 +345,29 @@ describe("applySignalLifecycleCommandUseCase", () => {
       expect(result.items).toHaveLength(1)
       expect(events).toHaveLength(1)
     })
+
+    it.each(["resolve", "unresolve", "ignore", "unignore", "mute", "unmute"] as const)(
+      "treats an unpromoted candidate as not found on %s",
+      async (command) => {
+        const candidate = makeSignal("c".repeat(24), { promotedAt: null })
+        const { effect, issues, events, softDeletedSignalIds } = run({
+          signals: [candidate],
+          command,
+        })
+
+        await expect(Effect.runPromise(effect)).rejects.toMatchObject({
+          _tag: "NotFoundError",
+          entity: "Signal",
+          id: candidate.id,
+        })
+        expect(issues.get(candidate.id)).toMatchObject({
+          resolvedAt: null,
+          ignoredAt: null,
+          mutedAt: null,
+        })
+        expect(events).toEqual([])
+        expect(softDeletedSignalIds).toEqual([])
+      },
+    )
   })
 })

--- a/packages/domain/signals/src/use-cases/apply-signal-lifecycle-command.ts
+++ b/packages/domain/signals/src/use-cases/apply-signal-lifecycle-command.ts
@@ -4,7 +4,7 @@ import {
   BadRequestError,
   type ConcurrentSqlTransactionError,
   cuidSchema,
-  type NotFoundError,
+  NotFoundError,
   ProjectId,
   RepositoryError,
   resolveSettings,
@@ -159,6 +159,9 @@ export const applySignalLifecycleCommandUseCase = (
             return yield* new BadRequestError({
               message: `Signal ${signal.id} does not belong to project ${parsed.projectId}`,
             })
+          }
+          if (signal.promotedAt === null) {
+            return yield* new NotFoundError({ entity: "Signal", id: signal.id })
           }
 
           const { nextSignal, changed } = applyCommandToSignal({ signal, command: parsed.command, now })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

After #4465, unpromoted candidates are hidden on every read. Lifecycle writes still went through `findByIdForUpdate`, which includes those rows. Anyone who had a score's `signalId` could ignore, resolve, or mute a hidden candidate. If that candidate later promoted, `signal.discovered` still fired.

Lifecycle commands now treat an unpromoted candidate as not found (same 404 as get/list). Discovery notify also skips muted, ignored, and resolved signals, matching agent dispatch, so a stamp that already landed through that back door cannot announce the signal on promotion.

`findByIdForUpdate` itself is unchanged. Promotion and score assignment still need the unpromoted row.

This stays on lifecycle + discovered notify. It does not re-check the promotion gate before stamping `promoted_at`.

## Related issue (if applicable)

Refs #4465. Replaces the approach in closed draft #4473, which used `BadRequestError` and would have admitted the candidate exists.

## How was this tested?

- `pnpm --filter @domain/signals test -- src/use-cases/apply-signal-lifecycle-command.test.ts` (208 passed, including 6 unpromoted no-op cases)
- `pnpm --filter @domain/notifications test -- src/use-cases/request-signal-discovered-notifications.test.ts` (71 passed, including the ignored/resolved/muted skip)
- `pnpm --filter @domain/signals typecheck` and `pnpm --filter @domain/notifications typecheck`
- `pnpm --filter @domain/signals check` and `pnpm --filter @domain/notifications check`

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a02673c-bc3e-4c78-a893-c5f57c5be999?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a02673c-bc3e-4c78-a893-c5f57c5be999&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790866596&installation_model_id=435055&pr_number=4530&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4530&signature=eafcdfee1e646b4490cecf0c2543e2504fca4bff50230688c6f5ba95ac3c44b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->