### PR TITLE
fix(web): classify rejected inputValidator requests as 400, not 500

### DIFF
--- a/apps/web/src/middlewares/server-fn-error.test.ts
+++ b/apps/web/src/middlewares/server-fn-error.test.ts
@@ -66,6 +66,32 @@ describe("recordServerFnError", () => {
     expect(info.status).toBe(500)
   })
 
+  it("does NOT report a rejected inputValidator (zod) request as 500", () => {
+    // What TanStack's `execValidator` throws when a Standard Schema
+    // `inputValidator` rejects the input: `new Error(JSON.stringify(issues))`.
+    const validationError = new Error(
+      JSON.stringify([{ code: "too_small", minimum: 1, path: ["organizationName"], message: "Please enter a name" }]),
+    )
+    const span = fakeSpan()
+    const info = recordServerFnError(span, validationError)
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(span.setStatus).not.toHaveBeenCalled()
+    expect(info.isClientError).toBe(true)
+    expect(info.status).toBe(400)
+    // The message must stay the raw issues array so `extractFieldErrors` on the client can still parse it.
+    expect(JSON.parse(JSON.parse(info.error.message).message)).toEqual(JSON.parse(validationError.message))
+  })
+
+  it("still reports a JSON-array error message that isn't a validator issues shape", () => {
+    const span = fakeSpan()
+    const info = recordServerFnError(span, new Error(JSON.stringify([{ unrelated: "shape" }])))
+
+    expect(span.recordException).toHaveBeenCalledTimes(1)
+    expect(info.isClientError).toBe(false)
+    expect(info.status).toBe(500)
+  })
+
   it("re-throwable error carries the serialized payload and original stack", () => {
     const original = new UnauthorizedError({ message: "No user in session" })
     const info = recordServerFnError(fakeSpan(), original)

--- a/apps/web/src/middlewares/server-fn-error.ts
+++ b/apps/web/src/middlewares/server-fn-error.ts
@@ -19,10 +19,38 @@ type ServerFnErrorInfo = {
 const errorTag = (e: unknown): string | undefined =>
   typeof e === "object" && e !== null && "_tag" in (e as DomainError) ? (e as DomainError)._tag : undefined
 
+interface StandardSchemaIssue {
+  readonly message: string
+  readonly path?: readonly unknown[]
+}
+
+const isStandardSchemaIssue = (issue: unknown): issue is StandardSchemaIssue =>
+  typeof issue === "object" &&
+  issue !== null &&
+  typeof (issue as StandardSchemaIssue).message === "string" &&
+  Array.isArray((issue as StandardSchemaIssue).path)
+
+/**
+ * TanStack's `execValidator` throws a plain `Error` whose message is the
+ * JSON-encoded Standard Schema issues array when an `inputValidator` (e.g.
+ * zod) rejects the request — rejected input, not a server fault, so it must
+ * be duck-typed from the message shape rather than an exception type.
+ */
+const isInputValidationError = (e: unknown): boolean => {
+  if (!(e instanceof Error)) return false
+  try {
+    const parsed = JSON.parse(e.message)
+    return Array.isArray(parsed) && parsed.length > 0 && parsed.every(isStandardSchemaIssue)
+  } catch {
+    return false
+  }
+}
+
 const errorStatus = (e: unknown): number => {
   if (isHttpError(e)) return e.httpStatus
   // Stale-tab server-fn hashes after a deploy — expected 404, not a 500.
   if (isMissingServerFnError(e)) return 404
+  if (isInputValidationError(e)) return 400
   return 500
 }
 
@@ -91,7 +119,7 @@ export const recordServerFnError = (span: Span, e: unknown): ServerFnErrorInfo =
   const httpError = isHttpError(e)
   const tag = errorTag(e)
   const message = httpError ? e.httpMessage : e instanceof Error ? e.message : "Unknown error occurred"
-  const status = httpError ? e.httpStatus : 500
+  const status = errorStatus(e)
   const isClientError = isExpectedClientError(status)
 
   if (!isClientError) {


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive noise source in Datadog Error Tracking: server functions that reject via `.inputValidator()` (zod) are recorded as `500` server faults instead of expected `400` client errors.

**Datadog issue addressed:** [`786d9ad4-8069-11f1-ab43-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/786d9ad4-8069-11f1-ab43-da7ad0900005) — `web` service, error type `Error`, 240 occurrences over the last 7 days (recurring since first seen ~54 days ago), most recently 2026-09-07T04:18 UTC. Sampled from `completeOnboarding`'s `organizationName` validation failing with `"Please enter an organization name"`.

**Root cause:** `apps/web/src/middlewares/server-fn-error.ts` has a deliberate `isExpectedClientError` filter so 4xx-class errors (bad input, no access, not logged in) are excluded from Error Tracking, keeping the signal focused on real 5xx bugs. It classifies via `errorStatus()`, which only recognized `HttpError`-shaped exceptions (objects with `httpStatus`/`httpMessage`).

TanStack Start's `execValidator` (`@tanstack/start-client-core`) does not throw an `HttpError` or `ZodError` when a Standard Schema `inputValidator` rejects input — it throws a plain `Error` whose message is `JSON.stringify(issues)`:

```js
if (result.issues) throw new Error(JSON.stringify(result.issues, void 0, 2));
```

`errorStatus()` didn't recognize this shape, so it fell through to the `500` default, and every rejected `.inputValidator()` call across the app (315+ call sites) got recorded into Datadog as a false server fault — exactly the noise the filter was built to prevent. The client already handles this gracefully via `extractFieldErrors`/`createFormSubmitHandler` (inline field errors, no raw error surfaced to the user), so this is purely an observability bug, not a user-facing one.

**This isn't specific to `completeOnboarding`** — `errorStatus()` is the single shared classification point for every server function using `.inputValidator()`, so the fix resolves the false-positive app-wide, not just for the observed call site.

**Note on prior art:** an earlier draft PR (#4488) proposed the identical fix back on 2026-08-21 but was never merged, so the issue kept accumulating occurrences for another ~17 days (74 → 240). This PR carries the same fix, independently re-verified against the current `development` HEAD, with tests re-run rather than assumed. Recommend closing #4488 as superseded once this merges.

**Fix:** duck-type the Standard Schema issues array shape (`{ message: string, path: array }[]`) in `errorStatus()` and classify it as `400`, the same way `NotFoundError`/`UnauthorizedError` are already excluded. Also routed `recordServerFnError`'s status through the shared `errorStatus()` helper instead of a narrower inline `httpError ? e.httpStatus : 500` check, so both call sites (`recordServerFnError` and `recordRequestError`) stay in sync.

No behavior change for users: the client-bound error message is untouched, so `extractFieldErrors` continues to parse field errors identically. This only changes what gets reported to Datadog (skipped) and the log level (`warn` instead of `error`).

## Related issue (if applicable)

N/A — found via scheduled Datadog Error Tracking triage, not a filed issue.

## How was this tested?

- Added two unit tests to `server-fn-error.test.ts`:
  - A rejected-validator-shaped `Error` is classified `400`/`isClientError: true` and **not** recorded to the span, while the client-bound message still round-trips correctly for `extractFieldErrors`.
  - A JSON-array error message that doesn't match the Standard Schema issue shape is still correctly reported as `500` (no over-broad matching).
- Confirmed the new tests **fail without the fix** (reverted the source change, reran) and **pass with it**.
- `pnpm --filter @app/web test` — full suite green except 2 pre-existing, unrelated failures in `phone-countries.test.ts` (ICU timezone data differences in this sandbox; untouched by this change).
- `pnpm --filter @app/web typecheck` (tsgo) — clean.
- `pnpm exec biome check` on changed files — clean.

**Verification after deploy:** occurrences of issue `786d9ad4-8069-11f1-ab43-da7ad0900005` (and the equivalent pattern on any other `.inputValidator()`-guarded server function) should stop appearing in Error Tracking going forward, since new occurrences will be classified as `400` at ingestion.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGQjNxrRnKpLJ22HRJTgpB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGQjNxrRnKpLJ22HRJTgpB)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791376640&installation_model_id=435055&pr_number=4587&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4587&signature=38045736f396d651d610748417e5e4b13dd4949e9a2692bea04ad7790f5fdcf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->