### PR TITLE
fix(conversation-intelligence): strip lone surrogates on the no-truncation path

### DIFF
--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
@@ -1341,6 +1341,32 @@ describe("analyzeSessionUseCase", () => {
     expect(prompt.match(/<\/conversation_data>/g)).toHaveLength(1)
     expect(prompt).toContain("\\u003c/conversation_data\\u003e")
   })
+
+  it("strips a lone surrogate from a transcript that fits without truncation", async () => {
+    const frustratedMessage = "This is frustrating and still unresolved \uD83D right now."
+    const { ai, generated } = createAdjudicationAi({
+      embeddingForText: (text) => {
+        if (text.includes("frustration annoyance or anger")) return [1, 0]
+        if (text.includes("frustrat")) return [1, 0]
+        return [-1, 0]
+      },
+      acceptedCandidateIds: (prompt) => candidatesFromPrompt(prompt).map((candidate) => candidate.id),
+    })
+    const { effect } = runUseCase({
+      session: makeSessionWithMessages([
+        message("user", "Can you help me update my billing email?"),
+        message("assistant", "Sure, open account settings and choose Profile."),
+        message("user", frustratedMessage),
+        message("assistant", "I will try a different approach."),
+      ]),
+      ai,
+    })
+
+    await Effect.runPromise(effect)
+
+    expect(generated.length).toBeGreaterThan(0)
+    expect(generated[0]?.prompt ?? "").not.toMatch(LONE_SURROGATE_PATTERN)
+  })
 })
 
 describe("middleTruncate", () => {
@@ -1359,5 +1385,10 @@ describe("middleTruncate", () => {
   it("returns the original value unchanged when it already fits", () => {
     const value = "😀".repeat(10)
     expect(middleTruncateForTesting(value, value.length)).toBe(value)
+  })
+
+  it("strips a lone surrogate even when the value already fits and needs no truncation", () => {
+    const value = `frustrated ${"\uD83D"} user`
+    expect(middleTruncateForTesting(value, value.length)).not.toMatch(LONE_SURROGATE_PATTERN)
   })
 })

--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
@@ -128,7 +128,7 @@ const TAXONOMY_DIRECT_PROJECTION_MAX_LENGTH = CONVERSATION_INTELLIGENCE_LLM_MAX_
 const TRUNCATION_MARKER = "\n[...truncated...]\n"
 
 const middleTruncate = (value: string, maxLength: number): string => {
-  if (value.length <= maxLength) return value
+  if (value.length <= maxLength) return stripLoneSurrogates(value)
   if (maxLength <= TRUNCATION_MARKER.length) return stripLoneSurrogates(value.slice(0, maxLength))
   const head = Math.floor((maxLength - TRUNCATION_MARKER.length) / 2)
   const tail = maxLength - TRUNCATION_MARKER.length - head
@@ -155,7 +155,7 @@ const renderMomentClassifierTranscript = (
 ): string | null => {
   const promptMessages = messages.map((message) => ({ ...message, text: escapePromptDelimiters(message.text) }))
   const fullTranscript = documentFromMessages(promptMessages)
-  if (fullTranscript.length <= maxLength) return fullTranscript
+  if (fullTranscript.length <= maxLength) return stripLoneSurrogates(fullTranscript)
 
   const contextIndexes = new Set<number>()
   for (const candidate of candidates) {


### PR DESCRIPTION
## What does this PR do?

Fixes a regression in the moment-classifier pipeline (`MomentClassifierError: "Moment classifier provider failed"`) surfaced by Datadog Error Tracking issue [`46a24228-87aa-11f1-83a2-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/46a24228-87aa-11f1-83a2-da7ad0900005) (case `ET-470`), ~15.3k occurrences in `env:production` over the last 7 days, still firing at the time of this investigation.

**Root cause:** `middleTruncate` and `renderMomentClassifierTranscript` in `packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts` only ran `stripLoneSurrogates` on their *truncated-slice* branches. When a session's full transcript already fit the classifier's character budget — the common case for shorter sessions — a lone UTF-16 surrogate in message text (e.g. an emoji split by an earlier length-based slice elsewhere in the pipeline) passed straight through, untouched, into the prompt sent to the Bedrock/Anthropic call. Bedrock rejects malformed UTF-8/UTF-16 payloads, and that provider failure surfaces here as `MomentClassifierError`.

This is the same class of bug fixed once before in #4230 (case comment on the issue calls out `middleTruncate` explicitly), but that fix only covered the truncation branches, not the "already fits, no truncation needed" pass-through — which is exactly why this regressed (`REGRESSION_VERSION_AWARE`, regressed 2026-08-20) and kept firing.

**Fix:** run `stripLoneSurrogates` unconditionally on both pass-through paths too, so every string handed back by these helpers is surrogate-safe regardless of whether truncation happened:
- `middleTruncate`: strip on the `value.length <= maxLength` early return.
- `renderMomentClassifierTranscript`: strip on the `fullTranscript.length <= maxLength` early return.

I audited sibling truncation helpers in the same codebase (`packages/domain/taxonomy/src/use-cases/name-taxonomy.ts` and `packages/domain/flaggers/src/use-cases/run-flagger-annotator.ts`) — both have their own hand-rolled `middleTruncate`/`truncateMiddle` with no `stripLoneSurrogates` call at all (not even on the truncated slices). Neither currently shows up as a distinct production error, so I left them out of this PR to keep the change minimal and tied to a confirmed, reproduced failure. Flagging them here as a follow-up worth a dedicated look.

**Not part of this PR:** the much higher-volume `billing_usage_events` partition-missing incident (`RepositoryError: no partition of relation ... found for row`, millions of occurrences 2026-09-01–02) was already root-caused and fixed by the team in #4540 before this investigation started; it's live in production and the errors stopped accordingly.

## Related issue (if applicable)

Datadog Error Tracking: `ET-470` / issue `46a24228-87aa-11f1-83a2-da7ad0900005`.

## How was this tested?

- Added a unit test on `middleTruncate` confirming a lone surrogate is stripped even when the value already fits (no truncation).
- Added an integration test on `analyzeSessionUseCase` reproducing the actual production path: a short conversation (transcript fits under the classifier budget without truncation) containing a lone surrogate, asserting the prompt handed to the AI `generate` call is free of lone surrogates.
- Verified both new tests **fail** without the fix (reverted the source change, confirmed the exact assertion failures) and **pass** with it.
- `pnpm --filter @domain/conversation-intelligence test` — 47/47 passing.
- `pnpm --filter @domain/conversation-intelligence typecheck` (via `tsgo`) — clean.
- `pnpm exec biome check` on both changed files — clean.

**Verification in production:** after deploy, occurrences of issue `46a24228-87aa-11f1-83a2-da7ad0900005` should drop to zero going forward (existing occurrences will remain in the historical count).

**Remaining risk:** low — the change only adds sanitization to two pass-through branches that previously returned raw input unchanged; well-formed strings (including valid surrogate pairs, e.g. emoji) are unaffected since `stripLoneSurrogates` is an identity function on them.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4QDsKcyyFDv8L6RYLA1H1

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4QDsKcyyFDv8L6RYLA1H1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791019214&installation_model_id=435055&pr_number=4546&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4546&signature=101212aeef252e704be5a47a004aed6a404fe6d1ce7acbb903c78dfef349bb42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->