### PR TITLE
fix(infra): cut CloudWatch Logs ingest to stay under the 5GB cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -295,6 +295,8 @@ LAT_VOYAGE_API_KEY=
 # LAT_OBSERVABILITY_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
 # Optional comma-separated OTLP headers (key=value,key2=value2)
 # LAT_OBSERVABILITY_OTLP_HEADERS=
+# Minimum stdout log level: info (default), warn, or error
+# LAT_LOG_LEVEL=info
 # Optional: also export spans to Latitude when the API key is set (ECS sets it in prod). The same API
 # key is reused by @platform/latitude-api to write product-feedback annotations (Latitude-on-Latitude
 # dogfood); when unset, the client no-ops. Auth is org-scoped, so this one key reaches every project.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -423,7 +423,7 @@ jobs:
                         map(if .name == "DD_LOG_LEVEL" then .value = "error" else . end) |
                         if any(.[]; .name == "DD_LOG_LEVEL") then . else . + [{ name: "DD_LOG_LEVEL", value: "error" }] end
                       ) |
-                      .logConfiguration = { logDriver: "none" }
+                      del(.logConfiguration)
                     else . end
                   ) |
                   del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
@@ -814,7 +814,7 @@ jobs:
                         map(if .name == "DD_LOG_LEVEL" then .value = "error" else . end) |
                         if any(.[]; .name == "DD_LOG_LEVEL") then . else . + [{ name: "DD_LOG_LEVEL", value: "error" }] end
                       ) |
-                      .logConfiguration = { logDriver: "none" }
+                      del(.logConfiguration)
                     else . end
                   ) |
                   del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -407,15 +407,23 @@ jobs:
                 --query 'taskDefinition' \
                 --output json | jq \
                   --arg image "${IMAGE}" \
-                  --arg name "${SERVICE}" '
+                  --arg name "${SERVICE}" \
+                  --arg logLevel "warn" '
                   .containerDefinitions |= map(
-                    if .name == $name then .image = $image
+                    if .name == $name then
+                      .image = $image |
+                      .environment = (
+                        (.environment // []) |
+                        map(if .name == "LAT_LOG_LEVEL" then .value = $logLevel else . end) |
+                        if any(.[]; .name == "LAT_LOG_LEVEL") then . else . + [{ name: "LAT_LOG_LEVEL", value: $logLevel }] end
+                      )
                     elif .name == "datadog-agent" then
                       .environment = (
                         (.environment // []) |
-                        map(if .name == "DD_LOG_LEVEL" then .value = "info" else . end) |
-                        if any(.[]; .name == "DD_LOG_LEVEL") then . else . + [{ name: "DD_LOG_LEVEL", value: "info" }] end
-                      )
+                        map(if .name == "DD_LOG_LEVEL" then .value = "error" else . end) |
+                        if any(.[]; .name == "DD_LOG_LEVEL") then . else . + [{ name: "DD_LOG_LEVEL", value: "error" }] end
+                      ) |
+                      .logConfiguration = { logDriver: "none" }
                     else . end
                   ) |
                   del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
@@ -790,15 +798,23 @@ jobs:
                 --query 'taskDefinition' \
                 --output json | jq \
                   --arg image "${IMAGE}" \
-                  --arg name "${SERVICE}" '
+                  --arg name "${SERVICE}" \
+                  --arg logLevel "warn" '
                   .containerDefinitions |= map(
-                    if .name == $name then .image = $image
+                    if .name == $name then
+                      .image = $image |
+                      .environment = (
+                        (.environment // []) |
+                        map(if .name == "LAT_LOG_LEVEL" then .value = $logLevel else . end) |
+                        if any(.[]; .name == "LAT_LOG_LEVEL") then . else . + [{ name: "LAT_LOG_LEVEL", value: $logLevel }] end
+                      )
                     elif .name == "datadog-agent" then
                       .environment = (
                         (.environment // []) |
-                        map(if .name == "DD_LOG_LEVEL" then .value = "info" else . end) |
-                        if any(.[]; .name == "DD_LOG_LEVEL") then . else . + [{ name: "DD_LOG_LEVEL", value: "info" }] end
-                      )
+                        map(if .name == "DD_LOG_LEVEL" then .value = "error" else . end) |
+                        if any(.[]; .name == "DD_LOG_LEVEL") then . else . + [{ name: "DD_LOG_LEVEL", value: "error" }] end
+                      ) |
+                      .logConfiguration = { logDriver: "none" }
                     else . end
                   ) |
                   del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)

--- a/apps/api/src/middleware/access-logger.test.ts
+++ b/apps/api/src/middleware/access-logger.test.ts
@@ -3,9 +3,14 @@ import { describe, expect, it } from "vitest"
 import { accessLogger } from "./access-logger.ts"
 
 const createApp = () => {
-  const logs: string[] = []
+  const logs: { level: "info" | "warn"; message: string }[] = []
   const app = new Hono()
-  app.use(accessLogger((message) => logs.push(message)))
+  app.use(
+    accessLogger({
+      info: (message) => logs.push({ level: "info", message }),
+      warn: (message) => logs.push({ level: "warn", message }),
+    }),
+  )
 
   return { app, logs }
 }
@@ -20,29 +25,43 @@ describe("accessLogger", () => {
     expect(logs).toEqual([])
   })
 
-  it("logs failed GET /health requests", async () => {
+  it("logs failed GET /health requests at warn", async () => {
     const { app, logs } = createApp()
     app.get("/health", (c) => c.json({ status: "starting" }, 503))
 
     await app.request("/health")
 
     expect(logs).toHaveLength(2)
-    expect(logs[0]).toBe("<-- GET /health")
-    expect(logs[1]).toContain("--> GET /health")
-    expect(logs[1]).toContain("503")
-    expect(logs[1]).toMatch(/\d+ms$/)
+    expect(logs[0]).toEqual({ level: "warn", message: "<-- GET /health" })
+    expect(logs[1]?.level).toBe("warn")
+    expect(logs[1]?.message).toContain("--> GET /health")
+    expect(logs[1]?.message).toContain("503")
+    expect(logs[1]?.message).toMatch(/\d+ms$/)
   })
 
-  it("logs requests other than GET /health", async () => {
+  it("logs successful requests other than GET /health at info", async () => {
     const { app, logs } = createApp()
     app.get("/status", (c) => c.json({ status: "ok" }))
 
     await app.request("/status")
 
     expect(logs).toHaveLength(2)
-    expect(logs[0]).toBe("<-- GET /status")
-    expect(logs[1]).toContain("--> GET /status")
-    expect(logs[1]).toContain("200")
-    expect(logs[1]).toMatch(/\d+ms$/)
+    expect(logs[0]).toEqual({ level: "info", message: "<-- GET /status" })
+    expect(logs[1]?.level).toBe("info")
+    expect(logs[1]?.message).toContain("--> GET /status")
+    expect(logs[1]?.message).toContain("200")
+    expect(logs[1]?.message).toMatch(/\d+ms$/)
+  })
+
+  it("logs failed requests other than GET /health at warn", async () => {
+    const { app, logs } = createApp()
+    app.get("/status", (c) => c.json({ status: "nope" }, 500))
+
+    await app.request("/status")
+
+    expect(logs).toHaveLength(2)
+    expect(logs[0]?.level).toBe("warn")
+    expect(logs[1]?.level).toBe("warn")
+    expect(logs[1]?.message).toContain("500")
   })
 })

--- a/apps/api/src/middleware/access-logger.test.ts
+++ b/apps/api/src/middleware/access-logger.test.ts
@@ -53,15 +53,30 @@ describe("accessLogger", () => {
     expect(logs[1]?.message).toMatch(/\d+ms$/)
   })
 
-  it("logs failed requests other than GET /health at warn", async () => {
+  it("logs the incoming line at info and the completion line at warn for failed requests", async () => {
     const { app, logs } = createApp()
     app.get("/status", (c) => c.json({ status: "nope" }, 500))
 
     await app.request("/status")
 
     expect(logs).toHaveLength(2)
-    expect(logs[0]?.level).toBe("warn")
+    expect(logs[0]).toEqual({ level: "info", message: "<-- GET /status" })
     expect(logs[1]?.level).toBe("warn")
     expect(logs[1]?.message).toContain("500")
+  })
+
+  it("writes the incoming line before the handler finishes", async () => {
+    const { app, logs } = createApp()
+    let logsDuringHandler: { level: "info" | "warn"; message: string }[] = []
+    app.get("/slow", async (c) => {
+      logsDuringHandler = [...logs]
+      return c.json({ ok: true })
+    })
+
+    await app.request("/slow")
+
+    expect(logsDuringHandler).toEqual([{ level: "info", message: "<-- GET /slow" }])
+    expect(logs[1]?.level).toBe("info")
+    expect(logs[1]?.message).toContain("--> GET /slow")
   })
 })

--- a/apps/api/src/middleware/access-logger.ts
+++ b/apps/api/src/middleware/access-logger.ts
@@ -9,16 +9,26 @@ type AccessLog = {
 export const accessLogger = (log: AccessLog) => {
   return createMiddleware(async (c, next) => {
     const isHealth = c.req.method === "GET" && c.req.path === "/health"
-    const messages: string[] = []
-    await logger((message) => messages.push(message))(c, next)
+    let incoming: string | undefined
 
-    if (isHealth && c.res.ok) {
-      return
-    }
+    await logger((message) => {
+      if (incoming === undefined) {
+        incoming = message
+        if (!isHealth) {
+          log.info(message)
+        }
+        return
+      }
 
-    const write = c.res.ok ? log.info : log.warn
-    for (const message of messages) {
+      if (isHealth && c.res.ok) {
+        return
+      }
+
+      const write = c.res.ok ? log.info : log.warn
+      if (isHealth && incoming) {
+        write(incoming)
+      }
       write(message)
-    }
+    })(c, next)
   })
 }

--- a/apps/api/src/middleware/access-logger.ts
+++ b/apps/api/src/middleware/access-logger.ts
@@ -1,21 +1,24 @@
 import { createMiddleware } from "hono/factory"
 import { logger } from "hono/logger"
 
-type AccessLog = (message: string) => void
+type AccessLog = {
+  info: (message: string) => void
+  warn: (message: string) => void
+}
 
 export const accessLogger = (log: AccessLog) => {
-  const logRequest = logger(log)
-
   return createMiddleware(async (c, next) => {
-    if (c.req.method !== "GET" || c.req.path !== "/health") {
-      return logRequest(c, next)
-    }
-
+    const isHealth = c.req.method === "GET" && c.req.path === "/health"
     const messages: string[] = []
     await logger((message) => messages.push(message))(c, next)
 
-    if (!c.res.ok) {
-      messages.forEach(log)
+    if (isHealth && c.res.ok) {
+      return
+    }
+
+    const write = c.res.ok ? log.info : log.warn
+    for (const message of messages) {
+      write(message)
     }
   })
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -38,7 +38,12 @@ const startServer = async () => {
   const url = Effect.runSync(parseEnv("LAT_API_URL", "string", "http://localhost:3001"))
   const port = Effect.runSync(parseEnv("LAT_API_PORT", "number", 3001))
 
-  app.use(accessLogger((message) => logger.info(message)))
+  app.use(
+    accessLogger({
+      info: (message) => logger.info(message),
+      warn: (message) => logger.warn(message),
+    }),
+  )
 
   // Add Hono OpenTelemetry middleware
   app.use(otel())

--- a/dev-docs/network-diagram.md
+++ b/dev-docs/network-diagram.md
@@ -25,7 +25,7 @@ Latitude production runs in AWS `eu-central-1` with public HTTPS ingress, privat
 - The bastion host is the controlled administrative network path for private infrastructure troubleshooting and is described as Tailscale VPN-backed in the security group configuration.
 - S3 and Secrets Manager are AWS managed services reached through configured VPC endpoints where applicable.
 - Application secrets, database credentials, OAuth secrets, Stripe secrets, Temporal credentials, Datadog credentials, and other provider keys are stored in AWS Secrets Manager.
-- Application logs are written to CloudWatch log groups and exported/observed through Datadog sidecars and Datadog SaaS.
+- Application containers write warn/error stdout to CloudWatch; Datadog sidecars collect APM traces and metrics. The Datadog agent itself does not ship logs to CloudWatch.
 - Outbound third-party integrations use TLS to approved SaaS services such as ClickHouse Cloud, Temporal Cloud, Datadog, Stripe, Mailgun, OAuth providers, Cloudflare Turnstile, PostHog, Loops, Intercom, and Voyage AI.
 
 ## Security boundaries represented

--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -134,6 +134,7 @@ These wire Latitude to its datastores, depending on your chosen [deployment opti
 | `LAT_TRUSTED_ORIGINS`, `LAT_CORS_ALLOWED_ORIGINS` | Comma-separated list of origins allowed to call the API. |
 | `LAT_WEB_PORT`, `LAT_API_PORT`, `LAT_INGEST_PORT` | Host bind ports (default `3000` / `3001` / `3002`). |
 | `LAT_WORKERS_HEALTH_PORT`, `LAT_WORKFLOWS_HEALTH_PORT` | Health-check ports for the background workers (default `9090` / `9091`). |
+| `LAT_LOG_LEVEL` | Minimum stdout log level: `info` (default), `warn`, or `error`. |
 | `LAT_IMAGE_TAG` | Image tag the stack pulls (default `latest`; pin `X.Y.Z` in production). |
 | `LAT_OSS_TELEMETRY_ENABLED` | Anonymous OSS deployment heartbeat sent to Latitude's PostHog project when the API starts (default `true` in production, `false` in development). Set `false` to opt out. Optional overrides: `LAT_OSS_TELEMETRY_POSTHOG_API_KEY`, `LAT_OSS_TELEMETRY_POSTHOG_HOST`. |
 | `LAT_TELEMETRY_RETENTION_DAYS` | How long spans, traces, and search rows are kept, in days (default `3650`, max `3650`). Stamped on each row at ingest, so a change applies to new data only. Ignored when `LAT_BILLING_ENABLED=true`, and for any organization given a manual billing override, where the plan sets retention. |

--- a/infra/lib/ecs.ts
+++ b/infra/lib/ecs.ts
@@ -476,6 +476,7 @@ function createTaskDefinition(
           { name: "DD_ENV", value: config.name },
           { name: "DD_SERVICE", value: serviceConfig.name },
           { name: "LAT_OBSERVABILITY_ENVIRONMENT", value: config.name },
+          { name: "LAT_LOG_LEVEL", value: "warn" },
           { name: "DD_DOGSTATSD_HOST", value: "localhost" },
           { name: "DD_DOGSTATSD_PORT", value: "8125" },
           { name: "DD_AGENT_HOST", value: "localhost" },
@@ -671,19 +672,14 @@ function createTaskDefinition(
             { name: "DD_OTLP_CONFIG_TRACES_ENABLED", value: "true" },
             { name: "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT", value: "0.0.0.0:4318" },
             { name: "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT", value: "0.0.0.0:4317" },
-            { name: "DD_LOG_LEVEL", value: "info" },
+            { name: "DD_LOG_LEVEL", value: "error" },
           ],
           secrets: [
             { name: "DD_API_KEY", valueFrom: datadogApiKeyArn },
             { name: "DD_SITE", valueFrom: datadogSiteArn },
           ],
           logConfiguration: {
-            logDriver: "awslogs",
-            options: {
-              "awslogs-group": `/ecs/${name}/datadog-agent`,
-              "awslogs-region": config.region,
-              "awslogs-stream-prefix": "datadog-agent",
-            },
+            logDriver: "none",
           },
           healthCheck: {
             command: ["CMD-SHELL", "agent health || exit 1"],

--- a/infra/lib/ecs.ts
+++ b/infra/lib/ecs.ts
@@ -678,9 +678,6 @@ function createTaskDefinition(
             { name: "DD_API_KEY", valueFrom: datadogApiKeyArn },
             { name: "DD_SITE", valueFrom: datadogSiteArn },
           ],
-          logConfiguration: {
-            logDriver: "none",
-          },
           healthCheck: {
             command: ["CMD-SHELL", "agent health || exit 1"],
             interval: 30,

--- a/infra/lib/rds.ts
+++ b/infra/lib/rds.ts
@@ -136,7 +136,8 @@ function createAuroraServerless(
     backupRetentionPeriod: config.rds.backupDays,
     storageEncrypted: true,
     preferredBackupWindow: "03:00-04:00",
-    enabledCloudwatchLogsExports: ["postgresql"],
+    enabledCloudwatchLogsExports: [],
+    applyImmediately: true,
     tags: {
       Name: `${name}-aurora`,
       Environment: config.name,
@@ -288,7 +289,8 @@ function createStandardInstance(
     backupRetentionPeriod: config.rds.backupDays,
     skipFinalSnapshot: config.name === "staging",
     finalSnapshotIdentifier: config.name === "production" ? `${name}-final-snapshot` : undefined,
-    enabledCloudwatchLogsExports: ["postgresql"],
+    enabledCloudwatchLogsExports: [],
+    applyImmediately: true,
     parameterGroupName: parameterGroup.name,
     tags: {
       Name: `${name}-postgres`,

--- a/infra/lib/rds.ts
+++ b/infra/lib/rds.ts
@@ -137,7 +137,6 @@ function createAuroraServerless(
     storageEncrypted: true,
     preferredBackupWindow: "03:00-04:00",
     enabledCloudwatchLogsExports: [],
-    applyImmediately: true,
     tags: {
       Name: `${name}-aurora`,
       Environment: config.name,
@@ -290,7 +289,6 @@ function createStandardInstance(
     skipFinalSnapshot: config.name === "staging",
     finalSnapshotIdentifier: config.name === "production" ? `${name}-final-snapshot` : undefined,
     enabledCloudwatchLogsExports: [],
-    applyImmediately: true,
     parameterGroupName: parameterGroup.name,
     tags: {
       Name: `${name}-postgres`,

--- a/infra/lib/security-compliance.ts
+++ b/infra/lib/security-compliance.ts
@@ -10,20 +10,6 @@ export interface SecurityComplianceOutput {
   guardDutyDetector: aws.guardduty.Detector
 }
 
-const serviceAssumeRolePolicy = (service: string) =>
-  JSON.stringify({
-    Version: "2012-10-17",
-    Statement: [
-      {
-        Effect: "Allow",
-        Principal: {
-          Service: service,
-        },
-        Action: "sts:AssumeRole",
-      },
-    ],
-  })
-
 function createComplianceBucket(name: string, config: EnvironmentConfig, purpose: string): aws.s3.Bucket {
   const bucket = new aws.s3.Bucket(
     `${name}-${purpose}`,
@@ -229,31 +215,6 @@ function createCloudTrailWithCloudWatch(name: string, config: EnvironmentConfig)
     },
   })
 
-  const role = new aws.iam.Role(`${name}-cloudtrail-cloudwatch-role`, {
-    assumeRolePolicy: serviceAssumeRolePolicy("cloudtrail.amazonaws.com"),
-    tags: {
-      Name: `${name}-cloudtrail-cloudwatch-role`,
-      Environment: config.name,
-      Purpose: "cloudtrail-cloudwatch-logs-delivery",
-    },
-  })
-
-  const rolePolicy = new aws.iam.RolePolicy(`${name}-cloudtrail-cloudwatch-policy`, {
-    role: role.id,
-    policy: pulumi.all([logGroup.arn]).apply(([logGroupArn]) =>
-      JSON.stringify({
-        Version: "2012-10-17",
-        Statement: [
-          {
-            Effect: "Allow",
-            Action: ["logs:CreateLogStream", "logs:PutLogEvents"],
-            Resource: `${logGroupArn}:log-stream:*`,
-          },
-        ],
-      }),
-    ),
-  })
-
   const trail = new aws.cloudtrail.Trail(
     `${name}-cloudtrail`,
     {
@@ -270,7 +231,7 @@ function createCloudTrailWithCloudWatch(name: string, config: EnvironmentConfig)
       },
     },
     {
-      dependsOn: [bucketPolicy, rolePolicy],
+      dependsOn: [bucketPolicy],
     },
   )
 

--- a/infra/lib/security-compliance.ts
+++ b/infra/lib/security-compliance.ts
@@ -259,8 +259,6 @@ function createCloudTrailWithCloudWatch(name: string, config: EnvironmentConfig)
     {
       name: trailName,
       s3BucketName: bucket.bucket,
-      cloudWatchLogsGroupArn: pulumi.interpolate`${logGroup.arn}:*`,
-      cloudWatchLogsRoleArn: role.arn,
       includeGlobalServiceEvents: true,
       isMultiRegionTrail: true,
       enableLogFileValidation: true,

--- a/packages/observability/src/config.ts
+++ b/packages/observability/src/config.ts
@@ -59,8 +59,7 @@ const getLogLevel = (): LogLevel => {
   return "info"
 }
 
-export const isLogLevelEnabled = (level: LogLevel): boolean =>
-  LOG_LEVEL_RANK[level] <= LOG_LEVEL_RANK[getLogLevel()]
+export const isLogLevelEnabled = (level: LogLevel): boolean => LOG_LEVEL_RANK[level] <= LOG_LEVEL_RANK[getLogLevel()]
 
 export const isObservabilityEnabled = () => parseBooleanEnv(process.env.LAT_OBSERVABILITY_ENABLED, false)
 

--- a/packages/observability/src/config.ts
+++ b/packages/observability/src/config.ts
@@ -1,4 +1,10 @@
-import type { ObservabilityState, TracesConfig } from "./types.ts"
+import type { LogLevel, ObservabilityState, TracesConfig } from "./types.ts"
+
+const LOG_LEVEL_RANK: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+}
 
 const parseBooleanEnv = (value: string | undefined, fallback: boolean): boolean => {
   if (value === undefined || value.length === 0) {
@@ -44,6 +50,17 @@ const parseHeaders = (value: string | undefined): Record<string, string> => {
 }
 
 export const getEnvironment = () => process.env.LAT_OBSERVABILITY_ENVIRONMENT || process.env.NODE_ENV || "development"
+
+const getLogLevel = (): LogLevel => {
+  const value = process.env.LAT_LOG_LEVEL?.trim().toLowerCase()
+  if (value === "error" || value === "warn" || value === "info") {
+    return value
+  }
+  return "info"
+}
+
+export const isLogLevelEnabled = (level: LogLevel): boolean =>
+  LOG_LEVEL_RANK[level] <= LOG_LEVEL_RANK[getLogLevel()]
 
 export const isObservabilityEnabled = () => parseBooleanEnv(process.env.LAT_OBSERVABILITY_ENABLED, false)
 

--- a/packages/observability/src/logger.test.ts
+++ b/packages/observability/src/logger.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { emitLog } from "./logger.ts"
+import type { ObservabilityState } from "./types.ts"
+
+const state: ObservabilityState = {
+  initialized: true,
+  enabled: true,
+  serviceName: "test",
+  environment: "test",
+}
+
+describe("emitLog", () => {
+  afterEach(() => {
+    delete process.env.LAT_LOG_LEVEL
+    vi.restoreAllMocks()
+  })
+
+  it("writes info when LAT_LOG_LEVEL is unset", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {})
+    emitLog(state, "info", "test", ["hello"])
+    expect(log).toHaveBeenCalledOnce()
+  })
+
+  it("drops info when LAT_LOG_LEVEL is warn", () => {
+    process.env.LAT_LOG_LEVEL = "warn"
+    const log = vi.spyOn(console, "log").mockImplementation(() => {})
+    emitLog(state, "info", "test", ["hello"])
+    expect(log).not.toHaveBeenCalled()
+  })
+
+  it("writes warn and error when LAT_LOG_LEVEL is warn", () => {
+    process.env.LAT_LOG_LEVEL = "warn"
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    emitLog(state, "warn", "test", ["careful"])
+    emitLog(state, "error", "test", ["boom"])
+    expect(warn).toHaveBeenCalledOnce()
+    expect(error).toHaveBeenCalledOnce()
+  })
+
+  it("drops warn when LAT_LOG_LEVEL is error", () => {
+    process.env.LAT_LOG_LEVEL = "error"
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    emitLog(state, "warn", "test", ["careful"])
+    emitLog(state, "error", "test", ["boom"])
+    expect(warn).not.toHaveBeenCalled()
+    expect(error).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -1,5 +1,5 @@
 import { context, trace } from "@opentelemetry/api"
-import { getEnvironment, getServiceName } from "./config.ts"
+import { getEnvironment, getServiceName, isLogLevelEnabled } from "./config.ts"
 import type { LogLevel, ObservabilityState } from "./types.ts"
 
 const getTraceContext = () => {
@@ -54,6 +54,10 @@ const stringifyValue = (value: unknown): string => {
 }
 
 export const emitLog = (state: ObservabilityState, level: LogLevel, scope: string, args: unknown[]) => {
+  if (!isLogLevelEnabled(level)) {
+    return
+  }
+
   const environment = state.environment || getEnvironment()
   const service = getServiceName(state, scope)
   const values = args.map(toSerializable)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Stops Latitude Cloud from shipping high-volume logs into CloudWatch Logs so the account stops blowing the free-tier 5GB/month ingest cap.

The noisy sources in this repo are ECS `awslogs` (every `logger.info` from api/web/ingest/workers/workflows, plus the Datadog sidecar), staging CloudTrail management events mirrored into CloudWatch, and RDS `postgresql` log export. There are no Lambdas, VPC flow logs, or ALB access logs in this infra.

## Disabled vs kept

**Silenced (ingest stops):**
- Datadog agent sidecar: omit `logConfiguration` (Fargate does not support driver `none`; valid drivers are awslogs/splunk/awsfirelens). APM traces/metrics still go to Datadog. The `/ecs/latitude-{env}/datadog-agent` group is left in place.
- Staging CloudTrail: S3 delivery stays; CloudWatch Logs delivery is removed. The `/aws/cloudtrail/latitude-staging` log group is left in place so Pulumi does not delete it. The unused CloudWatch IAM role and policy are removed.
- RDS postgres CloudWatch export: `enabledCloudwatchLogsExports` is emptied on staging Postgres and production Aurora, without `applyImmediately` baked into desired state.

**Kept, but much quieter:**
- App containers still use `awslogs` on `/ecs/latitude-{env}/{service}`.
- ECS sets `LAT_LOG_LEVEL=warn`, so only warn/error stdout is written. Failed API requests (including failed `/health`) log the completion line at warn; the incoming `<--` line is written immediately at info so long requests stay visible in-flight.
- Migrations stay on `awslogs` (rare, useful on deploy failure).

## Why this shape

Gerard is fine disabling logs. Errors and warn-level failures are cheap and still show up in the existing log groups. Datadog remains the production trace/metric path. Retention is unchanged; retention does not affect ingest.

## How to verify in AWS

After **pulumi up** (CloudTrail + RDS) and the next **app deploy** (ECS task defs; `deploy.yml` injects `LAT_LOG_LEVEL` and deletes the Datadog `logConfiguration` even before Pulumi updates the seed task def):

1. CloudWatch → Log groups → IncomingBytes (1d / 7d) on:
   - `/ecs/latitude-{staging,production}/{web,api,ingest,workers,workflows}` — should drop to occasional warn/error lines
   - `/ecs/latitude-{env}/datadog-agent` — should go quiet (group remains)
   - `/aws/cloudtrail/latitude-staging` — should stop receiving events
   - `/aws/rds/instance/latitude-staging-postgres/postgresql` and `/aws/rds/cluster/latitude-production-aurora/postgresql` — export should stop
2. ECS → task definition latest revision:
   - app container env includes `LAT_LOG_LEVEL=warn`
   - `datadog-agent` has no `logConfiguration`
3. CloudTrail trail `latitude-staging-management-events` has no CloudWatch Logs group attached; S3 delivery still works.
4. Billing → CloudWatch → `PutLogEvents` / Logs ingest should flatten after the deploy.

RDS export disable is in IaC only. If AWS parks it until the maintenance window, apply or reboot once from the console/CLI rather than leaving `applyImmediately: true` in Pulumi.

## How was this tested?

- Unit tests for `LAT_LOG_LEVEL` filtering and access-logger info vs warn, including in-flight incoming-line visibility.
- Infra typecheck.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows Conventional Commits
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dab7e7d-e8b8-4fd7-94f2-5f7c766acc8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dab7e7d-e8b8-4fd7-94f2-5f7c766acc8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790874602&installation_model_id=435055&pr_number=4539&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4539&signature=b3cb06b13bf834919305103af61e8caeca081662acdde10085948124f4c086a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->