### PR TITLE
docs: add Migrate from Latitude V1 guide and LinguaAI example

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -104,6 +104,7 @@
         "group": "Getting Started",
         "pages": [
           "telemetry/start-tracing",
+          "getting-started/migrate-from-v1",
           "telemetry/memory",
           {
             "group": "SDKs",

--- a/docs/getting-started/migrate-from-v1.mdx
+++ b/docs/getting-started/migrate-from-v1.mdx
@@ -277,6 +277,7 @@ V1 compared two prompt variants over a dataset. V2 compares two slices of real t
 
 `createExperiment` takes variants with a `filterSet`, a `query` and a `timeRange`. Each variant's tag filter here is `[{"op": "eq", "value": "release-2.1.0"}, {"op": "neq", "value": "simulation"}]`. The comparison covers sessions, users, cost, tokens, latency percentiles, tool usage and signal occurrences per cohort, with deltas against the baseline. Metrics fill in after sessions close, about five minutes after their last trace. Use `updateExperiment` (HTTP `PUT`) to change variants later.
 
+V1's `prompts.chat(conversationUuid, ...)` implied Latitude stored conversation history server-side; V2 has no such storage, so a multi-turn use case now keeps its own message array, keyed by the session id.
 Give each release its own sessions. A session that mixes traces from two releases cannot be assigned to one cohort; the smoke script suffixes session ids with the release for that reason. In our first attempt the regression replays also landed in the 2.1.0 cohort, because they carry the release tag; the `simulation` exclusion fixed it.
 
 ### Annotate, monitor, dispatch
@@ -302,6 +303,7 @@ The V1 human-in-the-loop evaluation becomes ordinary annotation. From the trace 
 - Keep replays out of production cohorts. Regression runs carry the release tag too, so exclude `simulation` in experiment variants and monitors.
 - Signals collect forward and sample at 10 percent by default. Create them first, then generate traffic, and raise sampling in the UI for low-volume projects.
 - No backticks in judge criteria. The criteria is compiled, and a backtick broke it with a syntax error.
+- A V1 prompt with `type: agent` and a Latitude-hosted tool (`latitude/extract` and similar) needs a real implementation and a hand-written tool-call loop in V2; there is no hosted-tool equivalent. The `latitude-migrate` skill's `promptl-to-code.md` has a full example.
 - Flush before exit. Short scripts lose their last batch without `flush()` and `shutdown()`.
 - The MCP is OAuth-only. An API key on the MCP URL returns 401. Use the API key for the SDK, CLI and REST, and OAuth for the MCP.
 - Old docs linger in agent memory. Point coding agents at `docs.latitude.so/llms.txt`.

--- a/docs/getting-started/migrate-from-v1.mdx
+++ b/docs/getting-started/migrate-from-v1.mdx
@@ -1,0 +1,330 @@
+---
+title: Migrate from Latitude V1
+description: "Move an app from the Latitude V1 prompt manager and gateway to Latitude V2: every V1 concept mapped to its V2 equivalent, then a worked migration driven from a coding agent over the Latitude MCP."
+---
+
+Latitude V1 was a prompt engineering platform. You wrote prompts in PromptL, published them, and your app called them through the Latitude gateway. Latitude V2 is an observability and signal-discovery platform for agents you run yourself. Your code calls the model provider directly, and Latitude watches through OpenTelemetry.
+
+This guide is for teams with a V1 workspace who want to move. It maps each V1 concept to its V2 equivalent, then walks through a real migration: LinguaAI, a FastAPI language tutor whose two prompts ran through `sdk.prompts.run()` on V1. The walkthrough drives the control plane from a coding agent over the Latitude MCP, because that is the quickest way to do it. Every MCP call has a REST, CLI, and SDK twin, listed at the end.
+
+<Info>
+  **Do I have to migrate?** V1 keeps running for existing customers, but new features ship only to V2. Treat V2 onboarding as a fresh start rather than a data migration. Your prompts move into your codebase, your golden datasets move over as CSV, and traces, signals and evaluations are rebuilt from live traffic within days.
+</Info>
+
+## What changed
+
+| | V1 | V2 |
+| --- | --- | --- |
+| Where prompts live | Latitude prompt manager (PromptL, drafts, published versions) | Your codebase and your version control |
+| Who calls the model | Latitude gateway (`prompts.run`, `.chat`) | Your app calls OpenAI, Anthropic, Bedrock and so on directly |
+| How Latitude sees traffic | Every gateway call produced a log | Telemetry SDK or any OpenTelemetry exporter sends spans |
+| Unit of analysis | Log (one prompt run) | Trace (one turn), Session (one conversation), User |
+| Finding problems | You defined evaluations per prompt | Latitude groups failed scores into Signals; you can also define signals |
+| Testing changes | Batch experiments over a dataset, run inside Latitude | Replay datasets locally (simulations, regression tests); compare live cohorts with Experiments |
+| Automation | Triggers, webhooks, prompt integrations | Monitors, Slack notifications, agent dispatch to Cursor, Claude Code, Linear or a webhook |
+| Driving Latitude | UI, REST at `gateway.latitude.so/api/v3`, SDK 5.x | UI, MCP server, `latitude` CLI, REST at `api.latitude.so/v1`, SDK 9.x |
+
+Latitude is no longer on the critical path of your application. If Latitude is down, your agent still answers. You lose observability for that window and nothing else.
+
+## Concept map
+
+Use this table as the checklist for your own migration.
+
+| V1 concept | V2 equivalent | Notes |
+| --- | --- | --- |
+| Workspace | Organization | API keys are organization-scoped (Settings, Keys) |
+| Project | Project | One project per agent or AI feature, not per team. Signals are scoped per project |
+| Prompt (PromptL document) | A prompt template in your code | Frontmatter (`provider`, `model`, `temperature`) becomes provider-call arguments; `{{ var }}` becomes string formatting; `<system>` and `<user>` become messages |
+| Version control: drafts, published version, `versionUuid` | Git, plus `metadata.prompt_version` and a release tag on every trace | Latitude tracks versions as tags and metadata on traces, so Experiments can compare them |
+| Playground | Your local dev loop, plus a Sandbox project for dev and staging traces | Sandbox keeps experiments out of production analytics |
+| AI Gateway, `latitude.prompts.run()`, `latitude.prompts.chat()` | Direct provider SDK call inside `capture()` | Removed. Nothing on the Latitude side replaces them |
+| `customIdentifier` on a run | `sessionId` and `userId` on `capture()` | Sessions group multi-turn conversations; Users get their own page |
+| Logs | Traces and Spans | One trace per turn; spans are the LLM calls, tool calls and retrieval steps inside it |
+| `logs.create()` (upload logs) | Telemetry SDK, or trace imports from Langfuse, LangSmith, Braintrust | There is no V1 log import |
+| LLM-as-judge evaluation (live) | Signal with an LLM-judge evaluation | Created with `createSignal` (kind `judge`, see [Create a signal](../signals/create)). Collects forward from creation; default sampling is 10 percent |
+| Programmatic rule evaluation | Signal with a rule evaluation, or a custom script | `text_match`, `empty_output`, `output_length`, `json_output`, `metric` conditions |
+| Human-in-the-loop evaluation | Annotations | Thumbs up or down with feedback, on any trace. Failed annotations feed signal discovery |
+| Composite scores | Scores | Every verdict is a score; custom pipelines submit scores through `createScore` |
+| `evaluations.annotate()` (SDK) | `annotations.create()` and `scores.create()` (SDK 9) | Target a trace by id or by filters |
+| Evaluation results dashboard | Score analytics, Signal detail, Evaluation alignment | Alignment measures agreement between evaluations and human annotations |
+| Dataset (CSV upload, parameter columns, label column) | [Dataset](../datasets/overview) (input, output, expected output, metadata, custom columns) | Map parameter columns into `input`, the label into `expectedOutput` |
+| Save logs to dataset | Add traces to a dataset | From the trace list, search, a signal, or `importDatasetRowsFromTraces` |
+| Batch evaluation over a dataset (experiment) | Local replay: [simulations](../test-and-fix/simulations) and [regression tests](../test-and-fix/regression-testing) | Your runner, your CI. Results come back as tagged sessions and scores |
+| Experiments (prompt A vs B on a dataset) | Experiments (traffic slice A vs B) | Slices are filters on tags, metadata, users, models. Every metric is compared. See [Experiments](../experiments/overview) |
+| Prompt suggestions | [Agent dispatch](../agent-dispatch/overview) | A signal wakes your coding agent with the evidence attached, and the agent proposes the fix |
+| Triggers (email, schedule) | Your scheduler or queue | Removed with the gateway |
+| Webhooks, prompt integrations | [Monitors](../monitors/overview), Slack notifications, agent-dispatch webhooks | Alerts fire on signals, saved searches, tools, or raw traffic |
+| Latitude tools (`latitude/search`), agents, subagents | Your agent framework | Tool calls appear in the Tools view with usage, error rate and latency |
+| Cache configuration | Provider prompt caching | The Cost view shows cache economics per model |
+| `@latitude-data/sdk` 5.x, `latitude-sdk` 5.x | `@latitude-data/telemetry` and `latitude-telemetry` for tracing; `@latitude-data/sdk` 9.x and `latitude-sdk` 9.x for the API | SDK 6 and later are a rewrite; none of the 5.x prompt surface carries over |
+| `gateway.latitude.so/api/v3` | `api.latitude.so/v1`, the MCP server at `api.latitude.so/v1/mcp`, the `latitude` CLI | MCP and CLI are generated from the same API |
+
+## Before you start
+
+1. Export your prompts while your V1 workspace is still active. `latitude.prompts.getAll()` (SDK 5) or `GET https://gateway.latitude.so/api/v3/projects/{projectId}/versions/live/documents` returns every PromptL document with its content and config. Commit them to your repository; they are the source material for [moving the prompts into code](#move-the-prompts-into-code).
+2. Export every dataset. Download the CSV from the Datasets page, or list them with `GET /api/v3/datasets` and pull rows with `GET /api/v3/dataset-rows?datasetId=...&page=1&pageSize=100`. Note which column is the label.
+3. List your evaluations per prompt: name, type (judge, rule, human), criteria, and whether it ran live. Each becomes a signal or an annotation habit.
+4. Write down your `customIdentifier` scheme. It usually maps to a session id or a user id.
+5. Pick a project boundary. V2 projects are per agent. LinguaAI's grammar checker and quiz writer share one project because they share one product surface and one user base.
+6. Connect the [MCP](../getting-started/mcp) to your coding agent. For Claude Code:
+
+   ```bash
+   claude mcp add --transport http latitude https://api.latitude.so/v1/mcp --scope user
+   ```
+
+   Then type `/mcp`, pick `latitude`, authenticate, and choose the organization. Other agents are covered on the [MCP page](../getting-started/mcp). The MCP is OAuth-only; an API key on that URL gets a 401 by design. Revoke the agent any time under Settings, Keys, OAuth Keys.
+
+7. Point your coding agent at the V2 docs. Older V1 pages survive in search caches, and agents sometimes pull them in. Tell the agent to use `https://docs.latitude.so/llms.txt` as its index.
+
+## The example: LinguaAI
+
+LinguaAI is a FastAPI service with two endpoints. `POST /grammar/check` corrects a learner's sentence and `POST /quiz/generate` writes a three-question vocabulary quiz. On V1 both endpoints called `sdk.prompts.run()` against PromptL documents named `grammar-check` and `vocab-quiz`. The grammar prompt had a live LLM-as-judge evaluation ("Misses a grammar error") and a golden dataset (`grammar-golden.csv`) used for batch experiments before publishing.
+
+The before and after code is in the [`examples/migrations/linguaai-v1-to-v2`](https://github.com/latitude-dev/latitude-llm/tree/development/examples/migrations/linguaai-v1-to-v2) folder of the Latitude repository.
+
+### Create the V2 project
+
+Ask your agent:
+
+> Create a Latitude project called LinguaAI and give me its slug.
+
+The agent calls `createProject` with `{"name": "LinguaAI"}` and gets back the slug `linguaai`. Slugs are permanent; renaming never changes them. Put the slug in `.env` as `LATITUDE_PROJECT_SLUG`. Create an organization API key under Settings, Keys and store it as `LATITUDE_API_KEY`.
+
+### Move the prompts into code
+
+The V1 document `grammar-check.promptl`:
+
+```markdown
+---
+provider: anthropic
+model: claude-3-5-sonnet-latest
+temperature: 0
+---
+<system>
+You are LinguaAI's grammar coach. The learner is studying {{ language }}.
+Check the learner's text for grammar errors.
+Reply ONLY with JSON of this shape: ...
+</system>
+
+<user>
+Language: {{ language }}
+Text: {{ text }}
+</user>
+```
+
+becomes a Python template with a version string ([`app/prompts.py`](https://github.com/latitude-dev/latitude-llm/tree/development/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/prompts.py)):
+
+```python
+GRAMMAR_CHECK_V2 = """You are LinguaAI's grammar coach. The learner is studying {language}.
+Check the learner's text for grammar errors.
+Reply ONLY with JSON of this shape: ..."""
+
+GRAMMAR_CHECK_VERSIONS = {
+    "2.0.0": ("grammar-check@2", GRAMMAR_CHECK_V2),
+    "2.1.0": ("grammar-check@3", GRAMMAR_CHECK_V3),
+}
+
+def grammar_check_prompt(language: str) -> tuple[str, str]:
+    version, template = GRAMMAR_CHECK_VERSIONS[APP_RELEASE]
+    return version, template.format(language=language)
+```
+
+The frontmatter became arguments to the provider call, so check each one against the provider SDK you use. The Anthropic Python SDK 1.x, for example, no longer accepts `temperature` on `messages.create()`. `{{ language }}` became `{language}`; the `<system>` block is the `system` argument and the `<user>` block is the first message. The published-version concept became a version string that travels to Latitude as `metadata.prompt_version`, which you can filter and compare on.
+
+### Replace the gateway call with a direct call plus telemetry
+
+V1 ([`backend/routers/grammar.py`](https://github.com/latitude-dev/latitude-llm/tree/development/examples/migrations/linguaai-v1-to-v2/before/linguaai/backend/routers/grammar.py)):
+
+```python
+from latitude_sdk import Latitude, LatitudeOptions, RunPromptOptions
+
+sdk = Latitude(api_key, LatitudeOptions(project_id=int(project_id), version_uuid=version_uuid))
+
+result = await sdk.prompts.run("grammar-check", RunPromptOptions(parameters={"text": req.text, "language": req.language}))
+data = _extract_json(result.response.text)
+```
+
+V2 ([`app/telemetry.py`](https://github.com/latitude-dev/latitude-llm/tree/development/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/telemetry.py) and [`app/services.py`](https://github.com/latitude-dev/latitude-llm/tree/development/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/services.py)):
+
+```python
+# telemetry.py: import this before any Anthropic client exists
+import anthropic
+from latitude_telemetry import Latitude
+
+latitude = Latitude(
+    api_key=os.environ["LATITUDE_API_KEY"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
+    instrumentations={"anthropic": anthropic},
+)
+```
+
+```python
+# services.py: one capture() per use case
+from anthropic import Anthropic
+from latitude_telemetry import capture
+
+client = Anthropic()
+
+def check_grammar(text, language, *, user_id, session_id):
+    version, system = prompts.grammar_check_prompt(language)
+    raw = capture(
+        "grammar-check",
+        lambda: client.messages.create(
+            model=prompts.MODEL, max_tokens=600, system=system,
+            messages=[{"role": "user", "content": f"Language: {language}\nText: {text}"}],
+        ).content[0].text,
+        {
+            "user_id": user_id,
+            "session_id": session_id,
+            "tags": ["grammar", f"release-{prompts.APP_RELEASE}", "production"],
+            "metadata": {"release": prompts.APP_RELEASE, "prompt_version": version, "language": language},
+        },
+    )
+    return _extract_json(raw)
+```
+
+What to get right:
+
+- Construct `Latitude(...)` once, at import time, before the provider client. Pass the same module your code imports (`anthropic`, not a wrapper around it).
+- Wrap the model call in `capture()`. It creates no spans of its own. It attaches user, session, tags and metadata to the spans the instrumentation creates inside the callback. The route handler reads `X-User-Id` and `X-Session-Id` headers and passes them down; the smoke script passes them directly.
+- Put the release in a tag as well as in metadata. Tags are the cohort key for session filters and Experiments; metadata holds exact values for search.
+- Flush before a short-lived process exits (`latitude.flush()`, then `latitude.shutdown()`). Servers export in the background, but scripts, tests and jobs can exit before the last batch ships.
+
+If you would rather have your coding agent do the whole migration, the `latitude-migrate` skill runs every step in this guide, from exporting your V1 prompts to verifying traces:
+
+> Install the `latitude-migrate` skill from `github.com/latitude-dev/skills` and use it to move this app from Latitude V1 to V2.
+
+To instrument only, the `latitude-telemetry` skill does the audit, the plan, and the verification:
+
+> Install the `latitude-telemetry` skill from `github.com/latitude-dev/skills` and use it to add Latitude tracing to this app.
+
+### Run traffic and verify it with the MCP
+
+Run the smoke script once per release, so there are two cohorts to compare later:
+
+```bash
+APP_RELEASE=2.0.0 python -m scripts.smoke
+APP_RELEASE=2.1.0 python -m scripts.smoke
+```
+
+Then ask your agent:
+
+> List the latest grammar traces in linguaai and open one. Show me the conversation, the metadata, and who the user was.
+
+`listTraces` with `{"filters": {"tags": [{"op": "eq", "value": "grammar"}]}}` returns rows with `traceId`, `sessionId`, `userId`, `tags`, `models`, `tokensInput`, `tokensOutput`, `costTotalMicrocents` and `rootSpanName`. `getTrace` adds `metadata` and the `conversation` in OpenTelemetry GenAI format: system instructions, the user message, the assistant reply. `listSessions` shows each study session with its trace count and cost, and `listUsers` shows the three learners.
+
+On the first trace, check that `metadata.release` and `metadata.prompt_version` carry what you set, and that the conversation renders as system, user, assistant rather than as one blob. If the model and token counts are zero, the instrumentation is not wrapping the client you actually call.
+
+### Recreate the evaluation as a signal
+
+The V1 live evaluation "Misses a grammar error" becomes a signal with a judge evaluation. Ask your agent:
+
+> Create a signal in linguaai called "Missed grammar error" for traces tagged grammar. Use an LLM judge: the behaviour is present when the learner's text has an error that the corrections list does not cover, or when is_correct is true although the text has an error.
+
+`createSignal` takes the name, a description, a pre-gate `filters` set, and `evaluation.settings` of kind `judge` with the criteria in plain language. Latitude returns the slug (`LIN-O84M` in our run) and creates the evaluation behind it. For the V1 programmatic rule "output must be valid JSON", use kind `rule` with a `json_output` condition instead.
+
+Plan for these differences from V1:
+
+- A signal detector collects forward from creation. It does not scan history, so create signals before you generate the traffic you want judged.
+- Judge evaluations default to 10 percent sampling. On a low-traffic demo, open the signal in the UI and set the scope to 100 percent, or it may never fire.
+- The criteria text is compiled into the detector. Avoid backticks in it. In our run, a criteria string with backticks was rejected with a syntax error.
+
+You do not have to define every signal yourself. Annotations, flaggers (frustration, refusal, empty output, tool errors) and custom scores feed discovery, which groups repeated failures into named signals on its own.
+
+### Bring your golden dataset
+
+Two sources feed the V2 dataset: real traces, and the CSV you exported from V1.
+
+> Create a dataset called grammar-regressions in linguaai. Import every grammar trace from release 2.0.0 with no errors as rows.
+
+`createDataset` returns the slug `grammar-regressions`. `importDatasetRowsFromTraces` with `{"traces": {"by": "filters", "filters": {"tags": [...], "metadata.release": [{"op": "eq", "value": "2.0.0"}], "errorCount": [{"op": "eq", "value": 0}]}}}` returned nine row ids. Each row's `input` is the user message list, `output` is the assistant reply, and `metadata.traceId` points back at the trace.
+
+For the V1 CSV, map parameter columns into `input` and the label into `expectedOutput` ([`scripts/import_v1_dataset.py`](https://github.com/latitude-dev/latitude-llm/tree/development/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/import_v1_dataset.py)):
+
+```python
+rows = [
+    {"input": {"text": r["text"], "language": r["language"]},
+     "expectedOutput": r["expected_output"],
+     "metadata": {"source": "latitude-v1-golden-dataset"}}
+    for r in csv.DictReader(fh)
+]
+client.datasets.insert_rows(project, "grammar-regressions", rows=rows)
+```
+
+That is `insertDatasetRows`; six rows landed. Then fill expected outputs on the trace-imported rows you want to check precisely:
+
+> Set the expected output of the row whose input contains "If I would have known" to "If I had known, I would have come earlier."
+
+`updateDatasetRow` changes only the cells you send and bumps the dataset version.
+
+### Regression test by replaying the dataset
+
+V1 ran batch evaluations inside Latitude. V2 hands the dataset to your own runner. [`tests/test_regression.py`](https://github.com/latitude-dev/latitude-llm/tree/development/examples/migrations/linguaai-v1-to-v2/after/linguaai/tests/test_regression.py) pulls every row with the SDK, replays the grammar check, applies the returned corrections to the original text, and compares the result with the expected output. Every replay is tagged `simulation` and `agent-<release>` and carries the dataset slug and row id as metadata, so it never counts as production and an Experiment can compare runs.
+
+```bash
+LATITUDE_DATASET_SLUG=grammar-regressions APP_RELEASE=2.1.0 pytest -q
+```
+
+The first full run failed one row. The V1 label read "Yo estoy muy cansado hoy." and the coach returned "Estoy muy cansado hoy.", which is also correct Spanish. Exact-match labels are brittle, which is why the judge evaluation exists for semantic checks. We kept the label, added a custom column `alsoAccepts` with `addDatasetColumn`, filled it on that row with `updateDatasetRow`, and taught the test to accept either answer. Nine of nine pass.
+
+In CI, run the same command on every change to prompts, tools or models. To keep score in Latitude, post each verdict as a custom score with `createScore` and a `sourceId` such as `ci-regression`; failing scores cluster into signals like any other failure. Because the replays carry the same release tag as production traffic, exclude the `simulation` tag from any cohort or monitor that should only see real users (see the experiment below).
+
+### Compare prompt versions with an Experiment
+
+V1 compared two prompt variants over a dataset. V2 compares two slices of real traffic across every metric Latitude tracks. Ask your agent:
+
+> Create an experiment in linguaai comparing sessions tagged release-2.0.0 (baseline) with sessions tagged release-2.1.0, excluding sessions tagged simulation, over the last 7 days.
+
+`createExperiment` takes variants with a `filterSet`, a `query` and a `timeRange`. Each variant's tag filter here is `[{"op": "eq", "value": "release-2.1.0"}, {"op": "neq", "value": "simulation"}]`. The comparison covers sessions, users, cost, tokens, latency percentiles, tool usage and signal occurrences per cohort, with deltas against the baseline. Metrics fill in after sessions close, about five minutes after their last trace. Use `updateExperiment` (HTTP `PUT`) to change variants later.
+
+Give each release its own sessions. A session that mixes traces from two releases cannot be assigned to one cohort; the smoke script suffixes session ids with the release for that reason. In our first attempt the regression replays also landed in the 2.1.0 cohort, because they carry the release tag; the `simulation` exclusion fixed it.
+
+### Annotate, monitor, dispatch
+
+The V1 human-in-the-loop evaluation becomes ordinary annotation. From the trace view, or through the MCP:
+
+> Annotate trace 2a27c6f2... in linguaai as passed with the feedback "Correctly recognised a well-formed sentence and returned is_correct=true with no spurious corrections."
+
+`createAnnotation` takes `value` (0 to 1), `passed`, `feedback` and the trace. Failed annotations are the primary input to signal discovery. Once a signal matters, monitor it. A monitor opens an incident and notifies in-app, by email or in Slack, and agent dispatch can send the signal with its example traces to Cursor, Claude Code or Linear.
+
+### Decommission V1
+
+- Remove `latitude-sdk<6` (Python) or `@latitude-data/sdk<6` (TypeScript) and every `prompts.run`, `prompts.chat`, `logs.create` and `evaluations.annotate` call.
+- Delete `LATITUDE_PROJECT_ID` and `LATITUDE_VERSION_UUID` from your environment. V2 uses `LATITUDE_PROJECT_SLUG`.
+- Keep the exported PromptL files in your repository history and delete them once every prompt has a code owner.
+- Rotate the V1 API key.
+
+## Gotchas from this migration
+
+- Provider parameters are yours now. The PromptL frontmatter hid provider differences; Anthropic's Python SDK 1.x rejected `temperature` on `messages.create()`. Check each setting you carry over.
+- Sessions belong to one release. Reusing session ids across releases produced sessions that no cohort filter could own. Suffix the id or start new sessions on deploy.
+- Split cohorts on tags. Tag filters worked on sessions and in Experiments in our run, while a `metadata.release` filter on sessions did not match even though the sessions showed the field. Metadata is for search and for filtering traces.
+- Keep replays out of production cohorts. Regression runs carry the release tag too, so exclude `simulation` in experiment variants and monitors.
+- Signals collect forward and sample at 10 percent by default. Create them first, then generate traffic, and raise sampling in the UI for low-volume projects.
+- No backticks in judge criteria. The criteria is compiled, and a backtick broke it with a syntax error.
+- Flush before exit. Short scripts lose their last batch without `flush()` and `shutdown()`.
+- The MCP is OAuth-only. An API key on the MCP URL returns 401. Use the API key for the SDK, CLI and REST, and OAuth for the MCP.
+- Old docs linger in agent memory. Point coding agents at `docs.latitude.so/llms.txt`.
+
+## Frequently asked
+
+**Can I import my V1 logs?** No. V2 imports exist for Langfuse, LangSmith and Braintrust. Start V2 from live traffic; a week of production gives discovery enough to work with.
+
+**Where do non-technical teammates edit prompts now?** They do not. Prompts live in code. Product and domain experts work through annotations, signals, datasets and expected outputs, which is where their judgment changes the agent's behaviour.
+
+**What replaces prompt suggestions?** Agent dispatch. A signal carries the evidence to your coding agent, which proposes the fix as a pull request, and the GitHub integration resolves the signal when the PR merges.
+
+**What about self-hosting?** V2 self-hosts from a single Docker host to a Kubernetes cluster; see [Deployment](../deployment/overview).
+
+## Reference: the MCP calls used in this guide
+
+| Step | MCP tool | REST twin |
+| --- | --- | --- |
+| Create project | `createProject` | `POST /v1/projects` |
+| Verify traffic | `listTraces`, `getTrace`, `listSessions`, `listUsers` | `POST /v1/projects/{slug}/traces/list`, `GET .../traces/{id}`, `POST .../sessions/list`, `GET .../users` |
+| Recreate evaluation | `createSignal`, `getSignal`, `updateSignal` | `POST /v1/projects/{slug}/signals`, `GET .../signals/{signalSlug}`, `PATCH .../signals/{signalSlug}` |
+| Dataset | `createDataset`, `importDatasetRowsFromTraces`, `insertDatasetRows`, `listDatasetRows`, `updateDatasetRow`, `addDatasetColumn` | `POST .../datasets`, `POST .../datasets/{ds}/rows/import/traces`, `POST .../datasets/{ds}/rows`, `GET .../datasets/{ds}/rows`, `PATCH .../datasets/{ds}/rows/{rowId}`, `POST .../datasets/{ds}/columns` |
+| Compare releases | `createExperiment`, `getExperiment`, `updateExperiment` | `POST .../experiments`, `GET .../experiments/{slug}`, `PUT .../experiments/{slug}` |
+| Human feedback | `createAnnotation`, `createScore` | `POST .../annotations`, `POST .../scores` |
+
+The same operations are available as `latitude <resource> <command>` in the CLI and as `client.<resource>.<method>()` in the SDKs.

--- a/docs/getting-started/skills.mdx
+++ b/docs/getting-started/skills.mdx
@@ -22,6 +22,7 @@ npx skills add https://github.com/latitude-dev/skills --skill latitude-setup,lat
 | `latitude-setup` | Zero-account orchestrator: bootstrap → instrument → verify → claim. |
 | `latitude-telemetry` | Adds Latitude / OpenTelemetry instrumentation to your app. |
 | `latitude-cli` | Installs and drives the [`latitude` CLI](/getting-started/cli). |
+| `latitude-migrate` | Moves an app from Latitude V1 (prompt manager and gateway) to V2. See [Migrate from Latitude V1](/getting-started/migrate-from-v1). |
 
 <Info>
   `latitude-setup` builds on the other two, so install all three together for the from-scratch flow.

--- a/examples/migrations/linguaai-v1-to-v2/README.md
+++ b/examples/migrations/linguaai-v1-to-v2/README.md
@@ -1,0 +1,18 @@
+# LinguaAI: Latitude V1 to V2
+
+Companion code for the [Migrate from Latitude V1](https://docs.latitude.so/getting-started/migrate-from-v1) guide.
+
+| Folder | What it is |
+| --- | --- |
+| `before/linguaai` | The V1 app: FastAPI routes calling `sdk.prompts.run()` on `latitude-sdk` 5.x, plus the PromptL documents and an inventory of the V1 control plane |
+| `after/linguaai` | The V2 app: prompts in code, direct Anthropic calls, `latitude-telemetry` with one `capture()` per use case, a smoke driver, a V1 CSV importer, and a pytest regression replay |
+
+```bash
+cd after/linguaai
+uv venv --python 3.13 .venv && uv pip install --python .venv/bin/python -r requirements.txt
+cp .env.example .env   # ANTHROPIC_API_KEY, LATITUDE_API_KEY, LATITUDE_PROJECT_SLUG
+APP_RELEASE=2.0.0 .venv/bin/python -m scripts.smoke
+APP_RELEASE=2.1.0 .venv/bin/python -m scripts.smoke
+.venv/bin/python -m scripts.import_v1_dataset datasets/grammar-golden.csv grammar-regressions
+LATITUDE_DATASET_SLUG=grammar-regressions .venv/bin/pytest -q
+```

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/.env.example
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/.env.example
@@ -1,0 +1,4 @@
+ANTHROPIC_API_KEY=sk-ant-...
+LATITUDE_API_KEY=lat_...            # Settings -> Keys -> API Keys (organization-scoped)
+LATITUDE_PROJECT_SLUG=linguaai      # the V2 project that receives traces
+APP_RELEASE=2.1.0                   # travels as metadata.release on every trace

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/.gitignore
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+.env
+__pycache__/
+.pytest_cache/

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/README.md
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/README.md
@@ -1,0 +1,25 @@
+# LinguaAI on Latitude V2
+
+The same language-tutor API that ran on Latitude V1 (prompt manager + gateway), moved to V2:
+prompts in code, direct Anthropic calls, Latitude observing through telemetry.
+
+```bash
+uv venv --python 3.13 .venv && uv pip install --python .venv/bin/python -r requirements.txt
+cp .env.example .env   # fill in ANTHROPIC_API_KEY, LATITUDE_API_KEY, LATITUDE_PROJECT_SLUG
+
+.venv/bin/uvicorn app.main:app --reload         # the API
+APP_RELEASE=2.0.0 .venv/bin/python -m scripts.smoke   # realistic traffic, release 2.0.0
+APP_RELEASE=2.1.0 .venv/bin/python -m scripts.smoke   # same traffic, release 2.1.0
+.venv/bin/python -m scripts.import_v1_dataset datasets/grammar-golden.csv grammar-regressions
+LATITUDE_DATASET_SLUG=grammar-regressions .venv/bin/pytest -q
+```
+
+| Path | What it is |
+| --- | --- |
+| `app/telemetry.py` | `Latitude(...)` bootstrap, imported before the Anthropic client |
+| `app/prompts.py` | the two V1 PromptL documents, now Python templates with version strings |
+| `app/services.py` | one `capture()` per use case: user, session, tags, release metadata |
+| `scripts/smoke.py` | twelve learner requests across three users and five sessions |
+| `datasets/grammar-golden.csv` | the V1 golden dataset export |
+| `scripts/import_v1_dataset.py` | V1 CSV -> V2 dataset rows (`insertDatasetRows`) |
+| `tests/test_regression.py` | dataset replay tagged `simulation` (the V1 batch evaluation) |

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/main.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/main.py
@@ -1,0 +1,25 @@
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.telemetry import latitude  # first import: telemetry before the model client
+from app.routers import grammar, quiz
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    yield
+    latitude.flush()
+    latitude.shutdown()
+
+
+app = FastAPI(title="LinguaAI", description="Language learning API, traced with Latitude", lifespan=lifespan)
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+app.include_router(grammar.router)
+app.include_router(quiz.router)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/prompts.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/prompts.py
@@ -1,0 +1,57 @@
+"""Prompts live in the codebase now.
+
+These were PromptL documents in the Latitude V1 prompt manager (`grammar-check`,
+`vocab-quiz`). The PromptL frontmatter (provider/model/temperature) became plain
+arguments to the provider call; `{{ variables }}` became Python string formatting.
+Version them with your code: the version string travels to Latitude as metadata,
+so traces and experiments can be sliced per prompt version.
+"""
+import os
+
+APP_RELEASE = os.environ.get("APP_RELEASE", "2.1.0")
+
+MODEL = "claude-haiku-4-5-20251001"
+
+GRAMMAR_CHECK_V2 = """You are LinguaAI's grammar coach. The learner is studying {language}.
+Check the learner's text for grammar errors.
+Reply ONLY with JSON of this shape:
+{{"corrections": [{{"original": "...", "corrected": "...", "explanation": "..."}}],
+ "is_correct": true|false,
+ "summary": "one encouraging sentence"}}
+If the text has no errors, return an empty corrections list and is_correct true."""
+
+GRAMMAR_CHECK_V3 = """You are LinguaAI's grammar coach. The learner is studying {language}.
+Check the learner's text for grammar, agreement, tense, and word-choice errors.
+Be strict: a sentence is only correct if a careful teacher would accept it as written.
+For every correction name the rule involved in the explanation.
+Reply ONLY with JSON of this shape:
+{{"corrections": [{{"original": "...", "corrected": "...", "explanation": "..."}}],
+ "is_correct": true|false,
+ "summary": "one encouraging sentence"}}
+If the text has no errors, return an empty corrections list and is_correct true."""
+
+# Release 2.0.0 shipped the V1 prompt as-is; 2.1.0 tightened it after the
+# "missed error" signal. Experiments compare the two by metadata.release.
+GRAMMAR_CHECK_VERSIONS = {
+    "2.0.0": ("grammar-check@2", GRAMMAR_CHECK_V2),
+    "2.1.0": ("grammar-check@3", GRAMMAR_CHECK_V3),
+}
+
+
+def grammar_check_prompt(language: str) -> tuple[str, str]:
+    """Return (prompt_version, system_prompt) for the current release."""
+    version, template = GRAMMAR_CHECK_VERSIONS.get(APP_RELEASE, GRAMMAR_CHECK_VERSIONS["2.1.0"])
+    return version, template.format(language=language)
+
+
+VOCAB_QUIZ_VERSION = "vocab-quiz@1"
+VOCAB_QUIZ_SYSTEM = """You are LinguaAI's quiz writer. Write a {difficulty} vocabulary quiz for a learner of {language}{topic_clause}.
+Write exactly 3 multiple-choice questions. Reply ONLY with JSON:
+{{"questions": [{{"question": "...", "options": [{{"label": "A", "value": "..."}}, {{"label": "B", "value": "..."}}, {{"label": "C", "value": "..."}}, {{"label": "D", "value": "..."}}], "correct_answer": "A", "explanation": "..."}}]}}"""
+
+
+def vocab_quiz_prompt(language: str, difficulty: str, topic: str | None) -> tuple[str, str]:
+    topic_clause = f" about {topic}" if topic else ""
+    return VOCAB_QUIZ_VERSION, VOCAB_QUIZ_SYSTEM.format(
+        language=language, difficulty=difficulty, topic_clause=topic_clause
+    )

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/prompts.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/prompts.py
@@ -30,8 +30,6 @@ Reply ONLY with JSON of this shape:
  "summary": "one encouraging sentence"}}
 If the text has no errors, return an empty corrections list and is_correct true."""
 
-# Release 2.0.0 shipped the V1 prompt as-is; 2.1.0 tightened it after the
-# "missed error" signal. Experiments compare the two by metadata.release.
 GRAMMAR_CHECK_VERSIONS = {
     "2.0.0": ("grammar-check@2", GRAMMAR_CHECK_V2),
     "2.1.0": ("grammar-check@3", GRAMMAR_CHECK_V3),

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/routers/grammar.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/routers/grammar.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel
+
+from app import services
+
+router = APIRouter(prefix="/grammar", tags=["grammar"])
+
+
+class GrammarCheckRequest(BaseModel):
+    text: str
+    language: str
+
+
+class Correction(BaseModel):
+    original: str
+    corrected: str
+    explanation: str
+
+
+class GrammarCheckResponse(BaseModel):
+    corrections: list[Correction]
+    is_correct: bool
+    summary: str
+
+
+@router.post("/check", response_model=GrammarCheckResponse)
+def check_grammar(
+    req: GrammarCheckRequest,
+    x_user_id: str = Header(default="anonymous"),
+    x_session_id: str = Header(default="no-session"),
+):
+    # Sync route on purpose: FastAPI runs it in a worker thread, and capture()
+    # must wrap the model call in the same thread.
+    try:
+        return services.check_grammar(req.text, req.language, user_id=x_user_id, session_id=x_session_id)
+    except ValueError:
+        raise HTTPException(status_code=502, detail="Failed to parse AI response as JSON")

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/routers/grammar.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/routers/grammar.py
@@ -26,6 +26,8 @@ class GrammarCheckResponse(BaseModel):
 @router.post("/check", response_model=GrammarCheckResponse)
 def check_grammar(
     req: GrammarCheckRequest,
+    # Demo only: these headers are trusted as-is. A real deployment must derive
+    # user_id/session_id from an authenticated session, not a client-set header.
     x_user_id: str = Header(default="anonymous"),
     x_session_id: str = Header(default="no-session"),
 ):

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/routers/quiz.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/routers/quiz.py
@@ -33,6 +33,7 @@ class QuizGenerateResponse(BaseModel):
 @router.post("/generate", response_model=QuizGenerateResponse)
 def generate_quiz(
     req: QuizGenerateRequest,
+    # Demo only: see the caveat on the equivalent headers in routers/grammar.py.
     x_user_id: str = Header(default="anonymous"),
     x_session_id: str = Header(default="no-session"),
 ):

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/routers/quiz.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/routers/quiz.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel
+
+from app import services
+
+router = APIRouter(prefix="/quiz", tags=["quiz"])
+
+
+class QuizGenerateRequest(BaseModel):
+    language: str
+    difficulty: str = "intermediate"
+    topic: str | None = None
+
+
+class QuizOption(BaseModel):
+    label: str
+    value: str
+
+
+class QuizQuestion(BaseModel):
+    question: str
+    options: list[QuizOption]
+    correct_answer: str
+    explanation: str
+
+
+class QuizGenerateResponse(BaseModel):
+    language: str
+    difficulty: str
+    questions: list[QuizQuestion]
+
+
+@router.post("/generate", response_model=QuizGenerateResponse)
+def generate_quiz(
+    req: QuizGenerateRequest,
+    x_user_id: str = Header(default="anonymous"),
+    x_session_id: str = Header(default="no-session"),
+):
+    try:
+        return services.generate_quiz(
+            req.language, req.difficulty, req.topic, user_id=x_user_id, session_id=x_session_id
+        )
+    except ValueError:
+        raise HTTPException(status_code=502, detail="Failed to parse AI response as JSON")

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/services.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/services.py
@@ -10,7 +10,6 @@ from anthropic import Anthropic
 from latitude_telemetry import capture
 
 from app import prompts
-from app.telemetry import latitude  # noqa: F401  (bootstraps telemetry before the client exists)
 
 client = Anthropic()
 

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/services.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/services.py
@@ -1,0 +1,76 @@
+"""LinguaAI use cases: grammar check and vocab quiz.
+
+Each function is one Latitude trace. `capture()` attaches the user, the session,
+tags, and metadata to every span the Anthropic instrumentation creates inside it.
+"""
+import json
+import re
+
+from anthropic import Anthropic
+from latitude_telemetry import capture
+
+from app import prompts
+from app.telemetry import latitude  # noqa: F401  (bootstraps telemetry before the client exists)
+
+client = Anthropic()
+
+
+def _extract_json(text: str) -> dict:
+    fenced = re.search(r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL)
+    return json.loads((fenced.group(1) if fenced else text).strip())
+
+
+def _complete(system: str, user: str, max_tokens: int) -> str:
+    response = client.messages.create(
+        model=prompts.MODEL,
+        max_tokens=max_tokens,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+    )
+    return response.content[0].text
+
+
+def check_grammar(text: str, language: str, *, user_id: str, session_id: str, tags: list[str] | None = None,
+                  metadata: dict | None = None) -> dict:
+    version, system = prompts.grammar_check_prompt(language)
+    user = f"Language: {language}\nText: {text}"
+    raw = capture(
+        "grammar-check",
+        lambda: _complete(system, user, max_tokens=600),
+        {
+            "user_id": user_id,
+            "session_id": session_id,
+            # Tags carry rollout labels (docs: tags for cohorts, metadata for exact values).
+            # Experiments and session filters split on tags, so the release goes in both.
+            "tags": ["grammar", f"release-{prompts.APP_RELEASE}", *(tags or ["production"])],
+            "metadata": {
+                "release": prompts.APP_RELEASE,
+                "prompt_version": version,
+                "language": language,
+                **(metadata or {}),
+            },
+        },
+    )
+    data = _extract_json(raw)
+    return {
+        "corrections": data.get("corrections", []),
+        "is_correct": data.get("is_correct", not data.get("corrections")),
+        "summary": data.get("summary", ""),
+    }
+
+
+def generate_quiz(language: str, difficulty: str, topic: str | None, *, user_id: str, session_id: str) -> dict:
+    version, system = prompts.vocab_quiz_prompt(language, difficulty, topic)
+    user = f"Language: {language}\nDifficulty: {difficulty}" + (f"\nTopic: {topic}" if topic else "")
+    raw = capture(
+        "vocab-quiz",
+        lambda: _complete(system, user, max_tokens=900),
+        {
+            "user_id": user_id,
+            "session_id": session_id,
+            "tags": ["quiz", f"release-{prompts.APP_RELEASE}", "production"],
+            "metadata": {"release": prompts.APP_RELEASE, "prompt_version": version, "language": language},
+        },
+    )
+    data = _extract_json(raw)
+    return {"language": language, "difficulty": difficulty, "questions": data.get("questions", [])}

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/telemetry.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/app/telemetry.py
@@ -1,0 +1,19 @@
+"""Latitude telemetry bootstrap.
+
+Import this module before any Anthropic client is created. In V1 the Latitude
+SDK sat between the app and the model (gateway); in V2 the model call is ours and
+Latitude only observes it through OpenTelemetry.
+"""
+import os
+
+import anthropic
+from dotenv import load_dotenv
+from latitude_telemetry import Latitude
+
+load_dotenv()
+
+latitude = Latitude(
+    api_key=os.environ["LATITUDE_API_KEY"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
+    instrumentations={"anthropic": anthropic},
+)

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/datasets/grammar-golden.csv
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/datasets/grammar-golden.csv
@@ -1,0 +1,7 @@
+text,language,expected_output
+"I have 25 years old.",English,"I am 25 years old."
+"She don't like apples.",English,"She doesn't like apples."
+"Yo soy muy cansado hoy.",Spanish,"Yo estoy muy cansado hoy."
+"Me gusta los perros.",Spanish,"Me gustan los perros."
+"Ich habe gestern nach Berlin gefahren.",German,"Ich bin gestern nach Berlin gefahren."
+"Less people came than expected.",English,"Fewer people came than expected."

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/pytest.ini
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/requirements.txt
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/requirements.txt
@@ -1,0 +1,8 @@
+fastapi>=0.115
+uvicorn[standard]>=0.34
+python-dotenv>=1.1
+anthropic>=1.0
+latitude-telemetry>=3.7
+latitude-sdk>=9.10
+httpx>=0.27
+pytest>=8

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/import_v1_dataset.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/import_v1_dataset.py
@@ -1,0 +1,42 @@
+"""Bring a Latitude V1 golden dataset into a V2 dataset.
+
+V1 datasets were CSVs whose columns mirrored the prompt's parameters plus a
+label column. V2 rows have input / output / expected_output / metadata. Map the
+parameter columns into `input`, the label into `expected_output`, and keep the
+rest as metadata. The same call is available as the MCP tool `insertDatasetRows`.
+
+    python -m scripts.import_v1_dataset datasets/grammar-golden.csv grammar-regressions
+"""
+import csv
+import os
+import sys
+
+from dotenv import load_dotenv
+from latitude_sdk import LatitudeClient
+
+load_dotenv()
+
+PARAMS = ("text", "language")
+LABEL = "expected_output"
+
+
+def main(csv_path: str, dataset_slug: str) -> int:
+    client = LatitudeClient(api_key=os.environ["LATITUDE_API_KEY"])
+    project = os.environ["LATITUDE_PROJECT_SLUG"]
+    with open(csv_path, newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    payload = [
+        {
+            "input": {k: r[k] for k in PARAMS},
+            "expectedOutput": r[LABEL],
+            "metadata": {"source": "latitude-v1-golden-dataset", "file": os.path.basename(csv_path)},
+        }
+        for r in rows
+    ]
+    result = client.datasets.insert_rows(project, dataset_slug, rows=payload)
+    print(f"inserted {len(payload)} rows into {project}/{dataset_slug}: {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/import_v1_dataset.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/import_v1_dataset.py
@@ -33,8 +33,8 @@ def main(csv_path: str, dataset_slug: str) -> int:
         }
         for r in rows
     ]
-    result = client.datasets.insert_rows(project, dataset_slug, rows=payload)
-    print(f"inserted {len(payload)} rows into {project}/{dataset_slug}: {result}")
+    client.datasets.insert_rows(project, dataset_slug, rows=payload)
+    print(f"inserted {len(payload)} rows into {project}/{dataset_slug}")
     return 0
 
 

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/import_v1_dataset.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/import_v1_dataset.py
@@ -34,7 +34,7 @@ def main(csv_path: str, dataset_slug: str) -> int:
         for r in rows
     ]
     client.datasets.insert_rows(project, dataset_slug, rows=payload)
-    print(f"inserted {len(payload)} rows into {project}/{dataset_slug}")
+    print(f"inserted {len(payload)} rows into dataset {dataset_slug}")
     return 0
 
 

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/smoke.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/smoke.py
@@ -4,11 +4,10 @@ Run twice with different releases to give Experiments two cohorts:
     APP_RELEASE=2.0.0 python -m scripts.smoke
     APP_RELEASE=2.1.0 python -m scripts.smoke
 """
-import json
 import sys
 
+from app.telemetry import latitude  # import before app.services, which constructs the Anthropic client
 from app import prompts, services
-from app.telemetry import latitude
 
 # (user, session, kind, payload). Sessions group turns of one study session.
 LEARNERS = [

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/smoke.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/scripts/smoke.py
@@ -1,0 +1,48 @@
+"""Drive LinguaAI the way real learners do, so the V2 project has traffic to work with.
+
+Run twice with different releases to give Experiments two cohorts:
+    APP_RELEASE=2.0.0 python -m scripts.smoke
+    APP_RELEASE=2.1.0 python -m scripts.smoke
+"""
+import json
+import sys
+
+from app import prompts, services
+from app.telemetry import latitude
+
+# (user, session, kind, payload). Sessions group turns of one study session.
+LEARNERS = [
+    ("usr_mara", "sess_mara_001", "grammar", {"text": "I have 25 years old and I live in Madrid since 2019.", "language": "English"}),
+    ("usr_mara", "sess_mara_001", "grammar", {"text": "She don't like apples but she love pears.", "language": "English"}),
+    ("usr_mara", "sess_mara_001", "quiz", {"language": "English", "difficulty": "intermediate", "topic": "travel"}),
+    ("usr_kenji", "sess_kenji_001", "grammar", {"text": "Yo soy muy cansado hoy porque trabajé mucho.", "language": "Spanish"}),
+    ("usr_kenji", "sess_kenji_001", "grammar", {"text": "Me gusta los perros y me gusta también los gatos.", "language": "Spanish"}),
+    ("usr_lena", "sess_lena_001", "grammar", {"text": "Ich habe gestern nach Berlin gefahren.", "language": "German"}),
+    ("usr_lena", "sess_lena_001", "quiz", {"language": "German", "difficulty": "beginner", "topic": "food"}),
+    ("usr_mara", "sess_mara_002", "grammar", {"text": "If I would have known, I would have came earlier.", "language": "English"}),
+    ("usr_mara", "sess_mara_002", "grammar", {"text": "Less people came to the party than we expected.", "language": "English"}),
+    ("usr_mara", "sess_mara_002", "grammar", {"text": "The results were better than we expected.", "language": "English"}),
+    ("usr_kenji", "sess_kenji_002", "grammar", {"text": "Ayer fui al cine con mis amigos y vimos una película muy buena.", "language": "Spanish"}),
+    ("usr_kenji", "sess_kenji_002", "quiz", {"language": "Spanish", "difficulty": "advanced", "topic": "work"}),
+]
+
+
+def main() -> int:
+    for user, base_session, kind, payload in LEARNERS:
+        # A real session belongs to one release; suffix the id so cohorts stay clean.
+        session = f"{base_session}-r{prompts.APP_RELEASE}"
+        if kind == "grammar":
+            out = services.check_grammar(payload["text"], payload["language"], user_id=user, session_id=session)
+            verdict = "ok" if out["is_correct"] else f"{len(out['corrections'])} correction(s)"
+            print(f"[{user}/{session}] grammar: {payload['text'][:45]!r} -> {verdict}")
+        else:
+            out = services.generate_quiz(payload["language"], payload["difficulty"], payload.get("topic"),
+                                         user_id=user, session_id=session)
+            print(f"[{user}/{session}] quiz: {payload['language']} {payload['difficulty']} -> {len(out['questions'])} questions")
+    latitude.flush()
+    latitude.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/tests/test_regression.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/tests/test_regression.py
@@ -1,0 +1,103 @@
+"""Replay the V2 dataset against the live agent (V1 called this a batch evaluation).
+
+Pulls every row of the dataset with the Latitude SDK, runs the grammar check on
+each input, and asserts the expected correction is produced. Each replay is
+tagged `simulation` so it never counts as production traffic, and tagged with
+the agent version so an Experiment can compare releases.
+
+    LATITUDE_DATASET_SLUG=grammar-regressions pytest -q
+"""
+import json
+import os
+import uuid
+
+import pytest
+from dotenv import load_dotenv
+from latitude_sdk import LatitudeClient
+
+from app import prompts, services
+from app.telemetry import latitude
+
+load_dotenv()
+
+PROJECT = os.environ["LATITUDE_PROJECT_SLUG"]
+DATASET = os.environ.get("LATITUDE_DATASET_SLUG", "grammar-regressions")
+RUN_ID = os.environ.get("SIMULATION_RUN_ID", uuid.uuid4().hex[:8])
+
+
+def _rows():
+    client = LatitudeClient(api_key=os.environ["LATITUDE_API_KEY"])
+    cursor, out = None, []
+    while True:
+        page = client.datasets.list_rows(PROJECT, DATASET, cursor=cursor, limit=200)
+        out.extend(page.items)
+        if not page.has_more or not page.next_cursor:
+            return out
+        cursor = page.next_cursor
+
+
+def _text_and_language(row_input):
+    """Rows inserted from the V1 CSV carry {text, language}; rows imported from
+    traces carry the GenAI message list. Handle both."""
+    if isinstance(row_input, dict) and "text" in row_input:
+        return row_input["text"], row_input.get("language", "English")
+    raw = row_input
+    if isinstance(row_input, list):
+        user = next((m for m in row_input if isinstance(m, dict) and m.get("role") == "user"), {})
+        parts = user.get("parts") or user.get("content") or ""
+        raw = " ".join(p.get("content", "") for p in parts if isinstance(p, dict)) if isinstance(parts, list) else parts
+    language, text = "English", str(raw)
+    for line in str(raw).splitlines():
+        if line.startswith("Language:"):
+            language = line.split(":", 1)[1].strip()
+        if line.startswith("Text:"):
+            text = line.split(":", 1)[1].strip()
+    return text, language
+
+
+def _apply(text: str, corrections: list[dict]) -> str:
+    """The coach returns fragment-level corrections; apply them to get the full sentence."""
+    for c in corrections:
+        text = text.replace(c["original"], c["corrected"])
+    return text
+
+
+def _norm(s: str) -> str:
+    return " ".join(str(s).lower().replace("\u00a0", " ").split()).rstrip(".")
+
+
+def _also_accepts_column():
+    client = LatitudeClient(api_key=os.environ["LATITUDE_API_KEY"])
+    cols = client.datasets.list_columns(PROJECT, DATASET).columns
+    return next((c.identifier for c in cols if c.name == "alsoAccepts"), None)
+
+
+ROWS = [r for r in _rows() if r.expected_output]
+ALSO_ACCEPTS = _also_accepts_column()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _flush():
+    yield
+    latitude.flush()
+    latitude.shutdown()
+
+
+@pytest.mark.parametrize("row", ROWS, ids=[r.row_id for r in ROWS])
+def test_grammar_regression(row):
+    text, language = _text_and_language(row.input)
+    result = services.check_grammar(
+        text,
+        language,
+        user_id="regression-suite",
+        session_id=f"sim-{RUN_ID}-{row.row_id}",
+        tags=["simulation", f"agent-{prompts.APP_RELEASE}"],
+        metadata={"dataset": DATASET, "rowId": row.row_id, "runId": RUN_ID},
+    )
+    produced = _apply(text, result["corrections"])
+    # A row can list equally valid answers in the custom `alsoAccepts` column.
+    also = (row.custom or {}).get(ALSO_ACCEPTS) or [] if ALSO_ACCEPTS else []
+    accepted = {_norm(row.expected_output), *(_norm(a) for a in also)}
+    assert _norm(produced) in accepted, (
+        f"expected one of {sorted(accepted)}, got {produced!r} via corrections={result['corrections']}"
+    )

--- a/examples/migrations/linguaai-v1-to-v2/after/linguaai/tests/test_regression.py
+++ b/examples/migrations/linguaai-v1-to-v2/after/linguaai/tests/test_regression.py
@@ -7,7 +7,6 @@ the agent version so an Experiment can compare releases.
 
     LATITUDE_DATASET_SLUG=grammar-regressions pytest -q
 """
-import json
 import os
 import uuid
 
@@ -15,8 +14,8 @@ import pytest
 from dotenv import load_dotenv
 from latitude_sdk import LatitudeClient
 
+from app.telemetry import latitude  # import before app.services, which constructs the Anthropic client
 from app import prompts, services
-from app.telemetry import latitude
 
 load_dotenv()
 
@@ -73,6 +72,8 @@ def _also_accepts_column():
 
 
 ROWS = [r for r in _rows() if r.expected_output]
+if not ROWS:
+    raise RuntimeError(f"No rows with expected_output in {PROJECT}/{DATASET}, so the regression suite would not test anything")
 ALSO_ACCEPTS = _also_accepts_column()
 
 

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/.gitignore
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/.gitignore
@@ -1,0 +1,24 @@
+# Environment variables
+.env
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+dist/
+build/
+
+# Virtual environment
+venv/
+.venv/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/LATITUDE-V1-STATE.md
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/LATITUDE-V1-STATE.md
@@ -1,0 +1,16 @@
+# What LinguaAI had in Latitude V1
+
+Reconstructed from the app code (`sdk.prompts.run("grammar-check")`, `sdk.prompts.run("vocab-quiz")`)
+and the V1 feature set. The V1 workspace's trial has ended, so the prompt bodies in
+`latitude-prompts/` are faithful reconstructions, not exports.
+
+| V1 object | Name | Notes |
+| --- | --- | --- |
+| Project | LinguaAI (`LATITUDE_PROJECT_ID`) | one project, one published version pinned by `LATITUDE_VERSION_UUID` |
+| Prompt | `grammar-check` | PromptL, parameters `text`, `language`; JSON output parsed by the app |
+| Prompt | `vocab-quiz` | PromptL, parameters `language`, `difficulty`, optional `topic` |
+| Evaluation (LLM-as-judge, live) | "Misses a grammar error" | on `grammar-check` logs: fail when the learner's text has an error the corrections do not cover |
+| Evaluation (programmatic, batch) | "Corrected text matches label" | exact/semantic match against the dataset's `expected_output` label column |
+| Dataset | `grammar-golden` | CSV with `text`, `language`, `expected_output` (marked as label), used for batch experiments before publishing |
+| Human-in-the-loop | thumbs up/down on logs | reviewers annotated bad corrections from the Logs page |
+| Integration | `latitude-sdk>=5.7.0`, gateway `https://gateway.latitude.so/api/v3` | every request to the model went through Latitude |

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/backend/main.py
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/backend/main.py
@@ -1,0 +1,45 @@
+import os
+
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from latitude_sdk import Latitude, LatitudeOptions
+
+from routers import grammar, quiz
+
+load_dotenv()
+
+api_key = os.getenv("LATITUDE_API_KEY")
+project_id = os.getenv("LATITUDE_PROJECT_ID")
+version_uuid = os.getenv("LATITUDE_VERSION_UUID") or None
+
+if not api_key:
+    raise ValueError("LATITUDE_API_KEY is not set in .env")
+if not project_id:
+    raise ValueError("LATITUDE_PROJECT_ID is not set in .env")
+
+sdk = Latitude(
+    api_key,
+    LatitudeOptions(
+        project_id=int(project_id),
+        version_uuid=version_uuid,
+    ),
+)
+
+app = FastAPI(title="LinguaAI", description="Language learning API powered by Latitude")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(grammar.router)
+app.include_router(quiz.router)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/backend/requirements.txt
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/backend/requirements.txt
@@ -1,0 +1,4 @@
+latitude-sdk>=5.7.0
+python-dotenv>=1.1.0
+fastapi>=0.115.0
+uvicorn[standard]>=0.34.0

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/backend/routers/grammar.py
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/backend/routers/grammar.py
@@ -1,0 +1,62 @@
+import json
+import re
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from latitude_sdk import RunPromptOptions
+
+router = APIRouter(prefix="/grammar", tags=["grammar"])
+
+
+class GrammarCheckRequest(BaseModel):
+    text: str
+    language: str
+
+
+class Correction(BaseModel):
+    original: str
+    corrected: str
+    explanation: str
+
+
+class GrammarCheckResponse(BaseModel):
+    corrections: list[Correction]
+    is_correct: bool
+    summary: str
+
+
+def _extract_json(text: str) -> dict:
+    """Extract JSON from a response that may contain markdown fences."""
+    fenced = re.search(r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL)
+    if fenced:
+        return json.loads(fenced.group(1).strip())
+    return json.loads(text.strip())
+
+
+@router.post("/check", response_model=GrammarCheckResponse)
+async def check_grammar(req: GrammarCheckRequest):
+    from main import sdk
+
+    try:
+        result = await sdk.prompts.run(
+            "grammar-check",
+            RunPromptOptions(
+                parameters={
+                    "text": req.text,
+                    "language": req.language,
+                },
+            ),
+        )
+
+        response_text = result.response.text if hasattr(result.response, "text") else str(result.response)
+        data = _extract_json(response_text)
+
+        return GrammarCheckResponse(
+            corrections=[Correction(**c) for c in data.get("corrections", [])],
+            is_correct=data.get("is_correct", len(data.get("corrections", [])) == 0),
+            summary=data.get("summary", ""),
+        )
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=502, detail="Failed to parse AI response as JSON")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/backend/routers/quiz.py
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/backend/routers/quiz.py
@@ -1,0 +1,88 @@
+import json
+import re
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from latitude_sdk import RunPromptOptions
+
+router = APIRouter(prefix="/quiz", tags=["quiz"])
+
+
+class QuizGenerateRequest(BaseModel):
+    language: str
+    difficulty: str = "intermediate"
+    topic: str | None = None
+
+
+class QuizOption(BaseModel):
+    label: str
+    value: str
+
+
+class QuizQuestion(BaseModel):
+    question: str
+    options: list[QuizOption]
+    correct_answer: str
+    explanation: str
+
+
+class QuizGenerateResponse(BaseModel):
+    language: str
+    difficulty: str
+    questions: list[QuizQuestion]
+
+
+def _extract_json(text: str) -> dict:
+    """Extract JSON from a response that may contain markdown fences."""
+    fenced = re.search(r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL)
+    if fenced:
+        return json.loads(fenced.group(1).strip())
+    return json.loads(text.strip())
+
+
+@router.post("/generate", response_model=QuizGenerateResponse)
+async def generate_quiz(req: QuizGenerateRequest):
+    from main import sdk
+
+    try:
+        parameters = {
+            "language": req.language,
+            "difficulty": req.difficulty,
+        }
+        if req.topic:
+            parameters["topic"] = req.topic
+
+        result = await sdk.prompts.run(
+            "vocab-quiz",
+            RunPromptOptions(parameters=parameters),
+        )
+
+        response_text = result.response.text if hasattr(result.response, "text") else str(result.response)
+        data = _extract_json(response_text)
+
+        questions = []
+        for q in data.get("questions", []):
+            options = []
+            for opt in q.get("options", []):
+                if isinstance(opt, dict):
+                    options.append(QuizOption(**opt))
+                else:
+                    options.append(QuizOption(label=str(opt), value=str(opt)))
+            questions.append(
+                QuizQuestion(
+                    question=q["question"],
+                    options=options,
+                    correct_answer=q["correct_answer"],
+                    explanation=q.get("explanation", ""),
+                )
+            )
+
+        return QuizGenerateResponse(
+            language=req.language,
+            difficulty=req.difficulty,
+            questions=questions,
+        )
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=502, detail="Failed to parse AI response as JSON")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/latitude-prompts/grammar-check.promptl
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/latitude-prompts/grammar-check.promptl
@@ -1,0 +1,19 @@
+---
+provider: anthropic
+model: claude-3-5-sonnet-latest
+temperature: 0
+---
+<system>
+You are LinguaAI's grammar coach. The learner is studying {{ language }}.
+Check the learner's text for grammar errors.
+Reply ONLY with JSON of this shape:
+{"corrections": [{"original": "...", "corrected": "...", "explanation": "..."}],
+ "is_correct": true|false,
+ "summary": "one encouraging sentence"}
+If the text has no errors, return an empty corrections list and is_correct true.
+</system>
+
+<user>
+Language: {{ language }}
+Text: {{ text }}
+</user>

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/latitude-prompts/vocab-quiz.promptl
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/latitude-prompts/vocab-quiz.promptl
@@ -1,0 +1,15 @@
+---
+provider: anthropic
+model: claude-3-5-sonnet-latest
+temperature: 0.7
+---
+<system>
+You are LinguaAI's quiz writer. Write a {{ difficulty }} vocabulary quiz for a learner of {{ language }}{{ topic ? " about " + topic : "" }}.
+Write exactly 3 multiple-choice questions. Reply ONLY with JSON:
+{"questions": [{"question": "...", "options": [{"label": "A", "value": "..."}, {"label": "B", "value": "..."}, {"label": "C", "value": "..."}, {"label": "D", "value": "..."}], "correct_answer": "A", "explanation": "..."}]}
+</system>
+
+<user>
+Language: {{ language }}
+Difficulty: {{ difficulty }}
+</user>

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/main.py
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/main.py
@@ -65,7 +65,7 @@ async def main():
     print("Latitude SDK configured successfully!\n")
 
     # List all available prompts
-    prompts = await list_prompts()
+    await list_prompts()
 
     # Uncomment the following to run a specific prompt:
     # result = await run_prompt("your-prompt-path", {"param_name": "param_value"})

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/main.py
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/main.py
@@ -1,0 +1,75 @@
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from latitude_sdk import (
+    Latitude,
+    LatitudeOptions,
+    RunPromptOptions,
+)
+
+load_dotenv()
+
+api_key = os.getenv("LATITUDE_API_KEY")
+project_id = os.getenv("LATITUDE_PROJECT_ID")
+version_uuid = os.getenv("LATITUDE_VERSION_UUID") or None
+
+if not api_key or api_key == "your-api-key-here":
+    raise ValueError(
+        "Please set your LATITUDE_API_KEY in the .env file. "
+        "You can find it in your Latitude project settings under 'API Access'."
+    )
+
+if not project_id or project_id == "your-project-id-here":
+    raise ValueError(
+        "Please set your LATITUDE_PROJECT_ID in the .env file. "
+        "You can find it in your Latitude project settings."
+    )
+
+sdk = Latitude(
+    api_key,
+    LatitudeOptions(
+        project_id=int(project_id),
+        version_uuid=version_uuid,
+    ),
+)
+
+
+async def run_prompt(prompt_path: str, parameters: dict | None = None):
+    """Run a prompt and print the result."""
+    result = await sdk.prompts.run(
+        prompt_path,
+        RunPromptOptions(
+            parameters=parameters or {},
+            on_event=lambda event: print(f"Event: {event}"),
+            on_finished=lambda result: print(f"Finished: {result.uuid}"),
+            on_error=lambda error: print(f"Error: {error}"),
+            stream=True,
+        ),
+    )
+    print(f"\nConversation UUID: {result.uuid}")
+    print(f"Response: {result.response}")
+    return result
+
+
+async def list_prompts():
+    """List all available prompts in your project."""
+    prompts = await sdk.prompts.get_all()
+    print("Available prompts:")
+    for prompt in prompts:
+        print(f"  - {prompt.path}")
+    return prompts
+
+
+async def main():
+    print("Latitude SDK configured successfully!\n")
+
+    # List all available prompts
+    prompts = await list_prompts()
+
+    # Uncomment the following to run a specific prompt:
+    # result = await run_prompt("your-prompt-path", {"param_name": "param_value"})
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/migrations/linguaai-v1-to-v2/before/linguaai/requirements.txt
+++ b/examples/migrations/linguaai-v1-to-v2/before/linguaai/requirements.txt
@@ -1,0 +1,2 @@
+latitude-sdk>=5.7.0
+python-dotenv>=1.1.0


### PR DESCRIPTION
## what this adds

A new docs page, `getting-started/migrate-from-v1`, for teams moving off Latitude V1 (prompt manager, PromptL, gateway `prompts.run`/`.chat`, SDK 5.x). It has three parts:

- a concept map from every V1 object to its V2 equivalent (prompts to code plus `metadata.prompt_version`, gateway calls to direct provider calls inside `capture()`, logs to traces and sessions, live evaluations to judge signals, HITL to annotations, datasets to datasets with the label mapped to `expectedOutput`, batch experiments to local replays, triggers and webhooks to monitors and agent dispatch, SDK 5 to `latitude-telemetry` plus SDK 9)
- a pre-migration checklist, including the V1 API routes that still export prompts (`/api/v3/projects/{id}/versions/live/documents`) and datasets (`/api/v3/datasets`, `/api/v3/dataset-rows`)
- a worked migration of LinguaAI, a FastAPI language tutor, with the exact prompts to type into a coding agent and the MCP tool behind each one: `createProject`, `listTraces`/`getTrace`, `createSignal` (judge), `createDataset`, `importDatasetRowsFromTraces`, `insertDatasetRows`, `updateDatasetRow`, `addDatasetColumn`, `createExperiment`, `createAnnotation`

The companion code lives in `examples/migrations/linguaai-v1-to-v2/` (`before/` is the SDK 5 app, `after/` the instrumented V2 app with a smoke driver, a V1 CSV importer and a pytest regression replay). Every snippet on the page links to a file there.

## why

Support and the community Slack are getting V1 to V2 migration questions, and coding agents keep pulling cached V1 docs into V2 projects. This page is the answer we can point both at, and it is listed in `llms.txt` through the nav.

## verified

The walkthrough was executed end to end against a real project (`linguaai` in the demo org): traffic for two releases, the signal, the dataset (nine rows from traces plus six from the V1 CSV), the experiment with tag cohorts, and a 9/9 regression replay. Two things learned doing that are written into the page as gotchas rather than papered over: session filters match on tags (a `metadata.release` session filter did not), and judge criteria containing backticks are rejected by `createSignal`.

## follow-ups

- The page references a `latitude-migrate` skill; that skill is proposed in latitude-dev/skills#6 (https://github.com/latitude-dev/skills/pull/6).
- `examples/` had only `sdks/` before; `migrations/` is a new folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791022565&installation_model_id=435055&pr_number=4547&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4547&signature=209c448786cc941d864e5ef422bcca594f6ceb43c5ae6c01f089f7f2da56d5a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
