### PR TITLE
fix(github): apply reference actions when a merged PR is edited

### DIFF
--- a/packages/domain/github/src/entities/github-signal-reference.ts
+++ b/packages/domain/github/src/entities/github-signal-reference.ts
@@ -13,7 +13,7 @@ export type GithubPrState = z.infer<typeof githubPrStateSchema>
  * A stored reference row (5.3): one signal ↔ one PR/commit. `prNumber`/`prState` are
  * set only for `pull_request` references; `commitSha`/`pushAfterSha` only for
  * `commit` references. `action` is the strongest matched intent; `actionAppliedAt`
- * is null until the lifecycle command actually ran (merge time). References are
+ * is null until the lifecycle command actually ran. References are
  * historical records — applied ones are never deleted (D8).
  */
 export const githubSignalReferenceSchema = z.object({

--- a/packages/domain/github/src/ports/repositories.ts
+++ b/packages/domain/github/src/ports/repositories.ts
@@ -164,9 +164,9 @@ export interface GithubSignalReferenceRepositoryShape {
   /**
    * Upserts a reference by its per-type natural key (`(org, signal, repo, pr_number)`
    * for PRs, `(org, signal, repo, commit_sha)` for commits). Refreshes the
-   * mutable label/state/action/sources; never clears an already-stamped
-   * `merged_at` or `action_applied_at` (those are owned by
-   * {@link setPrState}/{@link stampActionApplied}). Returns the stored row.
+   * mutable label/state/action/sources. Never clears an already-stamped
+   * `merged_at`. Clears `action_applied_at` when the stored action changes so
+   * the new intent is eligible to apply. Returns the stored row.
    */
   readonly upsert: (
     reference: GithubSignalReferenceUpsert,

--- a/packages/domain/github/src/testing/fake-github-signal-reference-repository.ts
+++ b/packages/domain/github/src/testing/fake-github-signal-reference-repository.ts
@@ -44,7 +44,8 @@ export const createFakeGithubSignalReferenceRepository = (init: {
           authorLogin: reference.authorLogin,
           matchedSources: [...reference.matchedSources],
           action: reference.action,
-          actionAppliedAt: existing?.actionAppliedAt ?? null,
+          actionAppliedAt:
+            existing && existing.action !== reference.action ? null : (existing?.actionAppliedAt ?? null),
           mergedAt: reference.mergedAt ?? existing?.mergedAt ?? null,
           createdAt: existing?.createdAt ?? now,
           updatedAt: now,

--- a/packages/domain/github/src/use-cases/process-github-pull-request.ts
+++ b/packages/domain/github/src/use-cases/process-github-pull-request.ts
@@ -173,6 +173,10 @@ export const processGithubPullRequestUseCase = (input: ProcessGithubPullRequestI
         if (!desiredSignals.has(reference.signalId) && reference.actionAppliedAt === null)
           yield* referenceRepo.deleteById(reference.id)
       }
+      if (prState === "merged") {
+        const references = yield* referenceRepo.listByPr({ repoId: input.repoId, prNumber: input.prNumber })
+        yield* applyReferenceActions({ references, now })
+      }
     }
 
     yield* deliveryRepo.finalize({ id: ledgerId, status: "processed" })

--- a/packages/platform/db-postgres/src/repositories/github-events-processing.test.ts
+++ b/packages/platform/db-postgres/src/repositories/github-events-processing.test.ts
@@ -285,6 +285,153 @@ describe("processGithubPullRequestUseCase", () => {
     )
     expect((await signalRow("LAT-AB12"))?.resolvedAt).toBeNull()
   })
+
+  it("unresolves via revert convention when push absorbs an applied commit reference first", async () => {
+    await inOrg(
+      processGithubPullRequestUseCase(
+        prInput({
+          integrationId,
+          deliveryId: "d-merge",
+          action: "closed",
+          state: "closed",
+          merged: true,
+          mergeCommitSha: "merge-sha-1",
+        }),
+      ),
+    )
+    expect((await signalRow("LAT-AB12"))?.resolvedAt).not.toBeNull()
+
+    await inOrg(
+      processGithubPushUseCase(
+        pushInput({
+          integrationId,
+          deliveryId: "push-revert",
+          after: "merge-sha-2",
+          commits: [
+            {
+              id: "merge-sha-2",
+              message: 'Revert "Fixes LAT-AB12"',
+              timestamp: "2026-06-01T02:00:00.000Z",
+              authorUsername: "octocat",
+              url: "https://github.com/acme/app/commit/merge-sha-2",
+            },
+          ],
+        }),
+      ),
+    )
+
+    await inOrg(
+      processGithubPullRequestUseCase(
+        prInput({
+          integrationId,
+          deliveryId: "d-revert",
+          prNumber: 8,
+          title: "Revert the fix",
+          body: "Reverts acme/app#7",
+          action: "closed",
+          state: "closed",
+          merged: true,
+          mergeCommitSha: "merge-sha-2",
+          headSha: "head-sha-2",
+          htmlUrl: "https://github.com/acme/app/pull/8",
+        }),
+      ),
+    )
+    expect((await signalRow("LAT-AB12"))?.resolvedAt).toBeNull()
+  })
+
+  it("unresolves via revert convention after absorbing a resolve-stamped commit", async () => {
+    await inOrg(
+      processGithubPullRequestUseCase(
+        prInput({
+          integrationId,
+          deliveryId: "d-merge",
+          action: "closed",
+          state: "closed",
+          merged: true,
+          mergeCommitSha: "merge-sha-1",
+        }),
+      ),
+    )
+    expect((await signalRow("LAT-AB12"))?.resolvedAt).not.toBeNull()
+
+    await inOrg(
+      processGithubPushUseCase(
+        pushInput({
+          integrationId,
+          deliveryId: "push-resolve",
+          after: "merge-sha-2",
+          commits: [
+            {
+              id: "merge-sha-2",
+              message: "Fixes LAT-AB12",
+              timestamp: "2026-06-01T02:00:00.000Z",
+              authorUsername: "octocat",
+              url: "https://github.com/acme/app/commit/merge-sha-2",
+            },
+          ],
+        }),
+      ),
+    )
+
+    await inOrg(
+      processGithubPullRequestUseCase(
+        prInput({
+          integrationId,
+          deliveryId: "d-revert",
+          prNumber: 8,
+          title: "Revert the fix",
+          body: "Reverts acme/app#7",
+          action: "closed",
+          state: "closed",
+          merged: true,
+          mergeCommitSha: "merge-sha-2",
+          headSha: "head-sha-2",
+          headRef: "revert/the-fix",
+          htmlUrl: "https://github.com/acme/app/pull/8",
+        }),
+      ),
+    )
+    expect((await signalRow("LAT-AB12"))?.resolvedAt).toBeNull()
+  })
+
+  it("applies a changed action when an already-merged PR is edited", async () => {
+    await inOrg(
+      processGithubPullRequestUseCase(
+        prInput({
+          integrationId,
+          deliveryId: "d-merge",
+          action: "closed",
+          state: "closed",
+          merged: true,
+          mergeCommitSha: "merge-sha-1",
+        }),
+      ),
+    )
+    expect((await signalRow("LAT-AB12"))?.resolvedAt).not.toBeNull()
+    expect((await references())[0]?.actionAppliedAt).not.toBeNull()
+
+    await inOrg(
+      processGithubPullRequestUseCase(
+        prInput({
+          integrationId,
+          deliveryId: "d-edit-merged",
+          action: "edited",
+          state: "closed",
+          merged: true,
+          mergeCommitSha: "merge-sha-1",
+          title: "Reopen LAT-AB12",
+          headRef: "reopen/lat-ab12",
+        }),
+      ),
+    )
+
+    const rows = await references()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.action).toBe("unresolve")
+    expect(rows[0]?.actionAppliedAt).not.toBeNull()
+    expect((await signalRow("LAT-AB12"))?.resolvedAt).toBeNull()
+  })
 })
 
 describe("processGithubPushUseCase", () => {

--- a/packages/platform/db-postgres/src/repositories/github-signal-reference-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/github-signal-reference-repository.test.ts
@@ -86,6 +86,24 @@ describe("GithubSignalReferenceRepositoryLive", () => {
     expect(references.map((l) => l.referenceType).sort()).toEqual(["commit", "pull_request"])
   })
 
+  it("clears actionAppliedAt when upsert changes the stored action", async () => {
+    const appliedAt = new Date("2026-06-01T00:00:00.000Z")
+    const { kept, cleared } = await run(
+      Effect.gen(function* () {
+        const repo = yield* GithubSignalReferenceRepository
+        const created = yield* repo.upsert(prLink())
+        yield* repo.stampActionApplied({ id: created.id, appliedAt })
+        const kept = yield* repo.upsert(prLink({ title: "Fixes LAT-AB12 still" }))
+        const cleared = yield* repo.upsert(prLink({ action: "unresolve", title: "Reopen LAT-AB12" }))
+        return { kept, cleared }
+      }),
+    )
+    expect(kept.action).toBe("resolve")
+    expect(kept.actionAppliedAt).toEqual(appliedAt)
+    expect(cleared.action).toBe("unresolve")
+    expect(cleared.actionAppliedAt).toBeNull()
+  })
+
   it("does not clear an existing merged_at when a later upsert passes null", async () => {
     const merged = new Date("2026-05-01T00:00:00.000Z")
     const after = await run(

--- a/packages/platform/db-postgres/src/repositories/github-signal-reference-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/github-signal-reference-repository.ts
@@ -94,6 +94,7 @@ export const GithubSignalReferenceRepositoryLive = Layer.succeed(GithubSignalRef
                 authorLogin: reference.authorLogin,
                 matchedSources: [...reference.matchedSources],
                 action: reference.action,
+                actionAppliedAt: sql`CASE WHEN ${githubSignalReferences.action} IS DISTINCT FROM ${reference.action} THEN NULL ELSE ${githubSignalReferences.actionAppliedAt} END`,
                 mergedAt: reference.mergedAt ?? sql`${githubSignalReferences.mergedAt}`,
                 updatedAt: new Date(),
               },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Supersedes #4244.

#4244 cleared `actionAppliedAt` whenever a GitHub signal reference upsert changed the stored action. That unblocks revert/unresolve after a push-first absorb stamps the old action. The same shared upsert also runs on `pull_request.edited`, including already-merged PRs. Those events never take the `closed && merged` path, so they never called `applyReferenceActions`. Editing a merged PR into a different resolve/unresolve match left a pending action that never applied.

This PR keeps the stamp reset on action change, and applies reference actions when an already-merged PR is edited. Revert still unresolves when the action changes. An edited merged PR cannot sit with a never-applies pending action.

## Related issue (if applicable)

Supersedes #4244.

## How was this tested?

- Integration: push-first revert merge (`Revert "Fixes LAT-AB12"` plus body-only revert convention)
- Integration: revert after absorbing a resolve-stamped commit (the case that actually needs the stamp reset)
- Integration: `pull_request.edited` on an already-merged PR that changes resolve → unresolve applies and restamps
- Repository: upsert keeps `actionAppliedAt` when the action is unchanged, clears it when the action changes
- `pnpm --filter @platform/db-postgres test` (406 tests pass)
- `pnpm --filter @platform/db-postgres typecheck` and `pnpm --filter @domain/github typecheck`

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9abf76fc-060e-49ee-a517-ae5077100340?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9abf76fc-060e-49ee-a517-ae5077100340&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790870453&installation_model_id=435055&pr_number=4533&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4533&signature=d9c4c724cd54a2f284dda4793d60f7691c685c039020a672b57296031f4f586e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->