### PR TITLE
fix(spans): strip lone UTF-16 surrogates from OTLP string attributes

### DIFF
--- a/packages/domain/spans/src/helpers/normalize-literal-phrase.test.ts
+++ b/packages/domain/spans/src/helpers/normalize-literal-phrase.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+import { deepStripLoneSurrogates, normalizeLiteralPhrase, stripLoneSurrogates } from "./normalize-literal-phrase.ts"
+
+describe("stripLoneSurrogates", () => {
+  it("replaces an unpaired high surrogate with the replacement character", () => {
+    expect(stripLoneSurrogates("before\uD83Dafter")).toBe("before�after")
+  })
+
+  it("replaces an unpaired low surrogate with the replacement character", () => {
+    expect(stripLoneSurrogates("before\uDC00after")).toBe("before�after")
+  })
+
+  it("leaves a valid surrogate pair (e.g. an emoji) untouched", () => {
+    expect(stripLoneSurrogates("hi 😀!")).toBe("hi 😀!")
+  })
+})
+
+describe("normalizeLiteralPhrase", () => {
+  it("trims, collapses whitespace, and strips lone surrogates", () => {
+    expect(normalizeLiteralPhrase("  hello   world\uD83D  ")).toBe("hello world�")
+  })
+})
+
+describe("deepStripLoneSurrogates", () => {
+  it("sanitizes strings nested in arrays and objects, including keys", () => {
+    const input = { a: ["ok", "bad\uD83D"], "key\uDC00": { nested: "value\uD83D" } }
+
+    expect(deepStripLoneSurrogates(input)).toEqual({
+      a: ["ok", "bad�"],
+      "key�": { nested: "value�" },
+    })
+  })
+
+  it("disambiguates rather than overwrites when two distinct keys sanitize to the same string", () => {
+    const input = Object.fromEntries([
+      ["\uD800", "first"],
+      ["�", "second"],
+    ]) as Record<string, string>
+
+    const result = deepStripLoneSurrogates(input) as Record<string, string>
+
+    expect(result).toEqual({
+      "�": "first",
+      "��": "second",
+    })
+  })
+
+  it("leaves non-string primitives untouched", () => {
+    expect(deepStripLoneSurrogates({ n: 1, b: true, u: undefined, nul: null })).toEqual({
+      n: 1,
+      b: true,
+      u: undefined,
+      nul: null,
+    })
+  })
+})

--- a/packages/domain/spans/src/helpers/normalize-literal-phrase.ts
+++ b/packages/domain/spans/src/helpers/normalize-literal-phrase.ts
@@ -22,3 +22,20 @@ export function stripLoneSurrogates(text: string): string {
 export function normalizeLiteralPhrase(text: string): string {
   return stripLoneSurrogates(text.trim().replace(/\s+/g, " "))
 }
+
+/** Recursively strips lone surrogates from every string (object keys included) in a JSON-shaped value. */
+export function deepStripLoneSurrogates<T>(value: T): T {
+  if (typeof value === "string") return stripLoneSurrogates(value) as T
+  if (Array.isArray(value)) return value.map(deepStripLoneSurrogates) as T
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {}
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      let sanitizedKey = stripLoneSurrogates(key)
+      // Two distinct raw keys can sanitize to the same string; disambiguate instead of overwriting.
+      while (sanitizedKey in result) sanitizedKey += "�"
+      result[sanitizedKey] = deepStripLoneSurrogates(val)
+    }
+    return result as T
+  }
+  return value
+}

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -143,7 +143,11 @@ export {
 export { parseMessagePayload, stringifyPayload } from "./helpers/message-payload.ts"
 export { modelCacheBreakEvenRate } from "./helpers/model-cache-break-even.ts"
 export { type ModelRegistryPricing, modelRegistryPricing } from "./helpers/model-registry-pricing.ts"
-export { normalizeLiteralPhrase, stripLoneSurrogates } from "./helpers/normalize-literal-phrase.ts"
+export {
+  deepStripLoneSurrogates,
+  normalizeLiteralPhrase,
+  stripLoneSurrogates,
+} from "./helpers/normalize-literal-phrase.ts"
 export {
   isLlmCompletionOperation,
   resolveLastLlmCompletionSpanId,

--- a/packages/domain/spans/src/otlp/sanitize.ts
+++ b/packages/domain/spans/src/otlp/sanitize.ts
@@ -1,0 +1,101 @@
+import { stripLoneSurrogates } from "../helpers/normalize-literal-phrase.ts"
+import { attrArray } from "./attributes.ts"
+import type {
+  OtlpAnyValue,
+  OtlpEvent,
+  OtlpExportTraceServiceRequest,
+  OtlpKeyValue,
+  OtlpLink,
+  OtlpResource,
+  OtlpResourceSpans,
+  OtlpSpan,
+  OtlpStatus,
+} from "./types.ts"
+
+/** Strips lone UTF-16 surrogates from every OTLP string once, before any consumer reads the request. */
+export function sanitizeOtlpRequest(request: OtlpExportTraceServiceRequest): OtlpExportTraceServiceRequest {
+  return { ...optional("resourceSpans", request.resourceSpans?.map(sanitizeResourceSpans)) }
+}
+
+/** Spreads `{ [key]: value }` only when defined — `exactOptionalPropertyTypes` rejects an explicit `undefined`. */
+function optional<K extends string, V>(key: K, value: V | undefined): { [P in K]?: V } {
+  return (value !== undefined ? { [key]: value } : {}) as { [P in K]?: V }
+}
+
+/** OTLP/JSON bodies are cast, not validated, so a "string" field can arrive as any JSON type. */
+function sanitizeStr(value: string | undefined): string | undefined {
+  return typeof value === "string" ? stripLoneSurrogates(value) : value
+}
+
+function sanitizeResourceSpans(resourceSpans: OtlpResourceSpans): OtlpResourceSpans {
+  return {
+    ...resourceSpans,
+    ...optional("resource", resourceSpans.resource && sanitizeResource(resourceSpans.resource)),
+    ...optional(
+      "scopeSpans",
+      resourceSpans.scopeSpans?.map((scopeSpans) => ({
+        ...scopeSpans,
+        ...optional(
+          "scope",
+          scopeSpans.scope && {
+            ...scopeSpans.scope,
+            ...optional("name", sanitizeStr(scopeSpans.scope.name)),
+            ...optional("version", sanitizeStr(scopeSpans.scope.version)),
+          },
+        ),
+        ...optional("spans", scopeSpans.spans?.map(sanitizeSpan)),
+      })),
+    ),
+  }
+}
+
+function sanitizeResource(resource: OtlpResource): OtlpResource {
+  return { ...resource, attributes: attrArray(resource.attributes).map(sanitizeKeyValue) }
+}
+
+function sanitizeSpan(span: OtlpSpan): OtlpSpan {
+  return {
+    ...span,
+    ...optional("name", sanitizeStr(span.name)),
+    ...optional("traceState", sanitizeStr(span.traceState)),
+    attributes: attrArray(span.attributes).map(sanitizeKeyValue),
+    ...optional("events", span.events?.map(sanitizeEvent)),
+    ...optional("links", span.links?.map(sanitizeLink)),
+    ...optional("status", span.status && sanitizeStatus(span.status)),
+  }
+}
+
+function sanitizeEvent(event: OtlpEvent): OtlpEvent {
+  return {
+    ...event,
+    ...optional("name", sanitizeStr(event.name)),
+    attributes: attrArray(event.attributes).map(sanitizeKeyValue),
+  }
+}
+
+function sanitizeLink(link: OtlpLink): OtlpLink {
+  return {
+    ...link,
+    ...optional("traceState", sanitizeStr(link.traceState)),
+    attributes: attrArray(link.attributes).map(sanitizeKeyValue),
+  }
+}
+
+function sanitizeStatus(status: OtlpStatus): OtlpStatus {
+  return { ...status, ...optional("message", sanitizeStr(status.message)) }
+}
+
+function sanitizeKeyValue(kv: OtlpKeyValue): OtlpKeyValue {
+  return { ...kv, key: sanitizeStr(kv.key) ?? kv.key, ...optional("value", kv.value && sanitizeAnyValue(kv.value)) }
+}
+
+function sanitizeAnyValue(value: OtlpAnyValue): OtlpAnyValue {
+  if (value.stringValue !== undefined) return { ...value, ...optional("stringValue", sanitizeStr(value.stringValue)) }
+  if (value.arrayValue?.values) {
+    return { ...value, arrayValue: { values: value.arrayValue.values.map(sanitizeAnyValue) } }
+  }
+  if (value.kvlistValue?.values) {
+    return { ...value, kvlistValue: { values: value.kvlistValue.values.map(sanitizeKeyValue) } }
+  }
+  return value
+}

--- a/packages/domain/spans/src/otlp/transform.test.ts
+++ b/packages/domain/spans/src/otlp/transform.test.ts
@@ -103,3 +103,108 @@ describe("transformOtlpToSpans — int64 precision", () => {
     expect(span?.attrInt["gen_ai.usage.input_tokens"]).toBe(215813)
   })
 })
+
+describe("transformOtlpToSpans — lone UTF-16 surrogate sanitization", () => {
+  it("strips a lone surrogate from a direct string span attribute value", () => {
+    const { spans } = transformOtlpToSpans(
+      requestWithSpanAttributes([{ key: "user.note", value: { stringValue: "before\uD83Dafter" } }]),
+      context,
+    )
+
+    expect(spans[0]?.attrString["user.note"]).toBe("before�after")
+  })
+
+  it("strips a lone surrogate from a string nested inside a structured attribute value", () => {
+    const { spans } = transformOtlpToSpans(
+      requestWithSpanAttributes([
+        {
+          key: "gen_ai.memory.records",
+          value: {
+            arrayValue: {
+              values: [{ kvlistValue: { values: [{ key: "content", value: { stringValue: "hi\uD83D" } }] } }],
+            },
+          },
+        },
+      ]),
+      context,
+    )
+
+    const records = spans[0]?.attrString["gen_ai.memory.records"]
+    expect(JSON.parse(records as string)).toEqual([{ content: "hi�" }])
+  })
+
+  it("strips a lone surrogate from a resource attribute value, including the promoted service name", () => {
+    const request: OtlpExportTraceServiceRequest = {
+      resourceSpans: [
+        {
+          resource: { attributes: [{ key: "service.name", value: { stringValue: "checkout\uD83D" } }] },
+          scopeSpans: [
+            {
+              scope: { name: "test-scope", version: "1" },
+              spans: [
+                {
+                  traceId: "0".repeat(32),
+                  spanId: "0".repeat(16),
+                  name: "span",
+                  startTimeUnixNano: "1",
+                  endTimeUnixNano: "2",
+                  attributes: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const { spans } = transformOtlpToSpans(request, context)
+
+    expect(spans[0]?.serviceName).toBe("checkout�")
+    expect(spans[0]?.resourceString["service.name"]).toBe("checkout�")
+  })
+
+  it("strips a lone surrogate from instrumentation scope name and version", () => {
+    const request: OtlpExportTraceServiceRequest = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [
+            {
+              scope: { name: "scope\uD83D", version: "v1\uD83D" },
+              spans: [
+                {
+                  traceId: "0".repeat(32),
+                  spanId: "0".repeat(16),
+                  name: "span",
+                  startTimeUnixNano: "1",
+                  endTimeUnixNano: "2",
+                  attributes: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const { spans } = transformOtlpToSpans(request, context)
+
+    expect(spans[0]?.scopeName).toBe("scope�")
+    expect(spans[0]?.scopeVersion).toBe("v1�")
+  })
+
+  it("strips a lone surrogate reintroduced by JSON-parsing a gen_ai message attribute", () => {
+    // The OTLP-level pass sees only the escaped text `\ud83d` (no real surrogate code unit yet),
+    // so it can't sanitize this; the surrogate only becomes real once JSON.parse decodes it below.
+    const stringValue = JSON.stringify([{ role: "user", parts: [{ type: "text", content: "hi\uD83D" }] }])
+
+    const { spans } = transformOtlpToSpans(
+      requestWithSpanAttributes([{ key: "gen_ai.input.messages", value: { stringValue } }]),
+      context,
+    )
+
+    const [message] = spans[0]?.inputMessages ?? []
+    const part = (message as { parts?: readonly { type: string; content?: unknown }[] } | undefined)?.parts?.[0]
+    expect(part?.content).toBe("hi�")
+  })
+})

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -10,6 +10,7 @@ import {
   TraceId,
 } from "@domain/shared"
 import type { SpanDetail, SpanKind, SpanStatusCode } from "../entities/span.ts"
+import { deepStripLoneSurrogates } from "../helpers/normalize-literal-phrase.ts"
 import { shouldReportUnpricedSpan } from "../helpers/should-report-unpriced.ts"
 import { anyValueToPlain } from "./any-value.ts"
 import { attrArray, stringAttr } from "./attributes.ts"
@@ -19,6 +20,7 @@ import { resolveAttributes } from "./resolvers/index.ts"
 import { resolvePerformance } from "./resolvers/performance.ts"
 import { resolveStatusCode } from "./resolvers/status.ts"
 import { resolveToolExecution } from "./resolvers/tool-execution.ts"
+import { sanitizeOtlpRequest } from "./sanitize.ts"
 import type { OtlpAnyValue, OtlpExportTraceServiceRequest, OtlpKeyValue, OtlpResource, OtlpSpan } from "./types.ts"
 
 const INT_TO_SPAN_KIND: Record<number, SpanKind> = {
@@ -172,7 +174,7 @@ function transformSpan({
   const otelStatusCode = INT_TO_STATUS_CODE[span.status?.code ?? 0] ?? "unset"
   const statusCode = resolveStatusCode(spanAttrs, otelStatusCode, scopeName)
 
-  const resolved = resolveAttributes({
+  const resolvedRaw = resolveAttributes({
     spanAttrs,
     statusCode,
     events: spanEvents,
@@ -180,7 +182,13 @@ function transformSpan({
     scopeName,
     hasParent: hasParentSpan(span.parentSpanId),
   })
-  const content = parseContent(spanAttrs)
+  // JSON.parse of an OTLP string (e.g. `gen_ai.input.messages`) can reintroduce a surrogate the OTLP-level pass escaped.
+  const resolved = {
+    ...resolvedRaw,
+    tags: deepStripLoneSurrogates(resolvedRaw.tags),
+    metadata: deepStripLoneSurrogates(resolvedRaw.metadata),
+  }
+  const content = deepStripLoneSurrogates(parseContent(spanAttrs))
   const serviceName = stringAttr(resourceAttrs, "service.name") ?? ""
   const performance = resolvePerformance({
     spanAttrs,
@@ -283,9 +291,12 @@ function transformSpan({
 }
 
 export function transformOtlpToSpans(
-  request: OtlpExportTraceServiceRequest,
+  rawRequest: OtlpExportTraceServiceRequest,
   context: TransformContext,
 ): TransformResult {
+  // Sanitized once, up front, so every reader downstream (attr_string capture, content parsers,
+  // tags/metadata enrichment, promoted service/scope names) sees the same clean attributes.
+  const request = sanitizeOtlpRequest(rawRequest)
   const spans: SpanDetail[] = []
   let rejectedSpans = 0
   const unpricedByKey = new Map<string, { projectId: string; provider: string; model: string; spans: number }>()


### PR DESCRIPTION
## What does this PR do?

Fixes a recurring production span-ingestion failure in the `workers` service:

```
RepositoryError: Repository insert failed: Repository query failed: Cannot parse escape sequence: missing second part of surrogate pair. In JSON input formats you can disable setting input_format_json_throw_on_bad_escape_sequence to save bad escape sequences as is: (while reading the value of key attr_string): ...
```

**Datadog issues addressed:**
- [ET · `11c196be-7b69-11f1-a2e3-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/11c196be-7b69-11f1-a2e3-da7ad0900005) — `RepositoryError` at `parseError` (ClickHouse client), resource `process span-ingestion`
- [ET · `11bddfc4-7b69-11f1-a2e3-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/11bddfc4-7b69-11f1-a2e3-da7ad0900005) — same root cause, resource `spans.processIngestedSpans`

Both are flagged `is_regression: true` after repeated RESOLVED ⇄ FOR_REVIEW flips from Datadog's auto-resolve/regression detection — the bug never actually went away. A prior PR (#4220) diagnosed this exact root cause, went through full review with all comments addressed, but was closed unmerged on 2026-08-10, so the fix never shipped. This PR re-implements that same reviewed design against the current codebase (the package has changed substantially since — a new redaction pipeline, content parsers, resolvers — so the old branch could not be reused directly).

**Root cause:** ClickHouse rejects an unpaired UTF-16 surrogate when parsing the JSON-encoded `Map(String, String)` payload used for the `attr_string`/`resource_string` columns, failing the whole async-insert batch. Arbitrary LLM/user content forwarded as an OTLP span or resource attribute value can contain a lone surrogate (e.g. text truncated mid-emoji by an upstream exporter), and the OTLP → span transform (`packages/domain/spans/src/otlp/transform.ts`, `any-value.ts`) copied `stringValue` straight through without sanitizing it.

**Fix:** sanitize once at the OTLP ingest boundary, before any consumer reads the request:
- New `otlp/sanitize.ts` (`sanitizeOtlpRequest`) walks the raw OTLP request tree and strips lone surrogates from every string field and attribute key/value — spans, resources, events, links, status messages, and instrumentation scope name/version — called once at the top of `transformOtlpToSpans`.
- A second `deepStripLoneSurrogates` pass (new export in `helpers/normalize-literal-phrase.ts`) runs on the parsed `content`, `tags`, and `metadata` outputs, covering the case where a JSON-encoded attribute (e.g. `gen_ai.input.messages`) re-escapes a lone surrogate as literal `\uD83D` text that only becomes a real unpaired surrogate again once our own `JSON.parse` runs on it — after the OTLP-level pass already happened.

## Related issue (if applicable)

N/A — found and triaged via scheduled Datadog Error Tracking review, not a filed issue.

## How was this tested?

Added test cases in `packages/domain/spans/src/otlp/transform.test.ts` covering a lone surrogate in:
1. a direct string span attribute value → `attrString`
2. a string nested inside a structured (`arrayValue`/`kvlistValue`) attribute value → `attrString` (JSON-stringified)
3. a resource attribute value, including the promoted `service_name` column
4. instrumentation scope `name`/`version`
5. the JSON-reparse case (a `gen_ai.input.messages` attribute whose JSON text contains an escaped surrogate that becomes real only after parsing)

Plus unit tests for the new `deepStripLoneSurrogates` helper in `helpers/normalize-literal-phrase.test.ts` (nested sanitization, key collisions, non-string primitives).

Confirmed all new tests fail without the fix (reverted `sanitize.ts`/`transform.ts`/`normalize-literal-phrase.ts` and reran) and pass with it. Ran the full `@domain/spans` test suite: 2156 passed, 0 newly failing (the 29 failures in `ingest-spans.test.ts` are a pre-existing `bytes.toBase64 is not a function` Node-version mismatch — reproduces identically on `development` before this change). `pnpm --filter @domain/spans typecheck` shows the same pre-existing unrelated `@domain/ai` → `@latitude-data/telemetry` module-resolution error as on `development`, nothing new. `pnpm exec biome check` clean on all changed files.

**Verification in production:** after deploy, occurrences of issues `11c196be-7b69-11f1-a2e3-da7ad0900005` and `11bddfc4-7b69-11f1-a2e3-da7ad0900005` should stop recurring. To reproduce locally, send an OTLP span with a string attribute value containing a lone UTF-16 surrogate (e.g. `"\uD83D"` with no matching low surrogate) through span ingestion and confirm the ClickHouse insert succeeds instead of throwing.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2ChBRU9qsVUnPcWsQ68TW


---
_Generated by [Claude Code](https://claude.ai/code/session_01J2ChBRU9qsVUnPcWsQ68TW)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791296096&installation_model_id=435055&pr_number=4559&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4559&signature=10f8e87b0a2652d908ff74974ea4ca9a09397fbd71b49a29151a06583303f13d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->