### PR TITLE
docs: latitude-setup builds the first Artifact from its own template

### DIFF
--- a/docs/getting-started/skills.mdx
+++ b/docs/getting-started/skills.mdx
@@ -26,7 +26,7 @@ npx skills add https://github.com/latitude-dev/skills --skill latitude-setup,lat
 | `latitude-artifacts` | Builds [Artifacts](/more/artifacts): self-contained HTML reports and KPI dashboards from your Latitude data, in the Latitude design language with light and dark themes. |
 
 <Info>
-  `latitude-setup` builds on `latitude-cli` and `latitude-telemetry`, and ends by building a first Artifact through `latitude-artifacts`, so the command above installs all four for the from-scratch flow.
+  `latitude-setup` builds on `latitude-cli` and `latitude-telemetry` and ends by building a first Artifact from its own template. `latitude-artifacts` is for the reports you ask for after that, so the command above installs all four.
 </Info>
 
 ## No account yet
@@ -44,7 +44,7 @@ The `latitude-setup` skill orchestrates the whole zero-account flow:
 3. Instruments your app (via the `latitude-telemetry` skill) against that project.
 4. Runs your real code and inspects the resulting traces, iterating until they look right.
 5. Cleans up the trace noise and hands you a **claim link**.
-6. Builds your first [Artifact](/more/artifacts), an HTML report of the traces that just landed, through the `latitude-artifacts` skill, and hands it back with the claim link.
+6. Builds your first [Artifact](/more/artifacts), an HTML page showing what the telemetry captured from the verified session, with a button to claim the workspace, and hands it back with the claim link.
 
 Open the claim link in your browser to take ownership of the temporary account and keep it. Unclaimed temporary accounts expire automatically.
 


### PR DESCRIPTION
## summary

Two lines on the skills page, matching latitude-dev/skills#10: `latitude-setup` now ships its own first-session Artifact template (with the claim button) instead of delegating to `latitude-artifacts`, which stays the skill for later reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791388540&installation_model_id=435055&pr_number=4596&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4596&signature=4cba44b355934068a41817500296558fc3af84ec81b54bd6193c2da38a20aea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->