### PR TITLE
docs: fix 404 homepage link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Contributions are welcome. Read the [Contributing Guide](CONTRIBUTING.md) to get
 
 ## 🔗 Links
 
-- [Home page](https://latitude.so/v2/?utm_source=github_readme)
+- [Home page](https://latitude.so/?utm_source=github_readme)
 - [Documentation](https://docs.latitude.so/)
 - [Changelog](https://latitude.so/changelog)
 - [Slack community](https://join.slack.com/t/trylatitude/shared_invite/zt-35wu2h9es-N419qlptPMhyOeIpj3vjzw)


### PR DESCRIPTION
The **Links** section of the README points to `https://latitude.so/v2/?utm_source=github_readme`, which 404s — the repo's first-impression page has had a dead link since the site restructure. This points it back at the live homepage (keeping the UTM tag).

Verified: `/v2/` → 404, `/` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791384412&installation_model_id=435055&pr_number=4591&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4591&signature=cb46ac1d8e3fc8b5b2dc790caa6bdfefc4f8795bbaaf2474045c01f714858932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->