### PR TITLE
fix(scores): treat a raced duplicate evaluation-score submission as idempotent

### DIFF
--- a/packages/domain/scores/src/use-cases/submit-api-score.test.ts
+++ b/packages/domain/scores/src/use-cases/submit-api-score.test.ts
@@ -4,6 +4,7 @@ import {
   ExternalUserId,
   OrganizationId,
   ProjectId,
+  RepositoryError,
   SessionId,
   SimulationId,
   SpanId,
@@ -347,6 +348,111 @@ describe("submitApiScoreUseCase", () => {
       expect(score.sourceId).toBe(evaluationCuid)
       expect(score.metadata).toEqual({ evaluationHash: "sha256:abc123" })
       expect(store.size).toBe(1)
+    })
+  })
+
+  describe("canonical evaluation-score conflicts", () => {
+    /**
+     * Simulates the Postgres partial unique index `scores_canonical_evaluation_trace_idx`
+     * (one non-draft evaluation score per project+evaluation+trace) at the fake-repository
+     * layer, so `save` fails exactly the way the real repository does on a losing race.
+     */
+    const createRacingScoreRepository = () => {
+      const { repository: base, scores: store } = createFakeScoreRepository()
+      let saveCalls = 0
+
+      return {
+        store,
+        saveCallCount: () => saveCalls,
+        repository: {
+          ...base,
+          save: (score: Parameters<typeof base.save>[0]) => {
+            saveCalls += 1
+            const conflict = [...store.values()].some(
+              (existing) =>
+                existing.id !== score.id &&
+                existing.projectId === score.projectId &&
+                existing.sourceType === "evaluation" &&
+                existing.sourceType === score.sourceType &&
+                existing.sourceId === score.sourceId &&
+                existing.traceId === score.traceId &&
+                existing.draftedAt === null,
+            )
+
+            if (conflict) {
+              return Effect.fail(
+                new RepositoryError({
+                  operation: "save",
+                  cause: { code: "23505", constraint: "scores_canonical_evaluation_trace_idx" },
+                }),
+              )
+            }
+
+            return base.save(score)
+          },
+        },
+      }
+    }
+
+    it("returns the winning score when a duplicate evaluation submission loses the canonical write race", async () => {
+      const { store, repository, saveCallCount } = createRacingScoreRepository()
+      const { layer } = createTestLayers()
+      const racingLayer = Layer.mergeAll(layer, Layer.succeed(ScoreRepository, repository))
+
+      const first = await Effect.runPromise(submitApiScoreUseCase(evaluationInput()).pipe(Effect.provide(racingLayer)))
+      // Second call: same evaluation + trace, a fresh server-generated id — mirrors an SDK
+      // retry or two concurrent submissions racing for the same canonical row.
+      const second = await Effect.runPromise(submitApiScoreUseCase(evaluationInput()).pipe(Effect.provide(racingLayer)))
+
+      expect(second.id).toBe(first.id)
+      expect(store.size).toBe(1)
+      expect(saveCallCount()).toBe(2)
+    })
+
+    it("still fails when the canonical row can't be found after losing the race", async () => {
+      const { repository: base } = createFakeScoreRepository()
+      const alwaysConflicts = {
+        ...base,
+        save: () =>
+          Effect.fail(
+            new RepositoryError({
+              operation: "save",
+              cause: { code: "23505", constraint: "scores_canonical_evaluation_trace_idx" },
+            }),
+          ),
+        findByEvaluationIdAndTraceId: () => Effect.succeed(null),
+      }
+      const { layer } = createTestLayers()
+      const racingLayer = Layer.mergeAll(layer, Layer.succeed(ScoreRepository, alwaysConflicts))
+
+      const exit = await Effect.runPromiseExit(
+        submitApiScoreUseCase(evaluationInput()).pipe(Effect.provide(racingLayer)),
+      )
+
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        expect(JSON.stringify(exit.cause)).toContain("scores_canonical_evaluation_trace_idx")
+      }
+    })
+
+    it("does not treat a custom score's save failure as a canonical-race conflict", async () => {
+      const { repository: base } = createFakeScoreRepository()
+      const alwaysConflicts = {
+        ...base,
+        save: () =>
+          Effect.fail(
+            new RepositoryError({
+              operation: "save",
+              cause: { code: "23505", constraint: "scores_canonical_evaluation_trace_idx" },
+            }),
+          ),
+      }
+      const { layer } = createTestLayers()
+      const racingLayer = Layer.mergeAll(layer, Layer.succeed(ScoreRepository, alwaysConflicts))
+
+      const exit = await Effect.runPromiseExit(submitApiScoreUseCase(customInput()).pipe(Effect.provide(racingLayer)))
+
+      expect(exit._tag).toBe("Failure")
     })
   })
 

--- a/packages/domain/scores/src/use-cases/submit-api-score.ts
+++ b/packages/domain/scores/src/use-cases/submit-api-score.ts
@@ -1,23 +1,19 @@
-import { BadRequestError, OrganizationId, type ProjectId, type RepositoryError } from "@domain/shared"
+import {
+  BadRequestError,
+  findPostgresUniqueViolationConstraint,
+  OrganizationId,
+  type ProjectId,
+  type RepositoryError,
+} from "@domain/shared"
 import { resolveScoreTraceContext, resolveTraceIdFromRef, traceRefSchema } from "@domain/spans"
 import { Cause, Effect, Exit } from "effect"
 import { z } from "zod"
-import type { Score } from "../entities/score.ts"
 import { customScoreSchema, evaluationScoreSchema } from "../entities/score.ts"
 import { ScoreRepository } from "../ports/score-repository.ts"
 import { baseWriteScoreInputSchema, type WriteScoreInput, writeScoreUseCase } from "./write-score.ts"
 
-const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null
-
 const isRepositoryError = (error: unknown): error is RepositoryError =>
-  isRecord(error) && error._tag === "RepositoryError" && "cause" in error
-
-// scores_canonical_evaluation_trace_idx; recurses because the driver may nest the raw pg error.
-const isCanonicalEvaluationConflict = (cause: unknown): boolean => {
-  if (!isRecord(cause)) return false
-  if (cause.code === "23505" && cause.constraint === "scores_canonical_evaluation_trace_idx") return true
-  return "cause" in cause && isCanonicalEvaluationConflict(cause.cause)
-}
+  typeof error === "object" && error !== null && (error as { _tag?: unknown })._tag === "RepositoryError"
 
 const formatValidationError = (error: z.ZodError): string => error.issues.map((issue) => issue.message).join(", ")
 
@@ -145,14 +141,14 @@ export const submitApiScoreUseCase = Effect.fn("scores.submitApiScore")(function
     parsed.source === "evaluation" &&
     errorOption._tag === "Some" &&
     isRepositoryError(errorOption.value) &&
-    isCanonicalEvaluationConflict(errorOption.value.cause)
+    findPostgresUniqueViolationConstraint(errorOption.value.cause) === "scores_canonical_evaluation_trace_idx"
 
   if (!isDuplicateEvaluationScore) {
     return yield* writeExit
   }
 
   const scoreRepository = yield* ScoreRepository
-  const existingScore: Score | null = yield* scoreRepository.findByEvaluationIdAndTraceId({
+  const existingScore = yield* scoreRepository.findByEvaluationIdAndTraceId({
     projectId: input.projectId,
     evaluationId: parsed.sourceId,
     traceId,

--- a/packages/domain/scores/src/use-cases/submit-api-score.ts
+++ b/packages/domain/scores/src/use-cases/submit-api-score.ts
@@ -12,12 +12,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> => typeof va
 const isRepositoryError = (error: unknown): error is RepositoryError =>
   isRecord(error) && error._tag === "RepositoryError" && "cause" in error
 
-/**
- * `scores_canonical_evaluation_trace_idx` enforces one non-draft evaluation score per
- * (project, evaluation, trace). A retried or concurrent submission for the same trace loses
- * this race in Postgres, not in application code, so the violation can be nested under
- * whatever the driver wraps it in.
- */
+// scores_canonical_evaluation_trace_idx; recurses because the driver may nest the raw pg error.
 const isCanonicalEvaluationConflict = (cause: unknown): boolean => {
   if (!isRecord(cause)) return false
   if (cause.code === "23505" && cause.constraint === "scores_canonical_evaluation_trace_idx") return true
@@ -144,10 +139,7 @@ export const submitApiScoreUseCase = Effect.fn("scores.submitApiScore")(function
     return writeExit.value
   }
 
-  // A duplicate evaluation-score submission (an SDK retry, or two concurrent calls for the
-  // same trace) loses the canonical-row race in Postgres. Treat it like the internal live-evaluation
-  // path does: the request is idempotently satisfied by whichever score won, so return that score
-  // instead of surfacing a 500 for something that already succeeded.
+  // A losing race here already has a winning score in Postgres; return it instead of failing.
   const errorOption = Cause.findErrorOption(writeExit.cause)
   const isDuplicateEvaluationScore =
     parsed.source === "evaluation" &&

--- a/packages/domain/scores/src/use-cases/submit-api-score.ts
+++ b/packages/domain/scores/src/use-cases/submit-api-score.ts
@@ -1,9 +1,28 @@
-import { BadRequestError, OrganizationId, type ProjectId } from "@domain/shared"
+import { BadRequestError, OrganizationId, type ProjectId, type RepositoryError } from "@domain/shared"
 import { resolveScoreTraceContext, resolveTraceIdFromRef, traceRefSchema } from "@domain/spans"
-import { Effect } from "effect"
+import { Cause, Effect, Exit } from "effect"
 import { z } from "zod"
+import type { Score } from "../entities/score.ts"
 import { customScoreSchema, evaluationScoreSchema } from "../entities/score.ts"
+import { ScoreRepository } from "../ports/score-repository.ts"
 import { baseWriteScoreInputSchema, type WriteScoreInput, writeScoreUseCase } from "./write-score.ts"
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null
+
+const isRepositoryError = (error: unknown): error is RepositoryError =>
+  isRecord(error) && error._tag === "RepositoryError" && "cause" in error
+
+/**
+ * `scores_canonical_evaluation_trace_idx` enforces one non-draft evaluation score per
+ * (project, evaluation, trace). A retried or concurrent submission for the same trace loses
+ * this race in Postgres, not in application code, so the violation can be nested under
+ * whatever the driver wraps it in.
+ */
+const isCanonicalEvaluationConflict = (cause: unknown): boolean => {
+  if (!isRecord(cause)) return false
+  if (cause.code === "23505" && cause.constraint === "scores_canonical_evaluation_trace_idx") return true
+  return "cause" in cause && isCanonicalEvaluationConflict(cause.cause)
+}
 
 const formatValidationError = (error: z.ZodError): string => error.issues.map((issue) => issue.message).join(", ")
 
@@ -120,5 +139,32 @@ export const submitApiScoreUseCase = Effect.fn("scores.submitApiScore")(function
       ? { ...sharedWriteInput, sourceType: "evaluation", sourceId: parsed.sourceId, metadata: parsed.metadata }
       : { ...sharedWriteInput, sourceType: "custom", sourceId: parsed.sourceId, metadata: parsed.metadata }
 
-  return yield* writeScoreUseCase(writeInput)
+  const writeExit = yield* Effect.exit(writeScoreUseCase(writeInput))
+  if (Exit.isSuccess(writeExit)) {
+    return writeExit.value
+  }
+
+  // A duplicate evaluation-score submission (an SDK retry, or two concurrent calls for the
+  // same trace) loses the canonical-row race in Postgres. Treat it like the internal live-evaluation
+  // path does: the request is idempotently satisfied by whichever score won, so return that score
+  // instead of surfacing a 500 for something that already succeeded.
+  const errorOption = Cause.findErrorOption(writeExit.cause)
+  const isDuplicateEvaluationScore =
+    parsed.source === "evaluation" &&
+    errorOption._tag === "Some" &&
+    isRepositoryError(errorOption.value) &&
+    isCanonicalEvaluationConflict(errorOption.value.cause)
+
+  if (!isDuplicateEvaluationScore) {
+    return yield* writeExit
+  }
+
+  const scoreRepository = yield* ScoreRepository
+  const existingScore: Score | null = yield* scoreRepository.findByEvaluationIdAndTraceId({
+    projectId: input.projectId,
+    evaluationId: parsed.sourceId,
+    traceId,
+  })
+
+  return existingScore ?? (yield* writeExit)
 })


### PR DESCRIPTION
## What does this PR do?

Fixes a production error surfaced by Datadog Error Tracking: [`RepositoryError: duplicate key value violates unique constraint "scores_canonical_evaluation_trace_idx"`](https://app.datadoghq.eu/error-tracking/issue/5a610778-a842-11f1-869f-da7ad0900005) on the `scores.writeScore` resource (`workers`, production, ~9 occurrences over the last week, still recurring).

**Root cause.** `scores_canonical_evaluation_trace_idx` is a partial unique index enforcing one non-draft evaluation score per `(organization, project, evaluation, trace)` (`packages/platform/db-postgres/src/schema/scores.ts:48-50`). The public `POST /projects/:projectSlug/scores` endpoint (`submitApiScoreUseCase` → `writeScoreUseCase`, `packages/domain/scores/src/use-cases/submit-api-score.ts`) never accepts a caller-supplied score `id`, so every call generates a fresh id. When two submissions race for the same evaluation+trace — an SDK retry after a timeout, or two concurrent calls — the loser hits this constraint in Postgres and the raw `RepositoryError` propagated all the way to the customer as an unhandled 500, even though a canonical score for that trace already exists and the request is semantically satisfied.

This exact race already happens internally in the live-evaluation runner (`packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts:530-560`, see its test `"skips when another worker wins the canonical write race after execution"`), which treats it as expected and recovers by looking up the winning row. The public API path had no equivalent handling.

**Fix.** `submitApiScoreUseCase` now catches this specific unique-violation for evaluation-sourced scores only (custom scores can't hit this index) and returns the already-persisted canonical score instead of failing — the request is treated as idempotent rather than as an error.

**Blast radius.** Change is scoped to `packages/domain/scores/src/use-cases/submit-api-score.ts`; no other call sites or schemas touched.

## Related issue (if applicable)

Datadog Error Tracking issue: https://app.datadoghq.eu/error-tracking/issue/5a610778-a842-11f1-869f-da7ad0900005

Closes #

## How was this tested?

- Added `packages/domain/scores/src/use-cases/submit-api-score.test.ts` cases:
  - a fake repository that simulates the real unique index reproduces the race across two real `submitApiScoreUseCase` calls; verified this test **fails** on the pre-fix code with the raw `RepositoryError`, and passes with the fix (returns the winning score, no duplicate row written).
  - a case where the canonical row genuinely can't be found after the conflict still fails loudly, rather than silently swallowing an unrelated error.
  - a case confirming a `custom`-sourced score's save failure is never treated as a canonical-race conflict (the new handling is scoped to `source: "evaluation"`).
- `pnpm --filter @domain/scores test` — 46/46 pass.
- `pnpm --filter @domain/scores typecheck` and `pnpm --filter @repo/operations typecheck` (the HTTP route wiring this use case) — clean via `tsgo`.
- `pnpm exec biome check` on the changed files — clean.

**Verification in production:** after deploy, occurrences of Datadog issue `5a610778-a842-11f1-869f-da7ad0900005` should drop to zero going forward (duplicate submissions now succeed idempotently instead of erroring). To reproduce locally: `POST /projects/:projectSlug/scores` twice with `_evaluation: true` and the same `trace` for the same evaluation `sourceId`.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197YT5mSiBweJ8XgKVg9PLx

---
_Generated by [Claude Code](https://claude.ai/code/session_0197YT5mSiBweJ8XgKVg9PLx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791520234&installation_model_id=435055&pr_number=4606&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4606&signature=2af646aa259f350a0895ce169cba7e5f13b14ecdc6395b813fc71bf51e6e8803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->