### PR TITLE
docs(telemetry): put the zero-account route in every page's first paragraph

### DIFF
--- a/docs/telemetry/claude-code.md
+++ b/docs/telemetry/claude-code.md
@@ -3,7 +3,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 # Claude Code telemetry
 
-Stream Claude Code conversations into Latitude as traces. After setup, Claude Code turns appear in your project's **Traces** view with prompts, responses, tool calls, and tool results.
+Stream Claude Code conversations into Latitude as traces. After setup, Claude Code turns appear in your project's **Traces** view with prompts, responses, tool calls, and tool results. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <SkillsCallout />
 

--- a/docs/telemetry/frameworks/cloudflare-ai-gateway.mdx
+++ b/docs/telemetry/frameworks/cloudflare-ai-gateway.mdx
@@ -13,7 +13,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) proxies requests to your
 LLM providers and can export an OpenTelemetry span for every request it handles. Those spans
 follow the OpenTelemetry [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/),
-so Latitude ingests them directly over OTLP — no SDK or code change in your application.
+so Latitude ingests them directly over OTLP — no SDK or code change in your application. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 You configure the exporter once in the AI Gateway dashboard, pointing it at Latitude's OTLP
 endpoint. Every model call routed through the gateway then shows up in Latitude with its model,

--- a/docs/telemetry/frameworks/cloudflare-think.mdx
+++ b/docs/telemetry/frameworks/cloudflare-think.mdx
@@ -12,7 +12,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 Cloudflare Think uses the Vercel AI SDK internally. Think owns the `streamText`
 call, so add Latitude telemetry in `beforeTurn()` instead of at a model call
-site.
+site. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Start with the basic setup. Add context only if you need traces to include
 user, session, tags, or metadata from your app.

--- a/docs/telemetry/frameworks/crewai.mdx
+++ b/docs/telemetry/frameworks/crewai.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application built with **CrewAI** (`crewai`).
+This guide shows you how to integrate **Latitude Telemetry** into an application built with **CrewAI** (`crewai`). No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Latitude includes dedicated instrumentation for CrewAI, so crew kickoffs, agent steps, model generations, and tool calls appear as traces.
 

--- a/docs/telemetry/frameworks/dspy.mdx
+++ b/docs/telemetry/frameworks/dspy.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into a program built with **DSPy**.
+This guide shows you how to integrate **Latitude Telemetry** into a program built with **DSPy**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 DSPy has no dedicated instrumentor — it routes every language-model call through **LiteLLM**. Instrumenting LiteLLM therefore captures all of DSPy's model calls, including those issued by modules like `Predict` and `ReAct`.
 

--- a/docs/telemetry/frameworks/elevenlabs.mdx
+++ b/docs/telemetry/frameworks/elevenlabs.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to get LLM observability for [**ElevenLabs Agents**](https://elevenlabs.io/docs/eleven-agents/overview) in Latitude.
+This guide shows you how to get LLM observability for [**ElevenLabs Agents**](https://elevenlabs.io/docs/eleven-agents/overview) in Latitude. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 ElevenLabs Agents is a fully hosted **voice platform**: speech-to-text, the LLM loop, and text-to-speech all run on ElevenLabs' infrastructure. ElevenLabs does not export STT or TTS traces to third parties — only the LLM step is observable, and only when you route it through infrastructure you control.
 

--- a/docs/telemetry/frameworks/eve.mdx
+++ b/docs/telemetry/frameworks/eve.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to send traces from an agent built with **[Eve](https://eve.dev)** to Latitude.
+This guide shows you how to send traces from an agent built with **[Eve](https://eve.dev)** to Latitude. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Eve is built on the **Vercel AI SDK** and exports standard OpenTelemetry spans (`ai.streamText`, `ai.toolCall`, …) through whatever exporter you register in `agent/instrumentation.ts`. Because Latitude already understands Vercel AI SDK spans, you can point Eve's OTel exporter straight at Latitude's OTLP endpoint — no Latitude SDK required.
 

--- a/docs/telemetry/frameworks/flue.mdx
+++ b/docs/telemetry/frameworks/flue.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to send traces from **[Flue](https://flueframework.com)** to Latitude.
+This guide shows you how to send traces from **[Flue](https://flueframework.com)** to Latitude. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Flue exposes an OpenTelemetry observer through `@flue/opentelemetry`. The observer converts Flue workflow runs, operations, model turns, tool calls, delegated tasks, compactions, and logs into standard OpenTelemetry spans. Latitude ingests those spans directly and understands Flue's `flue.*` attributes and OpenTelemetry GenAI `gen_ai.*` model metadata.
 

--- a/docs/telemetry/frameworks/google-adk.mdx
+++ b/docs/telemetry/frameworks/google-adk.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Google Agent Development Kit (ADK)** (`google-adk` for Python).
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Google Agent Development Kit (ADK)** (`google-adk` for Python). No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Latitude includes dedicated instrumentation for Google ADK, so agent runs, model generations, and tool calls appear as traces.
 

--- a/docs/telemetry/frameworks/haystack.mdx
+++ b/docs/telemetry/frameworks/haystack.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application built with **Haystack** (`haystack-ai`).
+This guide shows you how to integrate **Latitude Telemetry** into an application built with **Haystack** (`haystack-ai`). No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Latitude includes dedicated instrumentation for Haystack, so pipeline runs, generator calls, and tool invocations appear as traces.
 

--- a/docs/telemetry/frameworks/langchain.mdx
+++ b/docs/telemetry/frameworks/langchain.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **LangChain**.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **LangChain**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling LangChain exactly as you do today. Telemetry simply

--- a/docs/telemetry/frameworks/litellm.mdx
+++ b/docs/telemetry/frameworks/litellm.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **LiteLLM** to call models across providers behind a single API.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **LiteLLM** to call models across providers behind a single API. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Latitude wires LiteLLM's built-in OpenTelemetry callback, so every `litellm.completion` call — whatever the underlying provider — is captured with messages, model, and token usage.
 

--- a/docs/telemetry/frameworks/livekit.mdx
+++ b/docs/telemetry/frameworks/livekit.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to send traces from a [**LiveKit Agents**](https://docs.livekit.io/agents/) application to Latitude.
+This guide shows you how to send traces from a [**LiveKit Agents**](https://docs.livekit.io/agents/) application to Latitude. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 LiveKit Agents ships with built-in OpenTelemetry support and owns its own tracer provider. Instead of bootstrapping telemetry with the `Latitude` class, you attach a **`LatitudeSpanProcessor`** to LiveKit's provider — Latitude then receives the same spans LiveKit emits for LLM, agent, and tool activity. This works the same way for the **Python** (`livekit-agents`) and **Node.js** (`@livekit/agents`) SDKs.
 

--- a/docs/telemetry/frameworks/llamaindex.mdx
+++ b/docs/telemetry/frameworks/llamaindex.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **LlamaIndex**.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **LlamaIndex**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling LlamaIndex exactly as you do today. Telemetry simply

--- a/docs/telemetry/frameworks/mastra.mdx
+++ b/docs/telemetry/frameworks/mastra.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Mastra**.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Mastra**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Mastra has built-in observability support via `@mastra/observability` and `@mastra/otel-exporter`. It emits standard OpenTelemetry `gen_ai.*` spans, so you can point Mastra's OTel exporter directly at Latitude's OTLP ingestion endpoint — no Latitude SDK required.
 

--- a/docs/telemetry/frameworks/openai-agents.mdx
+++ b/docs/telemetry/frameworks/openai-agents.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **OpenAI Agents SDK** (`@openai/agents` for TypeScript, `openai-agents` for Python).
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **OpenAI Agents SDK** (`@openai/agents` for TypeScript, `openai-agents` for Python). No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Latitude includes dedicated instrumentation for the OpenAI Agents SDK, so agent runs, generations, function calls, handoffs, and guardrails appear as traces.
 

--- a/docs/telemetry/frameworks/pydantic-ai.mdx
+++ b/docs/telemetry/frameworks/pydantic-ai.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to send traces from a **[Pydantic AI](https://ai.pydantic.dev)** agent to Latitude.
+This guide shows you how to send traces from a **[Pydantic AI](https://ai.pydantic.dev)** agent to Latitude. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Pydantic AI has OpenTelemetry support built in. Calling `Agent.instrument_all()` makes it emit standard `gen_ai.*` spans for every agent run, model call, and tool execution. Latitude's Python SDK registers the global OpenTelemetry provider those spans flow into, so you get full traces without a dedicated instrumentor — Latitude reads Pydantic AI's native spans directly.
 

--- a/docs/telemetry/frameworks/strands.mdx
+++ b/docs/telemetry/frameworks/strands.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Strands Agents** — AWS's open-source AI agents SDK.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Strands Agents** — AWS's open-source AI agents SDK. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 Strands Agents has first-class OpenTelemetry support built in (`strands-agents[otel]`). It emits standard `gen_ai.*` spans for every agent run, LLM call, and tool execution, so you can point Strands' OTLP exporter directly at Latitude's ingestion endpoint — no Latitude SDK required.
 

--- a/docs/telemetry/frameworks/vercel-ai-sdk-v7.mdx
+++ b/docs/telemetry/frameworks/vercel-ai-sdk-v7.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Vercel AI SDK v7**.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Vercel AI SDK v7**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Note>
   Using **Vercel AI SDK v6**? See the [Vercel AI SDK](/telemetry/frameworks/vercel-ai-sdk) guide

--- a/docs/telemetry/frameworks/vercel-ai-sdk.mdx
+++ b/docs/telemetry/frameworks/vercel-ai-sdk.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Vercel AI SDK**.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Vercel AI SDK**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 The Vercel AI SDK can emit OpenTelemetry spans through its `experimental_telemetry` flag. Latitude can ingest those spans without a provider-specific instrumentation entry.
 

--- a/docs/telemetry/hermes.md
+++ b/docs/telemetry/hermes.md
@@ -3,7 +3,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 # Hermes telemetry
 
-Stream [Hermes Agent](https://github.com/NousResearch/hermes-agent) (Nous Research's open-source agent harness) runs into Latitude as traces. After setup, each Hermes turn appears in your project's **Traces** view with user prompts, model turns, tool calls and results, the tools the agent was offered, memory reads and writes, delegated subagents, token usage, cost, timing, and the real system prompt that reached the model.
+Stream [Hermes Agent](https://github.com/NousResearch/hermes-agent) (Nous Research's open-source agent harness) runs into Latitude as traces. After setup, each Hermes turn appears in your project's **Traces** view with user prompts, model turns, tool calls and results, the tools the agent was offered, memory reads and writes, delegated subagents, token usage, cost, timing, and the real system prompt that reached the model. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <SkillsCallout />
 

--- a/docs/telemetry/openclaw.md
+++ b/docs/telemetry/openclaw.md
@@ -3,7 +3,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 # OpenClaw telemetry
 
-Stream OpenClaw agent runs into Latitude as traces. After setup, agent runs appear in your project's **Traces** view with model calls, tool calls, token usage, cost, timing, and nested subagent activity — as a proper `invoke_agent → chat → execute_tool` tree.
+Stream OpenClaw agent runs into Latitude as traces. After setup, agent runs appear in your project's **Traces** view with model calls, tool calls, token usage, cost, timing, and nested subagent activity — as a proper `invoke_agent → chat → execute_tool` tree. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 The recommended way is OpenClaw's **official OpenTelemetry exporter** (the bundled `@openclaw/diagnostics-otel` plugin), pointed at Latitude's OTLP ingest. It follows OpenTelemetry GenAI semantic conventions and is maintained by OpenClaw — see [OpenClaw's OpenTelemetry docs](https://docs.openclaw.ai/gateway/opentelemetry).
 

--- a/docs/telemetry/otel-exporter.md
+++ b/docs/telemetry/otel-exporter.md
@@ -8,7 +8,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 # Connect with Any OpenTelemetry Exporter
 
-Latitude's ingestion endpoint speaks standard **OTLP over HTTP**. 
+Latitude's ingestion endpoint speaks standard **OTLP over HTTP**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 If your language has an OpenTelemetry SDK (Go, Java, Ruby, Rust, .NET, Elixir, PHP, etc.), you can send traces to Latitude without a Latitude-specific library.
 

--- a/docs/telemetry/pi-coding-agent.md
+++ b/docs/telemetry/pi-coding-agent.md
@@ -3,7 +3,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 # Pi coding agent telemetry
 
-Stream [pi coding agent](https://pi.dev) sessions into Latitude as traces with the first-party `@latitude-data/pi-telemetry` extension.
+Stream [pi coding agent](https://pi.dev) sessions into Latitude as traces with the first-party `@latitude-data/pi-telemetry` extension. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 After setup, pi prompts appear in your Latitude project's **Traces** view with model calls, prompts, responses, token usage, tool calls, and tool results.
 

--- a/docs/telemetry/prime-intellect.md
+++ b/docs/telemetry/prime-intellect.md
@@ -3,7 +3,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 # Prime Intellect (Verifiers) telemetry
 
-Stream [Prime Intellect Verifiers](https://github.com/PrimeIntellect-ai/verifiers) eval rollouts into Latitude as traces. After setup, each rollout appears in your project's **Traces** view with prompts, model calls, tool calls, token usage, timing, and rewards — optionally as Latitude custom scores.
+Stream [Prime Intellect Verifiers](https://github.com/PrimeIntellect-ai/verifiers) eval rollouts into Latitude as traces. After setup, each rollout appears in your project's **Traces** view with prompts, model calls, tool calls, token usage, timing, and rewards — optionally as Latitude custom scores. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <SkillsCallout />
 

--- a/docs/telemetry/providers/aleph-alpha.mdx
+++ b/docs/telemetry/providers/aleph-alpha.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Aleph Alpha** SDK (`aleph-alpha-client`).
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Aleph Alpha** SDK (`aleph-alpha-client`). No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Aleph Alpha exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/amazon-bedrock.mdx
+++ b/docs/telemetry/providers/amazon-bedrock.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Amazon Bedrock**.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Amazon Bedrock**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Bedrock exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/anthropic.mdx
+++ b/docs/telemetry/providers/anthropic.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Anthropic** SDK.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Anthropic** SDK. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Anthropic exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/azure.mdx
+++ b/docs/telemetry/providers/azure.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Azure OpenAI**. Azure OpenAI uses the same `openai` SDK under the hood, so the `"openai"` instrumentation handles it automatically.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Azure OpenAI**. Azure OpenAI uses the same `openai` SDK under the hood, so the `"openai"` instrumentation handles it automatically. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Azure OpenAI exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/cohere.mdx
+++ b/docs/telemetry/providers/cohere.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Cohere** SDK.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Cohere** SDK. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Cohere exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/gemini.mdx
+++ b/docs/telemetry/providers/gemini.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Google Gemini Developer API** (`google-genai`).
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Google Gemini Developer API** (`google-genai`). No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Gemini exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/google-ai-platform.mdx
+++ b/docs/telemetry/providers/google-ai-platform.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Google Cloud AI Platform**.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Google Cloud AI Platform**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling AI Platform exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/groq.mdx
+++ b/docs/telemetry/providers/groq.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Groq** SDK.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Groq** SDK. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Groq exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/mistral.mdx
+++ b/docs/telemetry/providers/mistral.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Mistral AI** SDK.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Mistral AI** SDK. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Mistral exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/ollama.mdx
+++ b/docs/telemetry/providers/ollama.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Ollama** for local model inference.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Ollama** for local model inference. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Ollama exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/openai.mdx
+++ b/docs/telemetry/providers/openai.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **OpenAI** SDK.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **OpenAI** SDK. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling OpenAI exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/replicate.mdx
+++ b/docs/telemetry/providers/replicate.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Replicate** SDK.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Replicate** SDK. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Replicate exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/sagemaker.mdx
+++ b/docs/telemetry/providers/sagemaker.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that invokes models hosted on **Amazon SageMaker** through `boto3`.
+This guide shows you how to integrate **Latitude Telemetry** into an application that invokes models hosted on **Amazon SageMaker** through `boto3`. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling SageMaker exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/together-ai.mdx
+++ b/docs/telemetry/providers/together-ai.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Together AI** SDK.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Together AI** SDK. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Together AI exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/transformers.mdx
+++ b/docs/telemetry/providers/transformers.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that runs models locally with **Hugging Face Transformers**.
+This guide shows you how to integrate **Latitude Telemetry** into an application that runs models locally with **Hugging Face Transformers**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Transformers exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/vertex-ai.mdx
+++ b/docs/telemetry/providers/vertex-ai.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Google Cloud Vertex AI**.
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Google Cloud Vertex AI**. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling Vertex AI exactly as you do today. Telemetry simply

--- a/docs/telemetry/providers/watsonx.mdx
+++ b/docs/telemetry/providers/watsonx.mdx
@@ -10,7 +10,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 ## Overview
 
-This guide shows you how to integrate **Latitude Telemetry** into an application that uses **IBM watsonx.ai** (`ibm-watsonx-ai`).
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses **IBM watsonx.ai** (`ibm-watsonx-ai`). No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <Check>
   You'll keep calling watsonx.ai exactly as you do today. Telemetry simply

--- a/docs/telemetry/python.md
+++ b/docs/telemetry/python.md
@@ -8,7 +8,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 # Python SDK
 
-Use `latitude-telemetry` to send LLM traces from Python applications to Latitude. The SDK is built on OpenTelemetry and can attach to an existing tracing setup when your app already uses one.
+Use `latitude-telemetry` to send LLM traces from Python applications to Latitude. The SDK is built on OpenTelemetry and can attach to an existing tracing setup when your app already uses one. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <SkillsCallout />
 

--- a/docs/telemetry/typescript.md
+++ b/docs/telemetry/typescript.md
@@ -8,7 +8,7 @@ import FirstArtifact from "/snippets/first-artifact.mdx"
 
 # TypeScript SDK
 
-Use `@latitude-data/telemetry` to send LLM traces from TypeScript and JavaScript applications to Latitude. The SDK is built on OpenTelemetry and can attach to an existing tracing setup when your app already uses one.
+Use `@latitude-data/telemetry` to send LLM traces from TypeScript and JavaScript applications to Latitude. The SDK is built on OpenTelemetry and can attach to an existing tracing setup when your app already uses one. No Latitude account yet? Your agent can create a temporary one and do this whole setup with the [`latitude-setup` skill](/getting-started/skills), no signup.
 
 <SkillsCallout />
 


### PR DESCRIPTION
## summary

The Hermes agent confirmed what its `web_extract` tool does to our pages: it drops the Tip callout and truncates with "...", but keeps the intro paragraph and headings. So the one sentence an agent must not miss now ends the first paragraph of all 44 telemetry pages, as plain text:

> No Latitude account yet? Your agent can create a temporary one and do this whole setup with the `latitude-setup` skill, no signup.

Same sentence everywhere, appended to the end of the first prose paragraph (wrapped paragraphs handled). Nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791391956&installation_model_id=435055&pr_number=4599&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4599&signature=b7f563b6e8cec7b66fd21e5689f1eb04adfe8bfbc8ada2261c348d46aeed78b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->