### PR TITLE
fix(spans): skip Wrapped report generation when project or org was deleted

### DIFF
--- a/packages/domain/spans/src/wrapped/use-cases/run-wrapped.test.ts
+++ b/packages/domain/spans/src/wrapped/use-cases/run-wrapped.test.ts
@@ -126,13 +126,13 @@ const makeOrganization = (): Organization => ({
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 })
 
-const makeOrganizationRepository = (organization: Organization): (typeof OrganizationRepository)["Service"] => ({
+const makeOrganizationRepository = (organization: Organization | null): (typeof OrganizationRepository)["Service"] => ({
   findById: (id) =>
-    id === organization.id
+    organization && id === organization.id
       ? Effect.succeed(organization)
       : Effect.fail(new NotFoundError({ entity: "Organization", id })),
   findByIdForUpdate: (id) =>
-    id === organization.id
+    organization && id === organization.id
       ? Effect.succeed(organization)
       : Effect.fail(new NotFoundError({ entity: "Organization", id })),
   listByUserId: () => Effect.die("listByUserId not used"),
@@ -143,11 +143,11 @@ const makeOrganizationRepository = (organization: Organization): (typeof Organiz
   listExpiredUnclaimed: () => Effect.die("listExpiredUnclaimed not used"),
 })
 
-const makeProjectRepository = (project: Project): (typeof ProjectRepository)["Service"] => ({
+const makeProjectRepository = (project: Project | null): (typeof ProjectRepository)["Service"] => ({
   findById: (id) =>
-    id === project.id ? Effect.succeed(project) : Effect.fail(new NotFoundError({ entity: "Project", id })),
+    project && id === project.id ? Effect.succeed(project) : Effect.fail(new NotFoundError({ entity: "Project", id })),
   findByIdForUpdate: (id) =>
-    id === project.id ? Effect.succeed(project) : Effect.fail(new NotFoundError({ entity: "Project", id })),
+    project && id === project.id ? Effect.succeed(project) : Effect.fail(new NotFoundError({ entity: "Project", id })),
   findBySlug: () => Effect.die("findBySlug not used"),
   list: () => Effect.die("list not used"),
   listIncludingDeleted: () => Effect.die("listIncludingDeleted not used"),
@@ -174,12 +174,14 @@ interface TestHarness {
 const setupHarness = (options: {
   readonly members: readonly MemberWithUser[]
   readonly sessions: number
+  readonly projectExists?: boolean
+  readonly organizationExists?: boolean
 }): TestHarness => {
   const { repository: memberships } = createFakeMembershipRepository({
     listMembersWithUser: () => Effect.succeed([...options.members]),
   })
-  const projectRepo = makeProjectRepository(makeProject())
-  const organizationRepo = makeOrganizationRepository(makeOrganization())
+  const projectRepo = makeProjectRepository(options.projectExists === false ? null : makeProject())
+  const organizationRepo = makeOrganizationRepository(options.organizationExists === false ? null : makeOrganization())
   const reader = makeReader({
     countSessionsForProjectInWindow: () => Effect.succeed(options.sessions),
   })
@@ -325,5 +327,35 @@ describe("runWrappedUseCase", () => {
     await runUseCase(harness)
 
     expect(harness.saved[0]?.ownerName).toBe("Acme")
+  })
+
+  it("skips instead of throwing when the project was deleted before the job ran", async () => {
+    // Regression: the fan-out enumerates eligible projects from ClickHouse
+    // ahead of publishing this task, so the project can be deleted by the
+    // time the job runs. `findById` used to propagate `NotFoundError`
+    // uncaught, failing the whole BullMQ job.
+    harness = setupHarness({
+      members: [makeMember("a", "a@test.com", true)],
+      sessions: 5,
+      projectExists: false,
+    })
+
+    const result = await runUseCase(harness)
+
+    expect(result).toEqual({ status: "skipped", reason: "project-not-found" })
+    expect(harness.saved).toHaveLength(0)
+  })
+
+  it("skips instead of throwing when the organization was deleted before the job ran", async () => {
+    harness = setupHarness({
+      members: [makeMember("a", "a@test.com", true)],
+      sessions: 5,
+      organizationExists: false,
+    })
+
+    const result = await runUseCase(harness)
+
+    expect(result).toEqual({ status: "skipped", reason: "organization-not-found" })
+    expect(harness.saved).toHaveLength(0)
   })
 })

--- a/packages/domain/spans/src/wrapped/use-cases/run-wrapped.test.ts
+++ b/packages/domain/spans/src/wrapped/use-cases/run-wrapped.test.ts
@@ -330,10 +330,6 @@ describe("runWrappedUseCase", () => {
   })
 
   it("skips instead of throwing when the project was deleted before the job ran", async () => {
-    // Regression: the fan-out enumerates eligible projects from ClickHouse
-    // ahead of publishing this task, so the project can be deleted by the
-    // time the job runs. `findById` used to propagate `NotFoundError`
-    // uncaught, failing the whole BullMQ job.
     harness = setupHarness({
       members: [makeMember("a", "a@test.com", true)],
       sessions: 5,

--- a/packages/domain/spans/src/wrapped/use-cases/run-wrapped.ts
+++ b/packages/domain/spans/src/wrapped/use-cases/run-wrapped.ts
@@ -14,7 +14,7 @@ export interface RunWrappedInput {
   readonly windowEnd: Date
 }
 
-export type RunWrappedSkippedReason = "no-activity"
+export type RunWrappedSkippedReason = "no-activity" | "project-not-found" | "organization-not-found"
 
 export type RunWrappedResult =
   | {
@@ -66,8 +66,22 @@ export const runWrappedUseCase = Effect.fn("wrapped.runForProject")(function* (i
   const projectRepo = yield* ProjectRepository
   const membershipRepo = yield* MembershipRepository
   const organizationRepo = yield* OrganizationRepository
-  const project = yield* projectRepo.findById(input.projectId)
-  const organization = yield* organizationRepo.findById(input.organizationId)
+  // The fan-out enumerates eligible projects from ClickHouse ahead of publishing
+  // this task, so the project (or its org) may be deleted by the time the job
+  // runs — treat that race as a skip, not a failure, same as
+  // `requestAgentDispatchUseCase`'s handling of the equivalent race.
+  const project = yield* projectRepo
+    .findById(input.projectId)
+    .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+  if (project === null) {
+    return { status: "skipped", reason: "project-not-found" } satisfies RunWrappedResult
+  }
+  const organization = yield* organizationRepo
+    .findById(input.organizationId)
+    .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+  if (organization === null) {
+    return { status: "skipped", reason: "organization-not-found" } satisfies RunWrappedResult
+  }
   // Fetch the full member list to snapshot the org owner's display name
   // onto the persisted row (`owner_name` anchors the web view's greeting).
   // Recipient resolution + delivery happens downstream in the notification

--- a/packages/domain/spans/src/wrapped/use-cases/run-wrapped.ts
+++ b/packages/domain/spans/src/wrapped/use-cases/run-wrapped.ts
@@ -66,10 +66,7 @@ export const runWrappedUseCase = Effect.fn("wrapped.runForProject")(function* (i
   const projectRepo = yield* ProjectRepository
   const membershipRepo = yield* MembershipRepository
   const organizationRepo = yield* OrganizationRepository
-  // The fan-out enumerates eligible projects from ClickHouse ahead of publishing
-  // this task, so the project (or its org) may be deleted by the time the job
-  // runs — treat that race as a skip, not a failure, same as
-  // `requestAgentDispatchUseCase`'s handling of the equivalent race.
+  // The project or its org may be deleted between fan-out and this job running, so treat that as a skip, not a failure.
   const project = yield* projectRepo
     .findById(input.projectId)
     .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))


### PR DESCRIPTION
## What does this PR do?

Fixes an uncaught `NotFoundError` in the weekly Wrapped report worker (`runWrappedUseCase`, `packages/domain/spans/src/wrapped/use-cases/run-wrapped.ts`).

**Datadog issues addressed:**
- [`ET-375` (`NotFoundError`)](https://app.datadoghq.eu/error-tracking/issue/4dea99da-6bbd-11f1-9869-da7ad0900005) — `workers`, still recurring (last occurrence 2026-09-04)
- [`ET-376` (`NotFoundError$1`)](https://app.datadoghq.eu/error-tracking/issue/4deecbfe-6bbd-11f1-bca4-da7ad0900005) — same underlying event (Datadog's minifier-fingerprint split of the same stack)

**Root cause:** `fanOutWeeklyRunUseCase` enumerates projects with Claude Code activity from ClickHouse, then publishes one `runForProject` BullMQ job per project on the `wrapped` topic. If a project (or its organization) is deleted between that enumeration and the job actually running, `ProjectRepository.findById` / `OrganizationRepository.findById` throw `NotFoundError`, which was uncaught — failing the whole BullMQ job and surfacing as an unhandled exception in Error Tracking.

This is the same race-condition class already fixed once for a different call site in `requestAgentDispatchUseCase` (PR #4099), which wraps the lookup in `Effect.catchTag("NotFoundError", ...)` and returns a skip result instead of propagating the failure. This PR applies the identical pattern to `runWrappedUseCase`.

A fix for this exact bug was drafted three weeks ago in #4445 but was left as a draft and never merged (its source branch has since diverged from `development` in a way that makes it unmergeable as-is), so the underlying race kept firing in production. This PR reimplements the same fix fresh against current `development`.

**Fix:** wrap both `findById` calls with `Effect.catchTag("NotFoundError", () => Effect.succeed(null))` and return `{ status: "skipped", reason: "project-not-found" | "organization-not-found" }` instead of letting the error propagate.

## Related issue (if applicable)

Closes #

## How was this tested?

- Added two regression tests to `run-wrapped.test.ts`: one where the project has been deleted, one where the organization has been deleted. Both assert the use case returns a `skipped` result instead of throwing, and that no report is persisted.
- Confirmed both new tests **fail** against the pre-fix code (uncaught `NotFoundError` propagates) and **pass** with the fix applied (verified by temporarily reverting just the source file).
- `pnpm --filter @domain/spans exec vitest run src/wrapped/use-cases/run-wrapped.test.ts` — 7/7 passing.
- `pnpm --filter @domain/spans typecheck` (tsgo) — clean.
- `pnpm exec biome check` on both changed files — clean.

**Post-deploy verification:** occurrences of Datadog issues `ET-375` / `ET-376` for this failure mode should stop (the underlying delete-race can still occur, but it now resolves as a silent skip instead of an error).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWqgcpLQWH9gEpNafyWzBC

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWqgcpLQWH9gEpNafyWzBC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791397653&installation_model_id=435055&pr_number=4600&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4600&signature=8b1909dd063377660c7ac1b3f4aa062e0345b0389fa8ee560931842888a86ab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->