### PR TITLE
chore(biome): enable cognitive complexity rule (max 15)

### DIFF
--- a/.agents/skills/code-style/SKILL.md
+++ b/.agents/skills/code-style/SKILL.md
@@ -17,6 +17,7 @@ Biome config (`biome.json`) is the source of truth:
 - Semicolons: as needed
 - Ignore generated/output paths: `dist/**`, `coverage/**`, `.turbo/**`, `node_modules/**`, `**/*.gen.ts`, `**/models.dev.json`
 - Prefer package-local formatting: `pnpm --filter @app/api format`
+- Cognitive complexity (`complexity/noExcessiveCognitiveComplexity`) is enabled at max **15**. Keep new and edited functions at or under that score — split nested conditionals, loops, and branches into named helpers rather than silencing the rule. Existing hotspots are warn-only until they are refactored; do not add complexity to them.
 
 ## Imports
 

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,15 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "level": "warn",
+          "options": {
+            "maxAllowedComplexity": 15
+          }
+        }
+      }
     }
   },
   "javascript": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Turns on Biome's `complexity/noExcessiveCognitiveComplexity` rule at the Sonar default of **15**, as a **warning** (not an error).

Motivation: keep agent- and human-written functions readable by flagging nested control flow that's hard to follow ([thread](https://x.com/asidorenko_/status/2096302171243315378)).

Also documents the bar in `.agents/skills/code-style/SKILL.md` so coding agents treat the limit as something to refactor toward, not ignore.

## Related issue (if applicable)

N/A — follow-up from https://x.com/asidorenko_/status/2096302171243315378

## How was this tested?

- `biome rage` loads the config successfully
- `biome check` on clean packages exits 0
- Packages with existing hotspots report warnings and still exit 0 (CI `pnpm check` stays green)
- Repo currently has ~450 functions above 15; warn-only avoids a mass refactor in this PR

Evidence from local check:

[biome_cognitive_complexity_check.log](https://cursor.com/agents/bc-01a07a92-aa98-7d57-9a81-a8bedc8389ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbiome_cognitive_complexity_check.log)

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

## Follow-up

Ratchet selected packages (or the whole repo) from `warn` → `error` as hotspots are split down under 15.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07a92-aa98-7d57-9a81-a8bedc8389ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07a92-aa98-7d57-9a81-a8bedc8389ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791355631&installation_model_id=435055&pr_number=4577&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4577&signature=0f2d60fd183c9d803d8e510bd49c78c062f4a0a4c9102ac783c4edf7a6695086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->