### PR TITLE
docs: fleet-operator quickstart and activation fixes (costs, behaviors cold-start)

### DIFF
--- a/docs/behaviours/overview.mdx
+++ b/docs/behaviours/overview.mdx
@@ -47,8 +47,20 @@ When you add a behavior, Latitude analyses a sample of your sessions through it 
 <Note>
   A behavior keeps itself up to date on a schedule as new sessions arrive. A brand-new behavior,
   or one on a project without enough traffic yet, shows a waiting state until it has clustered
-  enough sessions.
+  enough sessions. The timings are covered just below.
 </Note>
+
+## When behaviors populate
+
+On a freshly connected project, the Behaviors page starts **blank**. That is the expected cold-start state, not a broken one — groupings are built from analyzed sessions, and three things have to happen first:
+
+1. **Sessions have to exist and end.** Behaviors cluster [sessions](../observability/sessions), so your telemetry must send a `sessionId`. A session is analyzed after it ends, which happens after roughly five minutes without new activity, plus processing time.
+2. **Enough sessions have to accumulate.** The first grouping needs a minimum volume of analyzed sessions — currently around 15 — before clustering produces anything meaningful.
+3. **A grouping pass has to run.** Groupings are built and refreshed by scheduled passes that run every few hours, so there can be a gap between crossing the volume threshold and the first groups appearing.
+
+In practice: with moderate traffic, expect the first Topics groups **the same day** you connect; with a trickle of traffic, it can take a few days to reach the threshold. The same applies to a newly added behavior, which shows a waiting state until its first pass completes.
+
+If Behaviors stays empty longer than that with steady traffic — for example, hundreds of sessions over more than a day and still no groups — check that sessions (not just traces) are appearing on the Sessions page, and if they are, contact [hello@latitude.so](mailto:hello@latitude.so) so the team can check your project's analysis pipeline.
 
 ## Inspect a behavior
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -109,6 +109,7 @@
         "group": "Getting Started",
         "pages": [
           "telemetry/start-tracing",
+          "getting-started/fleet-quickstart",
           "getting-started/migrate-from-v1",
           "telemetry/memory",
           {
@@ -194,6 +195,7 @@
           "observability/users",
           "observability/tools",
           "observability/memory",
+          "observability/cost",
           "observability/traces",
           "observability/spans",
           "observability/tool-calls",

--- a/docs/getting-started/fleet-quickstart.mdx
+++ b/docs/getting-started/fleet-quickstart.mdx
@@ -1,0 +1,110 @@
+---
+title: Your first 30 minutes with a fleet
+description: Connect two or more agents as separate projects, watch traces arrive, set up your first signal, and know exactly when Behaviors and discovery will start paying off.
+---
+
+This guide is for teams running **several agents** — a support agent, a research agent, a couple of background workers — who want all of them in Latitude from the start. In 30 minutes you will have each agent reporting to its own project, live traces you can read, and a first signal that catches real failures.
+
+Just as important: this guide is honest about what you will *not* see in the first 30 minutes. Some of Latitude's most useful surfaces (Behaviors, signal discovery) are built from analyzed traffic and need volume and a little time. Knowing when they populate is the difference between "it's warming up" and "it's broken."
+
+## Prerequisites
+
+- A Latitude account ([console.latitude.so](https://console.latitude.so/login))
+- Two or more agents you can run, each using a supported provider or framework
+
+## Minutes 0–5: one project per agent
+
+Create a project for each agent. Signal discovery, behaviors, search, evaluations, and flaggers are all scoped to a project, and mixing unrelated agents in one project muddies all of them: frustration in a support agent and frustration in a code-review agent are different failures and should be tracked separately.
+
+The rule of thumb: **one project per agent or product surface**. Keep agents together only when they share the same user experience and should share signal discovery. The full reasoning and edge cases are in [Group traces by project](../observability/guides/group-traces-by-project).
+
+Name each project after the agent it monitors — `support-agent`, `research-agent` — so the project switcher reads like your fleet roster.
+
+## Minutes 5–15: connect telemetry, routed per agent
+
+Set up tracing for each agent. The fastest path is your coding agent: paste this into Claude Code, Cursor, Codex, or any other agent, once per codebase:
+
+```text
+Install the `latitude-setup` skill from `github.com/latitude-dev/skills` and use it to set up Latitude tracing here, following best practices.
+```
+
+For manual setup, use the [TypeScript](../telemetry/typescript) or [Python](../telemetry/python) SDK, or the [OpenTelemetry exporter](../telemetry/otel-exporter) for other languages. See [Start tracing](../telemetry/start-tracing).
+
+The fleet-specific part is **routing each agent's traces to its own project**:
+
+- **One agent per process**: set `project` once, in the SDK constructor or the `X-Latitude-Project` export header.
+- **Several agents in one process**: set `project` per agent run, through the `capture()` option or the `latitude.project` span attribute.
+
+Both patterns, in every SDK and raw OTEL, are shown in [Group traces by project](../observability/guides/group-traces-by-project#sdk-examples).
+
+While you are in there, send two more identifiers with `capture()` — they cost nothing now and unlock whole views later:
+
+- **`sessionId`**: groups traces into multi-turn conversations. Without it there is no [Sessions](../observability/sessions) view, and behaviors have nothing to cluster.
+- **`userId`**: powers the [Users](../observability/users) view and per-signal affected-user counts.
+
+If some of your agents share a codebase, [tags](../observability/features/tags) (for example `["production", "support-agent"]`) give you an extra filterable label on top of the project split.
+
+## Minutes 15–20: watch traces arrive
+
+Run one real request through each agent. Then open each project in Latitude: the **Sessions** page is the project's landing view, and the tab toggle at the top switches to **Traces**.
+
+The first trace should appear **within a few seconds** of the agent call. If it does not:
+
+- check the API key and project routing (a typo in `latitude.project` silently creates traces in the wrong place — check your other projects and the project switcher)
+- check the [provider or framework page](../telemetry/start-tracing) for instrumentation caveats
+
+One timing detail worth knowing up front: a trace appears immediately, but Latitude waits until it **stops receiving new spans** (on the order of a couple of minutes of span inactivity) before treating it as complete. Search indexing, [flaggers](../annotations/flaggers), evaluations, and signal discovery all run on completed traces, so a trace you can already read may take a few more minutes to become searchable and scored. Sessions settle similarly: a session is considered ended after roughly five minutes without new activity, and session-level analysis runs after that.
+
+## Minutes 20–25: per-agent and portfolio views
+
+Each project's sidebar is your **per-agent view**. Under **Observe** you get [Sessions](../observability/sessions), [Users](../observability/users), [Tools](../observability/tools), [Memory](../observability/memory), and Cost for that agent alone; under **Understand**, its [Signals](../signals/overview) and [Behaviors](../behaviours/overview). Because you split by project, every number you see belongs to one agent — a spike in tool errors points at a specific agent, not the fleet average.
+
+For the **portfolio view** across agents, be aware Latitude does not ship a cross-project dashboard in the web app. The supported pattern is [Artifacts](../more/artifacts): everything in the web app is also exposed through the [MCP](./mcp), [CLI](./cli), and [API](../more/api-reference), so your coding agent can pull numbers from every project and build a fleet report or a refreshable dashboard. A useful first prompt once traffic is flowing:
+
+```text
+Build an artifact comparing all my Latitude projects over the last 7 days: traces, error rate, p95 latency, and spend per project.
+```
+
+Day to day, the project switcher plus consistent project naming is the low-tech portfolio view — and it works from minute one.
+
+## Minutes 25–30: your first signal
+
+Signal *discovery* — Latitude grouping failures it finds on its own — needs failed scores to accumulate, so it starts paying off after real traffic, not in your first half hour. Your project's default [flaggers](../annotations/flaggers) are already annotating completed traces for frustration, refusals, tool errors, and other common failures, and discovered signals will form from those over the coming days.
+
+What you *can* have working before minute 30 is a signal you define yourself. On the Signals page of your busiest agent's project, select **New signal** and choose **Configure manually** with a **set of conditions** — conditions are free, deterministic, and run instantly on every new session, so they work at any traffic volume:
+
+- **Tool failed** (leave the tool name empty to match any tool) — the classic first signal for an agent fleet, catching every session where a tool call errored
+- or **Error** — sessions that ended in an error state
+- or **Metric**: cost or duration above a threshold you'd want to know about
+
+Set sampling to 100% (conditions cost nothing), use the **Test** step to preview it against the sessions you just sent, and give it a name your team will recognize. From now on every matching session is counted, trended, and inspectable. The full builder walkthrough is in [Create a signal](../signals/create).
+
+Repeat in your other projects if their failure modes differ — that per-agent scoping is exactly why you split them.
+
+## What fills in later, and when
+
+Everything above is live within your first session. The rest of the product builds itself from analyzed traffic, on roughly this schedule:
+
+| Surface | When it populates |
+| --- | --- |
+| Traces | Seconds after each agent call |
+| Search, flaggers, scores | Minutes after a trace completes (a trace completes a couple of minutes after its last span) |
+| Sessions analysis | After a session ends — about five minutes of inactivity — plus processing time |
+| [Behaviors](../behaviours/overview) (Topics) | After roughly **15 analyzed sessions**, on the next scheduled grouping pass — passes run every few hours, so expect first groups the same day at moderate traffic, or after a few days at a trickle |
+| Discovered [signals](../signals/overview) | As failed scores accumulate — days of real traffic, faster if you [annotate](../annotations/overview) failures yourself |
+| System [monitors](../monitors/overview) | Active immediately; they notify when signals are discovered, escalate, or regress, so they fire once signals exist |
+
+Two practical consequences:
+
+- **A blank Behaviors page in your first hours is expected**, not a failure. It is waiting on session volume and the next grouping pass. See [when behaviors populate](../behaviours/overview#when-behaviors-populate) for what to check if it stays empty.
+- **Don't judge signal discovery on day one.** Until failed scores accumulate, the Signals page shows only what you created yourself and what flaggers have caught so far. You can speed discovery up considerably by spending ten minutes annotating bad sessions with specific feedback — human annotations are a primary discovery input.
+
+If a surface stays empty well past these windows with steady traffic flowing — for example, no behaviors after a day and hundreds of sessions — something may genuinely be stuck; write to [hello@latitude.so](mailto:hello@latitude.so) and the team can check your project's analysis pipeline.
+
+## Next steps
+
+- [Group traces by project](../observability/guides/group-traces-by-project): the full routing reference for fleets
+- [Cost](../observability/cost): find what each agent, model, and conversation costs
+- [How to use Latitude](./how-to-use-latitude): the observe → understand → refine loop once data is flowing
+- [Artifacts](../more/artifacts): build cross-project fleet reports and dashboards
+- [Monitors](../monitors/overview): get notified in Slack or email when a signal fires

--- a/docs/observability/cost.mdx
+++ b/docs/observability/cost.mdx
@@ -1,0 +1,58 @@
+---
+title: Cost
+description: Find what a conversation, a trace, a user, a model, or your whole project costs.
+---
+
+Latitude estimates cost from the token usage and model information in your telemetry, and surfaces it at every level: per trace, per session, per user, per model, and per project. This page answers the practical questions — starting with the most common one.
+
+## How much did this conversation cost?
+
+A conversation is a [session](./sessions), and session cost is on the main **Sessions** view — the landing page of every project:
+
+1. Open your project. The Sessions tab is the default view.
+2. Each row has a **cost** column: the estimated total across every trace in that session.
+3. Click a row to open the session detail, where each trace keeps its own cost, so you can see which turn was expensive.
+
+To find the expensive conversations rather than look one up, add a **Cost** [filter](./filters) (for example, cost greater than `$1`) or sort by cost. Filters combine, so "Status is error **and** Cost > $1" finds your expensive failures.
+
+<Note>
+  Sessions only exist if your app sends a `sessionId` with telemetry. Without it you still get
+  per-trace cost on the Traces tab — see [Sessions](./sessions) for how to send one.
+</Note>
+
+## How much did this trace cost?
+
+Switch to the **Traces** tab (the toggle at the top of the Sessions page). The traces table has the same cost column per trace, and the trace detail view breaks usage down across the trace's LLM spans: input tokens, output tokens, model, and estimated cost per call. See [Token and cost tracking](./features/token-cost-tracking) for exactly which fields are captured.
+
+## How much does this user cost?
+
+The [Users](./users) view aggregates activity per `userId`, including cost, so you can see which users drive spend.
+
+## Where is the money going overall? The Cost view
+
+The **Cost** section in the project sidebar (under Observe) is the project-wide spend dashboard:
+
+- **Overview**: total spend for the selected time window, average per day, average per trace, top spend model, and spend over time.
+- **Session**: cost per session, decomposed into its drivers — traces per session, LLM calls per trace, tokens per call, which models, prompt vs output split, and prompt/output prices — so when cost per conversation moves, you can see *which* driver moved it.
+- **Model**: spend against usage per model, and a breakdown table (by model, provider, operation, or service) with input, output, and cache costs per row.
+- **Cache**: cache economics per model, with break-even points showing what prompt caching is actually saving you.
+
+Cost values are **estimates** built from the usage your instrumentation reports and known model pricing; the view shows how much of the window's usage is provider-verified versus estimated. Usage from models Latitude cannot price appears as unpriced rather than being silently guessed at.
+
+<Note>
+  The Cost view is rolling out per workspace. If you don't see **Cost** in your project sidebar
+  yet, the per-session and per-trace costs above are available to everyone — and you can ask for
+  access at [hello@latitude.so](mailto:hello@latitude.so).
+</Note>
+
+## Cost beyond the UI
+
+- **Alerts**: a [monitor](../monitors/overview) can watch a saved search that includes a cost filter, and a [signal](../signals/create) can use a cost condition — for example, sessions above a spend threshold.
+- **Reports**: cost is exposed through the [MCP, CLI, and API](../more/artifacts), so your coding agent can build cost reports and dashboards, including across projects.
+
+## Related
+
+- [Token and cost tracking](./features/token-cost-tracking): what usage data Latitude captures
+- [Sessions](./sessions): the conversation-level view
+- [Filters](./filters): filter by cost, tokens, and duration
+- [Percentile cohorts](./features/percentile-cohorts): compare a trace's cost against similar traces

--- a/docs/observability/features/token-cost-tracking.mdx
+++ b/docs/observability/features/token-cost-tracking.mdx
@@ -45,6 +45,7 @@ Cost values are estimates based on the usage and model/provider information avai
 
 ## Related
 
+- [Cost](../cost): Look up what a conversation costs and where project spend goes
 - [Percentile cohorts](./percentile-cohorts): Compare cost and token usage against similar tagged traces
 - [Traces](../traces): Trace-level usage and cost
 - [Sessions](../sessions): Session-level aggregation

--- a/docs/telemetry/start-tracing.mdx
+++ b/docs/telemetry/start-tracing.mdx
@@ -43,6 +43,7 @@ For other languages, use the [OpenTelemetry exporter](../telemetry/otel-exporter
 
 ## Next steps
 
+- Running several agents? Follow [Your first 30 minutes with a fleet](../getting-started/fleet-quickstart) to route each one to its own project
 - Explore traces in [Observability](../observability/overview)
 - Add provider-specific instrumentation from the Observability sidebar
 - Trace your agent's long-term memory with [Memory tracing](./memory)


### PR DESCRIPTION
Activation-focused docs for the fleet-operator persona: the three places new users stall (blank Behaviors cold start, early 'signals not useful', undocumented cost lookup) each get an answer.

## New pages

- **Your first 30 minutes with a fleet** (`getting-started/fleet-quickstart`) — connect 2+ agents as separate projects (the documented `latitude.project` routing pattern), watch traces arrive, per-agent vs portfolio views, and a first conditions-based signal that works at any traffic volume. Ends with an honest "what fills in later, and when" table so day-one expectations match reality: trace completion debounce, ~5 min session settle, ~15 analyzed sessions + scheduled passes before Behaviors, days of failed scores before discovery.
- **Cost** (`observability/cost`) — answers "how do I see cost per conversation": Sessions cost column and sorting, cost filters, per-trace and per-user cost, and the Cost view's overview/session/model/cache panels, with a rollout note since the section is workspace-gated.

## Patches

- **Behaviors overview**: new "When behaviors populate" section so the blank cold-start state reads as warming up, not broken — the three preconditions (sessions ending, ~15 analyzed sessions, a scheduled grouping pass), realistic timelines, and what to do if it stays empty (verify sessions exist, then hello@latitude.so).
- **Start tracing** and **Token and cost tracking**: cross-links to the new pages.
- **docs.json**: nav entries — fleet guide after Start tracing, Cost after Memory (matching the app sidebar order).

All timings and UI descriptions verified against the app source (trace/session debounce constants, taxonomy gardening cadence and cold-start gate, cost route panels, sessions table columns) and existing docs; no invented routes or UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791384826&installation_model_id=435055&pr_number=4594&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4594&signature=ba38c0673250fdcf364678603e2ee4795dabc6d0bdc5ff153c0482c825b02e91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->