### PR TITLE
chore(biome): reduce cognitive complexity in apps/ingest

### DIFF
--- a/apps/ingest/src/routes/traces.ts
+++ b/apps/ingest/src/routes/traces.ts
@@ -1,7 +1,7 @@
 import { NoCreditsRemainingError } from "@domain/billing"
 import { SandboxArchivedError, SandboxQuotaExceededError } from "@domain/sandboxes"
 import { OrganizationId } from "@domain/shared"
-import { ingestSpansWithBillingUseCase } from "@domain/spans"
+import { type IngestSpansResult, ingestSpansWithBillingUseCase } from "@domain/spans"
 import { RedisCacheStoreLive, SandboxSignalsLive } from "@platform/cache-redis"
 import {
   BillingOverrideRepositoryLive,
@@ -17,7 +17,7 @@ import { QueuePublisherLive } from "@platform/queue-bullmq"
 import { StorageDiskLive } from "@platform/storage-object"
 import { withTracing } from "@repo/observability"
 import { Cause, Effect, Exit, Layer, Option } from "effect"
-import type { Handler, Hono } from "hono"
+import type { Context, Handler, Hono } from "hono"
 import { getPostgresClient, getQueuePublisher, getRedisClient, getStorageDisk } from "../clients.ts"
 import { authMiddleware } from "../middleware/auth.ts"
 import { projectMiddleware } from "../middleware/project.ts"
@@ -45,6 +45,120 @@ const buildRejectionMessage = (rejected: number): string =>
   "OTEL resource attribute, or the `X-Latitude-Project` export header. If you already set one, " +
   "check that the slug exists in this Latitude organization."
 
+type RateLimitedTraceResult = {
+  readonly limitedBy: "requests" | "bytes"
+  readonly retryAfterSeconds: number
+}
+
+const rateLimitedTraceResponse = (c: Context<IngestEnv>, rateLimit: RateLimitedTraceResult) => {
+  const error =
+    rateLimit.limitedBy === "bytes"
+      ? "Trace ingestion volume exceeded. Please retry later."
+      : "Too many trace ingestion requests. Please retry later."
+
+  return c.json(
+    {
+      error,
+      retryAfter: rateLimit.retryAfterSeconds,
+    },
+    429,
+    { "Retry-After": String(rateLimit.retryAfterSeconds) },
+  )
+}
+
+const runTraceIngestion = async ({
+  organization,
+  apiKeyId,
+  isSandbox,
+  payload,
+  contentType,
+  defaultProjectSlug,
+}: {
+  organization: ReturnType<typeof OrganizationId>
+  apiKeyId: string
+  isSandbox: boolean
+  payload: Uint8Array
+  contentType: string
+  defaultProjectSlug?: string | undefined
+}) => {
+  const disk = getStorageDisk()
+  const publisher = await getQueuePublisher()
+  const postgresClient = getPostgresClient()
+  // The org half of the redaction cascade is read here, not in the domain: the
+  // cached resolver is a platform concern. The project half is free downstream,
+  // where project settings are already loaded for sampling.
+  return Effect.gen(function* () {
+    const organizationRedaction = yield* resolveOrganizationRedactionCached(organization)
+
+    return yield* ingestSpansWithBillingUseCase({
+      organizationId: organization,
+      apiKeyId,
+      isSandbox,
+      payload,
+      contentType,
+      organizationRedaction,
+      ...(defaultProjectSlug ? { defaultProjectSlug } : {}),
+    })
+  }).pipe(
+    withPostgres(traceIngestionBillingLayers, postgresClient, organization),
+    Effect.provide(
+      Layer.mergeAll(
+        StorageDiskLive(disk),
+        QueuePublisherLive(publisher),
+        SandboxSignalsLive(getRedisClient()),
+        RedisCacheStoreLive(getRedisClient()),
+      ),
+    ),
+    withTracing,
+  )
+}
+
+const mappedIngestionFailureResponse = (c: Context<IngestEnv>, cause: Cause.Cause<unknown>) => {
+  const failure = Cause.findErrorOption(cause)
+  if (Option.isNone(failure)) return undefined
+
+  const err = failure.value
+  if (err instanceof NoCreditsRemainingError) {
+    return c.json({ error: err.httpMessage, kind: "NoCreditsRemaining" }, err.httpStatus)
+  }
+  if (err instanceof SandboxArchivedError) {
+    return c.json({ error: err.httpMessage, kind: "SandboxArchived" }, err.httpStatus)
+  }
+  if (err instanceof SandboxQuotaExceededError) {
+    return c.json({ error: err.httpMessage, kind: "SandboxQuotaExceeded" }, err.httpStatus)
+  }
+  if ((err as { _tag?: string })._tag === "SpanDecodingError") {
+    const decoding = err as { httpMessage?: string }
+    return c.json({ error: decoding.httpMessage ?? "Invalid OTLP payload" }, 400)
+  }
+  return undefined
+}
+
+const traceIngestionSuccessResponse = (c: Context<IngestEnv>, result: IngestSpansResult) => {
+  // OTLP response contract:
+  //  - All-valid batch                   → 200 OK, empty `ExportTraceServiceResponse`
+  //  - Mixed (some rejected, some kept)  → 200 OK + `partialSuccess { rejectedSpans, errorMessage }`
+  //    (spec §3.2: `partialSuccess` ONLY belongs on 2xx — it conveys "we kept some")
+  //  - Empty batch (no spans to ingest)  → 202 Accepted (legacy no-op, OTLP-permissive)
+  //  - All rejected                      → 400 with a `google.rpc.Status`-shaped body
+  //    ({ code, message }) — NOT `partialSuccess`, since nothing was persisted
+  if (result.totalSpans === 0) {
+    return c.json({}, 202)
+  }
+  if (result.acceptedSpans === 0) {
+    return c.json({ code: 400, message: buildRejectionMessage(result.rejectedSpans) }, 400)
+  }
+  if (result.rejectedSpans > 0) {
+    return c.json({
+      partialSuccess: {
+        rejectedSpans: result.rejectedSpans,
+        errorMessage: buildRejectionMessage(result.rejectedSpans),
+      },
+    })
+  }
+  return c.json({})
+}
+
 export const registerTracesRoute = ({ app, tracePayloadProtection }: TracesRouteContext) => {
   const handleTraceRequest: Handler<IngestEnv> = async (c) => {
     const { payload: body, contentType } = c.get("tracePayload")
@@ -60,108 +174,26 @@ export const registerTracesRoute = ({ app, tracePayloadProtection }: TracesRoute
       payloadBytes: body.byteLength,
       isSandbox,
     })
+    if (!rateLimit.allowed) return rateLimitedTraceResponse(c, rateLimit)
 
-    if (!rateLimit.allowed) {
-      const error =
-        rateLimit.limitedBy === "bytes"
-          ? "Trace ingestion volume exceeded. Please retry later."
-          : "Too many trace ingestion requests. Please retry later."
-
-      return c.json(
-        {
-          error,
-          retryAfter: rateLimit.retryAfterSeconds,
-        },
-        429,
-        { "Retry-After": String(rateLimit.retryAfterSeconds) },
-      )
-    }
-
-    const organization = OrganizationId(organizationId)
-    const apiKeyId = c.get("apiKeyId")
-    const defaultProjectSlug = c.get("defaultProjectSlug")
-
-    const disk = getStorageDisk()
-    const publisher = await getQueuePublisher()
-    const postgresClient = getPostgresClient()
-    // The org half of the redaction cascade is read here, not in the domain: the
-    // cached resolver is a platform concern. The project half is free downstream,
-    // where project settings are already loaded for sampling.
-    const ingestionEffect = Effect.gen(function* () {
-      const organizationRedaction = yield* resolveOrganizationRedactionCached(organization)
-
-      return yield* ingestSpansWithBillingUseCase({
-        organizationId: organization,
-        apiKeyId,
+    const exit = await Effect.runPromiseExit(
+      await runTraceIngestion({
+        organization: OrganizationId(organizationId),
+        apiKeyId: c.get("apiKeyId"),
         isSandbox,
         payload: body,
         contentType,
-        organizationRedaction,
-        ...(defaultProjectSlug ? { defaultProjectSlug } : {}),
-      })
-    }).pipe(
-      withPostgres(traceIngestionBillingLayers, postgresClient, organization),
-      Effect.provide(
-        Layer.mergeAll(
-          StorageDiskLive(disk),
-          QueuePublisherLive(publisher),
-          SandboxSignalsLive(getRedisClient()),
-          RedisCacheStoreLive(getRedisClient()),
-        ),
-      ),
-      withTracing,
+        defaultProjectSlug: c.get("defaultProjectSlug"),
+      }),
     )
 
-    const exit = await Effect.runPromiseExit(ingestionEffect)
-
     if (Exit.isFailure(exit)) {
-      const failure = Cause.findErrorOption(exit.cause)
-      if (Option.isSome(failure) && failure.value instanceof NoCreditsRemainingError) {
-        const err = failure.value
-        return c.json({ error: err.httpMessage, kind: "NoCreditsRemaining" }, err.httpStatus)
-      }
-      if (Option.isSome(failure) && failure.value instanceof SandboxArchivedError) {
-        const err = failure.value
-        return c.json({ error: err.httpMessage, kind: "SandboxArchived" }, err.httpStatus)
-      }
-      if (Option.isSome(failure) && failure.value instanceof SandboxQuotaExceededError) {
-        const err = failure.value
-        return c.json({ error: err.httpMessage, kind: "SandboxQuotaExceeded" }, err.httpStatus)
-      }
-      if (Option.isSome(failure) && (failure.value as { _tag?: string })._tag === "SpanDecodingError") {
-        const err = failure.value as { httpMessage?: string }
-        return c.json({ error: err.httpMessage ?? "Invalid OTLP payload" }, 400)
-      }
+      const mapped = mappedIngestionFailureResponse(c, exit.cause)
+      if (mapped) return mapped
       throw new Error(Cause.pretty(exit.cause))
     }
 
-    const result = exit.value
-
-    // OTLP response contract:
-    //  - All-valid batch                   → 200 OK, empty `ExportTraceServiceResponse`
-    //  - Mixed (some rejected, some kept)  → 200 OK + `partialSuccess { rejectedSpans, errorMessage }`
-    //    (spec §3.2: `partialSuccess` ONLY belongs on 2xx — it conveys "we kept some")
-    //  - Empty batch (no spans to ingest)  → 202 Accepted (legacy no-op, OTLP-permissive)
-    //  - All rejected                      → 400 with a `google.rpc.Status`-shaped body
-    //    ({ code, message }) — NOT `partialSuccess`, since nothing was persisted
-    if (result.totalSpans === 0) {
-      return c.json({}, 202)
-    }
-
-    if (result.acceptedSpans === 0) {
-      return c.json({ code: 400, message: buildRejectionMessage(result.rejectedSpans) }, 400)
-    }
-
-    if (result.rejectedSpans > 0) {
-      return c.json({
-        partialSuccess: {
-          rejectedSpans: result.rejectedSpans,
-          errorMessage: buildRejectionMessage(result.rejectedSpans),
-        },
-      })
-    }
-
-    return c.json({})
+    return traceIngestionSuccessResponse(c, exit.value)
   }
 
   app.post(

--- a/apps/ingest/src/trace-payload.ts
+++ b/apps/ingest/src/trace-payload.ts
@@ -1,6 +1,6 @@
 import { parseEnv } from "@platform/env"
 import { Effect } from "effect"
-import type { MiddlewareHandler } from "hono"
+import type { Context, MiddlewareHandler } from "hono"
 import type { IngestEnv, TracePayload } from "./types.ts"
 
 interface TracePayloadLimits {
@@ -169,57 +169,60 @@ const cancelReader = async (reader: ReadableStreamDefaultReader<Uint8Array>) => 
   } catch {}
 }
 
-export const readTracePayload = async ({
-  stream,
+const emptyStreamResult = (declaredBytes?: number): ReadTracePayloadResult => {
+  if (declaredBytes !== undefined && declaredBytes !== 0) {
+    return { kind: "length_mismatch", observedBytes: 0 }
+  }
+  return { kind: "success", payload: new Uint8Array() }
+}
+
+type StreamedChunkResult =
+  | { readonly kind: "continue" }
+  | Extract<ReadTracePayloadResult, { kind: "too_large" | "length_mismatch" | "capacity_exceeded" }>
+
+const applyStreamedChunk = ({
+  chunk,
+  observedBytes,
   declaredBytes,
+  declaredPayload,
+  chunks,
   maxPayloadBytes,
   capacity,
-}: ReadTracePayloadInput): Promise<ReadTracePayloadResult> => {
-  if (!stream) {
-    if (declaredBytes !== undefined && declaredBytes !== 0) {
-      return { kind: "length_mismatch", observedBytes: 0 }
-    }
-    return { kind: "success", payload: new Uint8Array() }
+}: {
+  chunk: Uint8Array
+  observedBytes: number
+  declaredBytes?: number | undefined
+  declaredPayload?: Uint8Array | undefined
+  chunks: Uint8Array[]
+  maxPayloadBytes: number
+  capacity?: Pick<TracePayloadLease, "reserve" | "releaseReserved"> | undefined
+}): StreamedChunkResult => {
+  if (observedBytes > maxPayloadBytes) {
+    return { kind: "too_large", observedBytes }
   }
-
-  const reader = stream.getReader()
-  const declaredPayload = declaredBytes === undefined ? undefined : new Uint8Array(declaredBytes)
-  const chunks: Uint8Array[] = []
-  let observedBytes = 0
-
-  try {
-    while (true) {
-      const chunk = await reader.read()
-      if (chunk.done) break
-
-      observedBytes += chunk.value.byteLength
-      if (observedBytes > maxPayloadBytes) {
-        await cancelReader(reader)
-        return { kind: "too_large", observedBytes }
-      }
-      if (declaredBytes !== undefined && observedBytes > declaredBytes) {
-        await cancelReader(reader)
-        return { kind: "length_mismatch", observedBytes }
-      }
-
-      if (declaredPayload !== undefined) {
-        declaredPayload.set(chunk.value, observedBytes - chunk.value.byteLength)
-      } else {
-        if (capacity && !capacity.reserve(chunk.value.byteLength)) {
-          await cancelReader(reader)
-          return { kind: "capacity_exceeded", observedBytes }
-        }
-        chunks.push(chunk.value)
-      }
-    }
-  } finally {
-    reader.releaseLock()
+  if (declaredBytes !== undefined && observedBytes > declaredBytes) {
+    return { kind: "length_mismatch", observedBytes }
   }
-
   if (declaredPayload !== undefined) {
-    if (observedBytes !== declaredPayload.byteLength) return { kind: "length_mismatch", observedBytes }
-    return { kind: "success", payload: declaredPayload }
+    declaredPayload.set(chunk, observedBytes - chunk.byteLength)
+    return { kind: "continue" }
   }
+  if (capacity && !capacity.reserve(chunk.byteLength)) {
+    return { kind: "capacity_exceeded", observedBytes }
+  }
+  chunks.push(chunk)
+  return { kind: "continue" }
+}
+
+const assembleUndeclaredPayload = ({
+  chunks,
+  observedBytes,
+  capacity,
+}: {
+  chunks: Uint8Array[]
+  observedBytes: number
+  capacity?: Pick<TracePayloadLease, "reserve" | "releaseReserved"> | undefined
+}): ReadTracePayloadResult => {
   if (!observedBytes) return { kind: "success", payload: new Uint8Array() }
   if (capacity && !capacity.reserve(observedBytes)) return { kind: "capacity_exceeded", observedBytes }
 
@@ -238,6 +241,64 @@ export const readTracePayload = async ({
   chunks.length = 0
   capacity?.releaseReserved(observedBytes)
   return { kind: "success", payload }
+}
+
+const finalizeTracePayload = ({
+  declaredPayload,
+  observedBytes,
+  chunks,
+  capacity,
+}: {
+  declaredPayload?: Uint8Array | undefined
+  observedBytes: number
+  chunks: Uint8Array[]
+  capacity?: Pick<TracePayloadLease, "reserve" | "releaseReserved"> | undefined
+}): ReadTracePayloadResult => {
+  if (declaredPayload !== undefined) {
+    if (observedBytes !== declaredPayload.byteLength) return { kind: "length_mismatch", observedBytes }
+    return { kind: "success", payload: declaredPayload }
+  }
+  return assembleUndeclaredPayload({ chunks, observedBytes, capacity })
+}
+
+export const readTracePayload = async ({
+  stream,
+  declaredBytes,
+  maxPayloadBytes,
+  capacity,
+}: ReadTracePayloadInput): Promise<ReadTracePayloadResult> => {
+  if (!stream) return emptyStreamResult(declaredBytes)
+
+  const reader = stream.getReader()
+  const declaredPayload = declaredBytes === undefined ? undefined : new Uint8Array(declaredBytes)
+  const chunks: Uint8Array[] = []
+  let observedBytes = 0
+
+  try {
+    while (true) {
+      const chunk = await reader.read()
+      if (chunk.done) break
+
+      observedBytes += chunk.value.byteLength
+      const applied = applyStreamedChunk({
+        chunk: chunk.value,
+        observedBytes,
+        declaredBytes,
+        declaredPayload,
+        chunks,
+        maxPayloadBytes,
+        capacity,
+      })
+      if (applied.kind !== "continue") {
+        await cancelReader(reader)
+        return applied
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  return finalizeTracePayload({ declaredPayload, observedBytes, chunks, capacity })
 }
 
 interface TracePayloadProtectionInput {
@@ -307,6 +368,109 @@ const annotateProcessingMemory = (
   })
 }
 
+type PayloadAnnotation = {
+  span: TracePayloadSpan | undefined
+  runtime: TracePayloadRuntime
+  contentType: string
+  declaredBytes?: number | undefined
+}
+
+type TimedReadTracePayloadResult = ReadTracePayloadResult & { readonly bodyReadDurationMs: number }
+
+const invalidTraceLengthResponse = (c: Context<IngestEnv>, kind: "invalid" | "too_large") =>
+  c.json({ error: "Invalid trace payload length." }, kind === "too_large" ? 413 : 400)
+
+const admissionRejectedResponse = (
+  c: Context<IngestEnv>,
+  annotation: PayloadAnnotation,
+  limitedBy: "bytes" | "concurrency",
+) => {
+  annotatePayloadSpan({
+    ...annotation,
+    outcome: "admission_rejected",
+    observedBytes: 0,
+    bodyReadDurationMs: 0,
+    admissionLimitedBy: limitedBy,
+  })
+  return c.json({ error: "Trace ingestion is temporarily at capacity. Please retry later." }, 503, {
+    "Retry-After": "1",
+  })
+}
+
+const payloadReadFailureResponse = (
+  c: Context<IngestEnv>,
+  annotation: PayloadAnnotation,
+  result: Extract<TimedReadTracePayloadResult, { kind: "too_large" | "length_mismatch" | "capacity_exceeded" }>,
+  maxPayloadBytes: number,
+) => {
+  switch (result.kind) {
+    case "too_large":
+      annotatePayloadSpan({
+        ...annotation,
+        outcome: "streamed_too_large",
+        observedBytes: result.observedBytes,
+        bodyReadDurationMs: result.bodyReadDurationMs,
+      })
+      return c.json({ error: `Trace payload exceeds the ${maxPayloadBytes}-byte limit.` }, 413)
+    case "length_mismatch":
+      annotatePayloadSpan({
+        ...annotation,
+        outcome: "content_length_mismatch",
+        observedBytes: result.observedBytes,
+        bodyReadDurationMs: result.bodyReadDurationMs,
+      })
+      return c.json({ error: "Content-Length does not match the trace payload." }, 400)
+    case "capacity_exceeded":
+      annotatePayloadSpan({
+        ...annotation,
+        outcome: "stream_admission_rejected",
+        observedBytes: result.observedBytes,
+        bodyReadDurationMs: result.bodyReadDurationMs,
+        admissionLimitedBy: "bytes",
+      })
+      return c.json({ error: "Trace ingestion is temporarily at capacity. Please retry later." }, 503, {
+        "Retry-After": "1",
+      })
+    default: {
+      const _exhaustive: never = result
+      return _exhaustive
+    }
+  }
+}
+
+const readTracePayloadOrAnnotate = async ({
+  annotation,
+  stream,
+  declaredBytes,
+  maxPayloadBytes,
+  capacity,
+}: {
+  annotation: PayloadAnnotation
+  stream: ReadableStream<Uint8Array> | null
+  declaredBytes?: number | undefined
+  maxPayloadBytes: number
+  capacity: Pick<TracePayloadLease, "reserve" | "releaseReserved">
+}): Promise<TimedReadTracePayloadResult> => {
+  const startedAt = annotation.runtime.now()
+  try {
+    const result = await readTracePayload({
+      stream,
+      declaredBytes,
+      maxPayloadBytes,
+      capacity,
+    })
+    return { ...result, bodyReadDurationMs: annotation.runtime.now() - startedAt }
+  } catch (error) {
+    annotatePayloadSpan({
+      ...annotation,
+      outcome: "read_error",
+      observedBytes: 0,
+      bodyReadDurationMs: annotation.runtime.now() - startedAt,
+    })
+    throw error
+  }
+}
+
 export interface TracePayloadProtection {
   readonly rejectOversizedHeaders: MiddlewareHandler<IngestEnv>
   readonly readPayload: MiddlewareHandler<IngestEnv>
@@ -352,89 +516,31 @@ export const createTracePayloadProtection = ({
     const contentType = c.req.header("Content-Type") ?? "application/json"
     const parsed = parseTraceContentLength(c.req.header("Content-Length"), limits.maxPayloadBytes)
     if (parsed.kind !== "valid") {
-      return c.json({ error: "Invalid trace payload length." }, parsed.kind === "too_large" ? 413 : 400)
+      return invalidTraceLengthResponse(c, parsed.kind)
     }
 
     const span = runtime.getActiveSpan()
     const acquired = admission.tryAcquire(parsed.declaredBytes ?? 0)
+    const annotation = {
+      span,
+      runtime,
+      contentType,
+      declaredBytes: parsed.declaredBytes,
+    }
     if (acquired.kind === "rejected") {
-      annotatePayloadSpan({
-        span,
-        runtime,
-        contentType,
-        outcome: "admission_rejected",
-        observedBytes: 0,
-        declaredBytes: parsed.declaredBytes,
-        bodyReadDurationMs: 0,
-        admissionLimitedBy: acquired.limitedBy,
-      })
-      return c.json({ error: "Trace ingestion is temporarily at capacity. Please retry later." }, 503, {
-        "Retry-After": "1",
-      })
+      return admissionRejectedResponse(c, annotation, acquired.limitedBy)
     }
 
-    let startedAt = 0
     try {
-      startedAt = runtime.now()
-      let result: ReadTracePayloadResult
-      try {
-        result = await readTracePayload({
-          stream: c.req.raw.body,
-          declaredBytes: parsed.declaredBytes,
-          maxPayloadBytes: limits.maxPayloadBytes,
-          capacity: acquired.lease,
-        })
-      } catch (error) {
-        annotatePayloadSpan({
-          span,
-          runtime,
-          contentType,
-          outcome: "read_error",
-          observedBytes: 0,
-          declaredBytes: parsed.declaredBytes,
-          bodyReadDurationMs: runtime.now() - startedAt,
-        })
-        throw error
-      }
-      const bodyReadDurationMs = runtime.now() - startedAt
-
-      if (result.kind === "too_large") {
-        annotatePayloadSpan({
-          span,
-          runtime,
-          contentType,
-          outcome: "streamed_too_large",
-          observedBytes: result.observedBytes,
-          declaredBytes: parsed.declaredBytes,
-          bodyReadDurationMs,
-        })
-        return c.json({ error: `Trace payload exceeds the ${limits.maxPayloadBytes}-byte limit.` }, 413)
-      }
-      if (result.kind === "length_mismatch") {
-        annotatePayloadSpan({
-          span,
-          runtime,
-          contentType,
-          outcome: "content_length_mismatch",
-          observedBytes: result.observedBytes,
-          declaredBytes: parsed.declaredBytes,
-          bodyReadDurationMs,
-        })
-        return c.json({ error: "Content-Length does not match the trace payload." }, 400)
-      }
-      if (result.kind === "capacity_exceeded") {
-        annotatePayloadSpan({
-          span,
-          runtime,
-          contentType,
-          outcome: "stream_admission_rejected",
-          observedBytes: result.observedBytes,
-          bodyReadDurationMs,
-          admissionLimitedBy: "bytes",
-        })
-        return c.json({ error: "Trace ingestion is temporarily at capacity. Please retry later." }, 503, {
-          "Retry-After": "1",
-        })
+      const result = await readTracePayloadOrAnnotate({
+        annotation,
+        stream: c.req.raw.body,
+        declaredBytes: parsed.declaredBytes,
+        maxPayloadBytes: limits.maxPayloadBytes,
+        capacity: acquired.lease,
+      })
+      if (result.kind !== "success") {
+        return payloadReadFailureResponse(c, annotation, result, limits.maxPayloadBytes)
       }
 
       const tracePayload: TracePayload = {
@@ -443,13 +549,10 @@ export const createTracePayloadProtection = ({
       }
       c.set("tracePayload", tracePayload)
       annotatePayloadSpan({
-        span,
-        runtime,
-        contentType,
+        ...annotation,
         outcome: "accepted",
         observedBytes: result.payload.byteLength,
-        declaredBytes: parsed.declaredBytes,
-        bodyReadDurationMs,
+        bodyReadDurationMs: result.bodyReadDurationMs,
       })
       await next()
     } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Sixth cleanup batch after `complexity/noExcessiveCognitiveComplexity` (max 15, warn). The three remaining `apps/ingest` hotspots sat at 19–32. Each one is split into named helpers / flattened early returns. Same control flow, same HTTP responses, no product or API behavior change.

No `biome-ignore` for complexity.

### Functions

| File | Function | Before | After |
| --- | --- | --- | --- |
| `apps/ingest/src/trace-payload.ts` | `readTracePayload` | 29 | ≤15 |
| `apps/ingest/src/trace-payload.ts` | `createTracePayloadProtection` `readPayload` middleware | 19 | ≤15 |
| `apps/ingest/src/routes/traces.ts` | `handleTraceRequest` | 32 | ≤15 |

After this PR, `apps/ingest` has no remaining complexity warnings.

## Related issue (if applicable)

Follow-up to #4577 (enable the rule) and the earlier batches #4579–#4583. No issue to close.

## How was this tested?

- `pnpm --filter @app/ingest check` — clean
- `pnpm --filter @app/ingest typecheck` — clean
- `pnpm exec biome lint --only=complexity/noExcessiveCognitiveComplexity apps/ingest/src` — no warnings
- `pnpm --filter @app/ingest test` — 32 passed (2 files)

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdd93147-e519-4473-8819-46b6149c66f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdd93147-e519-4473-8819-46b6149c66f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791363304&installation_model_id=435055&pr_number=4585&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4585&signature=44c6c60f34180a263e58153c30b76df65cde6316c280897f459bbd6ef2b2a319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->