### PR TITLE
docs: add Migrate from Langfuse and Migrate from Braintrust guides

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,6 +110,8 @@
         "pages": [
           "telemetry/start-tracing",
           "getting-started/migrate-from-v1",
+          "getting-started/migrate-from-langfuse",
+          "getting-started/migrate-from-braintrust",
           "telemetry/memory",
           {
             "group": "SDKs",

--- a/docs/getting-started/migrate-from-braintrust.mdx
+++ b/docs/getting-started/migrate-from-braintrust.mdx
@@ -1,0 +1,153 @@
+---
+title: Migrate from Braintrust
+description: "Move an LLM app from Braintrust to Latitude: every Braintrust concept mapped to its Latitude equivalent, the telemetry switch, and the built-in import that brings your project logs along."
+---
+
+Braintrust is built around offline evaluation: you write `Eval()` runs over datasets with scorers, and production logging feeds that loop. Latitude starts from the other end: it watches your live agent through OpenTelemetry and turns the traffic into sessions, users, scores and signals, with offline testing handed to your own runner. Both platforms speak OpenTelemetry, so the migration is mostly a matter of re-pointing telemetry — and Latitude has a built-in [Braintrust import](../telemetry/imports/braintrust) for the project logs you already collected.
+
+This guide maps each Braintrust concept to its Latitude equivalent, switches your live telemetry, imports your history, and covers what has to be rebuilt rather than moved.
+
+<Info>
+  The whole migration is three moves: point your telemetry at Latitude, run the
+  [Braintrust import](../telemetry/imports/braintrust) for history, and recreate your
+  online scorers as [signals](../signals/create). Nothing in your application's request
+  path changes — neither platform sits between you and your model provider.
+</Info>
+
+## Concept map
+
+Use this table as the checklist for your own migration.
+
+| Braintrust concept | Latitude equivalent | Notes |
+| --- | --- | --- |
+| Organization | Organization | API keys are organization-scoped (Settings, Keys) |
+| Project | Project | One project per agent or AI feature. The import targets one Latitude project per Braintrust project |
+| Project logs | [Traces](../observability/traces) and [Spans](../observability/spans) | The import maps each Braintrust span to a Latitude span |
+| `metadata.session_id`, `metadata.user_id` | [Session](../observability/sessions), [User](../observability/users) | First-class in Latitude: set `session_id` and `user_id` on `capture()`, or the `session.id` and `user.id` span attributes |
+| Tags, metadata | Tags, metadata | Map directly, both live and in the import |
+| Score (from a scorer) | [Score](../scores/overview) | Every verdict in Latitude is a score; custom pipelines submit scores through `createScore` |
+| Online scoring | [Signal](../signals/overview) with a judge or rule evaluation | Created with `createSignal`; failed scores group into signals |
+| `Eval()` run (task + dataset + scorers) | Your own runner over a [Dataset](../datasets/overview) | See [simulations](../test-and-fix/simulations) and [regression tests](../test-and-fix/regression-testing); verdicts post back as scores |
+| Scorers, autoevals | Judge and rule [evaluations](../evaluations/overview), [custom scripts](../evaluations/custom-scripts) | Rule conditions cover text match, JSON validity, output length and metrics |
+| Experiments (two eval runs compared) | [Experiments](../experiments/overview) (two slices of live traffic compared) | Same word, different object — see below |
+| Human review | [Annotations](../annotations/overview) | Thumbs up or down with feedback on any trace; failed annotations feed signal discovery |
+| Datasets | [Dataset](../datasets/overview) | `input`, `output`, `expectedOutput`, metadata and custom columns |
+| Prompts, playground, functions | Your codebase | Latitude has no prompt registry or hosted functions; prompts and tools live in code |
+| Dashboards, monitor page | Traces, Sessions, Users, Tools and Cost views; [Monitors](../monitors/overview) | Monitors alert on signals, saved searches, tools or raw traffic |
+
+Two structural differences worth internalizing before you start:
+
+- **"Experiment" means something different.** A Braintrust experiment is an offline eval run over a dataset, compared with another run. A Latitude [Experiment](../experiments/overview) compares two slices of **live traffic** — release A against release B by tag, user, model or metadata — across every metric Latitude tracks. The offline half of the Braintrust workflow maps to your own runner over a Latitude dataset, not to Latitude Experiments.
+- **No hosted eval runner.** `Eval()` executes your task inside Braintrust's tooling. Latitude never runs your code: datasets are handed to your runner ([simulations](../test-and-fix/simulations), [regression tests](../test-and-fix/regression-testing)) in your CI, and results come back as tagged traces and scores. You trade a hosted runner for tests that live next to your code and run on every change.
+
+## Switch the live telemetry
+
+### If you use the Braintrust SDK
+
+Replace the Braintrust logger (wrapped clients, traced decorators, logger initialization) with the Latitude telemetry SDK. Latitude instruments the provider SDK you already call — there is no wrapper client to thread through your code.
+
+```python
+# pip install latitude-telemetry
+import openai
+from openai import OpenAI
+
+from latitude_telemetry import Latitude, capture
+
+latitude = Latitude(
+    api_key=os.environ["LATITUDE_API_KEY"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
+    instrumentations={"openai": openai},
+)
+
+client = OpenAI()
+
+capture(
+    "handle-user-request",
+    lambda: client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": user_message}],
+    ),
+    {
+        "user_id": user_id,        # was metadata.user_id in Braintrust
+        "session_id": session_id,  # was metadata.session_id in Braintrust
+        "tags": ["production"],
+        "metadata": {"request_id": request_id},
+    },
+)
+```
+
+The TypeScript setup is the same shape with `@latitude-data/telemetry`; see the [TypeScript SDK](../telemetry/typescript) and [Python SDK](../telemetry/python) pages. If you followed Braintrust's `metadata.session_id` / `metadata.user_id` convention, promote those values to `session_id` and `user_id` on `capture()` — in Latitude they are first-class: sessions group multi-turn conversations and users get their own page.
+
+### If you already export OTLP
+
+If your app sends OpenTelemetry — your own OTel SDK setup, or an OTLP exporter pointed at Braintrust — retarget the exporter at Latitude's ingest endpoint:
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://ingest.latitude.so/v1/traces"
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Bearer YOUR_API_KEY,X-Latitude-Project=YOUR_PROJECT_SLUG"
+```
+
+Latitude ingests standard OTLP over HTTP and reads the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) for model, tokens, cost and messages. Set `session.id` and `user.id` span attributes for sessions and users. The [OpenTelemetry exporter](../telemetry/otel-exporter) page has per-language examples, the Latitude-specific span attributes, and troubleshooting.
+
+### During the cutover
+
+Run both platforms in parallel for as long as you like: keep your existing Braintrust logging and add Latitude as a second OTLP exporter, or let the Latitude SDK attach to your existing OpenTelemetry provider (it does this automatically when one is registered — see [existing observability stack](../telemetry/otel-exporter#existing-observability-stack)). Logs that land in Braintrust during the overlap can still be picked up by re-running the import later — imports are idempotent, so nothing duplicates.
+
+<Note>
+  If you log to Braintrust over OpenTelemetry today, set
+  `braintrust.otel.preserve_attributes: true` in your instrumentation before importing —
+  Braintrust flattens OTel-logged messages and can drop reasoning blocks otherwise. Logs
+  written with Braintrust's own SDK are unaffected. Details on the
+  [import page](../telemetry/imports/braintrust).
+</Note>
+
+## Import your Braintrust history
+
+Latitude reads the logs in your Braintrust project (queried through BTQL) and maps each span to a Latitude span, so you do not start from an empty project. The import runs from **Project settings → Imports** with a Braintrust API key and your data plane (EU or US); it only reads from Braintrust, and credentials are discarded when it finishes.
+
+Messages, tool calls, tags and metadata come through directly, along with token usage and Braintrust's own cost estimate. Session and user identity are read from `metadata.session_id` and `metadata.user_id`. Images and files are fetched during the import and stored with the message (up to 2 MB each), so imported conversations do not depend on your Braintrust account afterwards. Imported traces are marked with `import.*` metadata naming Braintrust and the original ids, and go through the same pipeline as live traffic — grouped into sessions, embedded for search, evaluated by flaggers.
+
+Follow the [Braintrust import guide](../telemetry/imports/braintrust) for the steps, and the [imports overview](../telemetry/imports/overview) for limits, retries and billing. One constraint to know up front: **scores do not import**, and neither do datasets, experiment results, prompts or functions. Traces and spans move; judgments are rebuilt (next section).
+
+## Rebuild what does not import
+
+**Online scorers become signals.** For each scorer you ran on live traffic, create a signal: LLM-judge scorers become kind `judge` with the criteria in plain language, deterministic scorers become kind `rule` (text match, JSON validity, output length, metric conditions) — see [Create a signal](../signals/create). Scorers that need real code keep running in your pipeline and post verdicts with `createScore` ([custom scripts](../evaluations/custom-scripts)). Two behavioral differences: signals collect **forward from creation** — they do not scan imported history — and judge evaluations default to 10 percent sampling, so create signals before you cut traffic over, and raise sampling in the UI on low-volume projects.
+
+**Datasets** move as data. Export each Braintrust dataset and insert the rows with `insertDatasetRows`, mapping `input` to `input` and `expected` to `expectedOutput` — the same pattern as the [V1 dataset import](./migrate-from-v1#bring-your-golden-dataset). You can also build datasets directly from imported traces with [add traces to a dataset](../datasets/add-traces).
+
+**`Eval()` runs become replay tests in your CI.** Port each eval: the task is your own code calling your own model, the dataset is the Latitude dataset, and the scorers are assertions plus `createScore` calls. Tag every replay (for example `simulation`) so it stays out of production cohorts, monitors and experiment variants. The [regression testing](../test-and-fix/regression-testing) guide covers the pattern end to end.
+
+**Experiment comparisons move to live traffic.** Where you compared two eval runs in Braintrust, tag each release's traffic and create a Latitude [Experiment](../experiments/overview) comparing the two cohorts — sessions, cost, tokens, latency percentiles, tool usage and signal occurrences, with deltas against the baseline.
+
+**Prompts and functions** move into your codebase. Prompts become templates in code with the version in trace metadata and a release tag ([the V1 guide shows the pattern](./migrate-from-v1#move-the-prompts-into-code)); tools become ordinary functions in your agent, which Latitude observes in the [Tools view](../observability/tools) with usage, error rate and latency.
+
+## Differences to plan for
+
+- Latitude has **no hosted eval runner, no playground and no prompt registry**. Offline evaluation is your runner plus datasets plus scores; prompts and functions are code.
+- **Historical scores and experiment results stay in Braintrust.** Only traces and spans import. Export anything you need for an audit before you decommission.
+- **Signals collect forward.** Create them before generating the traffic you want judged.
+- **Latitude Experiments need live traffic** in each cohort; they are not a dataset-run comparison.
+- Cost figures in Latitude are **estimates** computed from the usage and model information in telemetry; see [token and cost tracking](../observability/features/token-cost-tracking). The import carries Braintrust's own cost estimates through on historical spans.
+
+## Why teams switch
+
+Reasons teams have given us, stated plainly so you can check them against your own situation:
+
+- **Production-first instead of eval-first.** Braintrust's loop starts from datasets you curate; Latitude's loop starts from what real users actually hit. Flaggers, annotations and evaluations turn live failures into named signals with example traces, and [agent dispatch](../agent-dispatch/overview) carries the evidence to your coding agent. Datasets and regression tests then lock the fix in — the curation step comes second, seeded from real traffic.
+- **The whole team can work in it.** Product managers and domain experts review sessions, annotate traces and curate expected outputs in the UI without touching an SDK or writing a scorer.
+- **Product-level answers.** Sessions, users, behaviors and signal discovery answer "what is going wrong for whom, how often" — not just how one experiment scored against another.
+- **Tests live in your repo.** Replacing a hosted `Eval()` runner with your own runner means regression tests run in your CI on every change, next to the code they protect.
+
+## For regulated and EU teams
+
+Latitude is [MIT-licensed](https://github.com/latitude-dev/latitude-llm/blob/development/LICENSE) and [self-hostable](../deployment/overview) from a single Docker host to a Kubernetes cluster. Hosted Latitude stores and processes customer data in AWS eu-central-1 (Frankfurt); see [GDPR](../security/compliance/gdpr) for the current readiness status, and [PII redaction](../security/pii-redaction) for redaction controls — which apply to imported Braintrust traces exactly as they do to live ones.
+
+## Frequently asked
+
+**Do I lose my Braintrust history?** No. The [import](../telemetry/imports/braintrust) brings traces, spans, messages, tool calls, attachments, token usage and cost into your Latitude project, with sessions and users read from your metadata. Scores, datasets, experiments and prompts do not import; this guide covers rebuilding each.
+
+**Can I run both during the transition?** Yes. Both platforms consume OpenTelemetry, so a second exporter — or the Latitude SDK attached to your existing OTel provider — sends the same spans to both. Re-run the import at the end to backfill the overlap; imports are idempotent.
+
+**What replaces `Eval()` in CI?** Your test runner replaying a Latitude dataset, posting verdicts as scores. The [regression testing](../test-and-fix/regression-testing) and [simulations](../test-and-fix/simulations) guides show the full pattern, including keeping replays out of production cohorts.
+
+**Where do prompts and functions go?** Into your codebase. Latitude tracks prompt versions as trace metadata and release tags rather than hosting a registry, and observes your tools from telemetry rather than hosting them.

--- a/docs/getting-started/migrate-from-langfuse.mdx
+++ b/docs/getting-started/migrate-from-langfuse.mdx
@@ -1,0 +1,150 @@
+---
+title: Migrate from Langfuse
+description: "Move an LLM app from Langfuse to Latitude: every Langfuse concept mapped to its Latitude equivalent, the telemetry switch, and the built-in import that brings your trace history along."
+---
+
+Langfuse and Latitude solve the same problem from different angles. Langfuse gives engineers traces, scores and prompt management; Latitude watches your agent through OpenTelemetry and turns the traffic into sessions, users, scores and signals that the whole team works from. Both platforms speak OpenTelemetry, so the migration is mostly a matter of re-pointing telemetry — and Latitude has a built-in [Langfuse import](../telemetry/imports/langfuse) for the history you already collected.
+
+This guide maps each Langfuse concept to its Latitude equivalent, switches your live telemetry, imports your history, and covers what has to be rebuilt rather than moved.
+
+<Info>
+  The whole migration is three moves: point your telemetry at Latitude, run the
+  [Langfuse import](../telemetry/imports/langfuse) for history, and recreate your
+  evaluators as [signals](../signals/create). Nothing in your application's request path
+  changes — neither platform sits between you and your model provider.
+</Info>
+
+## Concept map
+
+Use this table as the checklist for your own migration.
+
+| Langfuse concept | Latitude equivalent | Notes |
+| --- | --- | --- |
+| Organization | Organization | API keys are organization-scoped (Settings, Keys) |
+| Project | Project | One project per agent or AI feature. The import targets one Latitude project per Langfuse project |
+| Trace | Trace | One trace per turn or request |
+| Observation (span, generation, event) | [Span](../observability/spans) | Generations become LLM spans with model, tokens, cost and messages |
+| Session (`sessionId`) | [Session](../observability/sessions) | Grouped automatically from `session_id` on `capture()` or the `session.id` span attribute |
+| User (`userId`) | [User](../observability/users) | Users get their own page with sessions, cost and signals |
+| Tags, metadata | Tags, metadata | Map directly, both live and in the import |
+| Score (numeric, categorical, boolean) | [Score](../scores/overview) | Every verdict in Latitude is a score; custom pipelines submit scores through `createScore` |
+| LLM-as-a-judge evaluator | [Signal](../signals/overview) with a judge evaluation | Created with `createSignal` (kind `judge`); failed scores group into signals |
+| Custom evaluation pipeline | [Custom scripts](../evaluations/custom-scripts) posting scores | Your code, any language, `createScore` at the end |
+| Annotation queue, human review | [Annotations](../annotations/overview) | Thumbs up or down with feedback on any trace; failed annotations feed signal discovery |
+| Dataset, dataset runs | [Dataset](../datasets/overview), replayed by your own runner | See [simulations](../test-and-fix/simulations) and [regression tests](../test-and-fix/regression-testing) |
+| Prompt management (versions, labels) | Prompts live in your code | Latitude has no prompt registry. Version prompts in git; put the version in trace metadata and a release tag |
+| Playground | Your local dev loop, plus a [Sandbox](../observability/features/sandbox) project | Sandbox keeps experiments out of production analytics |
+| Dashboards, metrics | Traces, Sessions, Users, Tools and Cost views | Plus [saved searches](../search/saved-searches) and [behaviors](../behaviours/overview) |
+| Alerts | [Monitors](../monitors/overview) | Fire on signals, saved searches, tools or raw traffic; notify in-app, by email or in Slack |
+
+Two structural differences worth internalizing before you start:
+
+- **Signals, not per-prompt evaluators.** In Langfuse you attach evaluators to traffic and read results per evaluator. In Latitude, every evaluation verdict is a score, and failed scores are grouped into named signals — recurring problems with example traces attached. Flaggers, annotations and custom scores feed the same discovery pipeline, so problems you never wrote an evaluator for still surface.
+- **No prompt registry.** Latitude deliberately leaves prompts in your codebase and your version control. If Langfuse prompt management is load-bearing for your team, plan the move to code first; the [releases and versioning](../observability/features/releases-versioning) page covers how versions stay visible in Latitude.
+
+## Switch the live telemetry
+
+### If you use the Langfuse SDK
+
+Replace the Langfuse wrapper (decorators, wrapped clients or callback handlers) with the Latitude telemetry SDK. Latitude instruments the provider SDK you already call — there is no wrapper class to thread through your code.
+
+```python
+# pip install latitude-telemetry
+import openai
+from openai import OpenAI
+
+from latitude_telemetry import Latitude, capture
+
+latitude = Latitude(
+    api_key=os.environ["LATITUDE_API_KEY"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
+    instrumentations={"openai": openai},
+)
+
+client = OpenAI()
+
+capture(
+    "handle-user-request",
+    lambda: client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": user_message}],
+    ),
+    {
+        "user_id": user_id,        # was Langfuse user_id
+        "session_id": session_id,  # was Langfuse session_id
+        "tags": ["production"],
+        "metadata": {"request_id": request_id},
+    },
+)
+```
+
+The TypeScript setup is the same shape with `@latitude-data/telemetry`; see the [TypeScript SDK](../telemetry/typescript) and [Python SDK](../telemetry/python) pages. Carry your Langfuse `user_id` and `session_id` over as-is — the semantics (one session per conversation, one user per end user) match.
+
+### If you already export OTLP
+
+If your app sends OpenTelemetry directly — your own OTel SDK setup, or an OTLP exporter pointed at Langfuse — retarget the exporter at Latitude's ingest endpoint:
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://ingest.latitude.so/v1/traces"
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Bearer YOUR_API_KEY,X-Latitude-Project=YOUR_PROJECT_SLUG"
+```
+
+Latitude ingests standard OTLP over HTTP and reads the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) for model, tokens, cost and messages. Set `session.id` and `user.id` span attributes where you set Langfuse's session and user. The [OpenTelemetry exporter](../telemetry/otel-exporter) page has per-language examples, the Latitude-specific span attributes, and troubleshooting.
+
+### During the cutover
+
+Run both platforms in parallel for as long as you like: keep your existing Langfuse export and add Latitude as a second OTLP exporter, or let the Latitude SDK attach to your existing OpenTelemetry provider (it does this automatically when one is registered — see [existing observability stack](../telemetry/otel-exporter#existing-observability-stack)). Traces that arrive in Langfuse during the overlap can still be picked up by re-running the import later — imports are idempotent, so nothing duplicates.
+
+## Import your Langfuse history
+
+Latitude reads the observations in your Langfuse Cloud project and maps them to traces and spans, so you do not start from an empty project. The import runs from **Project settings → Imports** with your Langfuse public and secret keys; it only reads from Langfuse, and credentials are discarded when it finishes.
+
+Sessions, users, tags, metadata, messages, tool calls, token usage and cost all come through. Prompt references (`promptName`, `promptVersion`) land in span metadata. Imported traces are marked with `import.*` metadata naming Langfuse and the original ids, and go through the same pipeline as live traffic — grouped into sessions, embedded for search, evaluated by flaggers.
+
+Follow the [Langfuse import guide](../telemetry/imports/langfuse) for the steps, and the [imports overview](../telemetry/imports/overview) for limits, retries and billing. Two constraints to know up front:
+
+- The import reads from **Langfuse Cloud** (EU, US, Japan or HIPAA US). Self-hosted Langfuse is not supported yet.
+- **Scores and annotations do not import**, and neither do datasets, evaluator definitions or the prompt registry. Traces and spans move; judgments are rebuilt (next section).
+
+## Rebuild what does not import
+
+**Evaluators become signals.** For each Langfuse LLM-as-a-judge evaluator, create a signal with a judge evaluation: the criteria in plain language, plus filters scoping it to the right traffic (see [Create a signal](../signals/create)). Rule-style checks (valid JSON, output length, text match) use kind `rule`. Two behavioral differences: signals collect **forward from creation** — they do not scan imported history — and judge evaluations default to 10 percent sampling, so create signals before you cut traffic over, and raise sampling in the UI on low-volume projects.
+
+**Custom evaluation pipelines** keep running wherever they run today and post their verdicts with `createScore`; failing scores cluster into signals like any other failure. See [custom scripts](../evaluations/custom-scripts).
+
+**Datasets** move as data. Export each Langfuse dataset and insert the rows with `insertDatasetRows`, mapping inputs into `input` and the expected result into `expectedOutput` — the same pattern as the [V1 dataset import](./migrate-from-v1#bring-your-golden-dataset). You can also build datasets directly from your imported traces with [add traces to a dataset](../datasets/add-traces).
+
+**Dataset runs** have no hosted equivalent. Latitude hands the dataset to your own runner: replay it locally or in CI as [simulations](../test-and-fix/simulations) or [regression tests](../test-and-fix/regression-testing), tag the replays so they stay out of production cohorts, and post verdicts as scores. To compare a change on live traffic, use [Experiments](../experiments/overview), which compare two slices of real traffic (by tag, release, user or model) across every metric Latitude tracks.
+
+**Prompts** move into your codebase. Put the prompt version in trace metadata and a release tag so [Experiments](../experiments/overview) can compare versions; the [V1 migration guide](./migrate-from-v1#move-the-prompts-into-code) shows the pattern in full.
+
+## Differences to plan for
+
+- Latitude has **no prompt registry and no playground**. Prompts are code; iteration happens in your dev loop and a Sandbox project.
+- **Historical scores stay in Langfuse.** Only traces and spans import. If a score history matters for an audit, export it from Langfuse before you decommission.
+- **Signals collect forward.** Create them before generating the traffic you want judged.
+- **Experiments compare live traffic**, not dataset runs. Offline comparison is your runner plus scores.
+- Cost figures in Latitude are **estimates** computed from the usage and model information in telemetry; see [token and cost tracking](../observability/features/token-cost-tracking).
+
+## Why teams switch
+
+Reasons teams have given us, stated plainly so you can check them against your own situation:
+
+- **The whole team can work in it.** Product managers and domain experts review sessions, annotate traces, flag problems and curate expected outputs without writing code. In Langfuse these teams often stayed outside the tool and fed feedback back through engineers.
+- **Product-level answers, not just traces.** Sessions, users, behaviors and signal discovery answer "what is going wrong for whom, how often" rather than requiring someone to reason it out trace by trace.
+- **Feedback lives in one pipeline.** Annotations, flaggers, evaluations and custom scores all land as scores, cluster into signals, alert through monitors, and can [dispatch to a coding agent](../agent-dispatch/overview) with the evidence attached — rather than being spread across an evaluation tab, external spreadsheets and a ticket tracker.
+- **Cost visibility.** Teams told us their OpenAI cost accounting elsewhere missed processing tiers and cache discounts. Latitude estimates cost from the usage and model information in each span and the Cost view breaks down cache economics per model — verify the numbers against your own bill for your providers before relying on either tool's figures.
+
+## For regulated and EU teams
+
+Latitude is [MIT-licensed](https://github.com/latitude-dev/latitude-llm/blob/development/LICENSE) and [self-hostable](../deployment/overview) from a single Docker host to a Kubernetes cluster, so the same constraint that put you on self-hosted Langfuse is covered. Hosted Latitude stores and processes customer data in AWS eu-central-1 (Frankfurt); see [GDPR](../security/compliance/gdpr) for the current readiness status, and [PII redaction](../security/pii-redaction) for redaction controls — which apply to imported Langfuse traces exactly as they do to live ones.
+
+## Frequently asked
+
+**Do I lose my Langfuse history?** No. The [import](../telemetry/imports/langfuse) brings traces, sessions, users, tags, metadata, messages, token usage and cost into your Latitude project. Scores, annotations, datasets and prompts do not import; this guide covers rebuilding each.
+
+**Can I run both during the transition?** Yes. Both platforms consume OpenTelemetry, so a second exporter — or the Latitude SDK attached to your existing OTel provider — sends the same spans to both. Re-run the import at the end to backfill the overlap; imports are idempotent.
+
+**We self-host Langfuse. Can we import?** Not yet — the import reads from Langfuse Cloud regions only. Live telemetry from a self-hosted stack works fine: point your exporter at Latitude and history accumulates from cutover.
+
+**Where do prompts go?** Into your codebase. Latitude tracks prompt versions as trace metadata and release tags rather than hosting a registry; the [V1 migration guide](./migrate-from-v1#move-the-prompts-into-code) shows the pattern.


### PR DESCRIPTION
## What

Two new getting-started guides, listed in the nav right after **Migrate from Latitude V1**:

- `docs/getting-started/migrate-from-langfuse.mdx`
- `docs/getting-started/migrate-from-braintrust.mdx`

## Why

Requested in #gtm (Aug 31): docs explaining how to migrate from Braintrust or Langfuse to Latitude. Both platforms are OTel-compatible and we already ship trace imports for both, so the guides tie the existing pieces into one migration path per competitor.

## Each guide covers

1. **Concept map** — their objects mapped to Latitude objects (traces/observations → traces/spans, sessions, users, scores/evaluators → scores + signals + annotations, datasets → datasets, prompts → code), with the two structural differences called out up front.
2. **Switching live telemetry** — replacing their SDK with `latitude-telemetry` / `@latitude-data/telemetry`, or retargeting an existing OTLP exporter at `ingest.latitude.so/v1/traces`; parallel-run guidance for the cutover.
3. **Historical import** — links to the existing `telemetry/imports` pages rather than duplicating them; states plainly what does and does not come through.
4. **Rebuilding what doesn't import** — evaluators/scorers as signals, datasets via `insertDatasetRows`, dataset runs / `Eval()` as replay tests in your own CI, experiment semantics differences.
5. **Honest gaps** — no prompt registry, no playground, no hosted eval runner, signals collect forward, cost figures are estimates.
6. **Why teams switch** — kept factual; plus MIT license / self-hosting / eu-central-1 / PII redaction notes for regulated and EU readers.

Every Latitude claim (endpoints, headers, SDK snippets, import behavior, limits) is sourced from existing docs in this repo; competitor-side statements are kept high-level and neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791384626&installation_model_id=435055&pr_number=4593&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4593&signature=7409b2c80b344a00e5f3ffc5a524d19a11488eda2b3f1444792b6bc0761a44fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->