### PR TITLE
chore(biome): reduce cognitive complexity in apps/api handlers

### DIFF
--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -139,24 +139,26 @@ interface InternalRoute {
  * prepends `/${API_VERSION}`, and resolves against the outer MCP request's
  * origin so Hono's path matcher sees a fully-qualified URL.
  */
-const buildInternalRequestUrl = (
-  c: Context,
-  route: InternalRoute,
-  params: Record<string, unknown>,
-  query: Record<string, unknown>,
-): string => {
-  const path = route.pathTemplate
-  const prefix = route.routerPrefix.replace(/\/$/, "")
+const joinRoutePath = (routerPrefix: string, pathTemplate: string): string => {
+  const prefix = routerPrefix.replace(/\/$/, "")
   // `pathTemplate === "/"` collapses to the bare prefix — Hono treats
   // `/api-keys` and `/api-keys/` as distinct routes; ours mount un-trailing.
-  let joined = path === "/" ? prefix : `${prefix}${path.startsWith("/") ? path : `/${path}`}`
+  if (pathTemplate === "/") return prefix
+  return `${prefix}${pathTemplate.startsWith("/") ? pathTemplate : `/${pathTemplate}`}`
+}
+
+const substitutePathParams = (path: string, params: Record<string, unknown>): string => {
+  let joined = path
   // Substitute `{name}` placeholders across the full joined string — params
   // can appear either in the route's own path (e.g. `/api-keys/{id}`) or in
   // the mount prefix (e.g. `/projects/{projectSlug}/annotations`).
   for (const [name, value] of Object.entries(params)) {
     joined = joined.replaceAll(`{${name}}`, encodeURIComponent(String(value)))
   }
-  const subAppPath = joined === "" ? "/" : joined
+  return joined === "" ? "/" : joined
+}
+
+const appendQueryParams = (query: Record<string, unknown>): string => {
   const search = new URLSearchParams()
   for (const [key, value] of Object.entries(query)) {
     if (value === undefined || value === null) continue
@@ -166,14 +168,26 @@ const buildInternalRequestUrl = (
       search.append(key, String(value))
     }
   }
-  const qs = search.toString()
-  const internalPath = `/${API_VERSION}${subAppPath}${qs ? `?${qs}` : ""}`
+  return search.toString()
+}
+
+const resolveInternalUrl = (requestUrl: string, internalPath: string): string => {
   try {
-    const outerUrl = new URL(c.req.url)
-    return new URL(internalPath, outerUrl.origin).toString()
+    return new URL(internalPath, new URL(requestUrl).origin).toString()
   } catch {
     // Fallback for runtimes where `c.req.url` is relative — shouldn't happen
     // with TanStack Start / Hono node-server, but defensible.
     return `http://localhost${internalPath}`
   }
+}
+
+const buildInternalRequestUrl = (
+  c: Context,
+  route: InternalRoute,
+  params: Record<string, unknown>,
+  query: Record<string, unknown>,
+): string => {
+  const subAppPath = substitutePathParams(joinRoutePath(route.routerPrefix, route.pathTemplate), params)
+  const qs = appendQueryParams(query)
+  return resolveInternalUrl(c.req.url, `/${API_VERSION}${subAppPath}${qs ? `?${qs}` : ""}`)
 }

--- a/apps/api/src/middleware/access-logger.ts
+++ b/apps/api/src/middleware/access-logger.ts
@@ -6,29 +6,34 @@ type AccessLog = {
   warn: (message: string) => void
 }
 
+const createAccessLogWriter = (log: AccessLog, isHealth: boolean, isOk: () => boolean) => {
+  let incoming: string | undefined
+
+  return (message: string) => {
+    if (incoming === undefined) {
+      incoming = message
+      if (!isHealth) {
+        log.info(message)
+      }
+      return
+    }
+
+    const ok = isOk()
+    if (isHealth && ok) {
+      return
+    }
+
+    const write = ok ? log.info : log.warn
+    if (isHealth && incoming) {
+      write(incoming)
+    }
+    write(message)
+  }
+}
+
 export const accessLogger = (log: AccessLog) => {
   return createMiddleware(async (c, next) => {
     const isHealth = c.req.method === "GET" && c.req.path === "/health"
-    let incoming: string | undefined
-
-    await logger((message) => {
-      if (incoming === undefined) {
-        incoming = message
-        if (!isHealth) {
-          log.info(message)
-        }
-        return
-      }
-
-      if (isHealth && c.res.ok) {
-        return
-      }
-
-      const write = c.res.ok ? log.info : log.warn
-      if (isHealth && incoming) {
-        write(incoming)
-      }
-      write(message)
-    })(c, next)
+    await logger(createAccessLogWriter(log, isHealth, () => c.res.ok))(c, next)
   })
 }

--- a/apps/api/src/middleware/rate-limiter.ts
+++ b/apps/api/src/middleware/rate-limiter.ts
@@ -79,7 +79,7 @@ const createRedisRateLimiter = (config: RateLimitConfig) => {
     const key = `${config.keyPrefix}:${config.keyGenerator(c)}`
 
     try {
-      await enforceRedisRateLimit(c, next, config, key)
+      return await enforceRedisRateLimit(c, next, config, key)
     } catch (_error) {
       await next()
     }

--- a/apps/api/src/middleware/rate-limiter.ts
+++ b/apps/api/src/middleware/rate-limiter.ts
@@ -29,66 +29,58 @@ const getNumericPipelineValue = (result: [unknown, unknown]): number | null => {
   return typeof value === "number" ? value : null
 }
 
-/**
- * Create a Redis-backed rate limiting middleware
- */
+const enforceRedisRateLimit = async (c: Context, next: Next, config: RateLimitConfig, key: string) => {
+  const redis = c.get("redis")
+  const pipeline = redis.pipeline()
+  pipeline.incr(key)
+  pipeline.ttl(key)
+
+  const results = await pipeline.exec()
+  if (!results) {
+    await next()
+    return
+  }
+
+  const [incrResult, ttlResult] = results
+  if (incrResult[0] || ttlResult[0]) {
+    await next()
+    return
+  }
+
+  const count = getNumericPipelineValue(incrResult)
+  let ttl = getNumericPipelineValue(ttlResult)
+  if (count === null || ttl === null) {
+    await next()
+    return
+  }
+
+  if (count === 1 || ttl === -1) {
+    await redis.expire(key, config.windowSeconds)
+    ttl = config.windowSeconds
+  }
+
+  if (count > config.maxRequests) {
+    const retryAfter = ttl
+    return c.json(
+      {
+        error: config.errorMessage || "Too many requests",
+        retryAfter,
+      },
+      429,
+      { "Retry-After": String(retryAfter) },
+    )
+  }
+
+  await next()
+}
+
 const createRedisRateLimiter = (config: RateLimitConfig) => {
   return async (c: Context, next: Next) => {
-    const redis = c.get("redis")
     const key = `${config.keyPrefix}:${config.keyGenerator(c)}`
 
     try {
-      // Use Redis multi to atomically increment and set expiry
-      const pipeline = redis.pipeline()
-      pipeline.incr(key)
-      pipeline.ttl(key)
-
-      const results = await pipeline.exec()
-
-      if (!results) {
-        // Redis error, allow request but log warning
-        await next()
-        return
-      }
-
-      const [incrResult, ttlResult] = results
-
-      // Check for errors
-      if (incrResult[0] || ttlResult[0]) {
-        await next()
-        return
-      }
-
-      const count = getNumericPipelineValue(incrResult)
-      let ttl = getNumericPipelineValue(ttlResult)
-
-      if (count === null || ttl === null) {
-        await next()
-        return
-      }
-
-      // Set expiry on first request
-      if (count === 1 || ttl === -1) {
-        await redis.expire(key, config.windowSeconds)
-        ttl = config.windowSeconds
-      }
-
-      // Check if limit exceeded
-      if (count > config.maxRequests) {
-        const retryAfter = ttl
-        return c.json(
-          {
-            error: config.errorMessage || "Too many requests",
-            retryAfter,
-          },
-          429,
-          { "Retry-After": String(retryAfter) },
-        )
-      }
-
-      await next()
+      await enforceRedisRateLimit(c, next, config, key)
     } catch (_error) {
-      // Redis error - fail open (allow request) to avoid blocking legitimate users
       await next()
     }
   }

--- a/apps/api/src/routes/webhooks-github.ts
+++ b/apps/api/src/routes/webhooks-github.ts
@@ -1,8 +1,9 @@
-import type { PublishOptions } from "@domain/queue"
+import type { PublishOptions, QueuePublisherShape } from "@domain/queue"
 import type { OpenAPIHono } from "@hono/zod-openapi"
 import { loadGithubConfig, verifyGithubSignature } from "@platform/github"
 import { createLogger } from "@repo/observability"
 import { Effect, Exit } from "effect"
+import type { Context } from "hono"
 import { createGlobalRateLimiter } from "../middleware/rate-limiter.ts"
 import type { AppEnv } from "../types.ts"
 import { routeGithubWebhook } from "./webhooks-github-extract.ts"
@@ -26,64 +27,84 @@ const MAX_ATTEMPTS = 5
  * verification without Hono consuming it as validated JSON; the endpoint is
  * operational and stays out of the SDK either way.
  */
+type GithubWebhookRoute = ReturnType<typeof routeGithubWebhook>
+type EnqueueableGithubRoute = Exclude<GithubWebhookRoute, { kind: "ping" } | { kind: "ignore" }>
+
+const parseWebhookJson = (rawBody: string): { ok: true; value: unknown } | { ok: false } => {
+  try {
+    return { ok: true, value: JSON.parse(rawBody) }
+  } catch {
+    return { ok: false }
+  }
+}
+
+const publishGithubDelivery = (
+  queuePublisher: QueuePublisherShape,
+  route: EnqueueableGithubRoute,
+  base: PublishOptions,
+) => {
+  switch (route.kind) {
+    case "pull-request":
+      return queuePublisher.publish("github-events", "pull-request", route.task, base)
+    case "push":
+      return queuePublisher.publish("github-events", "push", route.task, { ...base, delayMs: PUSH_GRACE_DELAY_MS })
+    case "installation":
+      return queuePublisher.publish("github-events", "installation", route.task, base)
+    default: {
+      const _exhaustive: never = route
+      return _exhaustive
+    }
+  }
+}
+
+const handleGithubWebhook = async (c: Context<AppEnv>) => {
+  const config = await Effect.runPromise(loadGithubConfig)
+  if (!config) {
+    return c.json({ error: "GitHub integration is not configured" }, 503)
+  }
+
+  const rawBody = await c.req.text()
+  const verification = await Effect.runPromiseExit(
+    verifyGithubSignature({
+      secret: config.webhookSecret,
+      signature: c.req.header("x-hub-signature-256"),
+      body: rawBody,
+    }),
+  )
+  if (Exit.isFailure(verification)) {
+    return c.json({ error: "Invalid signature" }, 401)
+  }
+
+  const parsed = parseWebhookJson(rawBody)
+  if (!parsed.ok) {
+    return c.json({ error: "Invalid JSON body" }, 400)
+  }
+
+  const event = c.req.header("x-github-event") ?? ""
+  const deliveryId = c.req.header("x-github-delivery") ?? ""
+  const route = routeGithubWebhook({ event, deliveryId, body: parsed.value })
+  if (route.kind === "ping") return c.json({ ok: true }, 200)
+  if (route.kind === "ignore") return c.body(null, 202)
+
+  const base: PublishOptions = {
+    dedupeKey: `github:${deliveryId}`,
+    attempts: MAX_ATTEMPTS,
+    backoff: { type: "exponential", delayMs: RETRY_BACKOFF_BASE_MS },
+  }
+  const published = await Effect.runPromiseExit(publishGithubDelivery(c.get("queuePublisher"), route, base))
+  if (Exit.isFailure(published)) {
+    logger.error("failed to enqueue github delivery", { deliveryId, event })
+    return c.json({ error: "Failed to enqueue delivery" }, 500)
+  }
+
+  return c.body(null, 202)
+}
+
 export const registerGithubRoute = ({ app }: { app: OpenAPIHono<AppEnv> }) => {
   app.use(
     "/webhooks/github",
     createGlobalRateLimiter({ key: "webhooks-github", maxRequests: 10_000, windowSeconds: 60 }),
   )
 
-  app.post("/webhooks/github", async (c) => {
-    const config = await Effect.runPromise(loadGithubConfig)
-    if (!config) {
-      return c.json({ error: "GitHub integration is not configured" }, 503)
-    }
-
-    const rawBody = await c.req.text()
-    const verification = await Effect.runPromiseExit(
-      verifyGithubSignature({
-        secret: config.webhookSecret,
-        signature: c.req.header("x-hub-signature-256"),
-        body: rawBody,
-      }),
-    )
-    if (Exit.isFailure(verification)) {
-      return c.json({ error: "Invalid signature" }, 401)
-    }
-
-    const event = c.req.header("x-github-event") ?? ""
-    const deliveryId = c.req.header("x-github-delivery") ?? ""
-
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(rawBody)
-    } catch {
-      return c.json({ error: "Invalid JSON body" }, 400)
-    }
-
-    const route = routeGithubWebhook({ event, deliveryId, body: parsed })
-    if (route.kind === "ping") return c.json({ ok: true }, 200)
-    if (route.kind === "ignore") return c.body(null, 202)
-
-    const queuePublisher = c.get("queuePublisher")
-    const base: PublishOptions = {
-      dedupeKey: `github:${deliveryId}`,
-      attempts: MAX_ATTEMPTS,
-      backoff: { type: "exponential", delayMs: RETRY_BACKOFF_BASE_MS },
-    }
-
-    const published = await Effect.runPromiseExit(
-      route.kind === "pull-request"
-        ? queuePublisher.publish("github-events", "pull-request", route.task, base)
-        : route.kind === "push"
-          ? queuePublisher.publish("github-events", "push", route.task, { ...base, delayMs: PUSH_GRACE_DELAY_MS })
-          : queuePublisher.publish("github-events", "installation", route.task, base),
-    )
-
-    if (Exit.isFailure(published)) {
-      logger.error("failed to enqueue github delivery", { deliveryId, event })
-      return c.json({ error: "Failed to enqueue delivery" }, 500)
-    }
-
-    return c.body(null, 202)
-  })
+  app.post("/webhooks/github", handleGithubWebhook)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

First cleanup batch after `d14b9438` turned on `complexity/noExcessiveCognitiveComplexity` (max 15, warn). Four `apps/api` functions sat just over the bar (16–18). Each one is split into named helpers / flattened early returns. Same control flow, no product or API behavior change.

No `biome-ignore` for complexity.

### Functions

| File | Function | Before | After |
| --- | --- | --- | --- |
| `apps/api/src/middleware/rate-limiter.ts` | Redis limiter middleware (`createRedisRateLimiter` inner) | 16 | ≤15 |
| `apps/api/src/middleware/access-logger.ts` | `accessLogger` / Hono logger callback | 18 | ≤15 |
| `apps/api/src/mcp/server.ts` | `buildInternalRequestUrl` | 17 | ≤15 |
| `apps/api/src/routes/webhooks-github.ts` | GitHub webhook POST handler | 16 | ≤15 |

After this PR, `apps/api` has no remaining complexity warnings.

The limiter helper has to `return` its `c.json(429)` to Hono. The first extract awaited it and dropped the Response; the follow-up commit returns it so over-limit requests stay 429.

## Inventory (repo-wide, at `d14b9438`)

468 `noExcessiveCognitiveComplexity` warnings. Approximate counts by package:

| Count | Package |
| ---: | --- |
| 115 | `apps/web` |
| 37 | `packages/ui` |
| 35 | `packages/platform/db-clickhouse` |
| 28 | `packages/domain/spans` |
| 25 | `packages/domain/taxonomy` |
| 19 | `packages/domain/flaggers` |
| 18 | `packages/domain/memories` |
| 14 | `packages/domain/signals` |
| 14 | `tools/ai-benchmarks` |
| 12 | `packages/platform/db-postgres` |
| 10 | `packages/telemetry/claude-code` |
| 9 | `packages/telemetry/typescript` |
| 7 | `apps/workers` |
| 7 | `packages/domain/destinations` |
| 7 | `packages/domain/github` |
| 6 | `apps/workflows` |
| 6 | `packages/platform/agent-dispatch` |
| 6 | `packages/sdk` |
| 5 each | `packages/domain/{agent-dispatch,evaluations,monitors}`, `packages/operations`, `packages/telemetry/openclaw-cli` |
| 4 | `apps/api` (this PR) |
| 4 | `.agents` |
| 3 each | `apps/ingest`, `packages/domain/{conversation-intelligence,notifications}`, `packages/platform/workflows-temporal`, `packages/telemetry/{openclaw,pi}` |
| 2 or 1 | remaining domain/platform/tools/infra/scripts packages |

Histogram: 16 (57), 17 (37), 18 (35), 19 (35), 20 (27), then a long tail up to 133.

This PR takes the whole `apps/api` cluster (all four findings were 16–18) and leaves the rest for later small PRs.

## Related issue (if applicable)

Follow-up to #4577 (enable the rule). No issue to close.

## How was this tested?

- `pnpm --filter @app/api check` — clean
- `pnpm --filter @app/api typecheck` — clean
- `pnpm exec biome check` on the four files with `--diagnostic-level=info` — no complexity warnings
- `pnpm --filter @app/api exec vitest run` on `access-logger`, `mcp/server`, `partners` (includes the per-partner 429 case), `webhooks-github-extract`, plus health/account/well-known — 58 passed after the Response-return fix

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b733cc6-792a-4e66-8b67-688795193a0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b733cc6-792a-4e66-8b67-688795193a0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791358475&installation_model_id=435055&pr_number=4579&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4579&signature=36cec69cd1705becbe54ff75be3722ea81e276fa79df676a6731b301528b9430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->