### PR TITLE
docs: latitude-setup builds the first Artifact instead of offering it

### DIFF
--- a/docs/getting-started/skills.mdx
+++ b/docs/getting-started/skills.mdx
@@ -26,7 +26,7 @@ npx skills add https://github.com/latitude-dev/skills --skill latitude-setup,lat
 | `latitude-artifacts` | Builds [Artifacts](/more/artifacts): self-contained HTML reports and KPI dashboards from your Latitude data, in the Latitude design language with light and dark themes. |
 
 <Info>
-  `latitude-setup` builds on `latitude-cli` and `latitude-telemetry`, and ends by offering a first Artifact through `latitude-artifacts`, so the command above installs all four for the from-scratch flow.
+  `latitude-setup` builds on `latitude-cli` and `latitude-telemetry`, and ends by building a first Artifact through `latitude-artifacts`, so the command above installs all four for the from-scratch flow.
 </Info>
 
 ## No account yet
@@ -44,7 +44,7 @@ The `latitude-setup` skill orchestrates the whole zero-account flow:
 3. Instruments your app (via the `latitude-telemetry` skill) against that project.
 4. Runs your real code and inspects the resulting traces, iterating until they look right.
 5. Cleans up the trace noise and hands you a **claim link**.
-6. Offers to build your first [Artifact](/more/artifacts), an HTML report of the traces that just landed, through the `latitude-artifacts` skill.
+6. Builds your first [Artifact](/more/artifacts), an HTML report of the traces that just landed, through the `latitude-artifacts` skill, and hands it back with the claim link.
 
 Open the claim link in your browser to take ownership of the temporary account and keep it. Unclaimed temporary accounts expire automatically.
 

--- a/docs/snippets/skills-callout.mdx
+++ b/docs/snippets/skills-callout.mdx
@@ -1,5 +1,5 @@
 <Tip>
-  **Using an agent?** Install the [Latitude skills](/getting-started/skills) and let it handle the setup below. `latitude-setup` instruments your app or agent harness, verifies traces arrive, creates a temporary account if you don't have one yet (no signup), and ends by offering your first [Artifact](/more/artifacts).
+  **Using an agent?** Install the [Latitude skills](/getting-started/skills) and let it handle the setup below. `latitude-setup` instruments your app or agent harness, verifies traces arrive, creates a temporary account if you don't have one yet (no signup), and ends by building your first [Artifact](/more/artifacts).
 
   ```text
   Install the `latitude-setup` skill from `github.com/latitude-dev/skills` and use it to set up Latitude tracing here.

--- a/docs/telemetry/start-tracing.mdx
+++ b/docs/telemetry/start-tracing.mdx
@@ -3,7 +3,7 @@ title: Start tracing
 description: Connect your agent to Latitude and send your first traces.
 ---
 
-Use your agent to add Latitude tracing to your app or agent harness. The `latitude-setup` skill inspects your codebase, detects your LLM providers and existing OpenTelemetry setup, installs the right SDK or harness plugin, verifies that traces arrive in your project, and offers to build your first [Artifact](/more/artifacts) from them. If you don't have a Latitude account yet, it bootstraps a temporary one from the terminal, no signup, and gives you a link to claim it.
+Use your agent to add Latitude tracing to your app or agent harness. The `latitude-setup` skill inspects your codebase, detects your LLM providers and existing OpenTelemetry setup, installs the right SDK or harness plugin, verifies that traces arrive in your project, and builds your first [Artifact](/more/artifacts) from them. If you don't have a Latitude account yet, it bootstraps a temporary one from the terminal, no signup, and gives you a link to claim it.
 
 <Steps>
   <Step title="Ask your agent to install tracing">


### PR DESCRIPTION
## summary

Wording follow-up to latitude-dev/skills#9, which moved the first Artifact into the setup plan the user approves and made it part of `latitude-setup`'s definition of done. The skills callout, the start-tracing intro and the skills page said the skill "ends by offering" an Artifact; they now say it builds one and hands it back with the claim link. Three one-line edits, no structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791386834&installation_model_id=435055&pr_number=4595&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4595&signature=9928e4c546fc66fa89946770e03e81540c12db75e0e04ebb506215a52aebc238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->