### PR TITLE
chore(biome): reduce cognitive complexity in workflows-temporal client

### DIFF
--- a/packages/platform/workflows-temporal/src/client.ts
+++ b/packages/platform/workflows-temporal/src/client.ts
@@ -28,18 +28,38 @@ const toNonEmptyString = (value: unknown): string | undefined => {
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null
 
+const isJsonPrimitive = (value: unknown): value is string | number | boolean | bigint | null =>
+  value === null ||
+  typeof value === "string" ||
+  typeof value === "number" ||
+  typeof value === "boolean" ||
+  typeof value === "bigint"
+
+const serializeError = (value: Error, depth: number): Record<string, unknown> => {
+  const record: Record<string, unknown> = {
+    constructorName: value.constructor.name,
+    name: value.name,
+    message: value.message,
+  }
+
+  if (value.stack) record.stack = value.stack
+  if ("cause" in value && value.cause !== undefined) {
+    record.cause = toSerializableValue(value.cause, depth + 1)
+  }
+
+  for (const key of Object.keys(value)) {
+    record[key] = toSerializableValue(value[key as keyof Error], depth + 1)
+  }
+
+  return record
+}
+
 const toSerializableValue = (value: unknown, depth = 0): unknown => {
   if (depth >= 4) {
     return typeof value === "object" && value !== null ? `[${value.constructor?.name ?? "Object"}]` : value
   }
 
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean" ||
-    typeof value === "bigint"
-  ) {
+  if (isJsonPrimitive(value)) {
     return value
   }
 
@@ -52,22 +72,7 @@ const toSerializableValue = (value: unknown, depth = 0): unknown => {
   }
 
   if (value instanceof Error) {
-    const record: Record<string, unknown> = {
-      constructorName: value.constructor.name,
-      name: value.name,
-      message: value.message,
-    }
-
-    if (value.stack) record.stack = value.stack
-    if ("cause" in value && value.cause !== undefined) {
-      record.cause = toSerializableValue(value.cause, depth + 1)
-    }
-
-    for (const key of Object.keys(value)) {
-      record[key] = toSerializableValue(value[key as keyof Error], depth + 1)
-    }
-
-    return record
+    return serializeError(value, depth)
   }
 
   if (isRecord(value)) {
@@ -77,34 +82,44 @@ const toSerializableValue = (value: unknown, depth = 0): unknown => {
   return String(value)
 }
 
+const formatErrorInstance = (error: Error): string => {
+  const message = toNonEmptyString(error.message)
+  const causeMessage = "cause" in error ? formatUnknownError(error.cause) : undefined
+
+  if (message !== undefined && message !== OPAQUE_TEMPORAL_ERROR_MESSAGE) {
+    return causeMessage ? `${message} (cause: ${causeMessage})` : message
+  }
+
+  if (causeMessage) {
+    return causeMessage
+  }
+
+  return toNonEmptyString(error.name) ?? OPAQUE_TEMPORAL_ERROR_MESSAGE
+}
+
+const formatErrorRecord = (error: Record<string, unknown>): string | undefined => {
+  const message = toNonEmptyString(error.message)
+  const code = toNonEmptyString(error.code)
+  const details = toNonEmptyString(error.details)
+  const causeMessage = "cause" in error ? formatUnknownError(error.cause) : undefined
+  const pieces = [message, code, details, causeMessage ? `cause: ${causeMessage}` : undefined].filter(
+    (value): value is string => value !== undefined && value !== OPAQUE_TEMPORAL_ERROR_MESSAGE,
+  )
+
+  if (pieces.length === 0) {
+    return undefined
+  }
+
+  return pieces.join(" | ")
+}
+
 const formatUnknownError = (error: unknown): string => {
   if (error instanceof Error) {
-    const message = toNonEmptyString(error.message)
-    const causeMessage = "cause" in error ? formatUnknownError(error.cause) : undefined
-
-    if (message !== undefined && message !== OPAQUE_TEMPORAL_ERROR_MESSAGE) {
-      return causeMessage ? `${message} (cause: ${causeMessage})` : message
-    }
-
-    if (causeMessage) {
-      return causeMessage
-    }
-
-    return toNonEmptyString(error.name) ?? OPAQUE_TEMPORAL_ERROR_MESSAGE
+    return formatErrorInstance(error)
   }
 
   if (isRecord(error)) {
-    const message = toNonEmptyString(error.message)
-    const code = toNonEmptyString(error.code)
-    const details = toNonEmptyString(error.details)
-    const causeMessage = "cause" in error ? formatUnknownError(error.cause) : undefined
-    const pieces = [message, code, details, causeMessage ? `cause: ${causeMessage}` : undefined].filter(
-      (value): value is string => value !== undefined && value !== OPAQUE_TEMPORAL_ERROR_MESSAGE,
-    )
-
-    if (pieces.length > 0) {
-      return pieces.join(" | ")
-    }
+    return formatErrorRecord(error) ?? String(error)
   }
 
   return String(error)
@@ -324,6 +339,13 @@ export function createWorkflowStarter(client: Client, config: TemporalConfig): W
   }
 }
 
+const isAlreadyStoppedWorkflowError = (error: unknown): boolean => {
+  if (error instanceof WorkflowNotFoundError) return true
+  // Temporal reports a closed run as a plain Error naming the terminal state.
+  const message = error instanceof Error ? error.message.toLowerCase() : ""
+  return message.includes("completed") || message.includes("not found") || message.includes("terminated")
+}
+
 /**
  * Hard-stop a running workflow (e.g. a facet garden the user chose to stop or
  * refine). Best-effort: a workflow that finished or was GC'd between the user's
@@ -336,10 +358,7 @@ export function createWorkflowTerminator(client: Client): WorkflowTerminatorShap
         try {
           await client.workflow.getHandle(workflowId).terminate(reason)
         } catch (error) {
-          if (error instanceof WorkflowNotFoundError) return
-          // A completed/terminated workflow can't be terminated again. Nothing to stop.
-          const message = error instanceof Error ? error.message.toLowerCase() : ""
-          if (message.includes("completed") || message.includes("not found") || message.includes("terminated")) return
+          if (isAlreadyStoppedWorkflowError(error)) return
           throw error
         }
       }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Second cleanup batch after `d14b9438` turned on `complexity/noExcessiveCognitiveComplexity` (max 15, warn). The three findings in `@platform/workflows-temporal` sat at 16–19. Each one is split into named helpers. Same control flow, no product or Temporal client behavior change.

No `biome-ignore` for complexity.

Cluster: `packages/platform/workflows-temporal` (`src/client.ts` only). Left `apps/web` and the larger packages alone.

### Functions

| File | Function | Before | After |
| --- | --- | --- | --- |
| `packages/platform/workflows-temporal/src/client.ts` | `toSerializableValue` | 18 | 10 |
| `packages/platform/workflows-temporal/src/client.ts` | `formatUnknownError` | 19 | 3 |
| `packages/platform/workflows-temporal/src/client.ts` | `createWorkflowTerminator` terminate callback | 16 | 7 |

After this PR, `@platform/workflows-temporal` has no remaining complexity warnings.

## Related issue (if applicable)

Follow-up to #4577 (enable the rule). Sibling of #4579 (`apps/api`). No issue to close.

## How was this tested?

- `pnpm --filter @platform/workflows-temporal check` — clean
- `pnpm --filter @platform/workflows-temporal typecheck` — clean
- `pnpm exec biome check` on `src/client.ts` with `--diagnostic-level=info` — no complexity warnings
- `pnpm --filter @platform/workflows-temporal test` — package tests (connection-error formatting, starter, terminator)

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5aa05d66-91e7-4a18-a509-a1d98c99c86b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5aa05d66-91e7-4a18-a509-a1d98c99c86b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791359163&installation_model_id=435055&pr_number=4580&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4580&signature=f27d9f1fc889d082fd627df7a1dc52d7314e64fac8646429fc44f5fb548fd39b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->