### PR TITLE
fix(taxonomy): sanitize lone UTF-16 surrogates in cluster-naming samples

### DIFF
--- a/packages/domain/spans/src/helpers/normalize-literal-phrase.ts
+++ b/packages/domain/spans/src/helpers/normalize-literal-phrase.ts
@@ -1,12 +1,10 @@
-/**
- * Replace any unpaired UTF-16 surrogate with U+FFFD (`�`). ClickHouse rejects
- * lone surrogates when applying `LIKE`, so the lexical indexer canonicalises
- * them on the way in; the highlight endpoint uses the same canonicalisation
- * so matched substring offsets line up with what the index actually saw.
- */
-export function stripLoneSurrogates(text: string): string {
-  return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "�")
-}
+import { stripLoneSurrogates } from "@repo/utils"
+
+// Re-exported for existing consumers: ClickHouse rejects lone surrogates when
+// applying `LIKE`, so the lexical indexer canonicalises them on the way in;
+// the highlight endpoint uses the same canonicalisation so matched substring
+// offsets line up with what the index actually saw.
+export { stripLoneSurrogates }
 
 /**
  * Canonical normaliser for double-quoted literal phrases. Trim, collapse runs

--- a/packages/domain/taxonomy/package.json
+++ b/packages/domain/taxonomy/package.json
@@ -19,6 +19,7 @@
     "@domain/ai": "workspace:*",
     "@domain/queue": "workspace:*",
     "@domain/shared": "workspace:*",
+    "@domain/spans": "workspace:*",
     "@repo/utils": "workspace:*",
     "effect": "catalog:",
     "zod": "catalog:"

--- a/packages/domain/taxonomy/package.json
+++ b/packages/domain/taxonomy/package.json
@@ -19,7 +19,6 @@
     "@domain/ai": "workspace:*",
     "@domain/queue": "workspace:*",
     "@domain/shared": "workspace:*",
-    "@domain/spans": "workspace:*",
     "@repo/utils": "workspace:*",
     "effect": "catalog:",
     "zod": "catalog:"

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
@@ -301,10 +301,7 @@ describe("nameClusterUseCase", () => {
   })
 
   it("does not leave a lone surrogate when truncation splits a surrogate pair", async () => {
-    // Each "😀" is a surrogate pair (😀 — two UTF-16 code units). Repeating
-    // it past the cap forces the middle-truncate head/tail cuts to land mid-pair,
-    // which previously reached the model as an invalid `messages` payload
-    // ("lone leading surrogate in hex escape") and failed the taxonomy naming call.
+    // "😀" is a surrogate pair; repeating it past the cap forces the truncation cuts to land mid-pair.
     const oversized = "😀".repeat(TAXONOMY_NAMING_SAMPLE_CHAR_CAP)
     const prompts: string[] = []
     const { effect } = runNameCluster({
@@ -331,8 +328,7 @@ describe("nameClusterUseCase", () => {
   })
 
   it("replaces a lone surrogate already present in a summary shorter than the cap", async () => {
-    // No truncation needed here — the malformed character comes from upstream data
-    // (e.g. a mis-encoded customer transcript), not from slicing.
+    // Malformed upstream (e.g. a mis-encoded transcript), not introduced by slicing.
     const summary = "User asks: before \uD83D middle \uDE00 after"
     const prompts: string[] = []
     const { effect } = runNameCluster({

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
@@ -300,6 +300,66 @@ describe("nameClusterUseCase", () => {
     }
   })
 
+  it("does not leave a lone surrogate when truncation splits a surrogate pair", async () => {
+    // Each "😀" is a surrogate pair (😀 — two UTF-16 code units). Repeating
+    // it past the cap forces the middle-truncate head/tail cuts to land mid-pair,
+    // which previously reached the model as an invalid `messages` payload
+    // ("lone leading surrogate in hex escape") and failed the taxonomy naming call.
+    const oversized = "😀".repeat(TAXONOMY_NAMING_SAMPLE_CHAR_CAP)
+    const prompts: string[] = []
+    const { effect } = runNameCluster({
+      seedObservations: [observation({ projectionMetadata: { summary: oversized } })],
+      ai: {
+        generate: <T>(input: GenerateInput<T>) => {
+          prompts.push(input.prompt)
+          const object = input.prompt.includes("Candidates:")
+            ? { name: "Order Status", description: "Users check on the status of an order they placed." }
+            : { candidates: [{ theme: "order status", examples: [0] }] }
+          return Effect.succeed({ object: object as T, tokens: 10, duration: 1 } satisfies GenerateResult<T>)
+        },
+        embed: () => Effect.die("embed not used"),
+        rerank: () => Effect.die("rerank not used"),
+      },
+    })
+
+    await Effect.runPromise(effect)
+
+    expect(prompts.length).toBeGreaterThan(0)
+    for (const prompt of prompts) {
+      expect(hasLoneSurrogate(prompt)).toBe(false)
+    }
+  })
+
+  it("replaces a lone surrogate already present in a summary shorter than the cap", async () => {
+    // No truncation needed here — the malformed character comes from upstream data
+    // (e.g. a mis-encoded customer transcript), not from slicing.
+    const summary = "User asks: before \uD83D middle \uDE00 after"
+    const prompts: string[] = []
+    const { effect } = runNameCluster({
+      seedObservations: [observation({ projectionMetadata: { summary } })],
+      ai: {
+        generate: <T>(input: GenerateInput<T>) => {
+          prompts.push(input.prompt)
+          const object = input.prompt.includes("Candidates:")
+            ? { name: "Order Status", description: "Users check on the status of an order they placed." }
+            : { candidates: [{ theme: "order status", examples: [0] }] }
+          return Effect.succeed({ object: object as T, tokens: 10, duration: 1 } satisfies GenerateResult<T>)
+        },
+        embed: () => Effect.die("embed not used"),
+        rerank: () => Effect.die("rerank not used"),
+      },
+    })
+
+    await Effect.runPromise(effect)
+
+    expect(prompts.length).toBeGreaterThan(0)
+    for (const prompt of prompts) {
+      expect(hasLoneSurrogate(prompt)).toBe(false)
+      expect(prompt).toContain("before")
+      expect(prompt).toContain("after")
+    }
+  })
+
   // Interior + root modes are named from already-named children (no direct
   // members), and their modeContext is also parameterized/hardcoded — cover them
   // too so an edit to the interior `umbrella` string or the root prompt can't
@@ -704,3 +764,7 @@ describe("nameClusterUseCase", () => {
     expect(clusters.clusters.get(clusterId)?.name).toBe("Order Status")
   })
 })
+
+function hasLoneSurrogate(text: string): boolean {
+  return /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(text)
+}

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
@@ -15,7 +15,7 @@ import {
   type ProjectId,
   type RepositoryError,
 } from "@domain/shared"
-import { stripLoneSurrogates } from "@domain/spans"
+import { stripLoneSurrogates } from "@repo/utils"
 import { Effect, Option } from "effect"
 import { z } from "zod"
 import {

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
@@ -15,6 +15,7 @@ import {
   type ProjectId,
   type RepositoryError,
 } from "@domain/shared"
+import { stripLoneSurrogates } from "@domain/spans"
 import { Effect, Option } from "effect"
 import { z } from "zod"
 import {
@@ -127,7 +128,7 @@ const withNamingTimeout = <A, E, R>(effect: Effect.Effect<A, E, R>, durationMs =
 const defangTags = (text: string): string => text.replaceAll("<", "‹").replaceAll(">", "›")
 
 const truncateSample = (sample: string, maxChars: number): string =>
-  sample.length <= maxChars ? sample : `${sample.slice(0, maxChars)}…`
+  stripLoneSurrogates(sample.length <= maxChars ? sample : `${sample.slice(0, maxChars)}…`)
 
 /**
  * Samples per child come from this per-call budget, never from the sibling count:
@@ -305,11 +306,13 @@ const readableObservationSummary = (value: unknown): string | null => {
 const NAMING_SAMPLE_TRUNCATION_MARKER = "\n[...truncated...]\n"
 
 const middleTruncate = (value: string, maxLength: number): string => {
-  if (value.length <= maxLength) return value
-  if (maxLength <= NAMING_SAMPLE_TRUNCATION_MARKER.length) return value.slice(0, maxLength)
+  if (value.length <= maxLength) return stripLoneSurrogates(value)
+  if (maxLength <= NAMING_SAMPLE_TRUNCATION_MARKER.length) return stripLoneSurrogates(value.slice(0, maxLength))
   const head = Math.floor((maxLength - NAMING_SAMPLE_TRUNCATION_MARKER.length) / 2)
   const tail = maxLength - NAMING_SAMPLE_TRUNCATION_MARKER.length - head
-  return `${value.slice(0, head)}${NAMING_SAMPLE_TRUNCATION_MARKER}${value.slice(value.length - tail)}`
+  return stripLoneSurrogates(
+    `${value.slice(0, head)}${NAMING_SAMPLE_TRUNCATION_MARKER}${value.slice(value.length - tail)}`,
+  )
 }
 
 const serializedNamingSamplesLength = (bodies: readonly string[]): number => {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -49,4 +49,5 @@ export { inferModalityFromMime, resolveContentModality } from "./mime-modality.t
 export { LatitudeObservabilityTestError } from "./observability-test.ts"
 export { relativeTime } from "./relativeTime.ts"
 export { hammingDistance64, simhash64 } from "./simhash.ts"
+export { stripLoneSurrogates } from "./strip-lone-surrogates.ts"
 export { toTitle } from "./to-title.ts"

--- a/packages/utils/src/strip-lone-surrogates.test.ts
+++ b/packages/utils/src/strip-lone-surrogates.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { stripLoneSurrogates } from "./strip-lone-surrogates.ts"
+
+describe("stripLoneSurrogates", () => {
+  it("leaves valid text untouched", () => {
+    expect(stripLoneSurrogates("hello 😀 world")).toBe("hello 😀 world")
+  })
+
+  it("replaces a lone high surrogate", () => {
+    expect(stripLoneSurrogates("before \uD83D after")).toBe("before � after")
+  })
+
+  it("replaces a lone low surrogate", () => {
+    expect(stripLoneSurrogates("before \uDE00 after")).toBe("before � after")
+  })
+
+  it("does not touch a valid surrogate pair", () => {
+    expect(stripLoneSurrogates("😀")).toBe("😀")
+  })
+
+  it("replaces both halves of a pair split apart by unrelated text", () => {
+    expect(stripLoneSurrogates("\uD83D x \uDE00")).toBe("� x �")
+  })
+})

--- a/packages/utils/src/strip-lone-surrogates.ts
+++ b/packages/utils/src/strip-lone-surrogates.ts
@@ -1,0 +1,7 @@
+// JS strings are UTF-16 and can carry an unpaired surrogate — from malformed
+// input, or from a naive code-unit slice that split a surrogate pair. Several
+// strict downstream parsers (ClickHouse's JSON insert, LLM provider APIs)
+// reject those outright, so callers sanitize with this before handing text off.
+export function stripLoneSurrogates(text: string): string {
+  return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "�")
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,7 +320,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/inspector':
         specifier: 'catalog:'
-        version: 0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@22.14.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)
+        version: 0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@26.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)
       '@platform/testkit':
         specifier: workspace:*
         version: link:../../packages/platform/testkit
@@ -2161,6 +2161,9 @@ importers:
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared
+      '@domain/spans':
+        specifier: workspace:*
+        version: link:../spans
       '@repo/utils':
         specifier: workspace:*
         version: link:../../utils
@@ -2231,12 +2234,12 @@ importers:
       '@clickhouse/client':
         specifier: 'catalog:'
         version: 1.21.0
-      '@domain/annotations':
-        specifier: workspace:*
-        version: link:../domain/annotations
       '@domain/agent-score':
         specifier: workspace:*
         version: link:../domain/agent-score
+      '@domain/annotations':
+        specifier: workspace:*
+        version: link:../domain/annotations
       '@domain/api-keys':
         specifier: workspace:*
         version: link:../domain/api-keys
@@ -2699,12 +2702,12 @@ importers:
       '@domain/admin':
         specifier: workspace:*
         version: link:../../domain/admin
-      '@domain/agent-score':
-        specifier: workspace:*
-        version: link:../../domain/agent-score
       '@domain/agent-dispatch':
         specifier: workspace:*
         version: link:../../domain/agent-dispatch
+      '@domain/agent-score':
+        specifier: workspace:*
+        version: link:../../domain/agent-score
       '@domain/ai':
         specifier: workspace:*
         version: link:../../domain/ai
@@ -16335,7 +16338,7 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.7.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -16865,7 +16868,7 @@ snapshots:
       '@modelcontextprotocol/ext-apps': 1.7.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -16878,7 +16881,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
 
   '@modelcontextprotocol/inspector-cli@0.21.2(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
@@ -16915,7 +16918,7 @@ snapshots:
       pkce-challenge: 4.1.0
       prismjs: 1.30.0
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-simple-code-editor: 0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       serve-handler: 6.1.7
       tailwind-merge: 2.6.1
@@ -16943,7 +16946,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@22.14.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)':
+  '@modelcontextprotocol/inspector@0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@26.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)':
     dependencies:
       '@modelcontextprotocol/inspector-cli': 0.21.2(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@modelcontextprotocol/inspector-client': 0.21.2(@cfworker/json-schema@4.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)
@@ -16954,7 +16957,7 @@ snapshots:
       open: 10.2.0
       shell-quote: 1.8.4
       spawn-rx: 5.1.2
-      ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@22.14.1)(typescript@6.0.3)
+      ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@26.4.1)(typescript@6.0.3)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -18572,7 +18575,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18590,7 +18593,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18615,7 +18618,7 @@ snapshots:
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18643,7 +18646,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18667,7 +18670,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18748,7 +18751,7 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -18808,7 +18811,7 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18834,7 +18837,7 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18897,7 +18900,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18919,7 +18922,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18971,7 +18974,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19028,7 +19031,7 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -19070,7 +19073,7 @@ snapshots:
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/rect': 1.1.1
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19106,7 +19109,7 @@ snapshots:
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/rect': 1.1.2
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19134,7 +19137,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19154,7 +19157,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19174,7 +19177,7 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19193,7 +19196,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19211,7 +19214,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19229,7 +19232,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19247,7 +19250,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19273,7 +19276,7 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19319,7 +19322,7 @@ snapshots:
       '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -19435,7 +19438,7 @@ snapshots:
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19466,7 +19469,7 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19486,7 +19489,7 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19526,7 +19529,7 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19771,7 +19774,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19789,7 +19792,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -21438,7 +21441,6 @@ snapshots:
   '@types/node@26.4.1':
     dependencies:
       undici-types: 8.3.0
-    optional: true
 
   '@types/nodemailer@8.0.0':
     dependencies:
@@ -22349,7 +22351,7 @@ snapshots:
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -25342,10 +25344,10 @@ snapshots:
       date-fns: 3.6.0
       react: 19.2.5
 
-  react-dom@18.3.1(react@19.2.5):
+  react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
-      react: 19.2.5
+      react: 18.3.1
       scheduler: 0.23.2
 
   react-dom@19.2.5(react@19.2.5):
@@ -25443,7 +25445,7 @@ snapshots:
   react-simple-code-editor@0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@18.3.1):
     dependencies:
@@ -26422,26 +26424,6 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  ts-node@10.9.2(@swc/core@1.15.30)(@types/node@22.14.1)(typescript@6.0.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.14.1
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 6.0.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.30
-
   ts-node@10.9.2(@swc/core@1.15.30)(@types/node@22.19.17)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -26462,6 +26444,26 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.30
     optional: true
+
+  ts-node@10.9.2(@swc/core@1.15.30)(@types/node@26.4.1)(typescript@6.0.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 26.4.1
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 6.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.30
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -26585,8 +26587,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@8.3.0:
-    optional: true
+  undici-types@8.3.0: {}
 
   undici@6.27.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2161,9 +2161,6 @@ importers:
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared
-      '@domain/spans':
-        specifier: workspace:*
-        version: link:../spans
       '@repo/utils':
         specifier: workspace:*
         version: link:../../utils


### PR DESCRIPTION
## What does this PR do?

Fixes a Datadog Error Tracking issue where the `workflows` service throws `Error: Primary model amazon-bedrock/minimax.minimax-m2.5 failed: ... lone leading surrogate in hex escape` / `AI_APICallError: ... unexpected end of hex escape` from the taxonomy cluster-naming activity (`temporal.activity.nameTaxonomyClusterActivity`, resource `taxonomy.propose-themes`).

**Datadog issues addressed:**
- [`469bdd84-87aa-11f1-83a2-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/469bdd84-87aa-11f1-83a2-da7ad0900005) — `Error` wrapper, ~43 occurrences/7d from this call site
- [`4697cf5a-87aa-11f1-bcf2-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/4697cf5a-87aa-11f1-bcf2-da7ad0900005) — `AI_APICallError` from the AI SDK layer, same underlying malformed request

**Root cause:** `packages/domain/taxonomy/src/use-cases/name-taxonomy.ts` builds LLM naming prompts from raw conversation-summary samples and truncates them with two local helpers, `middleTruncate` (leaf naming) and `truncateSample` (contrastive sibling naming), both of which slice the sample by raw UTF-16 code unit. A cut landing inside a surrogate pair (e.g. an emoji in a customer transcript) leaves an unpaired UTF-16 surrogate in the text sent to Bedrock, which the provider's JSON deserializer rejects.

This is the same defect class already fixed for other call sites: `packages/domain/spans/src/use-cases/build-trace-search-document.ts` (ClickHouse insert) and `packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts` (the moment-classifier prompt, currently being re-fixed in #4557 after a regression). **This PR fixes a separate, previously-unaddressed call site** in the `@domain/taxonomy` package that funnels into the *same* two Datadog issues, because both are fingerprinted on the shared throw site in `packages/platform/ai-vercel/src/ai.ts`, not on the caller. That's very likely why these issues kept recurring even while #4557 was in flight — it fixes `analyze-session.ts` but this call site was never touched.

**Fix:** both truncation helpers now sanitize their **entire** output with a `stripLoneSurrogates` helper, not just inside the truncating branches — so a sample that is already malformed *before* truncation (short enough to skip slicing) is also cleaned, matching the fix-forward pattern used in `build-trace-search-document.ts`'s `normalizeSearchText`.

The sanitizer itself now lives in `packages/utils/src/strip-lone-surrogates.ts` (`@repo/utils`, which taxonomy already depended on) rather than `@domain/spans` — per review feedback, pulling in the entire spans bounded context for one pure string helper wasn't warranted. `@domain/spans`'s `normalize-literal-phrase.ts` re-exports it from there so its existing consumers (e.g. `analyze-session.ts`) are unaffected.

## Related issue (if applicable)

N/A — found via Datadog Error Tracking triage, no linked GitHub issue. Complements (does not replace) #4557, which fixes the same two issues from the `conversation-intelligence` call site.

Closes #

## How was this tested?

Added tests, confirmed to fail without the fix and pass with it:
- `packages/utils/src/strip-lone-surrogates.test.ts` — unit tests on the sanitizer itself (valid text/pairs untouched, lone high/low surrogates replaced).
- `name-taxonomy.test.ts` — `does not leave a lone surrogate when truncation splits a surrogate pair` (an oversized `"😀".repeat(...)` sample forces both truncation helpers' cut points to land mid-pair) and `replaces a lone surrogate already present in a summary shorter than the cap` (a sample under the truncation cap that already carries a malformed lone surrogate, asserting it's sanitized even though no truncation occurs).

`pnpm --filter @domain/taxonomy test` — 320/320 passing. `pnpm --filter @repo/utils test`, `pnpm --filter @domain/spans test`, `pnpm --filter @domain/conversation-intelligence test` — all passing (pre-existing, unrelated Node-version failures in `@repo/utils`/`@domain/spans`' `base64`/`toBase64` tests are present identically on `development`, not introduced by this change).
`pnpm --filter @domain/taxonomy typecheck`, `pnpm --filter @repo/utils typecheck`, `pnpm --filter @domain/spans typecheck`, `pnpm --filter @domain/conversation-intelligence typecheck` (tsgo) — all clean.
`pnpm exec biome check` on changed files — clean (one pre-existing, unrelated cognitive-complexity warning in `name-taxonomy.ts` predates this change).

**Post-deploy verification:** occurrences of issue `469bdd84-87aa-11f1-83a2-da7ad0900005` tagged `resource_name:taxonomy.propose-themes` should stop appearing; full resolution of both issues likely also needs #4557 merged, since both call sites feed the same fingerprint.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MW4wic6cKCMVdoGbpjo7t