### PR TITLE
fix(imports): clamp billable traces and record plan caps as capped

### DIFF
--- a/packages/domain/imports/src/entities/import-source.ts
+++ b/packages/domain/imports/src/entities/import-source.ts
@@ -134,6 +134,7 @@ export const importStatsSchema = z.object({
   tracesImported: z.number().int().min(0),
   spansImported: z.number().int().min(0),
   spansSkipped: z.number().int().min(0),
+  consumedCreditsAtStart: z.number().int().min(0).optional(),
 })
 export type ImportStats = z.infer<typeof importStatsSchema>
 

--- a/packages/domain/imports/src/testing/fake-adapter.ts
+++ b/packages/domain/imports/src/testing/fake-adapter.ts
@@ -154,11 +154,13 @@ export const createFakeImportAdapter = (options: FakeAdapterOptions = {}) => {
 }
 
 /** Deterministic stand-in for the platform normalizer's hashing, so idempotency is assertable. */
-const fakeHexId = <T extends string>(source: string, length: number): T => {
+export const fakeImportHexId = <T extends string>(source: string, length: number): T => {
   let hex = ""
   for (const char of source) hex += char.charCodeAt(0).toString(16)
   return hex.padEnd(length, "0").slice(0, length) as T
 }
+
+const fakeHexId = fakeImportHexId
 
 export const createFakeImportAdapterRegistry = (
   options: FakeAdapterOptions = {},

--- a/packages/domain/imports/src/testing/index.ts
+++ b/packages/domain/imports/src/testing/index.ts
@@ -3,6 +3,7 @@ export {
   createFakeImportAdapter,
   createFakeImportAdapterRegistry,
   FAKE_ROWS_LATEST,
+  fakeImportHexId,
   fakeImportRows,
 } from "./fake-adapter.ts"
 export {

--- a/packages/domain/imports/src/use-cases/import-usage-available.test.ts
+++ b/packages/domain/imports/src/use-cases/import-usage-available.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { remainingAfterInFlightImport } from "./import-usage-available.ts"
+
+describe("remainingAfterInFlightImport", () => {
+  it("leaves an uncapped plan alone", () => {
+    expect(
+      remainingAfterInFlightImport({
+        remaining: null,
+        consumedCredits: 10,
+        tracesImported: 5,
+        consumedCreditsAtStart: 10,
+      }),
+    ).toBeNull()
+  })
+
+  it("subtracts traces this job has billed that the period has not yet recorded", () => {
+    expect(
+      remainingAfterInFlightImport({
+        remaining: 10,
+        consumedCredits: 90,
+        tracesImported: 10,
+        consumedCreditsAtStart: 90,
+      }),
+    ).toBe(0)
+  })
+
+  it("does not subtract traces the period already recorded", () => {
+    expect(
+      remainingAfterInFlightImport({
+        remaining: 10,
+        consumedCredits: 100,
+        tracesImported: 10,
+        consumedCreditsAtStart: 90,
+      }),
+    ).toBe(10)
+  })
+})

--- a/packages/domain/imports/src/use-cases/import-usage-available.ts
+++ b/packages/domain/imports/src/use-cases/import-usage-available.ts
@@ -6,6 +6,11 @@ import {
 } from "@domain/billing"
 import { Effect } from "effect"
 
+interface ImportTraceBudget {
+  readonly remaining: number | null
+  readonly consumedCredits: number
+}
+
 export const importTraceBudget = (plan: EffectivePlanResolution) =>
   Effect.gen(function* () {
     const periodRepo = yield* BillingUsagePeriodRepository
@@ -14,8 +19,25 @@ export const importTraceBudget = (plan: EffectivePlanResolution) =>
       periodStart: plan.periodStart,
       periodEnd: plan.periodEnd,
     })
-    return tracesRemainingForPlan(plan, period?.consumedCredits ?? 0)
+    const consumedCredits = period?.consumedCredits ?? 0
+    return {
+      remaining: tracesRemainingForPlan(plan, consumedCredits),
+      consumedCredits,
+    } satisfies ImportTraceBudget
   })
+
+export const remainingAfterInFlightImport = (input: {
+  readonly remaining: number | null
+  readonly consumedCredits: number
+  readonly tracesImported: number
+  readonly consumedCreditsAtStart: number | undefined
+}): number | null => {
+  if (input.remaining === null) return null
+  const start = input.consumedCreditsAtStart ?? input.consumedCredits
+  const alreadyInPeriod = Math.max(0, input.consumedCredits - start)
+  const inFlight = Math.max(0, input.tracesImported - alreadyInPeriod)
+  return Math.max(0, input.remaining - inFlight)
+}
 
 const tracesRemainingForPlan = (plan: EffectivePlanResolution, consumedCredits: number): number | null => {
   if (plan.plan.hardCapped) {
@@ -48,6 +70,6 @@ const tracesRemainingForPlan = (plan: EffectivePlanResolution, consumedCredits: 
 export const importUsageAvailable = (plan: EffectivePlanResolution) =>
   Effect.gen(function* () {
     const budget = yield* importTraceBudget(plan)
-    if (budget === null) return true
-    return budget > 0
+    if (budget.remaining === null) return true
+    return budget.remaining > 0
   })

--- a/packages/domain/imports/src/use-cases/import-usage-available.ts
+++ b/packages/domain/imports/src/use-cases/import-usage-available.ts
@@ -1,4 +1,41 @@
-import { checkCreditAvailabilityUseCase, type EffectivePlanResolution } from "@domain/billing"
+import {
+  ACTION_CREDITS,
+  BillingUsagePeriodRepository,
+  calculateMaxAllowedConsumedCreditsForCap,
+  type EffectivePlanResolution,
+} from "@domain/billing"
+import { Effect } from "effect"
+
+export const importTraceBudget = (plan: EffectivePlanResolution) =>
+  Effect.gen(function* () {
+    const periodRepo = yield* BillingUsagePeriodRepository
+    const period = yield* periodRepo.findOptionalByPeriod({
+      organizationId: plan.organizationId,
+      periodStart: plan.periodStart,
+      periodEnd: plan.periodEnd,
+    })
+    return tracesRemainingForPlan(plan, period?.consumedCredits ?? 0)
+  })
+
+const tracesRemainingForPlan = (plan: EffectivePlanResolution, consumedCredits: number): number | null => {
+  if (plan.plan.hardCapped) {
+    const remainingCredits = Math.max(plan.plan.includedCredits - consumedCredits, 0)
+    return Math.floor(remainingCredits / ACTION_CREDITS.trace)
+  }
+
+  if (plan.plan.spendingLimitCents !== null && plan.plan.priceCents !== null) {
+    const maxAllowed = calculateMaxAllowedConsumedCreditsForCap(
+      plan.plan.slug,
+      plan.plan.includedCredits,
+      plan.plan.priceCents,
+      plan.plan.spendingLimitCents,
+    )
+    const remainingCredits = Math.max(maxAllowed - consumedCredits, 0)
+    return Math.floor(remainingCredits / ACTION_CREDITS.trace)
+  }
+
+  return null
+}
 
 /**
  * Whether the org can still bill a trace this period, which is all an import needs to make
@@ -9,14 +46,8 @@ import { checkCreditAvailabilityUseCase, type EffectivePlanResolution } from "@d
  * can be lowered mid-run, and a period can roll over.
  */
 export const importUsageAvailable = (plan: EffectivePlanResolution) =>
-  checkCreditAvailabilityUseCase({
-    organizationId: plan.organizationId,
-    action: "trace",
-    planSlug: plan.plan.slug,
-    periodStart: plan.periodStart,
-    periodEnd: plan.periodEnd,
-    includedCredits: plan.plan.includedCredits,
-    hardCapped: plan.plan.hardCapped,
-    priceCents: plan.plan.priceCents,
-    spendingLimitCents: plan.plan.spendingLimitCents,
+  Effect.gen(function* () {
+    const budget = yield* importTraceBudget(plan)
+    if (budget === null) return true
+    return budget > 0
   })

--- a/packages/domain/imports/src/use-cases/process-import-page.test.ts
+++ b/packages/domain/imports/src/use-cases/process-import-page.test.ts
@@ -10,9 +10,11 @@ import {
   ProjectId,
   type RedactionPolicy,
   SqlClient,
+  TraceId,
 } from "@domain/shared"
 import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
 import { SpanRepository } from "@domain/spans"
+import type { SpanDetail } from "@domain/spans"
 import { createFakeSpanRepository } from "@domain/spans/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
@@ -33,9 +35,10 @@ import {
   FAKE_ROWS_LATEST,
   type FakeAdapterOptions,
   type FakeImportRow,
+  fakeImportHexId,
   fakeImportRows,
 } from "../testing/fake-adapter.ts"
-import { createFakeImportJobRepository, stubImportPlan } from "../testing/fakes.ts"
+import { createFakeImportJobRepository, stubImportPlan, stubSpanDetail } from "../testing/fakes.ts"
 import { importHarness, stubImportJob } from "../testing/harness.ts"
 import { processImportPageUseCase, recordImportFinalFailureUseCase } from "./process-import-page.ts"
 
@@ -101,6 +104,7 @@ const harness = (
     readonly plan?: ReturnType<typeof stubImportPlan>
     readonly consumedCredits?: number
     readonly redactionPolicy?: RedactionPolicy
+    readonly seedSpans?: readonly SpanDetail[]
   } = {},
 ) => {
   const jobs = createFakeImportJobRepository()
@@ -113,6 +117,12 @@ const harness = (
   const periods = createFakeBillingUsagePeriodRepository()
 
   jobs.jobs.set(job.id, job)
+
+  if (deps.seedSpans !== undefined) {
+    for (const span of deps.seedSpans) {
+      spans.inserted.push([span])
+    }
+  }
 
   if (deps.consumedCredits !== undefined) {
     Effect.runSync(
@@ -722,6 +732,116 @@ describe("processImportPageUseCase", () => {
       expect(h.stored()?.status).toBe("capped")
       expect(h.stored()?.error).toContain("plan usage")
       expect(h.fetchPageCalls).toHaveLength(0)
+    })
+
+    it("finishes capped when the plan budget truncates a page", async () => {
+      const job = makeJob({ config: { ...BASE_CONFIG, sourcePageSize: 100 } })
+      const h = harness(
+        job,
+        { rows: fakeImportRows(50) },
+        {
+          plan: freePlan(job.organizationId),
+          consumedCredits: FREE_PLAN_CONFIG.includedCredits - 3,
+        },
+      )
+
+      const { result } = await h.drain()
+
+      expect(result).toEqual({ done: true, reason: "capped" })
+      expect(h.stored()?.status).toBe("capped")
+      expect(h.stored()?.error).toContain("plan usage")
+      expect(h.stored()?.stats.tracesImported).toBe(3)
+      expect(h.events.at(-1)?.payload.traceIds).toHaveLength(3)
+    })
+
+    it("still finishes succeeded when the user's own ceiling is the tighter bound", async () => {
+      const job = makeJob({ config: { ...withMaxTraces(3), sourcePageSize: 100 } })
+      const h = harness(
+        job,
+        { rows: fakeImportRows(50) },
+        {
+          plan: freePlan(job.organizationId),
+          consumedCredits: FREE_PLAN_CONFIG.includedCredits - 10,
+        },
+      )
+
+      const { result } = await h.drain()
+
+      expect(result).toEqual({ done: true, reason: "succeeded" })
+      expect(h.stored()?.status).toBe("succeeded")
+      expect(h.stored()?.error).toBeNull()
+      expect(h.stored()?.stats.tracesImported).toBe(3)
+    })
+
+    it("counts unseen rootless traces against the plan budget", async () => {
+      const job = makeJob({ config: { ...BASE_CONFIG, sourcePageSize: 100 } })
+      const rows = Array.from({ length: 10 }, (_, i) => ({
+        sourceTraceId: `rootless-${i}`,
+        sourceSpanId: `child-${i}`,
+        name: `child-${i}`,
+        startTime: new Date(FAKE_ROWS_LATEST.getTime() - i * 60_000),
+        isRoot: false,
+      }))
+      const h = harness(
+        job,
+        { rows },
+        {
+          plan: freePlan(job.organizationId),
+          consumedCredits: FREE_PLAN_CONFIG.includedCredits - 3,
+        },
+      )
+
+      const { result } = await h.drain()
+
+      expect(result).toEqual({ done: true, reason: "capped" })
+      expect(h.stored()?.status).toBe("capped")
+      expect(h.stored()?.error).toContain("plan usage")
+      expect(h.stored()?.stats.tracesImported).toBe(3)
+      expect(h.events.at(-1)?.payload.traceIds).toHaveLength(3)
+      expect(h.spans.inserted.flat()).toHaveLength(3)
+    })
+
+    it("does not charge continuation spans of already-imported traces", async () => {
+      const job = makeJob({ config: { ...BASE_CONFIG, sourcePageSize: 100 } })
+      const earlierTraceId = fakeImportHexId("trace-earlier", 32)
+      const rows: FakeImportRow[] = [
+        {
+          sourceTraceId: "trace-earlier",
+          sourceSpanId: "span-late",
+          name: "late child",
+          startTime: new Date(FAKE_ROWS_LATEST.getTime() - 1_000),
+          isRoot: false,
+        },
+        ...Array.from({ length: 10 }, (_, i) => ({
+          sourceTraceId: `rootless-${i}`,
+          sourceSpanId: `child-${i}`,
+          name: `child-${i}`,
+          startTime: new Date(FAKE_ROWS_LATEST.getTime() - (i + 2) * 60_000),
+          isRoot: false,
+        })),
+      ]
+      const h = harness(
+        job,
+        { rows },
+        {
+          plan: freePlan(job.organizationId),
+          consumedCredits: FREE_PLAN_CONFIG.includedCredits - 3,
+          seedSpans: [
+            stubSpanDetail({
+              organizationId: job.organizationId,
+              projectId: job.projectId,
+              traceId: TraceId(earlierTraceId),
+            }),
+          ],
+        },
+      )
+
+      const { result } = await h.drain()
+
+      expect(result).toEqual({ done: true, reason: "capped" })
+      expect(h.stored()?.stats.tracesImported).toBe(3)
+      expect(h.events.at(-1)?.payload.traceIds).toHaveLength(4)
+      expect(h.spans.inserted.flat()).toHaveLength(5)
     })
 
     it("keeps importing while the plan still has room", async () => {

--- a/packages/domain/imports/src/use-cases/process-import-page.test.ts
+++ b/packages/domain/imports/src/use-cases/process-import-page.test.ts
@@ -197,6 +197,23 @@ const harness = (
     return { result, pages }
   }
 
+  const setConsumedCredits = (consumedCredits: number) => {
+    Effect.runSync(
+      periods.repository
+        .upsert(
+          seedBillingUsagePeriod({
+            organizationId: job.organizationId,
+            planSlug: plan.plan.slug,
+            periodStart: plan.periodStart,
+            periodEnd: plan.periodEnd,
+            includedCredits: plan.plan.includedCredits,
+            consumedCredits,
+          }),
+        )
+        .pipe(Effect.provideService(SqlClient, createFakeSqlClient({ organizationId: job.organizationId }))),
+    )
+  }
+
   return {
     jobs,
     spans,
@@ -206,6 +223,7 @@ const harness = (
     fetchPageCalls,
     run,
     drain,
+    setConsumedCredits,
     stored: () => jobs.jobs.get(job.id),
   }
 }
@@ -752,6 +770,7 @@ describe("processImportPageUseCase", () => {
       expect(h.stored()?.error).toContain("plan usage")
       expect(h.stored()?.stats.tracesImported).toBe(3)
       expect(h.events.at(-1)?.payload.traceIds).toHaveLength(3)
+      expect(h.stored()?.cursor).toEqual(insideFirstWindow(null))
     })
 
     it("still finishes succeeded when the user's own ceiling is the tighter bound", async () => {
@@ -799,6 +818,137 @@ describe("processImportPageUseCase", () => {
       expect(h.stored()?.stats.tracesImported).toBe(3)
       expect(h.events.at(-1)?.payload.traceIds).toHaveLength(3)
       expect(h.spans.inserted.flat()).toHaveLength(3)
+    })
+
+    it("does not charge a root that arrives after its children were billed", async () => {
+      const job = makeJob({ config: { ...BASE_CONFIG, sourcePageSize: 3 } })
+      const rows: FakeImportRow[] = [
+        {
+          sourceTraceId: "a",
+          sourceSpanId: "a-child",
+          name: "a-child",
+          startTime: FAKE_ROWS_LATEST,
+          isRoot: false,
+        },
+        {
+          sourceTraceId: "b",
+          sourceSpanId: "b-child",
+          name: "b-child",
+          startTime: new Date(FAKE_ROWS_LATEST.getTime() - 60_000),
+          isRoot: false,
+        },
+        {
+          sourceTraceId: "c",
+          sourceSpanId: "c-child",
+          name: "c-child",
+          startTime: new Date(FAKE_ROWS_LATEST.getTime() - 120_000),
+          isRoot: false,
+        },
+        {
+          sourceTraceId: "a",
+          sourceSpanId: "a-root",
+          name: "a-root",
+          startTime: new Date(FAKE_ROWS_LATEST.getTime() - 180_000),
+          isRoot: true,
+        },
+        {
+          sourceTraceId: "b",
+          sourceSpanId: "b-root",
+          name: "b-root",
+          startTime: new Date(FAKE_ROWS_LATEST.getTime() - 240_000),
+          isRoot: true,
+        },
+        {
+          sourceTraceId: "c",
+          sourceSpanId: "c-root",
+          name: "c-root",
+          startTime: new Date(FAKE_ROWS_LATEST.getTime() - 300_000),
+          isRoot: true,
+        },
+      ]
+      const h = harness(
+        job,
+        { rows },
+        {
+          plan: freePlan(job.organizationId),
+          consumedCredits: FREE_PLAN_CONFIG.includedCredits - 10,
+        },
+      )
+
+      const { result } = await h.drain()
+
+      expect(result).toEqual({ done: true, reason: "succeeded" })
+      expect(h.stored()?.stats.tracesImported).toBe(3)
+      expect(h.fetchPageCalls).toHaveLength(2)
+    })
+
+    it("does not charge an already-stored rooted trace on re-import", async () => {
+      const job = makeJob({ config: { ...BASE_CONFIG, sourcePageSize: 100 } })
+      const storedTraceId = fakeImportHexId("trace-0", 32)
+      const h = harness(
+        job,
+        { rows: fakeImportRows(50) },
+        {
+          plan: freePlan(job.organizationId),
+          consumedCredits: FREE_PLAN_CONFIG.includedCredits - 3,
+          seedSpans: [
+            stubSpanDetail({
+              organizationId: job.organizationId,
+              projectId: job.projectId,
+              traceId: TraceId(storedTraceId),
+            }),
+          ],
+        },
+      )
+
+      const { result } = await h.drain()
+
+      expect(result).toEqual({ done: true, reason: "capped" })
+      expect(h.stored()?.stats.tracesImported).toBe(3)
+      expect(h.events.at(-1)?.payload.traceIds).toHaveLength(4)
+      expect(h.events.at(-1)?.payload.traceIds).toContain(storedTraceId)
+    })
+
+    it("does not admit a second page against the same remaining credits", async () => {
+      const job = makeJob({ config: { ...BASE_CONFIG, sourcePageSize: 10 } })
+      const h = harness(
+        job,
+        { rows: fakeImportRows(30, { spansPerTrace: 1 }) },
+        {
+          plan: freePlan(job.organizationId),
+          consumedCredits: FREE_PLAN_CONFIG.includedCredits - 10,
+        },
+      )
+
+      const { result } = await h.drain()
+
+      expect(result).toEqual({ done: true, reason: "capped" })
+      expect(h.fetchPageCalls).toHaveLength(1)
+      expect(h.stored()?.stats.tracesImported).toBe(10)
+    })
+
+    it("does not double-subtract once this job's traces have landed in the period", async () => {
+      const job = makeJob({ config: { ...BASE_CONFIG, sourcePageSize: 5 } })
+      const startConsumed = FREE_PLAN_CONFIG.includedCredits - 10
+      const h = harness(
+        job,
+        { rows: fakeImportRows(20, { spansPerTrace: 1 }) },
+        {
+          plan: freePlan(job.organizationId),
+          consumedCredits: startConsumed,
+        },
+      )
+
+      const first = await h.run()
+      expect(first).toEqual({ done: false, reason: "next_page" })
+      expect(h.stored()?.stats.tracesImported).toBe(5)
+
+      h.setConsumedCredits(startConsumed + 5)
+      const { result } = await h.drain()
+
+      expect(result).toEqual({ done: true, reason: "capped" })
+      expect(h.stored()?.stats.tracesImported).toBe(10)
+      expect(h.fetchPageCalls).toHaveLength(2)
     })
 
     it("does not charge continuation spans of already-imported traces", async () => {

--- a/packages/domain/imports/src/use-cases/process-import-page.test.ts
+++ b/packages/domain/imports/src/use-cases/process-import-page.test.ts
@@ -13,8 +13,8 @@ import {
   TraceId,
 } from "@domain/shared"
 import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
-import { SpanRepository } from "@domain/spans"
 import type { SpanDetail } from "@domain/spans"
+import { SpanRepository } from "@domain/spans"
 import { createFakeSpanRepository } from "@domain/spans/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"

--- a/packages/domain/imports/src/use-cases/process-import-page.ts
+++ b/packages/domain/imports/src/use-cases/process-import-page.ts
@@ -20,7 +20,7 @@ import { ImportSourceError, sanitizedImportError } from "../errors.ts"
 import { ImportJobRepository } from "../ports/import-job-repository.ts"
 import { getAdapter, ImportSourceAdapters } from "../ports/import-source-adapter.ts"
 import { finishImport } from "./finish-import.ts"
-import { importTraceBudget } from "./import-usage-available.ts"
+import { importTraceBudget, remainingAfterInFlightImport } from "./import-usage-available.ts"
 
 export interface ProcessImportPageInput {
   readonly organizationId: string
@@ -197,10 +197,11 @@ const sessionKeyOf = (group: TraceGroup): string => {
  * admitted, leaving a trace half-imported with no record that anything was dropped. A trace is
  * admitted with all of its spans or none of them.
  *
- * Rootless groups are free when the plan does not cap volume (`alreadyBilledTraceIds` is null),
- * or when that `traceId` was already billed — `TracesIngested` is idempotent, and dropping those
- * spans would strand a trace already paid for. Previously unseen rootless groups are billable:
- * the event charges every distinct admitted `traceId`.
+ * Groups whose `traceId` already exists in the span store are free — `TracesIngested` is
+ * idempotent, and dropping those spans would strand a trace already paid for. That includes
+ * a root that arrives after its children were billed on an earlier page. Previously unseen
+ * groups are billable: the event charges every distinct admitted `traceId`. When the plan
+ * does not cap volume (`alreadyBilledTraceIds` is null), only rootless groups stay free.
  */
 const admitNewestTraces = (
   spans: readonly SpanDetail[],
@@ -210,11 +211,9 @@ const admitNewestTraces = (
   const freeSpans: SpanDetail[] = []
   const billed: TraceGroup[] = []
   for (const group of groupSpansByTrace(spans)) {
-    if (group.root) {
-      billed.push(group)
-      continue
-    }
-    if (alreadyBilledTraceIds === null || alreadyBilledTraceIds.has(group.traceId)) {
+    const alreadyStored = alreadyBilledTraceIds?.has(group.traceId) === true
+    const uncappedOrphan = alreadyBilledTraceIds === null && group.root === undefined
+    if (alreadyStored || uncappedOrphan) {
       freeSpans.push(...group.spans)
       continue
     }
@@ -240,18 +239,16 @@ const admitNewestTraces = (
   return { spans: admitted, traces, sessions: sessionKeys.size, truncated }
 }
 
-const alreadyBilledRootlessIds = (organizationId: string, projectId: string, spans: readonly SpanDetail[]) =>
+const alreadyStoredTraceIds = (organizationId: string, projectId: string, spans: readonly SpanDetail[]) =>
   Effect.gen(function* () {
-    const rootlessIds = groupSpansByTrace(spans)
-      .filter((group) => group.root === undefined)
-      .map((group) => group.traceId)
-    if (rootlessIds.length === 0) return new Set<string>()
+    const traceIds = [...new Set(spans.map((span) => span.traceId as string))]
+    if (traceIds.length === 0) return new Set<string>()
 
     const spanRepo = yield* SpanRepository
     const existing = yield* spanRepo.listByTraceIds({
       organizationId: OrganizationId(organizationId),
       projectId: ProjectId(projectId),
-      traceIds: rootlessIds.map((id) => TraceId(id)),
+      traceIds: traceIds.map((id) => TraceId(id)),
     })
     return new Set(existing.map((span) => span.traceId as string))
   })
@@ -312,7 +309,19 @@ export const processImportPageUseCase =
         return { done: true as const, reason: "succeeded" as const }
       }
 
-      const traceBudget = input.isSandbox ? null : yield* importTraceBudget(input.plan)
+      const periodBudget = input.isSandbox ? null : yield* importTraceBudget(input.plan)
+      if (periodBudget !== null && stats.consumedCreditsAtStart === undefined) {
+        stats.consumedCreditsAtStart = periodBudget.consumedCredits
+      }
+      const traceBudget =
+        periodBudget === null
+          ? null
+          : remainingAfterInFlightImport({
+              remaining: periodBudget.remaining,
+              consumedCredits: periodBudget.consumedCredits,
+              tracesImported: stats.tracesImported,
+              consumedCreditsAtStart: stats.consumedCreditsAtStart,
+            })
 
       // Read fresh each page rather than trusting the snapshot, so live ingestion or a
       // spending-limit change during a long import stops it too. The snapshot in
@@ -449,7 +458,7 @@ export const processImportPageUseCase =
       const userTraceBudget = job.config.maxTraces - stats.tracesImported
       const admitBudget = traceBudget === null ? userTraceBudget : Math.min(userTraceBudget, traceBudget)
       const alreadyBilledTraceIds =
-        traceBudget === null ? null : yield* alreadyBilledRootlessIds(job.organizationId, job.projectId, normalized)
+        traceBudget === null ? null : yield* alreadyStoredTraceIds(job.organizationId, job.projectId, normalized)
       const admitted = admitNewestTraces(normalized, admitBudget, alreadyBilledTraceIds)
       const spans = admitted.spans
       const tracesInPage = admitted.traces
@@ -536,7 +545,7 @@ export const processImportPageUseCase =
       // traces would be left behind. `capped` is reserved for the plan's ceiling, which is the one
       // the user did not choose and can resume from once usage frees up.
       if (truncatedByPlan) {
-        yield* finishImport(job, "capped", { cursor: nextCursor, stats, runs, error: PLAN_CAP_REASON })
+        yield* finishImport(job, "capped", { cursor, stats, runs, error: PLAN_CAP_REASON })
         return { done: true as const, reason: "capped" as const }
       }
 

--- a/packages/domain/imports/src/use-cases/process-import-page.ts
+++ b/packages/domain/imports/src/use-cases/process-import-page.ts
@@ -240,11 +240,7 @@ const admitNewestTraces = (
   return { spans: admitted, traces, sessions: sessionKeys.size, truncated }
 }
 
-const alreadyBilledRootlessIds = (
-  organizationId: string,
-  projectId: string,
-  spans: readonly SpanDetail[],
-) =>
+const alreadyBilledRootlessIds = (organizationId: string, projectId: string, spans: readonly SpanDetail[]) =>
   Effect.gen(function* () {
     const rootlessIds = groupSpansByTrace(spans)
       .filter((group) => group.root === undefined)
@@ -453,9 +449,7 @@ export const processImportPageUseCase =
       const userTraceBudget = job.config.maxTraces - stats.tracesImported
       const admitBudget = traceBudget === null ? userTraceBudget : Math.min(userTraceBudget, traceBudget)
       const alreadyBilledTraceIds =
-        traceBudget === null
-          ? null
-          : yield* alreadyBilledRootlessIds(job.organizationId, job.projectId, normalized)
+        traceBudget === null ? null : yield* alreadyBilledRootlessIds(job.organizationId, job.projectId, normalized)
       const admitted = admitNewestTraces(normalized, admitBudget, alreadyBilledTraceIds)
       const spans = admitted.spans
       const tracesInPage = admitted.traces

--- a/packages/domain/imports/src/use-cases/process-import-page.ts
+++ b/packages/domain/imports/src/use-cases/process-import-page.ts
@@ -1,6 +1,6 @@
 import type { EffectivePlanResolution } from "@domain/billing"
 import type { DomainEvent, EventsPublisher } from "@domain/events"
-import { ImportJobId, OrganizationId, ProjectId, type RedactionPolicy } from "@domain/shared"
+import { ImportJobId, OrganizationId, ProjectId, type RedactionPolicy, TraceId } from "@domain/shared"
 import { redactSpans, type SpanDetail, SpanRepository } from "@domain/spans"
 import { Effect, Result } from "effect"
 import {
@@ -20,7 +20,7 @@ import { ImportSourceError, sanitizedImportError } from "../errors.ts"
 import { ImportJobRepository } from "../ports/import-job-repository.ts"
 import { getAdapter, ImportSourceAdapters } from "../ports/import-source-adapter.ts"
 import { finishImport } from "./finish-import.ts"
-import { importUsageAvailable } from "./import-usage-available.ts"
+import { importTraceBudget } from "./import-usage-available.ts"
 
 export interface ProcessImportPageInput {
   readonly organizationId: string
@@ -135,17 +135,50 @@ const advanceWindow = (cursor: ImportCursor, windowStart: Date, wasEmpty: boolea
   source: null,
 })
 
+interface TraceGroup {
+  readonly traceId: string
+  readonly spans: readonly SpanDetail[]
+  readonly root: SpanDetail | undefined
+}
+
 interface AdmittedSpans {
   readonly spans: readonly SpanDetail[]
-  /** Roots admitted, which is the number of traces this page contributes to the budget. */
+  /** Newly billed traces this page contributes — roots, plus unseen rootless groups when the plan caps. */
   readonly traces: number
   /**
-   * Distinct sessions among the admitted roots, counting a sessionless root as its own session
-   * — the same identity the session rollup uses. Per-page distinct, so the job-level sum counts
-   * a session once per page its traces land in.
+   * Distinct sessions among the admitted billed traces, counting a sessionless trace as its own
+   * session — the same identity the session rollup uses. Per-page distinct, so the job-level sum
+   * counts a session once per page its traces land in.
    */
   readonly sessions: number
   readonly truncated: boolean
+}
+
+const groupSpansByTrace = (spans: readonly SpanDetail[]): TraceGroup[] => {
+  const byTrace = new Map<string, SpanDetail[]>()
+  for (const span of spans) {
+    const traceId = span.traceId as string
+    const existing = byTrace.get(traceId)
+    if (existing) existing.push(span)
+    else byTrace.set(traceId, [span])
+  }
+
+  return [...byTrace.entries()].map(([traceId, group]) => ({
+    traceId,
+    spans: group,
+    root: group.find((span) => span.parentSpanId === ""),
+  }))
+}
+
+const newestTimeOf = (group: TraceGroup): number => {
+  if (group.root) return group.root.startTime.getTime()
+  return Math.max(...group.spans.map((span) => span.startTime.getTime()))
+}
+
+const sessionKeyOf = (group: TraceGroup): string => {
+  const sessionSpan = group.root ?? group.spans[0]
+  const sessionId = sessionSpan?.sessionId as string | undefined
+  return sessionId === "" || sessionId === undefined ? `trace:${group.traceId}` : sessionId
 }
 
 /**
@@ -157,51 +190,75 @@ interface AdmittedSpans {
  * reason ordering lives in the engine — so a page arrives in whatever order the source chose.
  * Truncating that stream keeps an arbitrary subset, and windows widen up to 32 days over sparse
  * history, so "newest first" could otherwise mean "some traces from a month-wide window".
- * Sorting by the root's start time makes the truncation exact whatever the source did.
+ * Sorting by the root's start time (or the newest span, for a rootless group) makes the
+ * truncation exact whatever the source did.
  *
  * Whole traces: cutting the stream mid-page also orphaned spans whose own root had already been
  * admitted, leaving a trace half-imported with no record that anything was dropped. A trace is
  * admitted with all of its spans or none of them.
  *
- * Spans whose root is not in this page cost no budget: their root was counted in an earlier page
- * of the same window, and dropping them would strand the trace that root already paid for.
+ * Rootless groups are free when the plan does not cap volume (`alreadyBilledTraceIds` is null),
+ * or when that `traceId` was already billed — `TracesIngested` is idempotent, and dropping those
+ * spans would strand a trace already paid for. Previously unseen rootless groups are billable:
+ * the event charges every distinct admitted `traceId`.
  */
-const admitNewestTraces = (spans: readonly SpanDetail[], remainingTraces: number): AdmittedSpans => {
-  const byTrace = new Map<string, SpanDetail[]>()
-  for (const span of spans) {
-    const traceId = span.traceId as string
-    const existing = byTrace.get(traceId)
-    if (existing) existing.push(span)
-    else byTrace.set(traceId, [span])
+const admitNewestTraces = (
+  spans: readonly SpanDetail[],
+  remainingTraces: number,
+  alreadyBilledTraceIds: ReadonlySet<string> | null,
+): AdmittedSpans => {
+  const freeSpans: SpanDetail[] = []
+  const billed: TraceGroup[] = []
+  for (const group of groupSpansByTrace(spans)) {
+    if (group.root) {
+      billed.push(group)
+      continue
+    }
+    if (alreadyBilledTraceIds === null || alreadyBilledTraceIds.has(group.traceId)) {
+      freeSpans.push(...group.spans)
+      continue
+    }
+    billed.push(group)
   }
 
-  const rooted: { readonly root: SpanDetail; readonly spans: readonly SpanDetail[] }[] = []
-  const orphans: SpanDetail[] = []
-  for (const group of byTrace.values()) {
-    const root = group.find((span) => span.parentSpanId === "")
-    if (root) rooted.push({ root, spans: group })
-    else orphans.push(...group)
-  }
+  billed.sort((left, right) => newestTimeOf(right) - newestTimeOf(left))
 
-  rooted.sort((left, right) => right.root.startTime.getTime() - left.root.startTime.getTime())
-
-  const admitted: SpanDetail[] = [...orphans]
+  const admitted: SpanDetail[] = [...freeSpans]
   const sessionKeys = new Set<string>()
   let traces = 0
   let truncated = false
-  for (const group of rooted) {
+  for (const group of billed) {
     if (traces >= remainingTraces) {
       truncated = true
       break
     }
     admitted.push(...group.spans)
     traces++
-    const sessionId = group.root.sessionId as string
-    sessionKeys.add(sessionId === "" ? `trace:${group.root.traceId}` : sessionId)
+    sessionKeys.add(sessionKeyOf(group))
   }
 
   return { spans: admitted, traces, sessions: sessionKeys.size, truncated }
 }
+
+const alreadyBilledRootlessIds = (
+  organizationId: string,
+  projectId: string,
+  spans: readonly SpanDetail[],
+) =>
+  Effect.gen(function* () {
+    const rootlessIds = groupSpansByTrace(spans)
+      .filter((group) => group.root === undefined)
+      .map((group) => group.traceId)
+    if (rootlessIds.length === 0) return new Set<string>()
+
+    const spanRepo = yield* SpanRepository
+    const existing = yield* spanRepo.listByTraceIds({
+      organizationId: OrganizationId(organizationId),
+      projectId: ProjectId(projectId),
+      traceIds: rootlessIds.map((id) => TraceId(id)),
+    })
+    return new Set(existing.map((span) => span.traceId as string))
+  })
 
 export const recordImportFinalFailureUseCase = (input: RecordImportFinalFailureInput) =>
   Effect.gen(function* () {
@@ -259,10 +316,12 @@ export const processImportPageUseCase =
         return { done: true as const, reason: "succeeded" as const }
       }
 
+      const traceBudget = input.isSandbox ? null : yield* importTraceBudget(input.plan)
+
       // Read fresh each page rather than trusting the snapshot, so live ingestion or a
       // spending-limit change during a long import stops it too. The snapshot in
       // `config.maxTraces` is the user's own ceiling; this is the plan's.
-      if (!input.isSandbox && !(yield* importUsageAvailable(input.plan))) {
+      if (traceBudget === 0) {
         yield* finishImport(job, "capped", { error: PLAN_CAP_REASON })
         return { done: true as const, reason: "capped" as const }
       }
@@ -391,10 +450,17 @@ export const processImportPageUseCase =
         normalized.push(result.span)
       }
 
-      const admitted = admitNewestTraces(normalized, job.config.maxTraces - stats.tracesImported)
+      const userTraceBudget = job.config.maxTraces - stats.tracesImported
+      const admitBudget = traceBudget === null ? userTraceBudget : Math.min(userTraceBudget, traceBudget)
+      const alreadyBilledTraceIds =
+        traceBudget === null
+          ? null
+          : yield* alreadyBilledRootlessIds(job.organizationId, job.projectId, normalized)
+      const admitted = admitNewestTraces(normalized, admitBudget, alreadyBilledTraceIds)
       const spans = admitted.spans
-      const rootsInPage = admitted.traces
+      const tracesInPage = admitted.traces
       const truncatedByCap = admitted.truncated
+      const truncatedByPlan = truncatedByCap && traceBudget !== null && traceBudget < userTraceBudget
 
       // An import is a second content sink into `spans`, so it runs the same redaction the
       // ingest pipeline runs — before the insert, which is the only point where stripping
@@ -420,7 +486,7 @@ export const processImportPageUseCase =
       const traceIds = new Set(importedSpans.map((span) => span.traceId as string))
 
       stats.sessionsImported += admitted.sessions
-      stats.tracesImported += rootsInPage
+      stats.tracesImported += tracesInPage
       stats.spansImported += importedSpans.length
       stats.spansSkipped += skipped
 
@@ -462,7 +528,7 @@ export const processImportPageUseCase =
         stats: {
           recordsFetched: page.rows.length,
           sessionsImported: admitted.sessions,
-          tracesImported: rootsInPage,
+          tracesImported: tracesInPage,
           spansImported: importedSpans.length,
           spansSkipped: skipped,
         },
@@ -475,6 +541,11 @@ export const processImportPageUseCase =
       // ends the job cleanly even with range left over — the preview already told them the oldest
       // traces would be left behind. `capped` is reserved for the plan's ceiling, which is the one
       // the user did not choose and can resume from once usage frees up.
+      if (truncatedByPlan) {
+        yield* finishImport(job, "capped", { cursor: nextCursor, stats, runs, error: PLAN_CAP_REASON })
+        return { done: true as const, reason: "capped" as const }
+      }
+
       if (truncatedByCap || stats.tracesImported >= job.config.maxTraces) {
         yield* finishImport(job, "succeeded", { cursor: nextCursor, stats, runs })
         return { done: true as const, reason: "succeeded" as const }

--- a/packages/domain/imports/src/use-cases/retry-import.test.ts
+++ b/packages/domain/imports/src/use-cases/retry-import.test.ts
@@ -122,7 +122,7 @@ describe("retryImportUseCase", () => {
       status: "capped",
       credentials: null,
       cursor: PARTWAY_CURSOR,
-      stats: CARRIED_STATS,
+      stats: { ...CARRIED_STATS, consumedCreditsAtStart: 19_990 },
       error: "Ran out of plan usage for this billing period.",
     })
     const h = importHarness({ seed: [capped] })
@@ -131,6 +131,7 @@ describe("retryImportUseCase", () => {
 
     expect(retried.cursor).toEqual(PARTWAY_CURSOR)
     expect(retried.stats).toEqual(CARRIED_STATS)
+    expect(retried.stats.consumedCreditsAtStart).toBeUndefined()
     expect(retried.status).toBe("created")
     // The cap reason belongs to the job that stopped, not to the one carrying on.
     expect(retried.error).toBeNull()

--- a/packages/domain/imports/src/use-cases/retry-import.ts
+++ b/packages/domain/imports/src/use-cases/retry-import.ts
@@ -80,6 +80,7 @@ export const retryImportUseCase = (input: RetryImportInput) =>
     // Resumes from the failed job's cursor and carries its counts forward: re-reading
     // the whole range would be wasted quota against sources we deliberately rate-limit,
     // and deterministic span ids make picking up mid-range safe.
+    const { consumedCreditsAtStart: _consumedCreditsAtStart, ...carriedStats } = job.stats
     const retryJob = createImportJob({
       organizationId: job.organizationId,
       projectId: job.projectId,
@@ -87,7 +88,7 @@ export const retryImportUseCase = (input: RetryImportInput) =>
       config: job.config,
       credentials: input.credentials,
       cursor: job.cursor,
-      stats: job.stats,
+      stats: carriedStats,
     })
 
     const outboxEventWriter = yield* OutboxEventWriter

--- a/packages/domain/spans/src/testing/fake-span-repository.ts
+++ b/packages/domain/spans/src/testing/fake-span-repository.ts
@@ -14,7 +14,10 @@ export const createFakeSpanRepository = (overrides?: Partial<SpanRepositoryShape
       return Effect.void
     },
     listByTraceId: () => Effect.succeed([]),
-    listByTraceIds: () => Effect.succeed([]),
+    listByTraceIds: ({ traceIds }) => {
+      const wanted = new Set(traceIds)
+      return Effect.succeed(inserted.flat().filter((span) => wanted.has(span.traceId)))
+    },
     listBySessionId: () => Effect.succeed([]),
     listToolSpansBySessionId: () => Effect.succeed([]),
     listMemoryOperationSpansByTraceId: () => Effect.succeed([]),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Supersedes #4382. That PR clamped `admitNewestTraces` to remaining plan credits, but two accounting bugs kept it unmergeable: a page truncated by the plan finished as `succeeded`, and previously unseen rootless `traceId`s were published on `TracesIngested` without counting against the budget.

This still computes `importTraceBudget` from the current period (hard-capped included credits, or a Pro spending-limit cap) and admits at most that many **billable** traces per page. Hitting that bound finishes the job as `capped` with `PLAN_CAP_REASON`, so the existing Continue import path works after usage returns.

Rootless groups are included in the plan clamp. `TracesIngested` bills every distinct admitted `traceId`, so a span-paginated Langfuse page of child spans can otherwise charge far more than the remaining credits. Any group whose `traceId` already exists in the span store is free, rooted or not, so children-then-root pagination and a re-import cannot consume the budget twice.

A plan-truncated page keeps the current cursor so Continue import refetches the omitted traces. Consecutive pages subtract this job's still-unrecorded traces from the remaining budget (`consumedCreditsAtStart` + `tracesImported`) and stop subtracting once the period has landed them.

The user's own `maxTraces` ceiling is unchanged: it still finishes as `succeeded` when it is the tighter bound, and on uncapped plans rootless continuation spans stay free.

## Related issue (if applicable)

Supersedes #4382. Do not merge that PR. Do not merge this one until review is satisfied.

## How was this tested?

- `pnpm --filter @domain/imports typecheck`
- `pnpm --filter @domain/imports test` — 277 passed
- Plan-budget truncation finishes `capped` and keeps the current cursor
- Unseen rootless groups consume the budget; already-imported continuation spans do not
- Children-then-root across two pages and re-import of a stored rooted trace stay free
- A 10-credit remainder cannot admit a second 10-trace page before billing lands; after it lands the clamp does not double-subtract
- User ceiling still wins when it is tighter

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows Conventional Commits
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0e912c2-8193-4276-8bbf-e2fba39f0430?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0e912c2-8193-4276-8bbf-e2fba39f0430&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790871207&installation_model_id=435055&pr_number=4537&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4537&signature=dc8fd1846501221c5a7030f2260d18830c0e6b695db162fc5801741286e88749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->