### PR TITLE
chore(biome): reduce cognitive complexity in operations handlers

### DIFF
--- a/packages/operations/src/core/flatten-input.ts
+++ b/packages/operations/src/core/flatten-input.ts
@@ -16,6 +16,46 @@ export interface FlatInput {
 
 const isZodObject = (schema: unknown): schema is z.ZodObject<z.ZodRawShape> => schema instanceof z.ZodObject
 
+const mergeShape = (
+  routeName: string,
+  shape: Record<string, z.ZodType>,
+  sources: Record<string, FieldSource>,
+  source: FieldSource,
+  partShape: Readonly<Record<string, z.ZodType>>,
+) => {
+  for (const [key, value] of Object.entries(partShape)) {
+    if (key in shape) {
+      throw new Error(
+        `MCP tool flatten collision on field "${key}" for route "${routeName}": source "${sources[key]}" already provided this field; "${source}" tried to overwrite it. Rename one of the fields.`,
+      )
+    }
+    shape[key] = value
+    sources[key] = source
+  }
+}
+
+const mergeJsonBodySchema = (
+  routeName: string,
+  bodySchema: unknown,
+  shape: Record<string, z.ZodType>,
+  sources: Record<string, FieldSource>,
+) => {
+  if (!bodySchema) return
+  if (isZodObject(bodySchema)) {
+    mergeShape(routeName, shape, sources, "body", bodySchema.shape as Readonly<Record<string, z.ZodType>>)
+    return
+  }
+  // Non-object body (discriminated union, array, …) — preserve discriminator
+  // semantics by keeping the whole body under a single property.
+  if ("body" in shape) {
+    throw new Error(
+      `MCP tool flatten collision: route "${routeName}" already has a "body" field but the request body is non-object and would need to wrap under "body". Rename the existing field.`,
+    )
+  }
+  shape.body = bodySchema as z.ZodType
+  sources.body = "wrapped-body"
+}
+
 /**
  * Flattens a route's `request.params + request.query + request.body` into a single Zod
  * object schema for use as an MCP tool's input schema.
@@ -37,44 +77,16 @@ export const flattenRouteInputSchema = (route: AppRouteConfig): FlatInput => {
   const shape: Record<string, z.ZodType> = {}
   const sources: Record<string, FieldSource> = {}
 
-  const merge = (source: FieldSource, partShape: Readonly<Record<string, z.ZodType>>) => {
-    for (const [key, value] of Object.entries(partShape)) {
-      if (key in shape) {
-        throw new Error(
-          `MCP tool flatten collision on field "${key}" for route "${route.name}": source "${sources[key]}" already provided this field; "${source}" tried to overwrite it. Rename one of the fields.`,
-        )
-      }
-      shape[key] = value
-      sources[key] = source
-    }
-  }
-
   if (route.request?.params && isZodObject(route.request.params)) {
-    merge("param", route.request.params.shape as Readonly<Record<string, z.ZodType>>)
+    mergeShape(route.name, shape, sources, "param", route.request.params.shape as Readonly<Record<string, z.ZodType>>)
   }
   if (route.request?.query && isZodObject(route.request.query)) {
-    merge("query", route.request.query.shape as Readonly<Record<string, z.ZodType>>)
+    mergeShape(route.name, shape, sources, "query", route.request.query.shape as Readonly<Record<string, z.ZodType>>)
   }
 
   const body = route.request?.body
   if (body && "content" in body && body.content) {
-    const jsonEntry = body.content["application/json"]
-    const bodySchema = jsonEntry?.schema
-    if (bodySchema) {
-      if (isZodObject(bodySchema)) {
-        merge("body", bodySchema.shape as Readonly<Record<string, z.ZodType>>)
-      } else {
-        // Non-object body (discriminated union, array, …) — preserve discriminator
-        // semantics by keeping the whole body under a single property.
-        if ("body" in shape) {
-          throw new Error(
-            `MCP tool flatten collision: route "${route.name}" already has a "body" field but the request body is non-object and would need to wrap under "body". Rename the existing field.`,
-          )
-        }
-        shape.body = bodySchema as z.ZodType
-        sources.body = "wrapped-body"
-      }
-    }
+    mergeJsonBodySchema(route.name, body.content["application/json"]?.schema, shape, sources)
   }
 
   return {

--- a/packages/operations/src/operations/projects.ts
+++ b/packages/operations/src/operations/projects.ts
@@ -34,7 +34,7 @@ import {
   ProjectParamsSchema,
   typedResponses,
 } from "../openapi/schemas.ts"
-import type { OrganizationScopedEnv } from "../types.ts"
+import type { AuthContext, OrganizationScopedEnv } from "../types.ts"
 
 // Project-settings shape, expressed at the API layer so each field carries a
 // description (the domain `projectSettingsSchema` is description-free by
@@ -216,6 +216,54 @@ const UpdateRequestSchema = z
   })
   .openapi("UpdateProjectBody")
 
+const oauthActorUserId = (auth: AuthContext): string | undefined =>
+  auth.method === "oauth" ? (auth.userId as string) : undefined
+
+const applyProjectNameAndSettings = (input: {
+  readonly projectId: Project["id"]
+  readonly body: z.infer<typeof UpdateRequestSchema>
+  readonly actorUserId: string | undefined
+}) =>
+  Effect.gen(function* () {
+    let updated = yield* updateProjectUseCase({
+      id: input.projectId,
+      ...(input.body.name !== undefined ? { name: input.body.name } : {}),
+      // Patch, not replace: this schema exposes a subset of the stored settings,
+      // so a replace would let one field's update silently clear the others.
+      ...(input.body.settings !== undefined ? { settingsPatch: input.body.settings } : {}),
+    })
+
+    // `updateProjectUseCase` refuses to write `redaction`, so the policy goes through its
+    // own use case to pick up the audit event that an irreversible change needs.
+    if (input.body.settings?.redaction !== undefined) {
+      updated = yield* updateProjectRedactionUseCase({
+        projectId: input.projectId,
+        actorUserId: input.actorUserId ?? "",
+        redaction: input.body.settings.redaction,
+      })
+    }
+
+    return updated
+  })
+
+const applyProjectFlaggers = (input: {
+  readonly flaggers: NonNullable<z.infer<typeof UpdateRequestSchema>["flaggers"]>
+  readonly organizationId: string
+  readonly projectId: Project["id"]
+  readonly actorUserId: string | undefined
+}) =>
+  Effect.gen(function* () {
+    for (const [slug, enabled] of Object.entries(input.flaggers)) {
+      yield* updateFlaggerUseCase({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        slug: slug as FlaggerSlug,
+        enabled,
+        ...(input.actorUserId !== undefined ? { actorUserId: input.actorUserId } : {}),
+      })
+    }
+  })
+
 const toResponse = (project: Project) => ({
   id: project.id as string,
   organizationId: project.organizationId as string,
@@ -337,39 +385,19 @@ const updateProject = projectEndpoint({
   execute: (input, ctx) =>
     Effect.gen(function* () {
       const body = input.body
-      const actorUserId = ctx.auth.method === "oauth" ? (ctx.auth.userId as string) : undefined
+      const actorUserId = oauthActorUserId(ctx.auth)
 
       const repo = yield* ProjectRepository
       const project = yield* repo.findBySlug(input.params.projectSlug)
-
-      let updated = yield* updateProjectUseCase({
-        id: project.id,
-        ...(body.name !== undefined ? { name: body.name } : {}),
-        // Patch, not replace: this schema exposes a subset of the stored settings,
-        // so a replace would let one field's update silently clear the others.
-        ...(body.settings !== undefined ? { settingsPatch: body.settings } : {}),
-      })
-
-      // `updateProjectUseCase` refuses to write `redaction`, so the policy goes through its
-      // own use case to pick up the audit event that an irreversible change needs.
-      if (body.settings?.redaction !== undefined) {
-        updated = yield* updateProjectRedactionUseCase({
-          projectId: project.id,
-          actorUserId: actorUserId ?? "",
-          redaction: body.settings.redaction,
-        })
-      }
+      const updated = yield* applyProjectNameAndSettings({ projectId: project.id, body, actorUserId })
 
       if (body.flaggers) {
-        for (const [slug, enabled] of Object.entries(body.flaggers)) {
-          yield* updateFlaggerUseCase({
-            organizationId: ctx.organization.id,
-            projectId: updated.id,
-            slug: slug as FlaggerSlug,
-            enabled,
-            ...(actorUserId !== undefined ? { actorUserId } : {}),
-          })
-        }
+        yield* applyProjectFlaggers({
+          flaggers: body.flaggers,
+          organizationId: ctx.organization.id,
+          projectId: updated.id,
+          actorUserId,
+        })
       }
 
       return { status: 200, body: toResponse(updated) } as const

--- a/packages/operations/src/operations/signals.ts
+++ b/packages/operations/src/operations/signals.ts
@@ -19,11 +19,13 @@ import {
   getSignalAnalyticsUseCase,
   getSignalDetailsUseCase,
   getSignalTrendUseCase,
+  type ListSignalsResult,
   listSignalsUseCase,
   listSignalTracesUseCase,
   SIGNAL_FEEDBACK_MAX_LENGTH,
   SIGNAL_PRIORITIES,
   type SignalLifecycleCommand,
+  type SignalLifecycleCommandItem,
   SignalRepository,
   submitSignalFeedbackUseCase,
   updateSignalUseCase,
@@ -176,6 +178,16 @@ const LifecycleResponseSchema = z
   })
   .openapi("SignalsLifecycleResponse")
 
+const toLifecycleItem = (item: SignalLifecycleCommandItem) => ({
+  signalId: item.signalId,
+  resolvedAt: item.resolvedAt ? item.resolvedAt.toISOString() : null,
+  ignoredAt: item.ignoredAt ? item.ignoredAt.toISOString() : null,
+  regressedAt: item.regressedAt ? item.regressedAt.toISOString() : null,
+  mutedAt: item.mutedAt ? item.mutedAt.toISOString() : null,
+  updatedAt: item.updatedAt.toISOString(),
+  changed: item.changed,
+})
+
 const signalsPath = "/projects/:projectSlug/signals"
 
 const signalEndpoint = defineOperation<OrganizationScopedEnv>(signalsPath)
@@ -232,15 +244,7 @@ const buildLifecycleEndpoint = ({
         return {
           status: 200,
           body: {
-            items: result.items.map((item) => ({
-              signalId: item.signalId,
-              resolvedAt: item.resolvedAt ? item.resolvedAt.toISOString() : null,
-              ignoredAt: item.ignoredAt ? item.ignoredAt.toISOString() : null,
-              regressedAt: item.regressedAt ? item.regressedAt.toISOString() : null,
-              mutedAt: item.mutedAt ? item.mutedAt.toISOString() : null,
-              updatedAt: item.updatedAt.toISOString(),
-              changed: item.changed,
-            })),
+            items: result.items.map(toLifecycleItem),
           },
         } as const
       }).pipe(
@@ -355,6 +359,43 @@ const ListSignalsQuerySchema = PaginatedQueryParamsSchema.extend({
   toIso: z.iso.datetime().optional().describe("Upper bound (inclusive) of the time window. Defaults to now."),
 })
 
+const decodeListSignalsOffset = (cursor: string | undefined) =>
+  Effect.gen(function* () {
+    if (!cursor) return 0
+    const decoded = decodeSignalOffsetCursor(cursor)
+    if (decoded === null) {
+      return yield* new BadRequestError({ message: "Invalid `cursor` value." })
+    }
+    return decoded
+  })
+
+const listSignalsTimeRange = (query: Pick<z.infer<typeof ListSignalsQuerySchema>, "fromIso" | "toIso">) =>
+  query.fromIso || query.toIso
+    ? {
+        ...(query.fromIso ? { from: new Date(query.fromIso) } : {}),
+        ...(query.toIso ? { to: new Date(query.toIso) } : {}),
+      }
+    : undefined
+
+const embedSignalSearchIfPresent = (input: {
+  readonly organizationId: OrganizationId
+  readonly projectId: string
+  readonly query: string | undefined
+}) =>
+  input.query
+    ? embedSignalSearchQueryUseCase({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        query: input.query,
+      })
+    : Effect.succeed(undefined)
+
+const toListSignalsBody = (result: ListSignalsResult, offset: number, organizationId: string) => ({
+  items: result.items.map((item) => toSignalResponse(item, organizationId)),
+  nextCursor: result.hasMore ? encodeSignalOffsetCursor(offset + result.items.length) : null,
+  hasMore: result.hasMore,
+})
+
 const listSignals = signalEndpoint({
   route: createRoute({
     method: "get",
@@ -377,34 +418,16 @@ const listSignals = signalEndpoint({
       const { projectSlug } = input.params
       const query = input.query
       const orgId = OrganizationId(ctx.organization.id as string)
-
-      let offset = 0
-      if (query.cursor) {
-        const decoded = decodeSignalOffsetCursor(query.cursor)
-        if (decoded === null) {
-          return yield* new BadRequestError({ message: "Invalid `cursor` value." })
-        }
-        offset = decoded
-      }
+      const offset = yield* decodeListSignalsOffset(query.cursor)
 
       const projectRepo = yield* ProjectRepository
       const project = yield* projectRepo.findBySlug(projectSlug)
-
-      const timeRange =
-        query.fromIso || query.toIso
-          ? {
-              ...(query.fromIso ? { from: new Date(query.fromIso) } : {}),
-              ...(query.toIso ? { to: new Date(query.toIso) } : {}),
-            }
-          : undefined
-
-      const search = query.query
-        ? yield* embedSignalSearchQueryUseCase({
-            organizationId: orgId,
-            projectId: project.id,
-            query: query.query,
-          })
-        : undefined
+      const timeRange = listSignalsTimeRange(query)
+      const search = yield* embedSignalSearchIfPresent({
+        organizationId: orgId,
+        projectId: project.id,
+        query: query.query,
+      })
 
       const result = yield* listSignalsUseCase({
         organizationId: orgId,
@@ -418,11 +441,7 @@ const listSignals = signalEndpoint({
       })
       return {
         status: 200,
-        body: {
-          items: result.items.map((item) => toSignalResponse(item, ctx.organization.id as string)),
-          nextCursor: result.hasMore ? encodeSignalOffsetCursor(offset + result.items.length) : null,
-          hasMore: result.hasMore,
-        },
+        body: toListSignalsBody(result, offset, ctx.organization.id as string),
       } as const
     }).pipe(
       withPostgres(

--- a/packages/operations/src/operations/spans.ts
+++ b/packages/operations/src/operations/spans.ts
@@ -2,8 +2,10 @@ import { ProjectRepository } from "@domain/projects"
 import { OrganizationId, ProjectId, SpanId, TraceId } from "@domain/shared"
 import {
   type SpanListCursor,
+  type SpanListOptions,
   type SpanListOrderDirection,
   type SpanListOrderField,
+  type SpanListPage,
   SpanRepository,
 } from "@domain/spans"
 import { createRoute, z } from "@hono/zod-openapi"
@@ -110,6 +112,59 @@ const QuerySpansResponseSchema = z
   })
   .openapi("QuerySpans")
 
+type QuerySpansBody = z.infer<typeof QuerySpansBodySchema>
+type QuerySpansOrderBy = { readonly field: SpanListOrderField; readonly direction: SpanListOrderDirection }
+
+const invalidCursorResponse = { status: 400, body: { error: "Invalid `cursor` value." } } as const
+const cursorOrderMismatchResponse = {
+  status: 400,
+  body: { error: "`cursor` does not match `orderBy`; restart pagination without the cursor." },
+} as const
+const invalidRangeResponse = {
+  status: 400,
+  body: { error: "`range.fromIso` must be strictly before `range.toIso`." },
+} as const
+
+const parseQuerySpansCursor = (
+  raw: string | undefined,
+  orderBy: QuerySpansOrderBy,
+):
+  | { ok: true; cursor: SpanListCursor | undefined }
+  | { ok: false; response: typeof invalidCursorResponse | typeof cursorOrderMismatchResponse } => {
+  if (!raw) return { ok: true, cursor: undefined }
+  const decoded = decodeSpanListCursor(raw)
+  if (decoded === null) return { ok: false, response: invalidCursorResponse }
+  // The cursor is pinned to the ordering it was minted under; replaying it
+  // under a different `orderBy` would page incoherently.
+  if (decoded.field !== orderBy.field || decoded.direction !== orderBy.direction) {
+    return { ok: false, response: cursorOrderMismatchResponse }
+  }
+  return { ok: true, cursor: decoded }
+}
+
+const isInvalidSpanQueryRange = (range: QuerySpansBody["range"]): boolean =>
+  Boolean(range && new Date(range.fromIso).getTime() >= new Date(range.toIso).getTime())
+
+const querySpansListOptions = (input: {
+  readonly limit: number
+  readonly orderBy: QuerySpansOrderBy
+  readonly cursor: SpanListCursor | undefined
+  readonly filters: QuerySpansBody["filters"]
+  readonly range: QuerySpansBody["range"]
+}): SpanListOptions => ({
+  limit: input.limit,
+  orderBy: input.orderBy,
+  ...(input.cursor ? { cursor: input.cursor } : {}),
+  ...(input.filters ? { filters: input.filters } : {}),
+  ...(input.range ? { startTimeFrom: new Date(input.range.fromIso), startTimeTo: new Date(input.range.toIso) } : {}),
+})
+
+const toQuerySpansPage = (page: SpanListPage) => ({
+  items: page.items.map(toSpanResponse),
+  nextCursor: page.nextCursor ? encodeSpanListCursor(page.nextCursor) : null,
+  hasMore: page.nextCursor !== null,
+})
+
 // A cross-trace span list is a POST so `filters` is a typed object in the body
 // (visible in the generated SDK/MCP schema) rather than a URL-encoded JSON string.
 const querySpans = spanEndpoint({
@@ -133,26 +188,10 @@ const querySpans = spanEndpoint({
     Effect.gen(function* () {
       const { projectSlug } = input.params
       const body = input.body
-
       const orderBy = body.orderBy ?? { field: "startTime" as const, direction: "desc" as const }
-
-      let cursor: SpanListCursor | undefined
-      if (body.cursor) {
-        const decoded = decodeSpanListCursor(body.cursor)
-        if (decoded === null) return { status: 400, body: { error: "Invalid `cursor` value." } } as const
-        // The cursor is pinned to the ordering it was minted under; replaying it
-        // under a different `orderBy` would page incoherently.
-        if (decoded.field !== orderBy.field || decoded.direction !== orderBy.direction) {
-          return {
-            status: 400,
-            body: { error: "`cursor` does not match `orderBy`; restart pagination without the cursor." },
-          } as const
-        }
-        cursor = decoded
-      }
-      if (body.range && new Date(body.range.fromIso).getTime() >= new Date(body.range.toIso).getTime()) {
-        return { status: 400, body: { error: "`range.fromIso` must be strictly before `range.toIso`." } } as const
-      }
+      const parsedCursor = parseQuerySpansCursor(body.cursor, orderBy)
+      if (!parsedCursor.ok) return parsedCursor.response
+      if (isInvalidSpanQueryRange(body.range)) return invalidRangeResponse
 
       const projectRepo = yield* ProjectRepository
       const project = yield* projectRepo.findBySlug(projectSlug)
@@ -161,24 +200,18 @@ const querySpans = spanEndpoint({
       const page = yield* spanRepo.listByProjectId({
         organizationId: OrganizationId(ctx.organization.id as string),
         projectId: ProjectId(project.id as string),
-        options: {
+        options: querySpansListOptions({
           limit: body.limit,
           orderBy,
-          ...(cursor ? { cursor } : {}),
-          ...(body.filters ? { filters: body.filters } : {}),
-          ...(body.range
-            ? { startTimeFrom: new Date(body.range.fromIso), startTimeTo: new Date(body.range.toIso) }
-            : {}),
-        },
+          cursor: parsedCursor.cursor,
+          filters: body.filters,
+          range: body.range,
+        }),
       })
 
       return {
         status: 200,
-        body: {
-          items: page.items.map(toSpanResponse),
-          nextCursor: page.nextCursor ? encodeSpanListCursor(page.nextCursor) : null,
-          hasMore: page.nextCursor !== null,
-        },
+        body: toQuerySpansPage(page),
       } as const
     }).pipe(
       withPostgres(ProjectRepositoryLive, ctx.postgresClient, ctx.organization.id),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fourth cleanup batch after `d14b9438` turned on `complexity/noExcessiveCognitiveComplexity` (max 15, warn). Five `@repo/operations` functions sat just over the bar (16–24). Each one is split into named helpers / flattened early returns. Same control flow, no product or API behavior change.

No `biome-ignore` for complexity.

### Functions

| File | Function | Before | After |
| --- | --- | --- | --- |
| `packages/operations/src/core/flatten-input.ts` | `flattenRouteInputSchema` | 16 | 6 |
| `packages/operations/src/operations/projects.ts` | `updateProject` execute generator | 18 | 2 |
| `packages/operations/src/operations/signals.ts` | lifecycle item mapper (`toLifecycleItem`) | 16 | 4 |
| `packages/operations/src/operations/signals.ts` | `listSignals` execute generator | 24 | 6 |
| `packages/operations/src/operations/spans.ts` | `querySpans` execute generator | 21 | 5 |

After this PR, `@repo/operations` has no remaining complexity warnings.

## Related issue (if applicable)

Follow-up to #4577 (enable the rule) and the first three cleanup batches: #4579 (`apps/api`), #4580 (`workflows-temporal`), #4581 (`notifications`). No issue to close.

## How was this tested?

- `pnpm --filter @repo/operations check` — clean
- `pnpm --filter @repo/operations typecheck` — clean
- `pnpm exec biome check --diagnostic-level=info packages/operations` — no complexity warnings
- `pnpm --filter @repo/operations test` — 15 files, 94 tests passed (Node 25)
- CI on this PR: check, typecheck, knip, test-unit, test-unit-heavy, test-integration, manifests all green

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cbbda6c-e469-4bb0-aece-6e2ccaa3de8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cbbda6c-e469-4bb0-aece-6e2ccaa3de8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791361040&installation_model_id=435055&pr_number=4582&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4582&signature=87486566ec187055dd4dcd04480b81bf2414b1dea96582505868c58852d1f93b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->