### PR TITLE
feat(monitors): anchor evaluation windows on activity, not start time

### DIFF
--- a/apps/web/src/components/filters-builder/filters-builder-fields.tsx
+++ b/apps/web/src/components/filters-builder/filters-builder-fields.tsx
@@ -19,8 +19,18 @@ import { groupFilterSections } from "./group-sections.ts"
 import { MetadataFilter } from "./metadata-filter/metadata-filter.tsx"
 import { type FilterMode, MultiSelectFilter, type StaticFilterItem } from "./multi-select-filter.tsx"
 import { PercentileFilter } from "./percentile-filter.tsx"
-import { StatusFilter, type StatusFilterValue } from "./status-filter.tsx"
+import { StatusFilter } from "./status-filter.tsx"
 import type { DistinctColumn } from "./types.ts"
+import {
+  getInValues,
+  getPercentileValue,
+  getRangeValues,
+  getStatusValues,
+  getTextFilterValue,
+  setFieldConditions,
+  toDisplayUnit,
+  toWireUnit,
+} from "./utils.ts"
 
 export type { FilterMode }
 
@@ -31,44 +41,6 @@ interface FiltersBuilderFieldsProps {
   readonly onFiltersChange: (filters: FilterSet) => void
   /** Field keys to omit from the builder (e.g. custom behaviors exclude `topics`). */
   readonly excludeFields?: readonly string[]
-}
-
-function getInValues(filters: FilterSet, field: string): readonly string[] {
-  const cond = filters[field]?.find((c) => c.op === "in")
-  return Array.isArray(cond?.value) ? cond.value.map(String) : []
-}
-
-function getTextFilterValue(filters: FilterSet, field: string): string {
-  const cond = filters[field]?.find((c) => c.op === "contains")
-  return typeof cond?.value === "string" ? cond.value : ""
-}
-
-function getRangeValues(filters: FilterSet, field: string): { min: number | undefined; max: number | undefined } {
-  const conditions = filters[field]
-  const minVal = conditions?.find((c) => c.op === "gte")?.value
-  const maxVal = conditions?.find((c) => c.op === "lte")?.value
-  return {
-    min: typeof minVal === "number" ? minVal : undefined,
-    max: typeof maxVal === "number" ? maxVal : undefined,
-  }
-}
-
-function toDisplayUnit(value: number | undefined, displayScale: number | undefined): number | undefined {
-  if (value === undefined) return undefined
-  if (!displayScale) return value
-  return value / displayScale
-}
-
-function toWireUnit(value: number | undefined, displayScale: number | undefined): number | undefined {
-  if (value === undefined) return undefined
-  if (!displayScale) return value
-  // Round to avoid float drift on conversions like 123.45 × 100_000_000.
-  return Math.round(value * displayScale)
-}
-
-function getPercentileValue(filters: FilterSet, field: string): number | undefined {
-  const cond = filters[field]?.find((c) => c.op === "gtePercentile")
-  return typeof cond?.value === "number" ? cond.value : undefined
 }
 
 const ANNOTATOR_FIELD = "score.annotatorId"
@@ -83,22 +55,6 @@ const ANNOTATOR_FIELD = "score.annotatorId"
  */
 function getHasAnnotationsOn(filters: FilterSet): boolean {
   return (filters[ANNOTATOR_FIELD] ?? []).some((c) => c.op === "neq")
-}
-
-const STATUS_VALUES: readonly StatusFilterValue[] = ["ok", "error"]
-
-function getStatusValues(filters: FilterSet, field: string): readonly StatusFilterValue[] {
-  const cond = filters[field]?.find((c) => c.op === "in")
-  const raw = Array.isArray(cond?.value) ? cond.value.map(String) : []
-  return raw.filter((v): v is StatusFilterValue => (STATUS_VALUES as readonly string[]).includes(v))
-}
-
-function setFieldConditions(filters: FilterSet, field: string, conditions: FilterCondition[]): FilterSet {
-  if (conditions.length === 0) {
-    const { [field]: _, ...rest } = filters
-    return rest
-  }
-  return { ...filters, [field]: conditions }
 }
 
 function CollapsibleSection({

--- a/apps/web/src/components/filters-builder/utils.test.ts
+++ b/apps/web/src/components/filters-builder/utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { getInValues, getStatusValues } from "./utils.ts"
+
+describe("getInValues", () => {
+  it("reads the values the controls write", () => {
+    expect(getInValues({ userId: [{ op: "in", value: ["u1", "u2"] }] }, "userId")).toEqual(["u1", "u2"])
+  })
+
+  // Monitor targets and API-created saved searches spell one value as `eq`; the sidebar has to
+  // show it, or the results look filtered by something the panel claims is unset.
+  it("reads a single value written as eq", () => {
+    expect(getInValues({ userId: [{ op: "eq", value: "u1" }] }, "userId")).toEqual(["u1"])
+  })
+
+  it("prefers in over eq when both are present", () => {
+    expect(
+      getInValues(
+        {
+          userId: [
+            { op: "eq", value: "u1" },
+            { op: "in", value: ["u2"] },
+          ],
+        },
+        "userId",
+      ),
+    ).toEqual(["u2"])
+  })
+
+  it("ignores operators it cannot render", () => {
+    expect(getInValues({ userId: [{ op: "contains", value: "u" }] }, "userId")).toEqual([])
+    expect(getInValues({}, "userId")).toEqual([])
+  })
+})
+
+describe("getStatusValues", () => {
+  it("keeps only known status values, from either operator", () => {
+    expect(getStatusValues({ status: [{ op: "in", value: ["error", "nope"] }] }, "status")).toEqual(["error"])
+    expect(getStatusValues({ status: [{ op: "eq", value: "ok" }] }, "status")).toEqual(["ok"])
+  })
+})

--- a/apps/web/src/components/filters-builder/utils.ts
+++ b/apps/web/src/components/filters-builder/utils.ts
@@ -4,9 +4,22 @@ import type { StatusFilterValue } from "./status-filter.tsx"
 
 const STATUS_VALUES: readonly StatusFilterValue[] = ["ok", "error"]
 
+/**
+ * Selected values for a multi-select field. The controls write `in`, but a predicate can arrive
+ * from anywhere the filter contract is honoured — a monitor target, an API- or MCP-created saved
+ * search — and those spell a single value as `eq`. Reading only `in` left such a filter applied to
+ * the results yet invisible in the sidebar; editing the control rewrites it as `in`.
+ */
 export function getInValues(filters: FilterSet, field: string): readonly string[] {
-  const cond = filters[field]?.find((c) => c.op === "in")
-  return Array.isArray(cond?.value) ? cond.value.map(String) : []
+  const conditions = filters[field]
+  const inCondition = conditions?.find((c) => c.op === "in")
+  if (Array.isArray(inCondition?.value)) return inCondition.value.map(String)
+  const eqCondition = conditions?.find((c) => c.op === "eq")
+  const eqValue = eqCondition?.value
+  if (typeof eqValue === "string" || typeof eqValue === "number" || typeof eqValue === "boolean") {
+    return [String(eqValue)]
+  }
+  return []
 }
 
 export function getTextFilterValue(filters: FilterSet, field: string): string {
@@ -33,9 +46,9 @@ export function getPercentileValue(filters: FilterSet, field: string): number | 
 }
 
 export function getStatusValues(filters: FilterSet, field: string): readonly StatusFilterValue[] {
-  const cond = filters[field]?.find((c) => c.op === "in")
-  const raw = Array.isArray(cond?.value) ? cond.value.map(String) : []
-  return raw.filter((v): v is StatusFilterValue => (STATUS_VALUES as readonly string[]).includes(v))
+  return getInValues(filters, field).filter((v): v is StatusFilterValue =>
+    (STATUS_VALUES as readonly string[]).includes(v),
+  )
 }
 
 /** Set (or, when `conditions` is empty, remove) a field's conditions. */

--- a/apps/web/src/domains/alerts/alerts.functions.ts
+++ b/apps/web/src/domains/alerts/alerts.functions.ts
@@ -36,6 +36,8 @@ export interface AlertIncidentRecord {
   readonly sourceId: string | null
   readonly startedAt: string
   readonly endedAt: string | null
+  /** When the monitor raised the incident. `startedAt` backdates to the offending run's start. */
+  readonly createdAt: string
   /** Resolved name of the issue tied to the incident; `null` if not found (e.g., deleted). */
   readonly signalName: string | null
   /** Resolved slug of the issue tied to the incident, for the deep link; `null` if not found. */
@@ -74,6 +76,7 @@ const toRecord = (
     sourceId: incident.sourceId,
     startedAt: incident.startedAt.toISOString(),
     endedAt: incident.endedAt?.toISOString() ?? null,
+    createdAt: incident.createdAt.toISOString(),
     signalName: issue?.name ?? null,
     signalSlug: issue?.slug ?? null,
     savedSearchName: savedSearchName ?? null,
@@ -89,7 +92,9 @@ const toRecord = (
 }
 
 /**
- * Returns incidents for the project whose lifetime overlaps `[fromIso, toIso]`,
+ * Returns incidents for the project whose lifetime overlaps `[fromIso, toIso]` or that were
+ * raised inside it (a match incident's lifetime is one instant, backdated to the start of the
+ * run it matched, which can predate the window it fired in),
  * enriched with the issue's name/uuid so the histogram tooltip can show a human label
  * without a follow-up request per incident. Signal lookup is best-effort — incidents
  * whose source issue has been deleted still come back, with `signalName: null`.

--- a/apps/web/src/domains/alerts/incident-markers.ts
+++ b/apps/web/src/domains/alerts/incident-markers.ts
@@ -41,8 +41,9 @@ function isRangedIncident(incident: AlertIncidentRecord): boolean {
 
 /**
  * Snaps a moment to the **index** of the bucket whose half-open `[start, start + width)` range
- * contains it. Returns `null` when the moment falls outside `[firstStartMs, firstStartMs + width *
- * (lastIndex + 1))` so callers drop those markers instead of piling them up at the edges.
+ * contains it, clamped into `[0, lastIndex]`. Callers decide what is visible by testing the
+ * incident's whole extent against the chart range, so a monitor incident backdated to the start
+ * of a long run still paints from the left edge instead of vanishing.
  */
 function snapMsToBucketIndex(
   ms: number,
@@ -52,8 +53,26 @@ function snapMsToBucketIndex(
 ): number | null {
   if (!Number.isFinite(ms) || bucketWidthMs <= 0) return null
   const idx = Math.floor((ms - firstBucketStartMs) / bucketWidthMs)
-  if (idx < 0 || idx > lastIndex) return null
-  return idx
+  return Math.min(lastIndex, Math.max(0, idx))
+}
+
+/**
+ * Which moment places an incident on a chart. `start` follows the offending run's `startedAt`,
+ * which lines up with start-anchored bars (the sessions histogram). `raised` follows `createdAt`,
+ * which lines up with activity-anchored bars (the monitor's own chart) — a backdated incident
+ * would otherwise be drawn over an empty bucket, or fall off a short range entirely.
+ */
+type IncidentTimeAxis = "start" | "raised"
+
+/** The moment an incident starts covering buckets, on the requested axis. */
+function incidentStartMs(incident: AlertIncidentRecord, timeAxis: IncidentTimeAxis): number {
+  return timeAxis === "raised" ? Date.parse(incident.createdAt) : Date.parse(incident.startedAt)
+}
+
+/** The moment a ranged incident stops covering buckets: its end, or `now` while it is open. */
+function incidentEndMs(incident: AlertIncidentRecord, startMs: number, nowMs: number): number {
+  if (!isRangedIncident(incident)) return startMs
+  return incident.endedAt ? Date.parse(incident.endedAt) : nowMs
 }
 
 interface IncidentRange {
@@ -63,7 +82,7 @@ interface IncidentRange {
 }
 
 interface IncidentGrouping {
-  /** Lookup of incidents whose `startedAt` snaps into a given bucket index. */
+  /** Lookup of incidents whose placement moment (per the requested axis) snaps into a bucket index. */
   readonly incidentsByBucketIndex: ReadonlyMap<number, readonly AlertIncidentRecord[]>
   /**
    * Per-bucket list of every incident that **touches** the bucket — both point-in-time incidents
@@ -81,6 +100,8 @@ interface GroupIncidentsByBucketInput {
   readonly incidents: readonly AlertIncidentRecord[]
   /** Used to clamp ongoing ranged incidents (`endedAt: null`) to the right edge of the chart. */
   readonly nowMs: number
+  /** Defaults to `start`; pass `raised` when the chart's bars are activity-anchored. */
+  readonly timeAxis?: IncidentTimeAxis
 }
 
 /**
@@ -96,6 +117,7 @@ export function groupIncidentsByBucket({
   bucketWidthMs,
   incidents,
   nowMs,
+  timeAxis = "start",
 }: GroupIncidentsByBucketInput): IncidentGrouping {
   const empty: IncidentGrouping = {
     incidentsByBucketIndex: new Map(),
@@ -117,8 +139,14 @@ export function groupIncidentsByBucket({
     incidentsTouchingBucketIndex.set(bucketIndex, existing)
   }
 
+  const lastBucketEndMs = firstStartMs + bucketWidthMs * (lastIndex + 1)
+
   for (const incident of incidents) {
-    const startMs = Date.parse(incident.startedAt)
+    const startMs = incidentStartMs(incident, timeAxis)
+    const endMs = incidentEndMs(incident, startMs, nowMs)
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) continue
+    // Only incidents whose extent misses the chart range entirely are dropped; the edges clamp.
+    if (endMs < firstStartMs || startMs >= lastBucketEndMs) continue
     const startIdx = snapMsToBucketIndex(startMs, firstStartMs, bucketWidthMs, lastIndex)
     if (startIdx === null) continue
 
@@ -128,10 +156,7 @@ export function groupIncidentsByBucket({
     pushTouching(startIdx, incident)
 
     if (isRangedIncident(incident)) {
-      const endMs = incident.endedAt ? Date.parse(incident.endedAt) : nowMs
-      const snapped = snapMsToBucketIndex(endMs, firstStartMs, bucketWidthMs, lastIndex)
-      // Clamp past-end to the last visible bucket so an in-progress incident paints to the edge.
-      const endIdx = snapped ?? (Number.isFinite(endMs) && endMs >= firstStartMs ? lastIndex : null)
+      const endIdx = snapMsToBucketIndex(endMs, firstStartMs, bucketWidthMs, lastIndex)
       if (endIdx !== null) {
         ranges.push({ startIndex: startIdx, endIndex: endIdx, incident })
         for (let i = startIdx + 1; i <= endIdx; i++) {
@@ -149,6 +174,8 @@ interface BuildIncidentMarkersInput {
   readonly bucketWidthMs: number
   readonly incidents: readonly AlertIncidentRecord[]
   readonly nowMs: number
+  /** Defaults to `start`; pass `raised` when the chart's bars are activity-anchored. */
+  readonly timeAxis?: IncidentTimeAxis
 }
 
 interface BuildIncidentMarkersResult {
@@ -165,7 +192,7 @@ interface BuildIncidentMarkersResult {
 /**
  * Builds eCharts overlays from a list of incidents:
  * - point-in-time incidents (`endedAt === startedAt`) → vertical mark lines snapped to the bucket
- *   containing `startedAt`
+ *   containing their placement moment (`startedAt`, or `createdAt` on the `raised` axis)
  * - ranged incidents (`endedAt > startedAt`, or `endedAt === null` for an open lifecycle) →
  *   translucent mark areas spanning `startedAt → endedAt` (clamped to `nowMs` when ongoing). The
  *   start line is always drawn so a 1-bucket range stays discoverable.
@@ -175,6 +202,7 @@ export function buildIncidentMarkers({
   bucketWidthMs,
   incidents,
   nowMs,
+  timeAxis = "start",
 }: BuildIncidentMarkersInput): BuildIncidentMarkersResult {
   const empty: BuildIncidentMarkersResult = {
     overlay: { lines: [], areas: [] },
@@ -183,7 +211,7 @@ export function buildIncidentMarkers({
   }
   if (bucketStartsMs.length === 0 || incidents.length === 0) return empty
 
-  const grouping = groupIncidentsByBucket({ bucketStartsMs, bucketWidthMs, incidents, nowMs })
+  const grouping = groupIncidentsByBucket({ bucketStartsMs, bucketWidthMs, incidents, nowMs, timeAxis })
 
   const lines: BarChartOverlayLine[] = []
   const areas: BarChartOverlayArea[] = []

--- a/apps/web/src/domains/monitors/monitors.functions.ts
+++ b/apps/web/src/domains/monitors/monitors.functions.ts
@@ -21,6 +21,7 @@ import {
   searchMonitorsUseCase,
   unmuteMonitorUseCase,
   updateMonitorUseCase,
+  withoutFixedTimeConditions,
 } from "@domain/monitors"
 import { listSavedSearches, SavedSearchRepository } from "@domain/saved-searches"
 import {
@@ -190,6 +191,8 @@ export interface MonitorLastIncidentRecord {
   readonly id: string
   readonly startedAtIso: string
   readonly endedAtIso: string | null
+  /** When the incident was raised; `startedAtIso` backdates to the offending run's start. */
+  readonly createdAtIso: string
 }
 
 export interface MonitorListRowRecord {
@@ -204,7 +207,12 @@ const toMonitorListRowRecord = (
 ): MonitorListRowRecord => ({
   monitor: toMonitorRecord(monitor, savedSearchRefs),
   lastIncident: last
-    ? { id: last.id, startedAtIso: last.startedAt.toISOString(), endedAtIso: last.endedAt?.toISOString() ?? null }
+    ? {
+        id: last.id,
+        startedAtIso: last.startedAt.toISOString(),
+        endedAtIso: last.endedAt?.toISOString() ?? null,
+        createdAtIso: last.createdAt.toISOString(),
+      }
     : null,
 })
 
@@ -313,14 +321,14 @@ const resolveMetricTarget = (monitor: Monitor) =>
       if (search === null) return null
       return {
         stream: target.stream,
-        filterSet: search.filterSet,
+        filterSet: withoutFixedTimeConditions(search.filterSet),
         query: search.query,
         metric: target.metric,
       } satisfies MetricSeriesTarget
     }
     return {
       stream: target.stream,
-      filterSet: target.filterSet ?? {},
+      filterSet: withoutFixedTimeConditions(target.filterSet ?? {}),
       query: target.query ?? null,
       metric: target.metric,
     } satisfies MetricSeriesTarget
@@ -862,6 +870,7 @@ const toMonitorIncidentRecord = (
       readonly id: string
       readonly startedAt: Date
       readonly endedAt: Date | null
+      readonly createdAt: Date
       readonly sourceType: string | null
       readonly sourceId: string | null
       readonly severity: string
@@ -875,6 +884,7 @@ const toMonitorIncidentRecord = (
   id: item.incident.id,
   startedAt: item.incident.startedAt.toISOString(),
   endedAt: item.incident.endedAt?.toISOString() ?? null,
+  createdAt: item.incident.createdAt.toISOString(),
   kind:
     item.incident.sourceType === "signal"
       ? "signal.escalating"

--- a/apps/web/src/domains/sessions/sessions.collection.ts
+++ b/apps/web/src/domains/sessions/sessions.collection.ts
@@ -76,11 +76,14 @@ export function useSessionsInfiniteScroll({
   sorting,
   filters,
   searchQuery,
+  enabled = true,
 }: {
   readonly projectId: string
   readonly sorting: InfiniteTableSorting
   readonly filters?: FilterSet
   readonly searchQuery?: string
+  /** Hold the query until the caller's predicate is resolved, so it can't fetch with placeholder filters. */
+  readonly enabled?: boolean
 }) {
   const scope = useProjectScope()
   const effectiveFilters = useMemo(() => withSessionDefaults(filters), [filters])
@@ -116,6 +119,7 @@ export function useSessionsInfiniteScroll({
         }
       | undefined,
     getNextPageParam: (lastPage) => lastPage?.nextCursor,
+    enabled,
   })
 
   const infiniteScroll: InfiniteTableInfiniteScroll = useMemo(

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index.tsx
@@ -330,7 +330,12 @@ function MonitorDetailPage() {
 
               {target ? (
                 <div className="shrink-0 px-6 pb-6">
-                  <MonitorMatchingTraces projectSlug={projectSlug} projectId={project.id} target={target} />
+                  <MonitorMatchingTraces
+                    projectSlug={projectSlug}
+                    projectId={project.id}
+                    target={target}
+                    savedSearchSlug={savedSearchTarget?.slug ?? null}
+                  />
                 </div>
               ) : null}
             </>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-card-form.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-card-form.tsx
@@ -39,13 +39,21 @@ const SENSITIVITY_MIN = 1
 const SENSITIVITY_MAX = 6
 // Field help copy — written so a non-engineer can predict what each control does.
 const KIND_HELP: Record<UserAlertKind, string> = {
-  "savedSearch.match": "Opens an incident each time a new matching trace is detected",
+  "savedSearch.match": "Opens an incident the first time each matching session is detected",
   "savedSearch.threshold": "Opens an incident once matching traces reach a threshold",
   "savedSearch.escalating": "Opens an incident when matching traces stay elevated for a sustained window",
-  "monitor.match": "Opens an incident each time the monitor target matches",
+  "monitor.match": "Opens an incident the first time each matching session is detected",
   "monitor.threshold": "Opens an incident once the metric crosses a threshold",
   "monitor.escalating": "Opens an incident when the metric stays elevated for a sustained window",
 }
+
+// Monitors window on the activity axis while every other view is start-anchored, so the same
+// filters can read differently here and on the dashboard. Say so wherever a monitor is created.
+const TIME_AXIS_HELP = [
+  "Monitors evaluate sessions by their latest activity, so a long session is checked while it progresses and again when it finishes.",
+  "Each session alerts at most once, and any fixed date range in the search is ignored.",
+  "Dashboards and analytics list sessions by start time, so a session that just alerted can appear further back there.",
+].join(" ")
 
 // Tab label + icon per kind. Saved-search exposes all three; a unified target
 // exposes only threshold/escalating (kindsForDraft drops "match" for targets).
@@ -543,8 +551,11 @@ export function AlertCardForm({
         />
       ) : null}
 
-      <div className="rounded-lg bg-muted/80 px-3 py-2 flex justify-start items-center">
-        <Text.H6 color="foregroundMuted">{previewAlertSentence(value, savedSearchName)}</Text.H6>
+      <div className="flex flex-col gap-1.5">
+        <div className="rounded-lg bg-muted/80 px-3 py-2 flex justify-start items-center">
+          <Text.H6 color="foregroundMuted">{previewAlertSentence(value, savedSearchName)}</Text.H6>
+        </div>
+        <Text.H6 color="foregroundMuted">{TIME_AXIS_HELP}</Text.H6>
       </div>
 
       <div className="flex flex-col gap-1.5">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/incident-status.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/incident-status.tsx
@@ -7,10 +7,13 @@ const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 export function IncidentStatus({
   startedAtIso,
   endedAtIso,
+  createdAtIso,
   onResolve,
 }: {
   readonly startedAtIso: string
   readonly endedAtIso: string | null
+  /** When the incident was raised. Point incidents report this instead of their backdated instant. */
+  readonly createdAtIso?: string
   /** When set on an ongoing incident, hovering the pill fades in a Resolve button over it. */
   readonly onResolve?: () => void
 }) {
@@ -46,6 +49,17 @@ export function IncidentStatus({
           </button>
         </Button>
       </div>
+    )
+  }
+  // A match incident is an instant (`endedAt === startedAt`) backdated to the start of the run it
+  // matched, which can be an hour before it fired — reporting that as a "close" would read as old
+  // news, so point incidents report when the monitor raised them.
+  const isPoint = Date.parse(endedAtIso) === Date.parse(startedAtIso)
+  if (isPoint) {
+    const detectedAt = createdAtIso ?? endedAtIso
+    const stalePoint = Date.now() - Date.parse(detectedAt) > ONE_WEEK_MS
+    return (
+      <Status variant={stalePoint ? "neutral" : "warning"} label={`Matched ${relativeTime(new Date(detectedAt))}`} />
     )
   }
   const stale = Date.now() - Date.parse(endedAtIso) > ONE_WEEK_MS

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
@@ -59,6 +59,7 @@ const incidentColumns = (onResolve?: (incidentId: string) => void): InfiniteTabl
       <IncidentStatus
         startedAtIso={incident.startedAt}
         endedAtIso={incident.endedAt}
+        createdAtIso={incident.createdAt}
         {...(onResolve && incident.endedAt === null ? { onResolve: () => onResolve(incident.id) } : {})}
       />
     ),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-matching-traces.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-matching-traces.tsx
@@ -1,51 +1,83 @@
-import type { MonitorTarget } from "@domain/monitors"
+import { type MonitorTarget, withoutFixedTimeConditions } from "@domain/monitors"
 import { Button, CopyableText, Icon, InfiniteTable, type InfiniteTableColumn, Sheet, Status, Text } from "@repo/ui"
 import { formatDuration, relativeTime } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import { ArrowUpRightIcon } from "lucide-react"
 import { useMemo, useState } from "react"
 import { targetToSessionFilters } from "../../../../../../domains/monitors/monitor-target.ts"
+import { useSavedSearchBySlug } from "../../../../../../domains/saved-searches/saved-searches.collection.ts"
 import { useSessionsInfiniteScroll } from "../../../../../../domains/sessions/sessions.collection.ts"
 import type { SessionRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { SessionDetailDrawer } from "../../-components/session-detail-drawer.tsx"
 
 const PREVIEW_LIMIT = 8
-const SESSION_SORTING = { column: "startTime", direction: "desc" } as const
+// Monitors evaluate by latest activity, so the preview leads with the sessions a check would see.
+const SESSION_SORTING = { column: "lastActivity", direction: "desc" } as const
 
 export function MonitorMatchingTraces({
   projectSlug,
   projectId,
   target,
+  savedSearchSlug,
 }: {
   readonly projectSlug: string
   readonly projectId: string
   readonly target: MonitorTarget
+  /** Set for saved-search monitors, whose target holds a reference instead of a copy of the filters. */
+  readonly savedSearchSlug?: string | null
 }) {
   const [openSessionId, setOpenSessionId] = useState<string | null>(null)
-  const { filters, query } = useMemo(() => targetToSessionFilters(target), [target])
+  // A saved-search target carries `filterSet: null`, so its predicate has to be read back
+  // from the search itself — the same resolution the monitor check does. Listing the target's
+  // own (empty) filters instead would preview every session in the project.
+  const byReference = target.savedSearchId !== null
+  const { data: savedSearch, isLoading: isLoadingSavedSearch } = useSavedSearchBySlug(
+    projectId,
+    byReference ? (savedSearchSlug ?? null) : null,
+  )
+  // Evaluation ignores fixed date ranges, so the preview has to as well: a search carrying a
+  // stale range would otherwise claim nothing matches while the incidents above it pile up.
+  const { filters, query } = useMemo(() => {
+    const resolved = byReference
+      ? { filters: savedSearch?.filterSet ?? {}, query: savedSearch?.query ?? null }
+      : targetToSessionFilters(target)
+    return { filters: withoutFixedTimeConditions(resolved.filters), query: resolved.query }
+  }, [byReference, savedSearch, target])
+  const predicateResolved = byReference ? savedSearch !== null : true
   const { data, isLoading } = useSessionsInfiniteScroll({
     projectId,
     sorting: SESSION_SORTING,
     filters,
+    enabled: predicateResolved,
     ...(query ? { searchQuery: query } : {}),
   })
   const rows = data.slice(0, PREVIEW_LIMIT)
 
-  const viewAllSearch = {
-    tab: "sessions",
-    filters: JSON.stringify(filters),
-    filtersOpen: true,
-    ...(query ? { query } : {}),
-  }
+  // "View all" has to land on the same sessions the preview lists, so it carries the monitor's
+  // effective predicate — ranges stripped — rather than letting the dashboard hydrate the saved
+  // search's own filters (which the dashboard skips when the link already carries filters). The
+  // slug rides along so the dashboard still shows which saved search is in play.
+  const viewAllSearch =
+    byReference && !savedSearchSlug
+      ? null
+      : {
+          tab: "sessions",
+          filters: JSON.stringify(filters),
+          filtersOpen: true,
+          ...(byReference && savedSearchSlug ? { savedSearch: savedSearchSlug } : {}),
+          ...(query ? { query } : {}),
+        }
 
   const columns: InfiniteTableColumn<SessionRecord>[] = [
     {
       key: "time",
-      header: "Time",
+      header: "Last activity",
       width: 110,
       minWidth: 100,
       render: (session) => (
-        <span title={new Date(session.startTime).toLocaleString()}>{relativeTime(new Date(session.startTime))}</span>
+        <span title={new Date(session.lastActivityTime).toLocaleString()}>
+          {relativeTime(new Date(session.lastActivityTime))}
+        </span>
       ),
     },
     {
@@ -96,24 +128,26 @@ export function MonitorMatchingTraces({
   return (
     <section className="flex min-w-0 flex-col gap-3">
       <div className="flex items-center justify-between gap-2">
-        <Text.H5M color="foreground">Matching sessions</Text.H5M>
-        <Button asChild variant="ghost" size="sm" className="w-auto">
-          <Link to="/projects/$projectSlug" params={{ projectSlug }} search={viewAllSearch}>
-            View all
-            <Icon icon={ArrowUpRightIcon} size="sm" />
-          </Link>
-        </Button>
+        <Text.H5M color="foreground">Sessions</Text.H5M>
+        {viewAllSearch ? (
+          <Button asChild variant="ghost" size="sm" className="w-auto">
+            <Link to="/projects/$projectSlug" params={{ projectSlug }} search={viewAllSearch}>
+              View all
+              <Icon icon={ArrowUpRightIcon} size="sm" />
+            </Link>
+          </Button>
+        ) : null}
       </div>
       <InfiniteTable
         data={rows}
-        isLoading={isLoading}
+        isLoading={isLoading || isLoadingSavedSearch}
         columns={columns}
         getRowKey={(session) => session.sessionId}
         onRowClick={(session) => setOpenSessionId(session.sessionId)}
         getRowAriaLabel={(session) => `Open session ${session.sessionId}`}
         scrollAreaLayout="intrinsic"
         className="max-h-[420px]"
-        blankSlate="No matching sessions in the recent window"
+        blankSlate="No sessions match this monitor's filters yet"
       />
       <Sheet open={openSessionId !== null} onClose={() => setOpenSessionId(null)} closeAriaLabel="Close session panel">
         {openSessionId ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-metric-chart.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-metric-chart.tsx
@@ -114,6 +114,9 @@ export function MonitorMetricChart({
       bucketWidthMs: bucketMs,
       incidents: monitorIncidents,
       nowMs: toMs,
+      // These bars are bucketed by latest activity, so markers follow when the monitor fired
+      // rather than the backdated start of the run — otherwise they land on an empty bucket.
+      timeAxis: "raised",
     })
     return { overlay: result.overlay, incidentsTouchingBucketIndex: result.incidentsTouchingBucketIndex }
   }, [series, monitorIncidents, bucketMs, toMs])
@@ -142,7 +145,12 @@ export function MonitorMetricChart({
   return (
     <section className="flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-4">
       <div className="flex items-baseline justify-between gap-2">
-        <Text.H6 color="foregroundMuted">{target ? metricLabel(target) : "Metric"}</Text.H6>
+        <Text.H6 color="foregroundMuted">
+          {target ? metricLabel(target) : "Metric"}
+          <Text.H6 color="foregroundMuted" asChild>
+            <span> · by latest activity</span>
+          </Text.H6>
+        </Text.H6>
         {latestValue !== null && metric ? (
           <Text.H5 color="foreground" className="tabular-nums">
             {formatMetricValue(latestValue, metric)}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-view.tsx
@@ -36,8 +36,10 @@ export interface MonitorsTableSorting {
 }
 export const DEFAULT_MONITORS_SORTING: MonitorsTableSorting = { column: "lastIncident", direction: "desc" }
 
+// Ranked by when the incident was raised, not by its backdated `startedAt` — a monitor that
+// just fired for a 40-minute run would otherwise sort below older, shorter incidents.
 const lastIncidentMs = (row: MonitorsTableRow): number | null =>
-  row.lastIncident ? Date.parse(row.lastIncident.startedAtIso) : null
+  row.lastIncident ? Date.parse(row.lastIncident.createdAtIso) : null
 
 const comparePrimary = (
   a: MonitorsTableRow,
@@ -90,6 +92,7 @@ function LastIncidentCell({
     <IncidentStatus
       startedAtIso={summary.startedAtIso}
       endedAtIso={summary.endedAtIso}
+      createdAtIso={summary.createdAtIso}
       {...(summary.endedAtIso === null ? { onResolve: () => onResolve(summary.id) } : {})}
     />
   )

--- a/apps/workers/src/workers/monitors.ts
+++ b/apps/workers/src/workers/monitors.ts
@@ -7,6 +7,7 @@ import {
 } from "@domain/monitors"
 import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
 import { OrganizationId, ProjectId } from "@domain/shared"
+import { RedisCacheStoreLive, type RedisClient } from "@platform/cache-redis"
 import { type ClickHouseClient, MetricSeriesReaderLive, withClickHouse } from "@platform/db-clickhouse"
 import {
   IncidentRepositoryLive,
@@ -18,7 +19,7 @@ import {
 } from "@platform/db-postgres"
 import { createLogger, withTracing } from "@repo/observability"
 import { Cause, Effect, Layer } from "effect"
-import { getAdminPostgresClient, getClickhouseClient, getPostgresClient } from "../clients.ts"
+import { getAdminPostgresClient, getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
 
 const logger = createLogger("monitors")
 
@@ -28,6 +29,7 @@ interface MonitorsDeps {
   postgresClient?: PostgresClient
   adminPostgresClient?: PostgresClient
   clickhouseClient?: ClickHouseClient
+  redisClient?: RedisClient
 }
 
 const monitorWorkerRepoLayer = Layer.mergeAll(
@@ -42,16 +44,19 @@ export const createMonitorsWorker = ({
   postgresClient,
   adminPostgresClient,
   clickhouseClient,
+  redisClient,
 }: MonitorsDeps) => {
   const pgClient = postgresClient ?? getPostgresClient()
   const adminPgClient = adminPostgresClient ?? getAdminPostgresClient()
   const chClient = clickhouseClient ?? getClickhouseClient()
+  const rdClient = redisClient ?? getRedisClient()
 
   consumer.subscribe("monitors", {
     checkSavedSearchMonitors: (payload) =>
       checkMonitorsUseCase({ projectId: ProjectId(payload.projectId) }).pipe(
         withPostgres(monitorWorkerRepoLayer, pgClient, OrganizationId(payload.organizationId)),
         withClickHouse(MetricSeriesReaderLive, chClient, OrganizationId(payload.organizationId)),
+        Effect.provide(RedisCacheStoreLive(rdClient)),
         Effect.tap((result) =>
           Effect.sync(() =>
             logger.info(

--- a/dev-docs/agent-data-access.md
+++ b/dev-docs/agent-data-access.md
@@ -82,6 +82,10 @@ Notes:
   `ReplacingMergeTree`, so both sides are read with `FINAL`.
 - **Semantic `query`** (free-text, AND-combined with `filters`) is only valid on `traces` and
   `sessions`.
+- **`range` is start-anchored**, here and on every dashboard: a run belongs to the range it started
+  in, even when it ends after it. Monitors are the one consumer that windows on latest activity
+  instead (see [`monitors.md`](./monitors.md#two-time-axes)), so the same filters can report
+  different numbers there.
 
 ### Response
 

--- a/dev-docs/monitors.md
+++ b/dev-docs/monitors.md
@@ -138,7 +138,37 @@ Monitor evaluation inserts incidents with:
 - `severity: monitor.rule.severity`
 - `condition: null` for `match`, or the rule condition snapshot for threshold/escalating
 
-`match` monitors are point events: they insert a row with `endedAt = startedAt` every time the rule fires. `threshold` and `escalating` monitors use the sustained path: one open row per monitor while the condition holds. `threshold` opens an incident on first breach (freezing the evaluated threshold into `entrySignals` so the close-side compares against what tripped it, not a drifting baseline), then closes it once the condition has been clear for `THRESHOLD_EXIT_DWELL_MS` (`exitEligibleSince` tracks the dwell). A `threshold` incident alerts once on open (`incident.event`) and closes **silently** — no `IncidentClosed` event, so no recovery notification; closing simply re-arms a fresh alert if the breach recurs. `escalating` incidents close when `EscalationEngine` exits (and do notify on close).
+`match` monitors are point events: they insert a row with `endedAt = startedAt` the first time each matching entity is seen (see [Two time axes](#two-time-axes)). `threshold` and `escalating` monitors use the sustained path: one open row per monitor while the condition holds. `threshold` opens an incident on first breach (freezing the evaluated threshold into `entrySignals` so the close-side compares against what tripped it, not a drifting baseline), then closes it once the condition has been clear for `THRESHOLD_EXIT_DWELL_MS` (`exitEligibleSince` tracks the dwell). A `threshold` incident alerts once on open (`incident.event`) and closes **silently** — no `IncidentClosed` event, so no recovery notification; closing simply re-arms a fresh alert if the breach recurs. `escalating` incidents close when `EscalationEngine` exits (and do notify on close).
+
+## Two time axes
+
+Monitor evaluation windows filter on the **end-time axis** — `max(max_end_time)` for the `traces`/`sessions` rollups, the span's own `end_time` for `spans` — while every other consumer of the shared metric-sql descriptors keeps the **start** axis. `MetricSqlInput.windowAnchor` carries the choice (default `"start"`); only `MetricSeriesReaderLive` passes `"end"`, so `queryAnalytics`, experiment metrics, and the dashboards are untouched. Before the flip, a run's `start_time` had aged out of the 5-minute window by the time its trace-end triggered the check, so runs longer than the window could never alert (LAT-885).
+
+An incident's `startedAt` stays on the **start** axis: `firstEventAt` reads `min(start_time)` over the matched entities, and a match incident backdates to the earliest newly alerted entity's start. The window answers "should this alert now", `startedAt` answers "when did the offending run begin", and an incident can therefore start ~40 minutes before its `createdAt`. This is deliberate, not an inconsistency to unify. Downstream consequences: the monitors list ranks recency by the incident's `createdAt`, the histogram marker code clamps a backdated incident to the left edge instead of dropping it, and incident duration displays intentionally show the whole backdated span.
+
+Two more evaluation-time rules follow from the anchor:
+
+- **Fixed date ranges are stripped.** `withoutFixedTimeConditions` drops `startTime`/`endTime` conditions from a resolved predicate (saved-search and inline targets alike, plus the monitor detail chart's own resolution). A saved search built from the dashboard date picker carries an absolute range that would silence the monitor once it aged out; the search keeps the range for dashboard use.
+- **`seriesPerBucket` buckets on the same end column the window filters on.** Bucketing on `start_time` while windowing on `end_time` would assign in-window rows to out-of-range bucket indexes, which the densify loop drops silently.
+
+On the **traces** stream the backdate is the earliest start among the entity's *in-window* traces, not the entity's lifetime start: a session whose first turn ran an hour ago and whose latest turn is what matched backdates to that latest turn. The **sessions** stream reports the session's lifetime start for the same shape, because its rollup folds every trace into one row. Both readings are intentional — "this turn began" vs "this session began" — and follow from the target's stream.
+
+Surfaces that display an incident have to pick an axis deliberately:
+
+- **Recency** (the monitors list's `lastIncident` sort, and the status pill for point incidents) uses `createdAt`. A match incident backdated an hour would otherwise sort below older alerts and read "Closed 1 hour ago" when it fired minutes ago. The ranking has to hold in `MonitorRepository.list`'s SQL, not just the client comparator — the page is cut server-side, so a low-ranked monitor never reaches the client to be re-sorted.
+- **Chart markers** follow the axis of the bars they sit on: `buildIncidentMarkers({ timeAxis })` takes `"start"` for the start-anchored sessions histogram and `"raised"` for the monitor's own activity-anchored chart. Mixing them draws the marker over an empty bucket. `IncidentRepository.listByProjectId` also matches incidents *raised* inside the window (`created_at >= from`), since a match incident's whole lifetime is one backdated instant and would otherwise never be fetched for the window it fired in.
+- **Duration and "Ongoing since"** stay on `startedAt` — the breach really has been running since the run started.
+- **"Matching sessions"** and its "View all" link both apply the monitor's *effective* predicate (ranges stripped) so the panel, the link's destination, the chart and the incidents all agree.
+
+Known consequences we accept rather than fix: notification copy derives its trend window from `startedAt`, so a backdated incident's email describes the window around the run's start; an escalating incident's `startedAt` is snapshotted at the enter transition while a live run slides between end-anchored buckets across checks; an analytics chart plots a monitor-detected spike at a different x-position than the monitor's firing time, because the two axes differ by design; and `lastActivityTime` in the UI is the latest span's *start* while the window filters on its *end*, so a session whose final span is long reads slightly earlier than the moment that matched it.
+
+## Check cadence
+
+Two triggers publish `checkSavedSearchMonitors`, both coalescing on `savedSearchMonitorsCheckDedupeKey`: `trace-end` (90 s after a trace goes quiet) and a 5-minute sweeper cron. The publish carries a **leading** throttle, so the first one runs immediately and the rest are dropped until the marker lapses.
+
+The throttle must stay **strictly shorter than the evaluation window**. With both at 5 minutes the sweeper tick raced the previous marker's expiry and lost, so every other tick published nothing: the real cadence was 10 minutes against a 5-minute window, activity that landed in a skipped window was never evaluated, and threshold closes slipped a full tick. `SAVED_SEARCH_MONITORS_THROTTLE_MS` is 4 minutes for that reason, guarded by a test in `constants.test.ts`. Slightly overlapping windows are harmless: match monitors dedupe per entity and threshold/escalating incidents are idempotent per episode.
+
+A monitor's predicate is persisted in `config.filterSet` and read back onto `target.filterSet` — `toMonitorRow` folds the target's own filters in, because the public API sends the predicate on the target while the web sends it in both places. A caller whose filters never reach `config` produces a monitor that evaluates against the whole project.
 
 ## Evaluation
 
@@ -146,14 +176,25 @@ Monitor evaluation inserts incidents with:
 
 Point rules use `MetricSeriesReader` directly:
 
-- `match` fires when any matching row exists in the lookback window, backdating the incident's `started_at` to the first event.
-- `threshold` computes the configured metric value over the window and compares it to the configured threshold (absolute, multiplier-over-baseline, or seasonal/expected).
+- `match` reads the entities matching in the lookback window, drops the ones already alerted for, and opens one incident for the rest, backdating `started_at` to the earliest of their start times.
+- `threshold` computes the configured metric value over the window and compares it to the configured threshold (absolute, multiplier-over-baseline, or seasonal/expected). A live long run contributes to every consecutive window while it runs; "activity in the window" is the intended semantic, since ClickHouse has no settledness flag (trace-end re-fires mid-run) and alerting before a 40-minute run finishes is the point.
+
+### Match dedupe
+
+A live run sits inside `[now - 5min, now)` on **every** check until it finishes, so match monitors alert **once per entity**:
+
+- `MetricSeriesReader.matchingEntities` returns `{ id, startTime }` per matching entity, capped at 1000, at the count metric's dedup grain (traces coalesce to session-or-trace, sessions to `session_id`, spans to `span_id`) — so a session's three matching traces are one entity, matching what the count metric reports.
+- Alerted entities are marked in Redis through the `CacheStore` port under `matchAlertedDedupeKey` (`org:${organizationId}:monitors:match-alerted:${monitorId}:${entityId}`) with a 24h TTL.
+- Markers are written **after** the incident transaction commits, so a failed insert retries cleanly; checks are serialized per project, so there is no race. Redis cannot join that transaction, so a marker write failing after the commit leaves the entity unmarked and the next check alerts for it again. That direction is deliberate: a duplicate alert on infrastructure failure beats marking first and silently dropping the alert when the insert is what fails. Making the two atomic would mean persisting the dedupe state in Postgres alongside the incident — worth doing only if this is ever observed.
+- A `CacheError` fails that monitor's evaluation rather than alerting anyway, which would spam on a Redis flap.
+- Muted monitors don't evaluate and so record no markers: unmuting may alert for a run that matched while muted if it still has activity in the window. Accepted.
 
 Before reading ClickHouse, saved-search monitor targets resolve their current saved-search `filterSet` and `query`; if the saved search has been deleted, that monitor is skipped until the delete cascade removes it. Escalating rules adapt `MetricSeriesReader` into the incidents package's generic `SeriesReader` and then call `EscalationEngine`. The engine owns the sustained state machine, including seasonal expected-mode thresholds, entry snapshots, dwell exits, and hard timeouts. This is the same engine used for signal escalation; the reader decides which source produces the bucket series.
 
 The ClickHouse adapter is `MetricSeriesReaderLive` in `@platform/db-clickhouse`. It turns a target's `(stream, filterSet, query, metric)` into per-stream ClickHouse queries (over `traces`, `spans`, or `sessions`) and returns:
 
 - point/window values for threshold checks
+- the matching entities (id + start time) for match dedupe
 - first/last event timestamps for point incidents
 - per-bucket series for the escalation engine
 

--- a/docs/monitors/overview.mdx
+++ b/docs/monitors/overview.mdx
@@ -82,31 +82,42 @@ Alerts each time a new trace matching 'Checkout 5xx errors' is detected.
 
 The alert card has a **severity** selector (**Low**, **Medium**, or **High**) that sets the tone of the incident badge and the notification.
 
+## How monitors measure time
+
+Every alert kind evaluates a **sliding window of recent activity**, and a session enters that window by its **latest activity** rather than by when it started. A session that has been running for 40 minutes is therefore checked while it progresses and again when it finishes, so long agent sessions alert instead of ageing out of the window before they end.
+
+Two things follow from that:
+
+- **Each session alerts at most once per monitor.** A session that stays active across several checks doesn't re-alert, and a monitor can't be flooded by one long session.
+- **An incident points back at the start of the session.** The incident's "started" time is when the offending session began, which can be well before the alert arrived.
+
+Dashboards, the Traces and Sessions pages, and the analytics API all list sessions by their **start** time instead. Same filters, different time axis: a session that just triggered a monitor can appear further back in those views, and a fixed date range saved inside a search is ignored while monitoring it (the sliding activity window is the monitor's only time axis).
 
 ## The three saved-search alert kinds
 
 A saved-search alert can watch its search in one of three ways, shown as tabs on the alert card: **Match**, **Threshold**, and **Escalating**.
 
-### Match: alert when matching traces start arriving
+### Match: alert when a matching session appears
 
-Use **Match** when even one matching trace is worth knowing about, for example a saved search for `status = 5xx in production`.
+Use **Match** when even one matching session is worth knowing about, for example a saved search for `status = 5xx in production`.
 
 ```text
 Alerts each time a new trace matching 'Production 5xx' is detected.
 ```
 
-<Frame caption="A Match alert card: pick the saved search to watch and a severity. It fires each time a new matching trace is detected.">
+<Frame caption="A Match alert card: pick the saved search to watch and a severity. It fires the first time each matching session is detected.">
   <img src="/images/monitors/alert-match.png" alt="A Match alert card with the saved-search selector and severity options" />
 </Frame>
 
-To keep this from becoming noise, matches are **limited to one alert every 5 minutes**:
+Matches are alerted **once per session**, and the monitor is checked at most every 5 minutes:
 
-- A burst of 500 matches arriving at once produces **one** alert, not 500.
-- If matching activity is **continuous**, you'll get a fresh alert **every 5 minutes** for as long as it keeps happening, so an ongoing problem stays visible instead of going quiet after the first alert.
-- After a **quiet period** with no matches, the next match opens a fresh alert again.
+- A burst of 500 matching sessions arriving at once produces **one** alert, not 500.
+- A single long session alerts **once**, at the first check that sees it, however long it keeps going.
+- While **new** matching sessions keep appearing, you keep getting alerts, at most one every 5 minutes, so an ongoing problem stays visible instead of going quiet after the first alert.
+- After a **quiet period** with no matches, the next new session opens a fresh alert again.
 
 <Tip>
-  The 5-minute cadence is deliberate: continuous matching keeps re-surfacing so you don't tune out and forget the problem is still live.
+  Because a session alerts only once, a Match monitor on a busy search reads as a stream of distinct problems rather than the same one repeating.
 </Tip>
 
 ### Threshold: alert at a milestone or a spike
@@ -129,7 +140,7 @@ Alerts when traces matching 'Production 5xx' are detected 100 times.
 
 Spike detection: alert when the current volume rises to some multiple **above a baseline** you choose. Pick the comparison **times more than** and then choose the baseline:
 
-- **The average of the last N hours/days**: the normal-traffic case. Latitude divides the baseline window into 5-minute slices and compares your current rate against the average slice.
+- **The average of the last N hours/days**: the normal-traffic case. Latitude divides the baseline window into 5-minute slices and compares the sessions active in your current slice against the average slice.
 - **The previous period** (yesterday, or the previous week): for traffic that follows **daily or weekly patterns**, where "normal" depends on the day or time.
 
 ```text

--- a/packages/domain/incidents/src/ports/incident-repository.ts
+++ b/packages/domain/incidents/src/ports/incident-repository.ts
@@ -121,13 +121,15 @@ export interface IncidentRepositoryShape {
    */
   closeById(input: SetIncidentEndedAtInput): Effect.Effect<Incident | null, RepositoryError, SqlClient>
   /**
-   * Returns every incident in the project whose lifetime overlaps the optional `[from, to]`
-   * window, ordered ascending by `started_at`. Uses the
-   * `(organization_id, project_id, started_at)` index. An incident overlaps the window when
-   * `started_at <= to` AND (`ended_at IS NULL` OR `ended_at >= from`) — ongoing incidents
-   * (null `ended_at`) overlap as long as they began on or before `to`. Each bound is
-   * skipped when omitted, so passing no bounds returns every incident for the project.
-   * Additional optional filters narrow by `sourceType`, `sourceId`, and `severity`.
+   * Returns every incident in the project that overlaps the optional `[from, to]` window or was
+   * raised inside it, ordered ascending by `started_at`. Uses the
+   * `(organization_id, project_id, started_at)` index. An incident qualifies when
+   * `started_at <= to` AND (`ended_at IS NULL` OR `ended_at >= from` OR `created_at >= from`) —
+   * ongoing incidents (null `ended_at`) qualify as long as they began on or before `to`, and the
+   * `created_at` arm keeps a match incident (one instant, backdated to the start of the run it
+   * matched) visible in the window it actually fired in. Each bound is skipped when omitted, so
+   * passing no bounds returns every incident for the project. Additional optional filters narrow
+   * by `sourceType`, `sourceId`, and `severity`.
    */
   listByProjectId(input: ListIncidentsByProjectInput): Effect.Effect<readonly Incident[], RepositoryError, SqlClient>
   /**

--- a/packages/domain/monitors/src/constants.test.ts
+++ b/packages/domain/monitors/src/constants.test.ts
@@ -6,6 +6,9 @@ import {
   ESCALATING_BUCKET_SMALL_MS,
   maxFailingBuckets,
   pickEscalatingBucketMs,
+  SAVED_SEARCH_CURRENT_WINDOW_MS,
+  SAVED_SEARCH_MONITORS_SWEEPER_PATTERN,
+  SAVED_SEARCH_MONITORS_THROTTLE_MS,
 } from "./constants.ts"
 
 describe("pickEscalatingBucketMs", () => {
@@ -54,5 +57,18 @@ describe("countFailingBuckets", () => {
 
   it("passes a bucket that meets the threshold exactly", () => {
     expect(countFailingBuckets([2, 2, 2], 2)).toBe(0)
+  })
+})
+
+describe("check cadence", () => {
+  // A throttle as long as the window lets the sweeper tick race the previous marker's expiry;
+  // the tick loses, and the window it would have covered is never evaluated.
+  it("throttles publishes for strictly less than the evaluation window", () => {
+    expect(SAVED_SEARCH_MONITORS_THROTTLE_MS).toBeLessThan(SAVED_SEARCH_CURRENT_WINDOW_MS)
+  })
+
+  it("sweeps at least as often as the throttle lapses, so a lapsed throttle is picked up promptly", () => {
+    const everyNMinutes = Number(SAVED_SEARCH_MONITORS_SWEEPER_PATTERN.split(" ")[0]?.replace("*/", ""))
+    expect(everyNMinutes * 60_000).toBeLessThanOrEqual(SAVED_SEARCH_CURRENT_WINDOW_MS)
   })
 })

--- a/packages/domain/monitors/src/constants.ts
+++ b/packages/domain/monitors/src/constants.ts
@@ -1,17 +1,44 @@
 /**
- * The "current activity" window for `savedSearch.threshold` (multiplier mode) and
- * `savedSearch.match` evaluation. Equals the firing throttle interval — a shorter
- * window would be evaluated less often than it claims to measure.
+ * The "recent activity" window for `savedSearch.threshold` (multiplier mode) and
+ * `savedSearch.match` evaluation. Monitors window on the activity axis, so this
+ * selects entities whose latest ingested span ended in the last 5 minutes —
+ * a 40-minute run qualifies while it progresses and when it finishes.
  */
 export const SAVED_SEARCH_CURRENT_WINDOW_MS = 5 * 60 * 1000
 
 /**
  * Leading-edge throttle window for the per-project `checkSavedSearchMonitors` publish:
- * the first publish runs immediately, then at most one run per 5 min per project. Leading
- * (not trailing) so the check's trailing evaluation window still covers the traces that
- * triggered it — a `throttleMs` delay would slide that window 5 min past the burst.
+ * the first publish runs immediately, then at most one run per project until it lapses.
+ * Leading (not trailing) so the check's trailing evaluation window still covers the traces
+ * that triggered it — a `throttleMs` delay would slide that window past the burst.
+ *
+ * Must stay **strictly shorter** than {@link SAVED_SEARCH_CURRENT_WINDOW_MS}, or consecutive
+ * windows leave gaps: with both at 5 minutes the sweeper's 5-minute tick raced this marker's
+ * expiry and lost, so every other tick published nothing and the real cadence was 10 minutes
+ * against a 5-minute window — activity landing in a skipped window was never evaluated, and
+ * threshold closes were delayed by a full tick. The slack also absorbs cron jitter. Overlapping
+ * windows are harmless: match monitors dedupe per entity ({@link matchAlertedDedupeKey}) and
+ * threshold/escalating incidents stay idempotent per episode.
  */
-export const SAVED_SEARCH_MONITORS_THROTTLE_MS = 5 * 60 * 1000
+export const SAVED_SEARCH_MONITORS_THROTTLE_MS = 4 * 60 * 1000
+
+/**
+ * How long a match monitor remembers having alerted for an entity. Spans the longest
+ * plausible run so a run sitting in the activity window across many checks alerts once;
+ * an entity that starts matching again after it expires alerts again.
+ */
+export const MATCH_ALERT_DEDUPE_TTL_SECONDS = 24 * 60 * 60
+
+/** Per-monitor, per-entity marker recording that a match monitor already alerted for that run. */
+export const matchAlertedDedupeKey = ({
+  organizationId,
+  monitorId,
+  entityId,
+}: {
+  readonly organizationId: string
+  readonly monitorId: string
+  readonly entityId: string
+}): string => `org:${organizationId}:monitors:match-alerted:${monitorId}:${entityId}`
 
 /**
  * How long a `threshold` monitor's condition must stay clear before its open incident

--- a/packages/domain/monitors/src/helpers.ts
+++ b/packages/domain/monitors/src/helpers.ts
@@ -3,10 +3,22 @@ import {
   type AlertDuration,
   type AlertIncidentCondition,
   type AlertMetricThreshold,
+  type FilterSet,
   formatMetricValue,
   type MonitorMetric,
   type MonitorTrigger,
+  TRACE_TIME_FILTER_FIELDS,
 } from "@domain/shared"
+
+/**
+ * A monitored predicate without its absolute time conditions. A saved search's
+ * date-picker range (or an API-created inline range) would fight the monitor's
+ * sliding activity window and silence it for good once the range aged out, so
+ * evaluation and the monitor's own chart both ignore it. The saved search keeps
+ * the range for dashboard use.
+ */
+export const withoutFixedTimeConditions = (filterSet: FilterSet): FilterSet =>
+  Object.fromEntries(Object.entries(filterSet).filter(([field]) => !TRACE_TIME_FILTER_FIELDS.includes(field as never)))
 
 export interface HumanReadableRuleContext {
   readonly savedSearchName?: string

--- a/packages/domain/monitors/src/index.ts
+++ b/packages/domain/monitors/src/index.ts
@@ -4,6 +4,8 @@ export {
   ESCALATING_BUCKET_LARGE_MS,
   ESCALATING_BUCKET_SIZE_CUTOFF_MS,
   ESCALATING_BUCKET_SMALL_MS,
+  MATCH_ALERT_DEDUPE_TTL_SECONDS,
+  matchAlertedDedupeKey,
   maxFailingBuckets,
   pickEscalatingBucketMs,
   SAVED_SEARCH_CURRENT_WINDOW_MS,
@@ -28,8 +30,10 @@ export {
   formatHumanReadableRule,
   type HumanReadableRuleContext,
   type HumanReadableRuleInput,
+  withoutFixedTimeConditions,
 } from "./helpers.ts"
 export type {
+  MatchingEntity,
   MetricSeriesBucketInput,
   MetricSeriesReaderAdapterInput,
   MetricSeriesReaderShape,

--- a/packages/domain/monitors/src/ports/metric-series-reader.test.ts
+++ b/packages/domain/monitors/src/ports/metric-series-reader.test.ts
@@ -30,6 +30,7 @@ const reader: MetricSeriesReaderShape = {
     if (hours(from, to) === 6) return Effect.succeed(72)
     return Effect.succeed(8)
   },
+  matchingEntities: () => Effect.succeed([]),
   firstEventAt: () => Effect.succeed(null),
   lastEventAt: () => Effect.succeed(null),
   seriesPerBucket: () => Effect.succeed([4, 12]),

--- a/packages/domain/monitors/src/ports/metric-series-reader.ts
+++ b/packages/domain/monitors/src/ports/metric-series-reader.ts
@@ -41,16 +41,37 @@ export interface MetricSeriesBucketInput extends MetricSeriesWindowInput {
   readonly bucketMs: number
 }
 
+/** One entity (run, session or span) that matched a target inside the window. */
+export interface MatchingEntity {
+  /** Identity at the `count` metric's dedup grain, so a session's traces are one entity. */
+  readonly id: string
+  /** The entity's earliest span start — the axis an incident backdates to. */
+  readonly startTime: Date
+}
+
 /**
  * The metric value of a target over a window + per-bucket, plus the first/last
  * matching-event times for incident backtracking. A dedicated port (not a trace
  * port widening) keeps the firing concern off the broadly-stubbed trace port.
  * For `metric.kind === 'count'` this is exactly the saved-search match reader it supersedes.
+ *
+ * Every window here is **activity-anchored**: a row falls in `[from, to)` by the
+ * time its latest ingested span ended, so a run that started hours ago is still
+ * evaluated while it progresses and when it finishes. `firstEventAt` is the one
+ * deliberate exception (see its doc).
  */
 export interface MetricSeriesReaderShape {
   /** The metric over rows whose time axis falls in `[from, to)`. */
   valueInWindow(input: MetricSeriesWindowInput): Effect.Effect<number, RepositoryError | ValidationError, ChSqlClient>
-  /** Earliest matching-row time in `[from, to)`, or `null` when none match. Backs the incident's backtraced `started_at`. */
+  /**
+   * The entities matching the target inside `[from, to)`, earliest start first and
+   * capped. Same population `valueInWindow` counts for a `count` metric, itemised
+   * so match monitors can alert once per entity.
+   */
+  matchingEntities(
+    input: MetricSeriesWindowInput,
+  ): Effect.Effect<readonly MatchingEntity[], RepositoryError | ValidationError, ChSqlClient>
+  /** Earliest matching-row **start** time in `[from, to)`, or `null` when none match. Backs the incident's backtraced `started_at`. */
   firstEventAt(
     input: MetricSeriesWindowInput,
   ): Effect.Effect<Date | null, RepositoryError | ValidationError, ChSqlClient>

--- a/packages/domain/monitors/src/ports/monitor-repository.ts
+++ b/packages/domain/monitors/src/ports/monitor-repository.ts
@@ -30,6 +30,8 @@ export interface MonitorLastIncident {
   readonly id: string
   readonly startedAt: Date
   readonly endedAt: Date | null
+  /** When the incident was raised. Ranks recency, since `startedAt` backdates to the offending run's start. */
+  readonly createdAt: Date
 }
 
 export interface MonitorListPage {

--- a/packages/domain/monitors/src/testing/fake-cache-store.ts
+++ b/packages/domain/monitors/src/testing/fake-cache-store.ts
@@ -1,0 +1,27 @@
+import { CacheStore } from "@domain/shared"
+import { Effect, Layer } from "effect"
+
+/**
+ * In-memory `CacheStore` for unit tests. TTLs are recorded but never expire —
+ * a test that needs expiry deletes the entry from `entries` instead.
+ */
+export const createFakeCacheStore = (seed: Iterable<readonly [string, string]> = []) => {
+  const entries = new Map<string, string>(seed)
+  const ttlSeconds = new Map<string, number | undefined>()
+
+  const layer = Layer.succeed(CacheStore, {
+    get: (key) => Effect.sync(() => entries.get(key) ?? null),
+    set: (key, value, options) =>
+      Effect.sync(() => {
+        entries.set(key, value)
+        ttlSeconds.set(key, options?.ttlSeconds)
+      }),
+    delete: (key) =>
+      Effect.sync(() => {
+        entries.delete(key)
+        ttlSeconds.delete(key)
+      }),
+  })
+
+  return { layer, entries, ttlSeconds }
+}

--- a/packages/domain/monitors/src/testing/fake-metric-series-reader.ts
+++ b/packages/domain/monitors/src/testing/fake-metric-series-reader.ts
@@ -1,26 +1,69 @@
 import { Effect, Layer } from "effect"
 import {
+  type MatchingEntity,
   type MetricSeriesBucketInput,
   MetricSeriesReader,
   type MetricSeriesWindowInput,
 } from "../ports/metric-series-reader.ts"
 
 /**
- * In-memory `MetricSeriesReader` for unit tests: seed matching-event
- * `start_time`s, and the methods window them by `[from, to)` as a `count` metric.
+ * A seeded matching entity. `startedAt` is the backdate axis, `endedAt` the
+ * activity axis the windows filter on — a long run has `endedAt` far after
+ * `startedAt`. Entities sharing an `id` collapse into one, like a session's
+ * traces do under the count metric's dedup grain.
  */
-export const createFakeMetricSeriesReader = (matchTimestamps: readonly Date[] = []) => {
+export interface FakeMetricEvent {
+  readonly id?: string
+  readonly startedAt: Date
+  /** Defaults to `startedAt`, i.e. an instantaneous event. */
+  readonly endedAt?: Date
+}
+
+/** A bare `Date` seeds an instantaneous event (start = end), which is all most cases need. */
+export type FakeMetricEventInput = Date | FakeMetricEvent
+
+interface NormalizedEvent {
+  readonly id: string
+  readonly startedAt: Date
+  readonly endedAt: Date
+}
+
+const normalize = (event: FakeMetricEventInput, index: number): NormalizedEvent =>
+  event instanceof Date
+    ? { id: `event-${index}`, startedAt: event, endedAt: event }
+    : { id: event.id ?? `event-${index}`, startedAt: event.startedAt, endedAt: event.endedAt ?? event.startedAt }
+
+/**
+ * In-memory `MetricSeriesReader` for unit tests: seed matching entities, and the
+ * methods window them by `[from, to)` on the activity axis as a `count` metric.
+ */
+export const createFakeMetricSeriesReader = (events: readonly FakeMetricEventInput[] = []) => {
   const calls: Array<MetricSeriesWindowInput | MetricSeriesBucketInput> = []
-  const inWindow = (input: MetricSeriesWindowInput) =>
-    matchTimestamps.filter((at) => at.getTime() >= input.from.getTime() && at.getTime() < input.to.getTime())
+  const seeded = events.map(normalize)
+
+  const inWindow = (input: MetricSeriesWindowInput): NormalizedEvent[] =>
+    seeded.filter(
+      (event) => event.endedAt.getTime() >= input.from.getTime() && event.endedAt.getTime() < input.to.getTime(),
+    )
+
+  const entities = (input: MetricSeriesWindowInput): MatchingEntity[] => {
+    const earliestById = new Map<string, Date>()
+    for (const event of inWindow(input)) {
+      const earliest = earliestById.get(event.id)
+      if (earliest === undefined || event.startedAt < earliest) earliestById.set(event.id, event.startedAt)
+    }
+    return [...earliestById.entries()]
+      .map(([id, startTime]) => ({ id, startTime }))
+      .sort((left, right) => left.startTime.getTime() - right.startTime.getTime())
+  }
 
   // Mirror the ClickHouse impl: `N = floor((to - from) / bucketMs)` buckets
   // aligned to `to`, newest-first (index 0 ends at `to`), zero-filled.
   const series = (input: MetricSeriesBucketInput): number[] => {
     const bucketCount = Math.max(0, Math.floor((input.to.getTime() - input.from.getTime()) / input.bucketMs))
     const counts = new Array<number>(bucketCount).fill(0)
-    for (const at of inWindow(input)) {
-      const index = Math.floor((input.to.getTime() - at.getTime()) / input.bucketMs)
+    for (const event of inWindow(input)) {
+      const index = Math.floor((input.to.getTime() - event.endedAt.getTime()) / input.bucketMs)
       if (index >= 0 && index < bucketCount) counts[index] += 1
     }
     return counts
@@ -30,17 +73,28 @@ export const createFakeMetricSeriesReader = (matchTimestamps: readonly Date[] = 
     valueInWindow: (input) =>
       Effect.sync(() => {
         calls.push(input)
-        return inWindow(input).length
+        return entities(input).length
+      }),
+    matchingEntities: (input) =>
+      Effect.sync(() => {
+        calls.push(input)
+        return entities(input)
       }),
     firstEventAt: (input) =>
       Effect.sync(() => {
         calls.push(input)
-        return inWindow(input).reduce<Date | null>((earliest, at) => (earliest && earliest <= at ? earliest : at), null)
+        return inWindow(input).reduce<Date | null>(
+          (earliest, event) => (earliest && earliest <= event.startedAt ? earliest : event.startedAt),
+          null,
+        )
       }),
     lastEventAt: (input) =>
       Effect.sync(() => {
         calls.push(input)
-        return inWindow(input).reduce<Date | null>((latest, at) => (latest && latest >= at ? latest : at), null)
+        return inWindow(input).reduce<Date | null>(
+          (latest, event) => (latest && latest >= event.endedAt ? latest : event.endedAt),
+          null,
+        )
       }),
     seriesPerBucket: (input) =>
       Effect.sync(() => {

--- a/packages/domain/monitors/src/testing/index.ts
+++ b/packages/domain/monitors/src/testing/index.ts
@@ -1,3 +1,5 @@
 export { createFakeAlertIncidentStore } from "./fake-alert-incident-store.ts"
+export { createFakeCacheStore } from "./fake-cache-store.ts"
+export type { FakeMetricEvent, FakeMetricEventInput } from "./fake-metric-series-reader.ts"
 export { createFakeMetricSeriesReader } from "./fake-metric-series-reader.ts"
 export { createFakeMonitorRepository } from "./fake-monitor-repository.ts"

--- a/packages/domain/monitors/src/use-cases/check-monitors.test.ts
+++ b/packages/domain/monitors/src/use-cases/check-monitors.test.ts
@@ -21,8 +21,10 @@ import { MetricSeriesReader } from "../ports/metric-series-reader.ts"
 import { MonitorRepository } from "../ports/monitor-repository.ts"
 import {
   createFakeAlertIncidentStore,
+  createFakeCacheStore,
   createFakeMetricSeriesReader,
   createFakeMonitorRepository,
+  type FakeMetricEventInput,
 } from "../testing/index.ts"
 import { checkMonitorsUseCase } from "./check-monitors.ts"
 
@@ -94,10 +96,12 @@ const twoMatches = [new Date("2026-06-23T11:57:00.000Z"), new Date("2026-06-23T1
 
 const layersFor = (
   monitors: readonly Monitor[],
-  matches: readonly Date[],
+  matches: readonly FakeMetricEventInput[],
   savedSearch: { readonly query: string | null; readonly filterSet: FilterSet } = { query: null, filterSet: {} },
   metricReaderLayer?: Layer.Layer<MetricSeriesReader>,
   seedIncidents: readonly Incident[] = [],
+  // Threaded in when a test needs two consecutive checks to share the dedupe markers.
+  cacheStore = createFakeCacheStore(),
 ) => {
   const monitorStore = createFakeMonitorRepository(monitors)
   const incidentStore = createFakeAlertIncidentStore(seedIncidents)
@@ -133,11 +137,13 @@ const layersFor = (
     events,
     incidents: incidentStore.incidents,
     metricCalls: metricReader.calls,
+    dedupeKeys: cacheStore.entries,
     layer: Layer.mergeAll(
       Layer.succeed(MonitorRepository, monitorStore.repo),
       Layer.succeed(SavedSearchRepository, savedSearchStore.repository),
       incidentStore.layer,
       metricReaderLayer ?? metricReader.layer,
+      cacheStore.layer,
       outboxLayer,
       sqlLayer,
       chLayer,
@@ -188,6 +194,119 @@ describe("checkMonitorsUseCase", () => {
         sourceId: MonitorId(cuid("m1")),
       },
     })
+  })
+
+  it("alerts on a long run whose activity is recent but which started before the window (LAT-885)", async () => {
+    const longRun = {
+      id: "long-run",
+      startedAt: new Date("2026-06-23T11:22:00.000Z"),
+      endedAt: new Date("2026-06-23T11:59:00.000Z"),
+    }
+    const { incidents, layer } = layersFor(
+      [monitor({ id: MonitorId(cuid("m-long")), rule: { trigger: "match", config: {}, severity: "medium" } })],
+      [longRun],
+    )
+
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(layer)))
+
+    // Windowed on the run's activity, backdated to when the run began.
+    expect(incidents).toHaveLength(1)
+    expect(incidents[0]).toMatchObject({ startedAt: longRun.startedAt, endedAt: longRun.startedAt })
+  })
+
+  it("alerts once for a run that stays in the activity window across checks", async () => {
+    const longRun = {
+      id: "long-run",
+      startedAt: new Date("2026-06-23T11:22:00.000Z"),
+      endedAt: new Date("2026-06-23T11:59:00.000Z"),
+    }
+    const matchMonitor = monitor({
+      id: MonitorId(cuid("m-dedupe")),
+      rule: { trigger: "match", config: {}, severity: "medium" },
+    })
+    const { events, incidents, dedupeKeys, layer } = layersFor([matchMonitor], [longRun])
+
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(layer)))
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(layer)))
+
+    expect(incidents).toHaveLength(1)
+    expect(events).toHaveLength(1)
+    expect([...dedupeKeys.keys()]).toEqual([
+      `org:${organizationId}:monitors:match-alerted:${matchMonitor.id}:${longRun.id}`,
+    ])
+  })
+
+  it("alerts again for a different run, backdated to that run's start", async () => {
+    const firstRun = {
+      id: "run-1",
+      startedAt: new Date("2026-06-23T11:22:00.000Z"),
+      endedAt: new Date("2026-06-23T11:59:00.000Z"),
+    }
+    const secondRun = {
+      id: "run-2",
+      startedAt: new Date("2026-06-23T11:40:00.000Z"),
+      endedAt: new Date("2026-06-23T11:59:30.000Z"),
+    }
+    const matchMonitor = monitor({
+      id: MonitorId(cuid("m-second")),
+      rule: { trigger: "match", config: {}, severity: "medium" },
+    })
+    const sharedCache = createFakeCacheStore()
+    const first = layersFor([matchMonitor], [firstRun], undefined, undefined, [], sharedCache)
+
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(first.layer)))
+
+    const second = layersFor([matchMonitor], [firstRun, secondRun], undefined, undefined, [], sharedCache)
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(second.layer)))
+
+    expect(first.incidents).toHaveLength(1)
+    expect(first.incidents[0]).toMatchObject({ startedAt: firstRun.startedAt })
+    // Only the new run is alerted for, so the incident backdates to its start, not the first run's.
+    expect(second.incidents).toHaveLength(1)
+    expect(second.incidents[0]).toMatchObject({ startedAt: secondRun.startedAt })
+  })
+
+  it("counts long runs still in the activity window towards a threshold", async () => {
+    const longRuns = [
+      {
+        id: "long-run-1",
+        startedAt: new Date("2026-06-23T11:22:00.000Z"),
+        endedAt: new Date("2026-06-23T11:58:00.000Z"),
+      },
+      {
+        id: "long-run-2",
+        startedAt: new Date("2026-06-23T11:30:00.000Z"),
+        endedAt: new Date("2026-06-23T11:59:00.000Z"),
+      },
+    ]
+    const { incidents, layer } = layersFor([thresholdMonitor()], longRuns)
+
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(layer)))
+
+    expect(incidents).toHaveLength(1)
+    expect(incidents[0]).toMatchObject({
+      startedAt: longRuns[0]?.startedAt,
+      entrySignals: { evaluatedThreshold: 2 },
+    })
+  })
+
+  it("ignores a monitored predicate's fixed date range", async () => {
+    const savedSearch = {
+      query: null,
+      filterSet: {
+        userId: [{ op: "eq" as const, value: "user-1" }],
+        startTime: [{ op: "gte" as const, value: "2026-06-01T00:00:00.000Z" }],
+      },
+    }
+    const { metricCalls, layer } = layersFor(
+      [monitor({ id: MonitorId(cuid("m-range")), rule: { trigger: "match", config: {}, severity: "medium" } })],
+      [new Date("2026-06-23T11:58:00.000Z")],
+      savedSearch,
+    )
+
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(layer)))
+
+    expect(metricCalls[0]?.target.filterSet).toEqual({ userId: savedSearch.filterSet.userId })
   })
 
   it("resolves saved-search targets from the live saved search", async () => {
@@ -455,6 +574,10 @@ describe("checkMonitorsUseCase", () => {
         input.target.filterSet.userId
           ? Effect.fail(new RepositoryError({ operation: "read metric series", cause: new Error("reader failed") }))
           : Effect.succeed(1),
+      matchingEntities: (input) =>
+        input.target.filterSet.userId
+          ? Effect.fail(new RepositoryError({ operation: "read metric series", cause: new Error("reader failed") }))
+          : Effect.succeed([{ id: "entity-good", startTime: firstMatch }]),
       firstEventAt: () => Effect.succeed(firstMatch),
       lastEventAt: () => Effect.succeed(firstMatch),
       seriesPerBucket: () => Effect.succeed([]),
@@ -505,6 +628,8 @@ describe("checkMonitorsUseCase", () => {
   it("reports all monitor failures so the worker can retry systemic outages", async () => {
     const failingMetricLayer = Layer.succeed(MetricSeriesReader, {
       valueInWindow: () =>
+        Effect.fail(new RepositoryError({ operation: "read metric series", cause: new Error("reader failed") })),
+      matchingEntities: () =>
         Effect.fail(new RepositoryError({ operation: "read metric series", cause: new Error("reader failed") })),
       firstEventAt: () => Effect.succeed(null),
       lastEventAt: () => Effect.succeed(null),

--- a/packages/domain/monitors/src/use-cases/check-monitors.ts
+++ b/packages/domain/monitors/src/use-cases/check-monitors.ts
@@ -16,6 +16,7 @@ import {
   AlertIncidentId,
   type AlertMetricThreshold,
   type AlertMetricThresholdDirection,
+  CacheStore,
   type ChSqlClient,
   DEFAULT_ESCALATION_SENSITIVITY,
   generateId,
@@ -27,10 +28,16 @@ import {
 } from "@domain/shared"
 import { SEASONAL_HISTORY_WEEKS } from "@domain/signals"
 import { Effect } from "effect"
-import { SAVED_SEARCH_CURRENT_WINDOW_MS, THRESHOLD_EXIT_DWELL_MS } from "../constants.ts"
+import {
+  MATCH_ALERT_DEDUPE_TTL_SECONDS,
+  matchAlertedDedupeKey,
+  SAVED_SEARCH_CURRENT_WINDOW_MS,
+  THRESHOLD_EXIT_DWELL_MS,
+} from "../constants.ts"
 import type { Monitor } from "../entities/monitor.ts"
 import { monitorConfigCondition } from "../entities/monitor.ts"
-import type { MetricSeriesReaderShape, MetricSeriesTarget } from "../ports/metric-series-reader.ts"
+import { withoutFixedTimeConditions } from "../helpers.ts"
+import type { MatchingEntity, MetricSeriesReaderShape, MetricSeriesTarget } from "../ports/metric-series-reader.ts"
 import { MetricSeriesReader, makeMetricSeriesReaderSeriesReader } from "../ports/metric-series-reader.ts"
 import { MonitorRepository } from "../ports/monitor-repository.ts"
 
@@ -99,7 +106,7 @@ const seasonalThreshold = (
 
 const inlineMonitorTarget = (monitor: Monitor, metric: MonitorMetric = monitor.target.metric): MetricSeriesTarget => ({
   stream: monitor.target.stream,
-  filterSet: monitor.target.filterSet ?? {},
+  filterSet: withoutFixedTimeConditions(monitor.target.filterSet ?? {}),
   query: monitor.target.query,
   metric,
 })
@@ -135,7 +142,7 @@ const resolveMonitorTargets = (monitors: readonly Monitor[]) =>
 
         return {
           stream: monitor.target.stream,
-          filterSet: predicate.filterSet,
+          filterSet: withoutFixedTimeConditions(predicate.filterSet),
           query: predicate.query,
           metric,
         } satisfies MetricSeriesTarget
@@ -163,31 +170,40 @@ const thresholdMetricTarget = (target: MetricSeriesTarget, condition: ThresholdC
   metric: condition.metric,
 })
 
-const evaluateMatchPoint = (
+/** Redis round-trips for the per-entity dedupe markers; a window normally holds a handful of entities. */
+const DEDUPE_LOOKUP_CONCURRENCY = 16
+
+const earliestStart = (entities: readonly MatchingEntity[], fallback: Date): Date =>
+  entities.reduce<Date>((earliest, entity) => (entity.startTime < earliest ? entity.startTime : earliest), fallback)
+
+const dedupeKey = (monitor: Monitor, entity: MatchingEntity): string =>
+  matchAlertedDedupeKey({ organizationId: monitor.organizationId, monitorId: monitor.id, entityId: entity.id })
+
+/**
+ * The entities matching in the current activity window that this monitor has not
+ * alerted for yet. A long run sits in the window on every check while it progresses,
+ * so without the per-entity markers one run would alert on each of them.
+ */
+const newMatchingEntities = (
   monitor: Monitor,
   target: MetricSeriesTarget,
   metricReader: MetricSeriesReaderShape,
   now: Date,
 ) =>
   Effect.gen(function* () {
-    const from = new Date(now.getTime() - SAVED_SEARCH_CURRENT_WINDOW_MS)
-    const matchTarget = { ...target, metric: { kind: "count" as const } }
-    const value = yield* metricReader.valueInWindow({
+    const cacheStore = yield* CacheStore
+    const entities = yield* metricReader.matchingEntities({
       organizationId: monitor.organizationId,
       projectId: monitor.projectId,
-      target: matchTarget,
-      from,
+      target: { ...target, metric: { kind: "count" as const } },
+      from: new Date(now.getTime() - SAVED_SEARCH_CURRENT_WINDOW_MS),
       to: now,
     })
-    if (value <= 0) return null
-    const firstEventAt = yield* metricReader.firstEventAt({
-      organizationId: monitor.organizationId,
-      projectId: monitor.projectId,
-      target: matchTarget,
-      from,
-      to: now,
+    if (entities.length === 0) return []
+    const alerted = yield* Effect.forEach(entities, (entity) => cacheStore.get(dedupeKey(monitor, entity)), {
+      concurrency: DEDUPE_LOOKUP_CONCURRENCY,
     })
-    return { startedAt: firstEventAt ?? now }
+    return entities.filter((_entity, index) => alerted[index] === null)
   })
 
 const computeThresholdValue = (
@@ -286,8 +302,10 @@ export const checkMonitorsUseCase = (input: CheckMonitorsInput) =>
 
     const checkMatchMonitor = (monitor: Monitor, target: MetricSeriesTarget) =>
       Effect.gen(function* () {
-        const point = yield* evaluateMatchPoint(monitor, target, metricReader, now)
-        if (point === null) return
+        const cacheStore = yield* CacheStore
+        const entities = yield* newMatchingEntities(monitor, target, metricReader, now)
+        if (entities.length === 0) return
+        const startedAt = earliestStart(entities, now)
         yield* sqlClient.transaction(
           Effect.gen(function* () {
             const createdAt = new Date()
@@ -298,8 +316,8 @@ export const checkMonitorsUseCase = (input: CheckMonitorsInput) =>
               sourceType: "monitor" as const,
               sourceId: monitor.id,
               severity: monitor.rule.severity,
-              startedAt: point.startedAt,
-              endedAt: point.startedAt,
+              startedAt,
+              endedAt: startedAt,
               createdAt,
               entrySignals: null,
               exitEligibleSince: null,
@@ -320,6 +338,15 @@ export const checkMonitorsUseCase = (input: CheckMonitorsInput) =>
               },
             })
           }),
+        )
+        // Marked only once the incident is committed, so a failed insert retries cleanly. Redis
+        // can't join that transaction, so a marker write that fails after the commit leaves the
+        // entity unmarked and the next check alerts for it again — a duplicate alert, which beats
+        // marking first and silently swallowing the alert when the insert is the thing that fails.
+        yield* Effect.forEach(
+          entities,
+          (entity) => cacheStore.set(dedupeKey(monitor, entity), "1", { ttlSeconds: MATCH_ALERT_DEDUPE_TTL_SECONDS }),
+          { concurrency: DEDUPE_LOOKUP_CONCURRENCY, discard: true },
         )
       })
 
@@ -543,6 +570,7 @@ export const checkMonitorsUseCase = (input: CheckMonitorsInput) =>
     RepositoryError,
     | SqlClient
     | ChSqlClient
+    | CacheStore
     | MonitorRepository
     | IncidentRepository
     | MetricSeriesReader

--- a/packages/platform/db-clickhouse/src/metric-sql/helpers.ts
+++ b/packages/platform/db-clickhouse/src/metric-sql/helpers.ts
@@ -1,8 +1,13 @@
 import type { BehaviorMetric, MomentMetric, MonitorMetric, ScoreMetric } from "@domain/shared"
 import { USAGE_OPERATIONS } from "@domain/spans"
+import type { StreamDescriptor, WindowAnchor } from "./types.ts"
 
 /** ClickHouse `DateTime64` params take a space-separated, zone-naive string (UTC). */
 const toClickHouseDateTime64 = (value: Date): string => value.toISOString().replace("T", " ").replace("Z", "")
+
+/** The column an anchor windows on, falling back to `start` for streams with no end axis. */
+export const anchorColumn = (columns: StreamDescriptor["timeColumns"], anchor: WindowAnchor = "start"): string =>
+  anchor === "end" ? (columns.end ?? columns.start) : columns.start
 
 /** Standard windowing clauses shared by every inner subquery (`[from, to)` on the time axis). */
 export const windowParams = (input: { organizationId: string; projectId: string; from: Date; to: Date }) => ({

--- a/packages/platform/db-clickhouse/src/metric-sql/streams/behaviors.ts
+++ b/packages/platform/db-clickhouse/src/metric-sql/streams/behaviors.ts
@@ -43,5 +43,5 @@ export const behaviorsDescriptor: StreamDescriptor<"behaviors"> = {
   buildInner,
   aggregate: (metric) => behaviorAggregate(metric),
   breakdowns: BREAKDOWN,
-  timeColumn: "start_time",
+  timeColumns: { start: "start_time" },
 }

--- a/packages/platform/db-clickhouse/src/metric-sql/streams/moments.ts
+++ b/packages/platform/db-clickhouse/src/metric-sql/streams/moments.ts
@@ -69,5 +69,5 @@ export const momentsDescriptor: StreamDescriptor<"moments"> = {
   buildInner,
   aggregate: (metric) => momentAggregate(metric),
   breakdowns: BREAKDOWN,
-  timeColumn: "start_time",
+  timeColumns: { start: "start_time" },
 }

--- a/packages/platform/db-clickhouse/src/metric-sql/streams/scores.ts
+++ b/packages/platform/db-clickhouse/src/metric-sql/streams/scores.ts
@@ -96,5 +96,5 @@ export const scoresDescriptor: StreamDescriptor<"scores"> = {
   buildInner,
   aggregate: (metric) => scoreAggregate(metric),
   breakdowns: BREAKDOWN,
-  timeColumn: "created_at",
+  timeColumns: { start: "created_at" },
 }

--- a/packages/platform/db-clickhouse/src/metric-sql/streams/sessions.ts
+++ b/packages/platform/db-clickhouse/src/metric-sql/streams/sessions.ts
@@ -8,8 +8,10 @@ import {
   LIST_SELECT,
   resolvePercentileFilters,
 } from "../../repositories/session-repository.ts"
-import { type TraceFamilyColumns, traceFamilyAggregate, windowParams } from "../helpers.ts"
+import { anchorColumn, type TraceFamilyColumns, traceFamilyAggregate, windowParams } from "../helpers.ts"
 import type { BreakdownExpr, InnerQuery, MetricSqlInput, StreamDescriptor } from "../types.ts"
+
+const TIME_COLUMNS = { start: "start_time", end: "end_time" } as const
 
 // Sessions share the trace rollup columns; each inner row is already one session,
 // so the count is a plain row count rather than a trace/session dedup.
@@ -38,9 +40,10 @@ const BREAKDOWN = {
 
 /**
  * The grouped per-session subquery. The window is a `HAVING` on the aggregated
- * `start_time`, combined with the target's filters and (optionally) a semantic
- * query: the trace-grained search plan resolves to its sessions via the `traces`
- * rollup, restricting the session set with `session_id IN (…)`.
+ * `start_time` (or `end_time` when the caller anchors on activity), combined with
+ * the target's filters and (optionally) a semantic query: the trace-grained search
+ * plan resolves to its sessions via the `traces` rollup, restricting the session
+ * set with `session_id IN (…)`.
  */
 const buildInner = (input: MetricSqlInput): Effect.Effect<InnerQuery, RepositoryError | ValidationError, ChSqlClient> =>
   Effect.gen(function* () {
@@ -71,9 +74,10 @@ const buildInner = (input: MetricSqlInput): Effect.Effect<InnerQuery, Repository
     }
 
     const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
+    const windowColumn = anchorColumn(TIME_COLUMNS, input.windowAnchor)
     const having = [
-      "start_time >= toDateTime64({windowFrom:String}, 9, 'UTC')",
-      "start_time < toDateTime64({windowTo:String}, 9, 'UTC')",
+      `${windowColumn} >= toDateTime64({windowFrom:String}, 9, 'UTC')`,
+      `${windowColumn} < toDateTime64({windowTo:String}, 9, 'UTC')`,
       ...havingClauses,
     ].join(" AND ")
 
@@ -104,5 +108,6 @@ export const sessionsDescriptor: StreamDescriptor<"sessions"> = {
   buildInner,
   aggregate: (metric) => traceFamilyAggregate(metric, COLUMNS),
   breakdowns: BREAKDOWN,
-  timeColumn: "start_time",
+  timeColumns: TIME_COLUMNS,
+  entityIdExpr: "session_id",
 }

--- a/packages/platform/db-clickhouse/src/metric-sql/streams/spans.ts
+++ b/packages/platform/db-clickhouse/src/metric-sql/streams/spans.ts
@@ -2,8 +2,10 @@ import type { SpanBreakdownField, ValidationError } from "@domain/shared"
 import { Effect } from "effect"
 import { runFilterBuild } from "../../filter-builder.ts"
 import { buildSpanFilterClauses } from "../../registries/span-fields.ts"
-import { type TraceFamilyColumns, traceFamilyAggregate, usageGated, windowParams } from "../helpers.ts"
+import { anchorColumn, type TraceFamilyColumns, traceFamilyAggregate, usageGated, windowParams } from "../helpers.ts"
 import type { BreakdownExpr, InnerQuery, MetricSqlInput, StreamDescriptor } from "../types.ts"
+
+const TIME_COLUMNS = { start: "start_time", end: "end_time" } as const
 
 // Spans are row-grained; cost/tokens are gated to billable operations (NULL
 // otherwise) so sum/avg ignore wrapper + tool spans, while count/errorRate/
@@ -33,21 +35,25 @@ const BREAKDOWN = {
 
 /**
  * Per-span subquery: one row per span, windowed on the span's own `start_time`
- * (plain WHERE — no aggregation), filtered by the row-local span predicate. The
- * outer metric then aggregates these rows (no dedup — same convention as
- * tool-analytics over `execute_tool` spans).
+ * (or `end_time` when the caller anchors on activity) with a plain WHERE — no
+ * aggregation — filtered by the row-local span predicate. The outer metric then
+ * aggregates these rows (no dedup — same convention as tool-analytics over
+ * `execute_tool` spans).
  */
 const buildInner = (input: MetricSqlInput): Effect.Effect<InnerQuery, ValidationError, never> =>
   Effect.gen(function* () {
     const { whereClauses, params: filterParams } = yield* runFilterBuild(() => buildSpanFilterClauses(input.filterSet))
     const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
+    // The end anchor forfeits the `start_time` partition/sort-key pruning by design:
+    // bounding `start_time` too would drop spans that outlive the window.
+    const windowColumn = anchorColumn(TIME_COLUMNS, input.windowAnchor)
     return {
-      sql: `SELECT span_id, start_time, status_code, operation, model, provider, service_name, tool_name, tags, duration_ns, cost_total_microcents, tokens_input, tokens_output, tokens_cache_read, tokens_cache_create
+      sql: `SELECT span_id, start_time, end_time, status_code, operation, model, provider, service_name, tool_name, tags, duration_ns, cost_total_microcents, tokens_input, tokens_output, tokens_cache_read, tokens_cache_create
           FROM spans
           WHERE organization_id = {organizationId:String}
             AND project_id = {projectId:String}
-            AND start_time >= toDateTime64({windowFrom:String}, 9, 'UTC')
-            AND start_time < toDateTime64({windowTo:String}, 9, 'UTC')
+            AND ${windowColumn} >= toDateTime64({windowFrom:String}, 9, 'UTC')
+            AND ${windowColumn} < toDateTime64({windowTo:String}, 9, 'UTC')
             ${extraWhere}`,
       params: {
         ...windowParams({
@@ -65,5 +71,6 @@ export const spansDescriptor: StreamDescriptor<"spans"> = {
   buildInner,
   aggregate: (metric) => traceFamilyAggregate(metric, COLUMNS),
   breakdowns: BREAKDOWN,
-  timeColumn: "start_time",
+  timeColumns: TIME_COLUMNS,
+  entityIdExpr: "span_id",
 }

--- a/packages/platform/db-clickhouse/src/metric-sql/streams/traces.ts
+++ b/packages/platform/db-clickhouse/src/metric-sql/streams/traces.ts
@@ -4,11 +4,17 @@ import { Effect } from "effect"
 import { runFilterBuild } from "../../filter-builder.ts"
 import { isActiveSearch, planSearch } from "../../repositories/search-plan.ts"
 import { buildTraceFilterClauses, LIST_SELECT, resolvePercentileFilters } from "../../repositories/trace-repository.ts"
-import { type TraceFamilyColumns, traceFamilyAggregate, windowParams } from "../helpers.ts"
+import { anchorColumn, type TraceFamilyColumns, traceFamilyAggregate, windowParams } from "../helpers.ts"
 import type { BreakdownExpr, InnerQuery, MetricSqlInput, StreamDescriptor } from "../types.ts"
 
+const TIME_COLUMNS = { start: "start_time", end: "end_time" } as const
+
+// A trace whose spans carry a session id counts as its session, so a session's
+// traces collapse to one entity — `ENTITY_ID_EXPR` must stay at this grain.
+const ENTITY_ID_EXPR = "coalesce(nullIf(session_id, ''), toString(trace_id))"
+
 const COLUMNS: TraceFamilyColumns = {
-  count: "uniqExact(coalesce(nullIf(session_id, ''), toString(trace_id)))",
+  count: `uniqExact(${ENTITY_ID_EXPR})`,
   isError: "error_count > 0",
   duration: "duration_ns",
   cost: "cost_total_microcents",
@@ -31,7 +37,8 @@ const BREAKDOWN = {
 
 /**
  * The grouped per-trace subquery: filters + percentile resolution + an optional
- * semantic-query prefilter, windowed on the aggregated `start_time`.
+ * semantic-query prefilter, windowed on the aggregated `start_time` (or
+ * `end_time` when the caller anchors on activity).
  */
 const buildInner = (input: MetricSqlInput): Effect.Effect<InnerQuery, RepositoryError | ValidationError, ChSqlClient> =>
   Effect.gen(function* () {
@@ -54,9 +61,10 @@ const buildInner = (input: MetricSqlInput): Effect.Effect<InnerQuery, Repository
       clickhouseSettings = plan.clickhouseSettings
     }
 
+    const windowColumn = anchorColumn(TIME_COLUMNS, input.windowAnchor)
     const having = [
-      "start_time >= toDateTime64({windowFrom:String}, 9, 'UTC')",
-      "start_time < toDateTime64({windowTo:String}, 9, 'UTC')",
+      `${windowColumn} >= toDateTime64({windowFrom:String}, 9, 'UTC')`,
+      `${windowColumn} < toDateTime64({windowTo:String}, 9, 'UTC')`,
       ...havingClauses,
     ].join(" AND ")
 
@@ -87,5 +95,6 @@ export const tracesDescriptor: StreamDescriptor<"traces"> = {
   buildInner,
   aggregate: (metric) => traceFamilyAggregate(metric, COLUMNS),
   breakdowns: BREAKDOWN,
-  timeColumn: "start_time",
+  timeColumns: TIME_COLUMNS,
+  entityIdExpr: ENTITY_ID_EXPR,
 }

--- a/packages/platform/db-clickhouse/src/metric-sql/types.ts
+++ b/packages/platform/db-clickhouse/src/metric-sql/types.ts
@@ -13,6 +13,14 @@ import type {
 } from "@domain/shared"
 import type { Effect } from "effect"
 
+/**
+ * Which end of an entity's lifespan the `[from, to)` window filters on. Monitors
+ * window on `"end"` (an entity qualifies when its latest activity lands in the
+ * window, so a long run is still visible when it finishes); analytics,
+ * experiments and the dashboards window on `"start"`.
+ */
+export type WindowAnchor = "start" | "end"
+
 /** The metric vocabulary a given stream accepts — each non-trace stream has its own; the rest are trace-family. */
 export type MetricForStream<S extends AnalyticsStream> = S extends "scores"
   ? ScoreMetric
@@ -49,6 +57,8 @@ export interface MetricSqlInput<S extends AnalyticsStream = AnalyticsStream> {
   readonly from: Date
   /** Exclusive upper bound. */
   readonly to: Date
+  /** The time axis the window filters on. Defaults to `"start"`; only the monitor firing path passes `"end"`. */
+  readonly windowAnchor?: WindowAnchor
 }
 
 export type InnerQuery = {
@@ -81,6 +91,17 @@ export interface StreamDescriptor<S extends AnalyticsStream = AnalyticsStream> {
   aggregate(metric: MetricForStream<S>): string
   /** Breakdown dimensions this stream exposes (logical field → SQL expression). */
   readonly breakdowns: Record<string, BreakdownExpr>
-  /** The inner column to bucket on for time series. */
-  readonly timeColumn: string
+  /**
+   * The inner columns to window and bucket on, per anchor. `end` is absent on
+   * streams whose rows are a point in time rather than a lifespan (a score, a
+   * behavior observation, a moment) — those are unreachable from monitors, so
+   * they never see a non-default anchor.
+   */
+  readonly timeColumns: { readonly start: string; readonly end?: string }
+  /**
+   * The inner expression identifying the entity a row belongs to, at the same
+   * grain as {@link aggregate}'s `count` dedup. Monitors read it to alert once
+   * per matching run; only the monitor streams need it.
+   */
+  readonly entityIdExpr?: string
 }

--- a/packages/platform/db-clickhouse/src/repositories/analytics-query-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/analytics-query-repository.test.ts
@@ -433,4 +433,19 @@ describe("AnalyticsQueryReaderLive (traces)", () => {
     expect((await run(momentsInput({ metric: { kind: "avg", field: "confidence" } })))[0]?.value).toBeCloseTo(0.6, 5)
     expect((await run(momentsInput({ metric: { kind: "avg", field: "coherence" } })))[0]?.value).toBeCloseTo(0.7, 5)
   })
+
+  it("attributes a trace to the range it started in, even when it ends after it", async () => {
+    // Analytics stays start-anchored while monitors window on activity; a trace that
+    // starts at 23:50 and runs 30 min belongs to the day it started.
+    const day11From = new Date("2026-06-11T00:00:00.000Z")
+    const day11To = new Date("2026-06-12T00:00:00.000Z")
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [
+        span(71, new Date("2026-06-11T23:50:00.000Z"), { durationMs: 30 * 60 * 1000 }),
+      ]),
+    )
+
+    expect(await run(tracesInput({ from: day11From, to: day11To }))).toEqual([{ value: 1 }])
+    expect(await run(tracesInput({ from: day11To, to: new Date("2026-06-13T00:00:00.000Z") }))).toEqual([{ value: 0 }])
+  })
 })

--- a/packages/platform/db-clickhouse/src/repositories/analytics-query-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/analytics-query-repository.ts
@@ -79,7 +79,7 @@ const make = (): AnalyticsQueryReaderShape => ({
         groupParts.push("key")
       }
       if (input.timeBucket) {
-        selectParts.push(`${bucketExpr(input.timeBucket, descriptor.timeColumn)} AS bucket_start`)
+        selectParts.push(`${bucketExpr(input.timeBucket, descriptor.timeColumns.start)} AS bucket_start`)
         groupParts.push("bucket_start")
       }
       selectParts.push(`${aggregate} AS value`)

--- a/packages/platform/db-clickhouse/src/repositories/metric-series-reader.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/metric-series-reader.test.ts
@@ -179,7 +179,7 @@ describe("MetricSeriesReaderLive (traces / count)", () => {
 
   const target = countTarget()
 
-  it("counts only traces whose start_time falls in [from, to)", async () => {
+  it("counts only traces whose activity falls in [from, to)", async () => {
     // [10:00, 11:00) includes t10 + t1030 (and the 'other'-tagged trace at t1030); excludes t11.
     const count = await runCh(
       reader.valueInWindow({ organizationId: ORG_ID, projectId: PROJECT_ID, target, from: t10, to: t11 }),
@@ -214,12 +214,13 @@ describe("MetricSeriesReaderLive (traces / count)", () => {
     expect(first).toBeNull()
   })
 
-  it("returns the latest matching trace start_time", async () => {
-    // [10:00, 11:00) includes t10 + t1030; t11 == the exclusive upper bound is excluded ⇒ latest is t1030.
+  it("returns the latest matching trace end_time", async () => {
+    // [10:00, 11:00) includes t10 + t1030; t11's trace ends past the upper bound and is
+    // excluded ⇒ the latest activity is t1030's 1s-long span.
     const last = await runCh(
       reader.lastEventAt({ organizationId: ORG_ID, projectId: PROJECT_ID, target, from: t10, to: t11 }),
     )
-    expect(last).toEqual(t1030)
+    expect(last).toEqual(new Date(t1030.getTime() + 1_000))
   })
 
   it("returns null from lastEventAt when no trace matches the window", async () => {
@@ -261,10 +262,11 @@ describe("MetricSeriesReaderLive (traces / count)", () => {
   })
 
   it("buckets matches newest-first, zero-filled, aligned to `to`", async () => {
-    // [09:30, 11:00) tiled into 3×30-min buckets aligned to 11:00 (newest-first):
-    //   idx 0 = (10:30, 11:00) → empty (t11 == `to` is excluded)
-    //   idx 1 = (10:00, 10:30] → t1030 (+ the 'other'-tagged trace, no filter applied) → 2
-    //   idx 2 = (09:30, 10:00] → t10 → 1
+    // [09:30, 11:00) tiled into 3×30-min buckets aligned to 11:00 (newest-first). Buckets
+    // key on activity, and every fixture span runs 1s past its start:
+    //   idx 0 = (10:30, 11:00) → t1030 ends 10:30:01 (+ the 'other'-tagged trace) → 2
+    //   idx 1 = (10:00, 10:30] → t10 ends 10:00:01 → 1
+    //   idx 2 = (09:30, 10:00] → empty (t11's trace ends past `to` and is excluded)
     const counts = await runCh(
       reader.seriesPerBucket({
         organizationId: ORG_ID,
@@ -275,7 +277,7 @@ describe("MetricSeriesReaderLive (traces / count)", () => {
         bucketMs: 30 * 60 * 1000,
       }),
     )
-    expect(counts).toEqual([0, 2, 1])
+    expect(counts).toEqual([2, 1, 0])
   })
 
   it("honours the structured filters per bucket", async () => {
@@ -290,8 +292,8 @@ describe("MetricSeriesReaderLive (traces / count)", () => {
         bucketMs: 30 * 60 * 1000,
       }),
     )
-    // The 'other'-tagged trace at 10:30 is dropped by the tag filter → idx 1 falls to 1.
-    expect(counts).toEqual([0, 1, 1])
+    // The 'other'-tagged trace at 10:30 is dropped by the tag filter → idx 0 falls to 1.
+    expect(counts).toEqual([1, 1, 0])
   })
 
   it("computes errorRate / avg / sum / min / max / median over the matched traces", async () => {
@@ -500,5 +502,132 @@ describe("MetricSeriesReaderLive (traces / count)", () => {
       }),
     )
     expect(counts).toEqual([1, 1])
+  })
+})
+
+// Runs whose start and end sit on opposite sides of the window edge.
+describe("MetricSeriesReaderLive (activity window)", () => {
+  let reader: MetricSeriesReaderShape
+
+  beforeAll(async () => {
+    reader = await Effect.runPromise(
+      Effect.gen(function* () {
+        return yield* MetricSeriesReader
+      }).pipe(Effect.provide(MetricSeriesReaderLive)),
+    )
+  })
+
+  const runStart = new Date("2026-06-03T12:00:00.000Z")
+  const runLatestSpan = new Date("2026-06-03T12:58:00.000Z")
+  const runLatestActivity = new Date("2026-06-03T12:58:01.000Z")
+  const windowFrom = new Date("2026-06-03T12:55:00.000Z")
+  const windowTo = new Date("2026-06-03T13:00:00.000Z")
+
+  // Extra spans on an existing trace, so its `start_time` stays old while its `end_time` advances.
+  const spanOnTrace = (spanN: number, traceN: number, startTime: Date, durationMs = 1_000): SpanRow => ({
+    ...span(spanN, startTime, [TAG], durationMs),
+    trace_id: traceId(traceN),
+  })
+
+  const spanInSession = (spanN: number, traceN: number, sessionId: string, startTime: Date): SpanRow => ({
+    ...spanOnTrace(spanN, traceN, startTime),
+    session_id: sessionId,
+  })
+
+  // A 58-minute run that is still emitting, plus a short run that finished before the window.
+  const longRunFixtures = [
+    spanOnTrace(101, 101, runStart),
+    spanOnTrace(102, 101, runLatestSpan),
+    spanOnTrace(201, 201, new Date("2026-06-03T11:58:00.000Z")),
+  ]
+
+  const window = { organizationId: ORG_ID, projectId: PROJECT_ID, from: windowFrom, to: windowTo }
+
+  it("counts a run that started before the window but is still active inside it", async () => {
+    await Effect.runPromise(insertJsonEachRow(ch.client, "spans", longRunFixtures))
+
+    const count = await runCh(reader.valueInWindow({ ...window, target: countTarget() }))
+
+    // The run's start_time (12:00) is 55 min before the window; only its activity is inside.
+    expect(count).toBe(1)
+  })
+
+  it("backdates firstEventAt to the run's start while lastEventAt follows its activity", async () => {
+    await Effect.runPromise(insertJsonEachRow(ch.client, "spans", longRunFixtures))
+
+    expect(await runCh(reader.firstEventAt({ ...window, target: countTarget() }))).toEqual(runStart)
+    expect(await runCh(reader.lastEventAt({ ...window, target: countTarget() }))).toEqual(runLatestActivity)
+  })
+
+  it("itemises matching entities with their start times", async () => {
+    await Effect.runPromise(insertJsonEachRow(ch.client, "spans", longRunFixtures))
+
+    const entities = await runCh(reader.matchingEntities({ ...window, target: countTarget() }))
+
+    expect(entities).toEqual([{ id: traceId(101), startTime: runStart }])
+  })
+
+  it("folds a session's traces into one entity on the traces stream", async () => {
+    // Two traces of one session, each still active inside the window.
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [
+        spanInSession(301, 301, "session-a", runStart),
+        spanInSession(302, 301, "session-a", runLatestSpan),
+        spanInSession(303, 302, "session-a", runLatestSpan),
+      ]),
+    )
+
+    const entities = await runCh(reader.matchingEntities({ ...window, target: countTarget() }))
+
+    expect(entities).toEqual([{ id: "session-a", startTime: runStart }])
+    // Same grain the count metric reports.
+    expect(await runCh(reader.valueInWindow({ ...window, target: countTarget() }))).toBe(1)
+  })
+
+  it("itemises sessions by session id on the sessions stream", async () => {
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [
+        spanInSession(301, 301, "session-a", runStart),
+        spanInSession(302, 301, "session-a", runLatestSpan),
+      ]),
+    )
+
+    const entities = await runCh(reader.matchingEntities({ ...window, target: sessionTarget({ kind: "count" }) }))
+
+    expect(entities).toEqual([{ id: "session-a", startTime: runStart }])
+  })
+
+  it("windows the spans stream on the span's own end_time", async () => {
+    // One 38-minute span: starts 55 min before the window, ends inside it.
+    const longSpanStart = new Date("2026-06-03T12:20:00.000Z")
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [spanOnTrace(401, 401, longSpanStart, 38 * 60 * 1000)]),
+    )
+    const spansCount = spanTarget({ kind: "count" }, {})
+
+    expect(await runCh(reader.valueInWindow({ ...window, target: spansCount }))).toBe(1)
+    expect(await runCh(reader.matchingEntities({ ...window, target: spansCount }))).toEqual([
+      { id: spanId(401), startTime: longSpanStart },
+    ])
+  })
+
+  it("buckets a long run by its activity, not by its start", async () => {
+    await Effect.runPromise(insertJsonEachRow(ch.client, "spans", longRunFixtures))
+
+    // [12:00, 13:00) into 2×30-min buckets aligned to 13:00. The run's activity (12:58:01)
+    // lands in the newest bucket; its start (12:00) would fall outside the tiling entirely
+    // and be dropped by the densify loop.
+    const counts = await runCh(
+      reader.seriesPerBucket({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        target: countTarget(),
+        from: runStart,
+        to: windowTo,
+        bucketMs: 30 * 60 * 1000,
+      }),
+    )
+
+    expect(counts).toEqual([1, 0])
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/metric-series-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/metric-series-reader.ts
@@ -1,14 +1,26 @@
 import type { ClickHouseClient } from "@clickhouse/client"
 import {
+  type MatchingEntity,
   type MetricSeriesBucketInput,
   MetricSeriesReader,
   type MetricSeriesReaderShape,
   type MetricSeriesWindowInput,
 } from "@domain/monitors"
 import { ChSqlClient, type ChSqlClientShape, toRepositoryError } from "@domain/shared"
+import { normalizeCHString } from "@repo/utils"
 import { Effect, Layer } from "effect"
+import { anchorColumn } from "../metric-sql/helpers.ts"
 import { streamFor } from "../metric-sql/index.ts"
 
+/**
+ * Most entities a single match check itemises. Alerting still fires past the cap;
+ * the entities beyond it just go unrecorded and may alert again next window.
+ */
+const MATCH_ENTITY_LIMIT = 1000
+
+// Monitors evaluate on the activity axis: a run enters the window when its latest span
+// ended, not when it started, so a run longer than the window can still alert. Only this
+// reader anchors that way; analytics and experiments stay start-anchored.
 const toSqlInput = (input: MetricSeriesWindowInput) => ({
   organizationId: input.organizationId,
   projectId: input.projectId,
@@ -17,7 +29,15 @@ const toSqlInput = (input: MetricSeriesWindowInput) => ({
   metric: input.target.metric,
   from: input.from,
   to: input.to,
+  windowAnchor: "end" as const,
 })
+
+/** ClickHouse `DateTime64` renders as `YYYY-MM-DD hh:mm:ss.fff`, which `Date` only parses once made ISO. */
+const parseChDate = (value: string | null | undefined): Date | null => {
+  if (!value) return null
+  const parsed = new Date(value.includes(" ") ? `${value.replace(" ", "T")}Z` : value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
 
 const make = (): MetricSeriesReaderShape => ({
   valueInWindow: (input) =>
@@ -41,17 +61,61 @@ const make = (): MetricSeriesReaderShape => ({
           Effect.mapError((error) => toRepositoryError(error, "MetricSeriesReader.valueInWindow")),
         )
     }),
+  matchingEntities: (input) =>
+    Effect.gen(function* () {
+      const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+      const descriptor = streamFor(input.target.stream)
+      const entityIdExpr = descriptor.entityIdExpr
+      if (entityIdExpr === undefined) {
+        return yield* Effect.fail(
+          toRepositoryError(
+            new Error(`Stream '${input.target.stream}' has no entity grain`),
+            "MetricSeriesReader.matchingEntities",
+          ),
+        )
+      }
+      const inner = yield* descriptor.buildInner(toSqlInput(input))
+      const startColumn = descriptor.timeColumns.start
+      const rows = yield* chSqlClient
+        .query(async (client) => {
+          const result = await client.query({
+            // Group by the entity grain: the traces grain folds a session's traces
+            // into one entity, so several inner rows can share an id.
+            query: `SELECT ${entityIdExpr} AS entity_id, toString(min(${startColumn})) AS started_at
+                    FROM (${inner.sql})
+                    GROUP BY entity_id
+                    ORDER BY min(${startColumn}) ASC
+                    LIMIT ${MATCH_ENTITY_LIMIT}`,
+            query_params: inner.params,
+            ...(inner.clickhouseSettings ? { clickhouse_settings: inner.clickhouseSettings } : {}),
+            format: "JSONEachRow",
+          })
+          return result.json<{ entity_id: string; started_at: string | null }>()
+        })
+        .pipe(Effect.mapError((error) => toRepositoryError(error, "MetricSeriesReader.matchingEntities")))
+      if (rows.length === MATCH_ENTITY_LIMIT) {
+        yield* Effect.annotateCurrentSpan("monitors.matchingEntitiesTruncated", true)
+      }
+      return rows.flatMap((row): MatchingEntity[] => {
+        const id = normalizeCHString(row.entity_id)
+        const startTime = parseChDate(row.started_at)
+        return id === "" || startTime === null ? [] : [{ id, startTime }]
+      })
+    }),
   firstEventAt: (input) =>
     Effect.gen(function* () {
       const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
       const descriptor = streamFor(input.target.stream)
       const inner = yield* descriptor.buildInner(toSqlInput(input))
+      // Deliberately the start axis while the window filters on the end axis: an
+      // incident points at when the offending run began, not at when it alerted.
+      const startColumn = descriptor.timeColumns.start
       return yield* chSqlClient
         .query(async (client) => {
           const result = await client.query({
             // `count()` guards the empty case — `min()` over zero rows returns the
             // epoch, not NULL, so we'd otherwise report a bogus 1970 first event.
-            query: `SELECT toString(min(start_time)) AS first_at, count() AS matches FROM (${inner.sql})`,
+            query: `SELECT toString(min(${startColumn})) AS first_at, count() AS matches FROM (${inner.sql})`,
             query_params: inner.params,
             ...(inner.clickhouseSettings ? { clickhouse_settings: inner.clickhouseSettings } : {}),
             format: "JSONEachRow",
@@ -61,9 +125,8 @@ const make = (): MetricSeriesReaderShape => ({
         .pipe(
           Effect.map((rows) => {
             const row = rows[0]
-            if (!row || Number(row.matches) === 0 || !row.first_at) return null
-            const parsed = new Date(row.first_at.includes(" ") ? `${row.first_at.replace(" ", "T")}Z` : row.first_at)
-            return Number.isNaN(parsed.getTime()) ? null : parsed
+            if (!row || Number(row.matches) === 0) return null
+            return parseChDate(row.first_at)
           }),
           Effect.mapError((error) => toRepositoryError(error, "MetricSeriesReader.firstEventAt")),
         )
@@ -73,12 +136,13 @@ const make = (): MetricSeriesReaderShape => ({
       const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
       const descriptor = streamFor(input.target.stream)
       const inner = yield* descriptor.buildInner(toSqlInput(input))
+      const endColumn = anchorColumn(descriptor.timeColumns, "end")
       return yield* chSqlClient
         .query(async (client) => {
           const result = await client.query({
             // `count()` guards the empty case — `max()` over zero rows returns the
             // epoch, not NULL, so we'd otherwise report a bogus 1970 last event.
-            query: `SELECT toString(max(start_time)) AS last_at, count() AS matches FROM (${inner.sql})`,
+            query: `SELECT toString(max(${endColumn})) AS last_at, count() AS matches FROM (${inner.sql})`,
             query_params: inner.params,
             ...(inner.clickhouseSettings ? { clickhouse_settings: inner.clickhouseSettings } : {}),
             format: "JSONEachRow",
@@ -88,9 +152,8 @@ const make = (): MetricSeriesReaderShape => ({
         .pipe(
           Effect.map((rows) => {
             const row = rows[0]
-            if (!row || Number(row.matches) === 0 || !row.last_at) return null
-            const parsed = new Date(row.last_at.includes(" ") ? `${row.last_at.replace(" ", "T")}Z` : row.last_at)
-            return Number.isNaN(parsed.getTime()) ? null : parsed
+            if (!row || Number(row.matches) === 0) return null
+            return parseChDate(row.last_at)
           }),
           Effect.mapError((error) => toRepositoryError(error, "MetricSeriesReader.lastEventAt")),
         )
@@ -102,16 +165,18 @@ const make = (): MetricSeriesReaderShape => ({
       const inner = yield* descriptor.buildInner(toSqlInput(input))
       const aggregate = descriptor.aggregate(input.target.metric)
       const bucketCount = Math.max(0, Math.floor((input.to.getTime() - input.from.getTime()) / input.bucketMs))
-      // Bucket each matching trace by how far its `start_time` sits before `to`,
-      // in `bucketNs` (= bucketMs) steps — index 0 is the bucket ending at `to`.
-      // ClickHouse only returns non-empty buckets, so we densify to `bucketCount`
-      // zero-filled entries in code.
+      // Bucket each match by how far its activity sits before `to`, in `bucketNs`
+      // (= bucketMs) steps — index 0 is the bucket ending at `to`. Must be the same
+      // column the window filters on, or in-window rows land on out-of-range indexes
+      // and the densify loop below drops them. ClickHouse only returns non-empty
+      // buckets, so we densify to `bucketCount` zero-filled entries in code.
+      const bucketColumn = anchorColumn(descriptor.timeColumns, "end")
       const rows = yield* chSqlClient
         .query(async (client) => {
           const result = await client.query({
             query: `SELECT
                       intDiv(
-                        reinterpretAsInt64(toDateTime64({windowTo:String}, 9, 'UTC')) - reinterpretAsInt64(start_time),
+                        reinterpretAsInt64(toDateTime64({windowTo:String}, 9, 'UTC')) - reinterpretAsInt64(${bucketColumn}),
                         {bucketNs:Int64}
                       ) AS bucket_index,
                       ${aggregate} AS value

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
@@ -178,7 +178,12 @@ const makeIncidentRepository = (): IncidentRepositoryShape =>
                 eq(incidents.organizationId, organizationId),
                 eq(incidents.projectId, projectId),
                 to ? lte(incidents.startedAt, to) : undefined,
-                from ? or(isNull(incidents.endedAt), gte(incidents.endedAt, from)) : undefined,
+                // `created_at` widens the lower bound past the incident's own lifetime: a match
+                // incident is a single instant backdated to the start of the run it matched, so
+                // one raised inside the window can have ended before it began.
+                from
+                  ? or(isNull(incidents.endedAt), gte(incidents.endedAt, from), gte(incidents.createdAt, from))
+                  : undefined,
                 sourceTypes && sourceTypes.length > 0 ? inArray(incidents.sourceType, sourceTypes) : undefined,
                 sourceId ? eq(incidents.sourceId, sourceId) : undefined,
                 severities && severities.length > 0 ? inArray(incidents.severity, severities) : undefined,

--- a/packages/platform/db-postgres/src/repositories/incident-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/incident-repository.test.ts
@@ -48,6 +48,50 @@ afterEach(async () => {
 })
 
 describe("IncidentRepositoryLive", () => {
+  it("returns a backdated match incident for the window it was raised in", async () => {
+    // A match incident is one instant, backdated to the start of the run it matched: this one
+    // points at 09:00 but only fired at 10:30, so a lifetime-only overlap test would hide it
+    // from the very window a user is looking at.
+    const backdated = makeIncident({
+      startedAt: new Date("2026-06-23T09:00:00.000Z"),
+      endedAt: new Date("2026-06-23T09:00:00.000Z"),
+      createdAt: new Date("2026-06-23T10:30:00.000Z"),
+      condition: null,
+    })
+    await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* IncidentRepositoryTag
+        yield* repo.insert(backdated)
+      }),
+    )
+
+    const raisedWindow = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* IncidentRepositoryTag
+        return yield* repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          from: new Date("2026-06-23T10:00:00.000Z"),
+          to: new Date("2026-06-23T11:00:00.000Z"),
+        })
+      }),
+    )
+    expect(raisedWindow.map((incident) => incident.id)).toEqual([backdated.id])
+
+    const laterWindow = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* IncidentRepositoryTag
+        return yield* repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          from: new Date("2026-06-23T11:00:00.000Z"),
+          to: new Date("2026-06-23T12:00:00.000Z"),
+        })
+      }),
+    )
+    expect(laterWindow).toHaveLength(0)
+  })
+
   it("inserts and finds incidents in the current org scope", async () => {
     const incident = makeIncident()
 

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
@@ -1,7 +1,8 @@
 import { type Monitor, MonitorRepository } from "@domain/monitors"
-import { MonitorId, OrganizationId, ProjectId, type SqlClient } from "@domain/shared"
+import { AlertIncidentId, MonitorId, OrganizationId, ProjectId, type SqlClient } from "@domain/shared"
 import { Effect } from "effect"
 import { beforeEach, describe, expect, it } from "vitest"
+import { incidents } from "../schema/alert-incidents.ts"
 import { monitors } from "../schema/monitors.ts"
 import { setupTestPostgres } from "../test/in-memory-postgres.ts"
 import { withPostgres } from "../with-postgres.ts"
@@ -128,5 +129,81 @@ describe("MonitorRepositoryLive target round-trip", () => {
 
     const loaded = await findById("metric")
     expect(loaded.target.metric).toEqual({ kind: "sum", field: "cost" })
+  })
+
+  it("persists a predicate that only the target carries, so an API-created monitor keeps its filters", async () => {
+    const filterSet = { userId: [{ op: "eq" as const, value: "user-1" }] }
+    await create(
+      makeMonitor(
+        "target-only-filters",
+        {
+          type: "user",
+          id: null,
+          filterSet,
+          kind: "user",
+          stream: "traces",
+          query: null,
+          savedSearchId: null,
+          metric: { kind: "count" },
+        },
+        // The public API builds its rule config from metric/condition alone; the predicate
+        // arrives on the target, and evaluating without it would watch the whole project.
+        { trigger: "match", config: { metric: { kind: "count" } }, severity: "low" },
+      ),
+    )
+
+    const loaded = await findById("target-only-filters")
+    expect(loaded.target.filterSet).toEqual(filterSet)
+    expect(loaded.rule.config.filterSet).toEqual(filterSet)
+  })
+})
+
+describe("MonitorRepositoryLive list ordering", () => {
+  beforeEach(async () => {
+    await pg.db.delete(incidents)
+    await pg.db.delete(monitors)
+  })
+
+  const insertIncident = async (monitorId: string, startedAt: Date, createdAt: Date) => {
+    await pg.db.insert(incidents).values({
+      id: AlertIncidentId(`inc-${monitorId}`.padEnd(24, "x").slice(0, 24)),
+      organizationId: ORG_ID,
+      projectId: PROJECT_ID,
+      sourceType: "monitor",
+      sourceId: MonitorId(monitorId.padEnd(24, "x").slice(0, 24)),
+      severity: "medium",
+      startedAt,
+      endedAt: startedAt,
+      createdAt,
+    })
+  }
+
+  // The page is cut server-side, so a monitor that just fired has to rank high here — the client
+  // comparator only reorders what this query already returned.
+  it("ranks monitors by when their last incident was raised, not by its backdated start", async () => {
+    const userTarget: Monitor["target"] = {
+      type: "user",
+      id: null,
+      kind: "user",
+      stream: "traces",
+      query: null,
+      savedSearchId: null,
+      metric: { kind: "count" },
+    }
+    await create(makeMonitor("backdated", userTarget))
+    await create(makeMonitor("older", userTarget))
+    // Fired a minute ago for a run that began long before it.
+    await insertIncident("backdated", new Date("2026-06-01T08:00:00.000Z"), new Date("2026-06-01T11:59:00.000Z"))
+    // Fired an hour earlier, pointing at a more recent instant.
+    await insertIncident("older", new Date("2026-06-01T10:30:00.000Z"), new Date("2026-06-01T10:30:00.000Z"))
+
+    const page = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* MonitorRepository
+        return yield* repo.list({ projectId: PROJECT_ID, limit: 10, offset: 0 })
+      }),
+    )
+
+    expect(page.items.map((monitor) => monitor.slug)).toEqual(["slug-backdated", "slug-older"])
   })
 })

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.ts
@@ -97,8 +97,13 @@ const toMonitorRow = (monitor: Monitor): typeof monitors.$inferInsert => ({
   targetType: monitor.target.type,
   targetId: monitor.target.id,
   trigger: monitor.rule.trigger,
+  // `config.filterSet` is the persisted home of the target predicate — `toMonitor` reads the
+  // target back out of it — so the target's own filters have to be folded in here or a caller
+  // that only sets `target.filterSet` (the public API's shape) would store an empty predicate
+  // and the monitor would evaluate against the whole project.
   config: toMonitorConfigRow({
     ...monitor.rule.config,
+    ...(monitor.target.filterSet ? { filterSet: monitor.target.filterSet } : {}),
     ...(monitor.target.query === null ? {} : { query: monitor.target.query }),
   }),
   severity: monitor.rule.severity,
@@ -166,10 +171,14 @@ export const MonitorRepositoryLive = Layer.effect(
           )
 
           const [rows, totals] = yield* sqlClient.query((db) => {
+            // Recency is when the incident was raised, not its `started_at`: a match incident
+            // backdates to the start of the run it matched, so ordering by that buries a monitor
+            // that just fired below one whose older alert happens to point further back. The page
+            // is cut server-side, so the client comparator can't repair this ordering.
             const lastIncident = db
               .select({
                 monitorId: incidents.sourceId,
-                lastStartedAt: max(incidents.startedAt).as("last_started_at"),
+                lastCreatedAt: max(incidents.createdAt).as("last_created_at"),
               })
               .from(incidents)
               .where(and(eq(incidents.sourceType, "monitor"), eq(incidents.organizationId, organizationId)))
@@ -181,7 +190,7 @@ export const MonitorRepositoryLive = Layer.effect(
               .from(monitors)
               .leftJoin(lastIncident, eq(lastIncident.monitorId, monitors.id))
               .where(where)
-              .orderBy(sql`${lastIncident.lastStartedAt} desc nulls last`, desc(monitors.createdAt), asc(monitors.id))
+              .orderBy(sql`${lastIncident.lastCreatedAt} desc nulls last`, desc(monitors.createdAt), asc(monitors.id))
               .limit(limit)
               .offset(offset)
             const totalPromise = db.select({ value: count() }).from(monitors).where(where)
@@ -201,6 +210,7 @@ export const MonitorRepositoryLive = Layer.effect(
                 incidentId: incidents.id,
                 startedAt: incidents.startedAt,
                 endedAt: incidents.endedAt,
+                createdAt: incidents.createdAt,
               })
               .from(incidents)
               .where(
@@ -210,7 +220,9 @@ export const MonitorRepositoryLive = Layer.effect(
                   inArray(incidents.sourceId, ids),
                 ),
               )
-              .orderBy(asc(incidents.sourceId), desc(incidents.endedAt), desc(incidents.id)),
+              // Open incidents win (they are the actionable ones), then the most recently raised —
+              // `ended_at` desc would rank a backdated point incident by the instant it points at.
+              .orderBy(asc(incidents.sourceId), sql`(${incidents.endedAt} is null) desc`, desc(incidents.createdAt)),
           )
           const lastIncidentByMonitorId = new Map<string, MonitorLastIncident>()
           for (const row of incidentRows) {
@@ -219,6 +231,7 @@ export const MonitorRepositoryLive = Layer.effect(
                 id: row.incidentId,
                 startedAt: row.startedAt,
                 endedAt: row.endedAt,
+                createdAt: row.createdAt,
               })
             }
           }


### PR DESCRIPTION
Monitors never fired on long runs. A client's 4–38 minute production runs produced no incidents at all while a short staging run on the same monitor shape did, and the one incident they got was backdated to its trace's start. `LAT-885`.

The cause is a mismatch between when a monitor looks and what it looks at. A check asks "did any matching trace happen in the last 5 minutes?" and answers it against the trace's earliest span, but a run only becomes visible when it ends — and the check is *triggered* by trace-end. So by the time anything looked at a 38-minute run, its `start_time` was 38 minutes old: outside the window, invisible, permanently. Only runs shorter than the window could ever alert.

## the change

Monitor evaluation windows now filter on the **end axis** for all three monitor streams: a row qualifies when its latest ingested span ended inside the window. `MetricSqlInput` carries a `windowAnchor` and each stream descriptor exposes both columns, but only `MetricSeriesReaderLive` passes `"end"` — `queryAnalytics`, experiment populations, and every dashboard keep plotting by start time. That split is deliberate and permanent, so the copy says so and `dev-docs/monitors.md` records which axis each surface uses.

Incidents still backdate `startedAt` to `min(start_time)`. The window decides *whether* to alert; the backdate says *which run* to look at. An incident can therefore start 40+ minutes before it was raised — one test case backdated 89 minutes, to a session that went quiet for half an hour and then resumed.

Because a live run sits inside the window on every check until it finishes, match monitors now alert **once per run**. `MetricSeriesReader.matchingEntities` itemises the matching entities at the count metric's dedup grain — a session's three traces are one entity, a session-less trace is its own, a span is its own — and Redis markers (24h, via the existing `CacheStore` port) record the ones already alerted. Markers are written after the incident transaction commits, so a failed insert retries cleanly, and a `CacheError` fails the check rather than alerting anyway.

Monitored predicates also drop absolute `startTime`/`endTime` conditions at evaluation. A saved search built from the dashboard date picker carries a frozen range that would silence its monitor for good once the range aged out; the saved search keeps the range for dashboard use.

## bugs this turned up

I ran the whole feature end to end against a local instance — real OTLP ingest, real workers, real ClickHouse — and it found six problems worth fixing here. Two are pre-existing and independent of the anchor:

- **The API dropped a monitor's filters.** `config.filterSet` is the persisted home of the predicate, and `toMonitorRow` only ever wrote `rule.config`. The web sets both, so UI-created monitors were fine; the public API sends the predicate on the target, so **every monitor created through the API/MCP/SDK/CLI has been evaluating against its whole project**. A monitor filtered to a nonexistent user opened an incident on unrelated traffic. Monitors created before this fix are stored with an empty predicate and need re-creating.
- **Half the evaluation windows were never evaluated.** The sweeper cron and the publish throttle were both 5 minutes and shared a phase, so the tick raced the previous marker's expiry and lost. Observed cadence was one check per 10 minutes against a 5-minute window, and threshold closes slipped a full tick. The throttle is now strictly shorter than the window, guarded by a test.

The rest are display-layer consequences of backdates getting large: a match incident reporting its backdated instant as "Closed 1 hour ago" when it fired 25 minutes ago, the chart marker sitting over an empty bucket 90 minutes from the bar that triggered it (and vanishing entirely on short ranges, since the incident query matched on lifetime overlap), the matching-sessions panel claiming nothing matched while the incident list beside it filled up, its "View all" landing on an empty page, and a filter arriving as `eq` — which is how a monitor target spells one value — applying to the results but rendering blank in the filters sidebar.

## how it was validated

Unit and integration coverage: two-axis fixtures against real ClickHouse (window inclusion by end, `firstEventAt` by start, bucket-by-end, all three entity grains), the LAT-885 regression and the dedupe cases in the domain, a start-anchor guard so analytics can't drift, and the cadence invariant.

End to end on a live instance, logged in `specs/monitor-activity-window.md` §9: a 44-minute run alerting once with `started_at` matching ClickHouse to the millisecond, a run that finished 30 minutes ago staying silent, one incident per run across four consecutive checks with in-window activity, a second run getting its own incident backdated to its own start, thresholds seeing in-flight long runs and closing silently after their dwell, muting suppressing both incidents and markers, and — as the control group — analytics, the sessions and traces lists, and an experiment's variant population all still counting that same long run in the range it *started* in and not in the range its activity lands in.

## follow-ups

Two documented, deliberately unfixed: notification copy derives its trend window from `startedAt`, so a backdated incident's email describes the window around the run's start; and an escalating incident's `startedAt` is snapshotted at the enter transition while a live run slides between end-anchored buckets. Both are noted in `dev-docs/monitors.md` rather than papered over.

No migrations. Expect a one-time burst of match incidents on deploy: runs that are live (or recently finished) enter the window for the first time and alert once each. That's the bug being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791028558&installation_model_id=435055&pr_number=4548&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4548&signature=cc5907c8da793c5d0c128d05423f88a7f3e2be385902ca7ed50c5495d9d42ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->