### PR TITLE
fix(conversation-intelligence): sanitize lone surrogates that skip truncation

### DIFF
--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
@@ -1341,6 +1341,32 @@ describe("analyzeSessionUseCase", () => {
     expect(prompt.match(/<\/conversation_data>/g)).toHaveLength(1)
     expect(prompt).toContain("\\u003c/conversation_data\\u003e")
   })
+
+  it("sanitizes a pre-existing lone surrogate in the classifier transcript when the full conversation fits without truncation", async () => {
+    const frustratedUserMessage = "\uD800 This is frustrating and still unresolved."
+    const { ai, generated } = createAdjudicationAi({
+      embeddingForText: (text) => {
+        if (text.toLowerCase().includes("frustrat")) return [1, 0]
+        return [-1, 0]
+      },
+      acceptedCandidateIds: (prompt) => candidatesFromPrompt(prompt).map((candidate) => candidate.id),
+    })
+    const { effect } = runUseCase({
+      session: makeSessionWithMessages([
+        message("user", "Can you help me update my billing email?"),
+        message("assistant", "Sure, open account settings and choose Profile."),
+        message("user", frustratedUserMessage),
+        message("assistant", "I'm sorry, I will correct that now."),
+      ]),
+      ai,
+    })
+
+    await Effect.runPromise(effect)
+
+    const prompt = generated[0]?.prompt ?? ""
+    expect(prompt.length).toBeGreaterThan(0)
+    expect(prompt).not.toMatch(LONE_SURROGATE_PATTERN)
+  })
 })
 
 describe("middleTruncate", () => {
@@ -1359,5 +1385,10 @@ describe("middleTruncate", () => {
   it("returns the original value unchanged when it already fits", () => {
     const value = "😀".repeat(10)
     expect(middleTruncateForTesting(value, value.length)).toBe(value)
+  })
+
+  it("sanitizes a lone surrogate already present in the input when nothing needs truncating", () => {
+    const value = "\uD800 hello"
+    expect(middleTruncateForTesting(value, value.length)).not.toMatch(LONE_SURROGATE_PATTERN)
   })
 })

--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
@@ -128,7 +128,7 @@ const TAXONOMY_DIRECT_PROJECTION_MAX_LENGTH = CONVERSATION_INTELLIGENCE_LLM_MAX_
 const TRUNCATION_MARKER = "\n[...truncated...]\n"
 
 const middleTruncate = (value: string, maxLength: number): string => {
-  if (value.length <= maxLength) return value
+  if (value.length <= maxLength) return stripLoneSurrogates(value)
   if (maxLength <= TRUNCATION_MARKER.length) return stripLoneSurrogates(value.slice(0, maxLength))
   const head = Math.floor((maxLength - TRUNCATION_MARKER.length) / 2)
   const tail = maxLength - TRUNCATION_MARKER.length - head
@@ -155,7 +155,7 @@ const renderMomentClassifierTranscript = (
 ): string | null => {
   const promptMessages = messages.map((message) => ({ ...message, text: escapePromptDelimiters(message.text) }))
   const fullTranscript = documentFromMessages(promptMessages)
-  if (fullTranscript.length <= maxLength) return fullTranscript
+  if (fullTranscript.length <= maxLength) return stripLoneSurrogates(fullTranscript)
 
   const contextIndexes = new Set<number>()
   for (const candidate of candidates) {


### PR DESCRIPTION
## What does this PR do?

Fixes a Datadog Error Tracking issue where the `workflows` service still throws `AI_APICallError: ... unexpected end of hex escape` / `lone leading surrogate in hex escape` from the Bedrock `minimax.minimax-m2.5` provider, wrapped as `AIError`/`MomentClassifierError` in `packages/domain/conversation-intelligence`.

**Datadog issues addressed:**
- [`4697cf5a-87aa-11f1-bcf2-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/4697cf5a-87aa-11f1-bcf2-da7ad0900005) — `AI_APICallError` (96 occurrences/7d)
- [`469bdd84-87aa-11f1-83a2-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/469bdd84-87aa-11f1-83a2-da7ad0900005) — `Error` wrapper (48 occurrences/7d)

Both **regressed on 2026-09-02** after having been marked fixed in July via #4225/#4230.

**Root cause:** those two July PRs applied the existing `stripLoneSurrogates` helper inside `middleTruncate()` (`packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts`), but only on the branches that actually perform truncation. Both `middleTruncate` and `renderMomentClassifierTranscript`'s early-return path return their input **unsanitized whenever it already fits the length budget**. If a message's *original* text already carries an unpaired UTF-16 surrogate (e.g. from malformed/truncated client input further upstream) and happens to be short enough not to need truncation, it flows straight into the Bedrock prompt, reproducing the same "hex escape" rejection the July fix addressed only for the truncation case.

This is the same defect class documented in `packages/domain/spans/src/use-cases/build-trace-search-document.ts`, which already handles it correctly by wrapping its *entire* output in `stripLoneSurrogates` regardless of whether truncation occurred (`normalizeSearchText`). This PR mirrors that pattern here.

**Fix:**
- `middleTruncate`: sanitize the pass-through (`value.length <= maxLength`) branch, not just the truncated branches.
- `renderMomentClassifierTranscript`: sanitize the full-transcript pass-through branch the same way.

## How was this tested?

Added two tests and confirmed both fail without the fix and pass with it:
- `middleTruncate > sanitizes a lone surrogate already present in the input when nothing needs truncating` — unit test on the exported `middleTruncateForTesting`.
- `analyzeSessionUseCase > sanitizes a pre-existing lone surrogate in the classifier transcript when the full conversation fits without truncation` — integration test asserting the generated moment-classifier prompt contains no lone surrogate.

Full package suite: `pnpm --filter @domain/conversation-intelligence test` — 47/47 passing.
`pnpm --filter @domain/conversation-intelligence typecheck` (tsgo) — clean.
`pnpm exec biome check` on changed files — clean.

**Post-deploy verification:** occurrences of issues `4697cf5a-87aa-11f1-bcf2-da7ad0900005` and `469bdd84-87aa-11f1-83a2-da7ad0900005` should drop to zero.

## Related issue (if applicable)

N/A — found via Datadog Error Tracking triage, no linked GitHub issue.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows Conventional Commits
- [ ] I have signed the CLA

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhjtUuR5X5t5uodpT1W3ig

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhjtUuR5X5t5uodpT1W3ig)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791191785&installation_model_id=435055&pr_number=4557&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4557&signature=919c679c35682f6da243e8d396640cd5503dfff1455b53f4947281ad1fd310c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->