### PR TITLE
fix(cost): All-time KPIs and breakdown use full history

### DIFF
--- a/apps/web/src/domains/traces/traces.collection.ts
+++ b/apps/web/src/domains/traces/traces.collection.ts
@@ -155,6 +155,8 @@ export function useProjectLastTraceAt({
 /**
  * Earliest trace `start_time` (ISO) for the whole project, or null. The concrete "All time" lower
  * bound for analytics screens whose endpoints require one (robust, unlike `project.firstTraceAt`).
+ * `isLoading` separates "not settled yet" from "no traces", so callers can hold a query whose window
+ * would otherwise fall back to a narrower default.
  */
 export function useProjectFirstTraceAt({
   projectId,
@@ -164,14 +166,14 @@ export function useProjectFirstTraceAt({
   readonly enabled?: boolean
 }) {
   const scope = useProjectScope()
-  const { data = null } = useQuery({
+  const { data = null, isLoading } = useQuery({
     queryKey: [...projectScopeKey(scope), "traces-first-at", projectId],
     queryFn: () => getProjectFirstTraceAt({ data: { ...projectScopeData(scope), projectId } }),
     staleTime: 30_000,
     enabled: enabled && projectId.length > 0,
   })
 
-  return { firstTraceAt: data }
+  return { firstTraceAt: data, isLoading }
 }
 
 export function useTraceMetrics({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/model-impact-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/-components/model-impact-panel.tsx
@@ -244,9 +244,9 @@ export function ModelImpactPanel({
         fromIso={rangeFromIso}
         toIso={rangeToIso}
         isAllTime={isAllTime}
-        // The picker above states this window already, and the recent-activity
-        // distinction that other dashboards flag isn't relevant to this panel.
-        showWindow={false}
+        // Totals here follow listRange (full history in All-time) while the
+        // sibling usage chart stays on the recent-activity slice.
+        showWindow={isAllTime}
         titleColor="foregroundMuted"
       />
       {isLoading || !breakdown ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cost/index.tsx
@@ -72,7 +72,7 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/cost
 function CostPageContent() {
   const project = useRouteProject()
   const projectSlug = project.slug
-  const { firstTraceAt } = useProjectFirstTraceAt({ projectId: project.id })
+  const { firstTraceAt, isLoading: firstTraceLoading } = useProjectFirstTraceAt({ projectId: project.id })
   const { lastTraceAt } = useProjectLastTraceAt({ projectId: project.id })
   const tw = useAnalyticsTimeWindow({
     project,
@@ -86,97 +86,124 @@ function CostPageContent() {
   const [usageMeasure, setUsageMeasure] = useParamState("costUsage", "cost", { validate: isModelUsageMeasure })
   const costDashboard = useFeatureFlagGate("costDashboard")
 
-  // One window for the KPIs and the chart, so the two can be reconciled.
-  const range = useMemo(
-    () =>
-      tw.isAllTime
-        ? tw.trendRange
-        : { fromIso: tw.listRange.fromIso ?? tw.trendRange.fromIso, toIso: tw.listRange.toIso },
-    [tw.isAllTime, tw.listRange, tw.trendRange],
+  const listRange = useMemo(
+    () => ({ fromIso: tw.listRange.fromIso ?? tw.trendRange.fromIso, toIso: tw.listRange.toIso }),
+    [tw.listRange, tw.trendRange],
   )
-  const bucketSeconds = useMemo(
-    () => pickCostBucketSeconds(Date.parse(range.toIso) - Date.parse(range.fromIso)),
-    [range],
+  const chartRange = useMemo(() => (tw.isAllTime ? tw.trendRange : listRange), [tw.isAllTime, tw.trendRange, listRange])
+  const chartBucketSeconds = useMemo(
+    () => pickCostBucketSeconds(Date.parse(chartRange.toIso) - Date.parse(chartRange.fromIso)),
+    [chartRange],
+  )
+  const listBucketSeconds = useMemo(
+    () => pickCostBucketSeconds(Date.parse(listRange.toIso) - Date.parse(listRange.fromIso)),
+    [listRange],
   )
 
   const enabled = costDashboard.isEnabled
-  const { data: overview, isLoading: overviewLoading } = useCostOverview({ projectId: project.id, range, enabled })
+  // Until the first trace settles, All time has no lower bound and `listRange` falls back to the
+  // chart window, so the full-history reads wait rather than fetch a narrower window and refetch.
+  const listEnabled = enabled && !firstTraceLoading
+  const { data: overview, isLoading: overviewLoading } = useCostOverview({
+    projectId: project.id,
+    range: listRange,
+    enabled: listEnabled,
+  })
   const { data: series = [], isLoading: seriesLoading } = useCostSeries({
     projectId: project.id,
-    range,
+    range: chartRange,
     metric,
-    bucketSeconds,
+    bucketSeconds: chartBucketSeconds,
     enabled,
   })
-  // Same query key as above while `total` is selected, so the toggle costs no
-  // second request in the common case.
+  // Feeds the Avg per day KPI, so it follows the KPI window, not the chart's. Outside All time the
+  // two windows are the same key as the series above, so the metric toggle costs no second request.
   const { data: totalSeries = [], isLoading: totalSeriesLoading } = useCostSeries({
     projectId: project.id,
-    range,
+    range: listRange,
     metric: "total",
-    bucketSeconds,
-    enabled,
+    bucketSeconds: listBucketSeconds,
+    enabled: listEnabled,
   })
   const { data: modelUsage, isLoading: modelUsageLoading } = useModelUsageSeries({
     projectId: project.id,
-    range,
-    bucketSeconds,
+    range: chartRange,
+    bucketSeconds: chartBucketSeconds,
     enabled,
   })
   const { data: perSession, isLoading: perSessionLoading } = useCostPerSessionDecomposition({
     projectId: project.id,
-    range,
-    bucketSeconds,
-    enabled,
+    range: listRange,
+    bucketSeconds: listBucketSeconds,
+    enabled: listEnabled,
   })
   const { data: cacheEconomics, isLoading: cacheEconomicsLoading } = useCacheEconomics({
     projectId: project.id,
-    range,
-    enabled,
+    range: listRange,
+    enabled: listEnabled,
   })
   const { data: breakdown, isLoading: breakdownLoading } = useCostBreakdown({
     projectId: project.id,
-    range,
+    range: listRange,
     dimension,
-    enabled,
+    enabled: listEnabled,
   })
   // The impact panel is about models whichever dimension the table below is showing.
   // Same query key as above while the Model tab is selected, so that costs no request.
   const { data: modelBreakdown, isLoading: modelBreakdownLoading } = useCostBreakdown({
     projectId: project.id,
-    range,
+    range: listRange,
     dimension: "model",
-    enabled,
+    enabled: listEnabled,
   })
 
   const buckets = useMemo(
-    () => densifyCostBuckets({ buckets: series, ...range, bucketSeconds }),
-    [series, range, bucketSeconds],
+    () => densifyCostBuckets({ buckets: series, ...chartRange, bucketSeconds: chartBucketSeconds }),
+    [series, chartRange, chartBucketSeconds],
   )
   const provisionalIndex = useMemo(
-    () => resolveIncompleteBucketIndex({ buckets, bucketSeconds, toIso: range.toIso, nowMs: Date.now() }),
-    [buckets, bucketSeconds, range.toIso],
+    () =>
+      resolveIncompleteBucketIndex({
+        buckets,
+        bucketSeconds: chartBucketSeconds,
+        toIso: chartRange.toIso,
+        nowMs: Date.now(),
+      }),
+    [buckets, chartBucketSeconds, chartRange.toIso],
   )
   const denseModelUsage = useMemo(
     () =>
       modelUsage
-        ? { ...modelUsage, buckets: densifyModelUsageBuckets({ buckets: modelUsage.buckets, ...range, bucketSeconds }) }
+        ? {
+            ...modelUsage,
+            buckets: densifyModelUsageBuckets({
+              buckets: modelUsage.buckets,
+              ...chartRange,
+              bucketSeconds: chartBucketSeconds,
+            }),
+          }
         : undefined,
-    [modelUsage, range, bucketSeconds],
+    [modelUsage, chartRange, chartBucketSeconds],
   )
   const modelUsageProvisionalIndex = useMemo(
     () =>
       resolveIncompleteBucketIndex({
         buckets: denseModelUsage?.buckets ?? [],
-        bucketSeconds,
-        toIso: range.toIso,
+        bucketSeconds: chartBucketSeconds,
+        toIso: chartRange.toIso,
         nowMs: Date.now(),
       }),
-    [denseModelUsage, bucketSeconds, range.toIso],
+    [denseModelUsage, chartBucketSeconds, chartRange.toIso],
   )
   const dailyAverageMicrocents = useMemo(
-    () => computeDailyAverageMicrocents({ buckets: totalSeries, bucketSeconds, ...range, nowMs: Date.now() }),
-    [totalSeries, bucketSeconds, range],
+    () =>
+      computeDailyAverageMicrocents({
+        buckets: totalSeries,
+        bucketSeconds: listBucketSeconds,
+        ...listRange,
+        nowMs: Date.now(),
+      }),
+    [totalSeries, listBucketSeconds, listRange],
   )
 
   if (costDashboard.isLoading || !enabled) {
@@ -197,7 +224,12 @@ function CostPageContent() {
         title={
           <SectionHeader
             title="Cost dashboard"
-            badge={<PricingCoverageBadge confidence={overview?.confidence} isLoading={overviewLoading} />}
+            badge={
+              <PricingCoverageBadge
+                confidence={overview?.confidence}
+                isLoading={firstTraceLoading || overviewLoading}
+              />
+            }
             description="Optimize your spending"
           />
         }
@@ -206,9 +238,6 @@ function CostPageContent() {
             {...(tw.pickerStartFrom ? { startTimeFrom: tw.pickerStartFrom } : {})}
             {...(tw.pickerStartTo ? { startTimeTo: tw.pickerStartTo } : {})}
             onChange={tw.onTimeChange}
-            // Unlike the other sections, every figure here is clamped to the recent
-            // slice, so an unset range is not all time.
-            placeholder="Recent activity"
           />
         }
       />
@@ -217,24 +246,28 @@ function CostPageContent() {
           <CostKpiRow
             overview={overview}
             dailyAverageMicrocents={dailyAverageMicrocents}
-            bucketSeconds={bucketSeconds}
+            bucketSeconds={listBucketSeconds}
             projectSlug={projectSlug}
-            isLoading={overviewLoading || seriesLoading || totalSeriesLoading}
+            isLoading={firstTraceLoading || overviewLoading || totalSeriesLoading}
           />
           <CostOverTimePanel
             buckets={buckets}
             metric={metric}
             onMetricChange={setMetric}
-            bucketSeconds={bucketSeconds}
+            bucketSeconds={chartBucketSeconds}
             provisionalIndex={provisionalIndex}
-            rangeFromIso={range.fromIso}
-            rangeToIso={range.toIso}
+            rangeFromIso={chartRange.fromIso}
+            rangeToIso={chartRange.toIso}
             isAllTime={tw.isAllTime}
             isLoading={seriesLoading}
           />
         </Section>
         <Section heading="Session">
-          <CostPerSessionPanel record={perSession} rangeFromIso={range.fromIso} isLoading={perSessionLoading} />
+          <CostPerSessionPanel
+            record={perSession}
+            rangeFromIso={listRange.fromIso}
+            isLoading={firstTraceLoading || perSessionLoading}
+          />
         </Section>
         {/* The two model questions stacked: how spend moves, then who it goes to. Side by
             side, one panel's fixed-height chart and the other's variable-length model list
@@ -244,31 +277,35 @@ function CostPageContent() {
             series={denseModelUsage}
             measure={usageMeasure}
             onMeasureChange={setUsageMeasure}
-            bucketSeconds={bucketSeconds}
+            bucketSeconds={chartBucketSeconds}
             provisionalIndex={modelUsageProvisionalIndex}
-            rangeFromIso={range.fromIso}
-            rangeToIso={range.toIso}
+            rangeFromIso={chartRange.fromIso}
+            rangeToIso={chartRange.toIso}
             isAllTime={tw.isAllTime}
             isLoading={modelUsageLoading}
           />
           <ModelImpactPanel
             breakdown={modelBreakdown}
-            rangeFromIso={range.fromIso}
-            rangeToIso={range.toIso}
+            rangeFromIso={listRange.fromIso}
+            rangeToIso={listRange.toIso}
             isAllTime={tw.isAllTime}
             projectSlug={projectSlug}
-            isLoading={modelBreakdownLoading}
+            isLoading={firstTraceLoading || modelBreakdownLoading}
           />
         </Section>
         <Section heading="Cache">
-          <CacheEconomicsPanel economics={cacheEconomics} projectSlug={projectSlug} isLoading={cacheEconomicsLoading} />
+          <CacheEconomicsPanel
+            economics={cacheEconomics}
+            projectSlug={projectSlug}
+            isLoading={firstTraceLoading || cacheEconomicsLoading}
+          />
         </Section>
         <Section>
           <CostBreakdownPanel
             breakdown={breakdown}
             dimension={dimension}
             onDimensionChange={setDimension}
-            isLoading={breakdownLoading}
+            isLoading={firstTraceLoading || breakdownLoading}
           />
         </Section>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Replays the All-time cost accuracy fix onto the current cost page.

The picker and ChartHeader already say All-time, but KPIs, session, cache, breakdown, and model impact still queried the ~30-day recent-activity chart window. This splits the windows the same way Tools does:

- `listRange` for totals: overview KPIs, avg per day, session, cache, breakdown, model impact
- `chartRange` for the trend: cost over time and model usage stay on the latest-activity-anchored slice

Full-history reads wait until `firstTraceAt` settles. While that query is in flight, `listRange` would otherwise fall back to the chart window and refetch.

`ModelImpactPanel` keeps `showWindow={isAllTime}`. That panel is the place totals and the chart diverge; hiding the caption makes All-time look like one window.

Cost-only. The old agent-dispatch / send-time repo-override work is not in this PR.

Same commit as #4316 (`e5f4031e9`). #4316 is the merge vehicle: its branch was force-updated onto current `development` and retitled. This PR exists because #4316's description could not be rewritten here.

## Related issue (if applicable)

N/A. Originally found against #4313 when ChartHeader claimed All-time and the queries did not.

## How was this tested?

- Replayed the `listRange` / `chartRange` split onto current `development` `cost/index.tsx` (Section layout, `CostPerSessionPanel`, cache, stacked model panels).
- Confirmed no dispatch files remain in the diff. `gh pr view 4316` reports `mergeable: MERGEABLE`.
- `pnpm --filter web typecheck` passed.
- 66 unit tests passed (`use-analytics-time-window`, cost formatters, cache economics view, session sparkline).
- Browser walkthrough was not run: Docker did not start in this environment, so the cost page could not be exercised against live data.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a633aaac-0604-4ad8-b6e7-ff0a254cebf8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a633aaac-0604-4ad8-b6e7-ff0a254cebf8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790867677&installation_model_id=435055&pr_number=4532&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4532&signature=d2b97e2b4768fd4eb9b31605258eac1e35539c34a680318b8b51db78b03fde69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->