### PR TITLE
fix(ci): resolve production workers service for signal backfill

### DIFF
--- a/.github/workflows/backfill-signal-score-evidence.yml
+++ b/.github/workflows/backfill-signal-score-evidence.yml
@@ -59,15 +59,22 @@ jobs:
             exit 1
           fi
 
-          SERVICE_JSON=$(aws ecs describe-services \
+          SERVICE_ARNS=$(aws ecs list-services \
             --cluster "${CLUSTER}" \
-            --services "${SERVICE}" \
+            --query "serviceArns[?contains(@, '${SERVICE}')]" \
             --output json)
 
-          if [ "$(echo "${SERVICE_JSON}" | jq '.services | length')" != "1" ]; then
-            echo "Could not resolve the production workers service."
+          if [ "$(echo "${SERVICE_ARNS}" | jq 'length')" != "1" ]; then
+            echo "Expected exactly one production workers service matching ${SERVICE}."
+            echo "${SERVICE_ARNS}" | jq
             exit 1
           fi
+
+          SERVICE_ARN=$(echo "${SERVICE_ARNS}" | jq -r '.[0]')
+          SERVICE_JSON=$(aws ecs describe-services \
+            --cluster "${CLUSTER}" \
+            --services "${SERVICE_ARN}" \
+            --output json)
 
           BASE_TASK_DEF=$(echo "${SERVICE_JSON}" | jq -r '.services[0].taskDefinition')
           NETWORK=$(echo "${SERVICE_JSON}" | jq -c '.services[0].networkConfiguration.awsvpcConfiguration')


### PR DESCRIPTION
The signal score-evidence backfill action authenticated with AWS but failed before launch because it passed the logical Pulumi service name directly to `describe-services`. The physical ECS service name has an auto-generated suffix.

This change finds the deployed workers service ARN with `list-services`, requires exactly one match, and passes that ARN to `describe-services`. It uses the same lookup pattern as the production deployment workflow. The failed run stopped before registering the one-time task definition, so the action can still be retried after this merges.

Validation:
- `actionlint .github/workflows/backfill-signal-score-evidence.yml`
- verified one-match ARN parsing with a suffixed ECS service name

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791041418&installation_model_id=435055&pr_number=4550&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4550&signature=db0436512c5e04ae1ea9d00142cfdbb8edcab526eec99f77948bd712a65a2e72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->