### PR TITLE
fix(sessions): exclude non-LLM sessions from cohort baselines

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-outlier-badge.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-outlier-badge.tsx
@@ -147,8 +147,8 @@ function QuantileStrip({ baseline, value }: { baseline: Baselines[SessionOutlier
 }
 
 /**
- * A tooltip that explains that the outlier is scoped to all sessions in the
- * current project, then displays the baseline values for the given metric.
+ * A tooltip that explains that the outlier is scoped to LLM-active sessions
+ * in the current project, then displays the baseline values for the given metric.
  */
 function OutlierTooltip({
   cohorts,
@@ -166,8 +166,8 @@ function OutlierTooltip({
     <div className="flex flex-col gap-4 min-w-64">
       <div className="flex flex-col gap-2">
         <Text.H6>
-          This session's <b>{METRIC_LABELS[metric]}</b> is greater than <b>{LEVEL_LABELS[level]}</b> of the sessions in
-          this project.
+          This session's <b>{METRIC_LABELS[metric]}</b> is greater than <b>{LEVEL_LABELS[level]}</b> of the LLM-active
+          sessions in this project.
         </Text.H6>
       </div>
       <div className="flex flex-col gap-2">
@@ -190,7 +190,7 @@ function OutlierTooltip({
 
 /**
  * Renders a p90/p95/p99 outlier badge when a session's metric value exceeds the
- * percentile thresholds of the project-wide cohort. The baseline is fetched
+ * percentile thresholds of the project-wide LLM-active cohort. The baseline is fetched
  * once per project via `useSessionCohortSummary` — TanStack Query dedupes
  * across every row in the table.
  *

--- a/dev-docs/flaggers.md
+++ b/dev-docs/flaggers.md
@@ -126,7 +126,7 @@ Hints (`src/hints/`) are cheap, deterministic, session-scoped evidence — gathe
 | span-errors | `span:error` | `session.errorCount > 0` |
 | tool-errors | `tool:error` (≤10, anchored) | `collectToolCallErrorFindings` |
 | tool-loop | `tool:loop` | one tool ≥60% of ≥5 calls (`findDominantToolUsage`) |
-| analytical-outliers | `outlier:duration/ttft/tokens/cost` | session value ≥ project p90 (`getCohortBaseline`, gated ≥30 samples, Redis-cached 15 min per project) |
+| analytical-outliers | `outlier:duration/ttft/tokens/cost` | session value ≥ the LLM-active project cohort's p90 (`getCohortBaseline`, gated ≥30 samples, Redis-cached 15 min per project) |
 | moment-labels | `moment:<kind>` (10 kinds, anchored to the label range) | `SessionMomentLabelRepository`, pinned to the latest **analyzed** generation |
 | frustration/refusal/deferral/injection/nsfw/pii patterns | `pattern:*` | strategy-tuned regex/scoring extractors (the pattern extractors used by jailbreaking/nsfw/pii prompts are shared with their strategies) — a regex miss drops the hint, so `jailbreaking`/`nsfw` evidence prompts fall back to the real conversation text rather than an empty block |
 

--- a/packages/domain/flaggers/src/hints/gatherers.ts
+++ b/packages/domain/flaggers/src/hints/gatherers.ts
@@ -110,7 +110,7 @@ export const momentLabelsGatherer: SessionHintGatherer<MomentLabelsEnv> = {
 const COHORT_BASELINE_CACHE_TTL_SECONDS = 15 * 60
 
 const cohortBaselineCacheKey = (organizationId: string, projectId: string): string =>
-  `org:${organizationId}:flaggers:cohort-baseline:${projectId}`
+  `org:${organizationId}:flaggers:cohort-baseline:${projectId}:v2`
 
 const parseCachedBaseline = (value: string): CohortBaselineData | null => {
   try {

--- a/packages/domain/spans/src/cohort-baselines.ts
+++ b/packages/domain/spans/src/cohort-baselines.ts
@@ -1,8 +1,8 @@
 /**
  * Project-wide cohort percentile baselines, shared by traces and sessions.
  *
- * A "cohort" is every trace (or session) in the project. For each numeric
- * metric we compute p50/p90/p95/p99 across the cohort and expose them as a
+ * A "cohort" is the stable project-wide population defined by each repository.
+ * For each numeric metric we compute p50/p90/p95/p99 across the cohort and expose them as a
  * baseline that the UI compares a single item's value against (the
  * trace/session outlier badge).
  *

--- a/packages/domain/spans/src/ports/session-repository.ts
+++ b/packages/domain/spans/src/ports/session-repository.ts
@@ -28,9 +28,9 @@ import { emptyTokenAnalytics } from "./trace-repository.ts"
  */
 export interface SessionRepositoryShape {
   /**
-   * Baseline percentiles across every session in the project. Intentionally
-   * ignores user filters — the goal is a stable "what's normal for this
-   * project" reference.
+   * Baseline percentiles across every LLM-active session in the project.
+   * Intentionally ignores user filters beyond the session list's default
+   * LLM-activity eligibility.
    */
   getCohortBaseline(input: {
     readonly organizationId: OrganizationId

--- a/packages/domain/spans/src/use-cases/get-session-cohort-summary.ts
+++ b/packages/domain/spans/src/use-cases/get-session-cohort-summary.ts
@@ -10,7 +10,7 @@ export interface GetSessionCohortSummaryInput {
 }
 
 const buildCacheKey = (organizationId: string, projectId: string): string =>
-  `org:${organizationId}:projects:${projectId}:session-cohort-baseline`
+  `org:${organizationId}:projects:${projectId}:session-cohort-baseline:v2`
 
 const parseCachedSummary = (json: string): CohortSummary | null => {
   try {
@@ -33,7 +33,7 @@ const parseCachedSummary = (json: string): CohortSummary | null => {
 }
 
 /**
- * Loads the project-wide cohort baseline used to render outlier badges.
+ * Loads the project-wide LLM-active cohort baseline used to render outlier badges.
  *
  * The repository's `excludeSessionId` param is intentionally not threaded
  * through: the badge is meant to compare against a stable project-wide

--- a/packages/platform/db-clickhouse/src/registries/helpers.ts
+++ b/packages/platform/db-clickhouse/src/registries/helpers.ts
@@ -181,7 +181,7 @@ export function buildCacheHitRateClause(
   }
 }
 
-const HAS_LLM_ACTIVITY_FRAGMENT = "(tokens_total > 0 OR length(models) > 0)"
+export const HAS_LLM_ACTIVITY_SQL = "(tokens_total > 0 OR length(models) > 0)"
 
 export function buildHasLlmActivityClause(
   cond: FilterCondition,
@@ -191,9 +191,9 @@ export function buildHasLlmActivityClause(
 
   switch (cond.op) {
     case "eq":
-      return { clause: truthy ? HAS_LLM_ACTIVITY_FRAGMENT : `NOT ${HAS_LLM_ACTIVITY_FRAGMENT}`, params: {} }
+      return { clause: truthy ? HAS_LLM_ACTIVITY_SQL : `NOT ${HAS_LLM_ACTIVITY_SQL}`, params: {} }
     case "neq":
-      return { clause: truthy ? `NOT ${HAS_LLM_ACTIVITY_FRAGMENT}` : HAS_LLM_ACTIVITY_FRAGMENT, params: {} }
+      return { clause: truthy ? `NOT ${HAS_LLM_ACTIVITY_SQL}` : HAS_LLM_ACTIVITY_SQL, params: {} }
     default:
       throw new Error(`Unsupported hasLlmActivity filter operator: ${cond.op}`)
   }

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
@@ -708,7 +708,7 @@ describe("SessionRepository", () => {
 
   describe("getCohortBaseline", () => {
     const taggedSpan = (overrides: SpanOverrides & { readonly tags?: readonly string[] }): SpanRow => ({
-      ...makeSpanRow(overrides),
+      ...makeSpanRow({ model: "test-model", ...overrides }),
       ...(overrides.tags ? { tags: [...overrides.tags] } : {}),
     })
 
@@ -747,6 +747,44 @@ describe("SessionRepository", () => {
       expect(baseline.count).toBe(3)
       expect(baseline.metrics.costTotalMicrocents.sampleCount).toBe(3)
       expect(baseline.metrics.costTotalMicrocents.p50).toBe(200)
+    })
+
+    it("excludes non-LLM sessions from the cohort and percentile sample gates", async () => {
+      const start = new Date(Date.UTC(2026, 5, 1, 11, 0, 0))
+      const nonLlmRows = Array.from({ length: 1_001 }, (_value, index) =>
+        makeSpanRow({
+          traceId: (index + 16).toString(16).padStart(32, "0"),
+          spanId: (index + 16).toString(16).padStart(16, "0"),
+          startTime: new Date(start.getTime() + index * 1_000),
+          durationMs: 100,
+          operation: "unspecified",
+        }),
+      )
+      await insertSpans([
+        ...nonLlmRows,
+        taggedSpan({
+          traceId: `04${"a".repeat(30)}`,
+          spanId: `04${"b".repeat(14)}`,
+          sessionId: "model-session",
+          startTime: new Date(start.getTime() + 2_000_000),
+          durationMs: 5_000,
+        }),
+        makeSpanRow({
+          traceId: `05${"a".repeat(30)}`,
+          spanId: `05${"b".repeat(14)}`,
+          sessionId: "token-session",
+          startTime: new Date(start.getTime() + 2_001_000),
+          durationMs: 5_000,
+          tokensOutput: 10,
+        }),
+      ])
+
+      const baseline = await runCh(repo.getCohortBaseline({ organizationId: ORG_ID, projectId: PROJECT_ID }))
+
+      expect(baseline.count).toBe(2)
+      expect(baseline.metrics.durationNs.sampleCount).toBe(2)
+      expect(baseline.metrics.durationNs.p50).toBe(5_000_000_000)
+      expect(baseline.metrics.durationNs.p99).toBeNull()
     })
 
     it("ignores zero-filled cost and token values in percentile baselines", async () => {

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.ts
@@ -41,7 +41,11 @@ import { Effect, Layer } from "effect"
 import type { GenAIMessage, GenAISystem } from "rosetta-ai"
 import { buildClickHouseWhere } from "../filter-builder.ts"
 import { USAGE_OPERATIONS_SQL } from "../metric-sql/helpers.ts"
-import { MESSAGE_OPERATION_FILTER, SYSTEM_INSTRUCTION_OPERATION_FILTER } from "../registries/helpers.ts"
+import {
+  HAS_LLM_ACTIVITY_SQL,
+  MESSAGE_OPERATION_FILTER,
+  SYSTEM_INSTRUCTION_OPERATION_FILTER,
+} from "../registries/helpers.ts"
 import { SESSION_FIELD_REGISTRY } from "../registries/session-fields.ts"
 import { buildScoreRollupSubquery, splitScoreFilters } from "../score-filter-subquery.ts"
 import { buildSessionIntelligenceFilters } from "../session-intelligence-filters.ts"
@@ -749,6 +753,7 @@ export const SessionRepositoryLive = Layer.effect(
                         AND project_id = {projectId:String}
                         ${excludeClause}
                       GROUP BY organization_id, project_id, session_id
+                      HAVING ${HAS_LLM_ACTIVITY_SQL}
                     )`,
               query_params: {
                 organizationId: organizationId as string,


### PR DESCRIPTION
Session outlier baselines currently include synthetic sessions created from non-LLM HTTP traces, while the sessions table hides those rows by default. In projects with high HTTP trace volume, subsecond requests dominate the distribution and make most visible conversational sessions appear as p99 outliers.

This change applies the session table's shared LLM-activity predicate after session aggregation when computing cohort percentiles. Sessions qualify when they have token usage or a model. The UI and flagger cache keys are versioned so previously cached baselines are not reused, and the tooltip and flagger documentation now describe the LLM-active cohort.

Regression coverage includes 1,001 excluded non-LLM sessions plus model-only and token-only eligible sessions, verifying that excluded traffic cannot satisfy the p99 sample gate.

Checks run:
- `pnpm --filter @platform/db-clickhouse exec vitest run src/repositories/session-repository.test.ts src/registries/helpers.test.ts`
- `pnpm --filter @domain/flaggers exec vitest run src/hints/gatherers.test.ts`
- typecheck for `@platform/db-clickhouse`, `@domain/spans`, `@domain/flaggers`, and `@app/web`
- pre-commit format, typecheck, and knip hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791554924&installation_model_id=435055&pr_number=4611&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4611&signature=2551ed9b788af496ff1f9eb96eb76d3cb66381029cf8fd9e8e9cf67869b0a1a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->