### PR TITLE
fix(db-clickhouse): degrade over-long FixedString filter values instead of crashing ClickHouse

### DIFF
--- a/packages/platform/db-clickhouse/src/filter-builder.test.ts
+++ b/packages/platform/db-clickhouse/src/filter-builder.test.ts
@@ -286,6 +286,83 @@ describe("buildClickHouseWhere with arrayContains", () => {
   })
 })
 
+describe("buildClickHouseWhere with FixedString(N) fields", () => {
+  const VALID_TRACE_ID = "a".repeat(32)
+  // ClickHouse right-pads shorter values, so only an *over-long* value ever fails to bind — a
+  // 36-char UUID passed where a 32-hex trace id is expected (the real production incident).
+  const OVERLONG_TRACE_ID = "84dc2b84-4aad-444c-9253-49495fd63a5b"
+
+  const arrayContainsRegistry: ChFieldRegistry = {
+    traceId: { column: "trace_ids", chType: "FixedString(32)", isArray: true, arrayContains: true },
+  }
+
+  const scalarRegistry: ChFieldRegistry = {
+    sourceId: { column: "source_id", chType: "FixedString(24)" },
+  }
+
+  it("degrades an over-long eq value to a static no-match clause instead of binding it", () => {
+    const filters: FilterSet = { traceId: [{ op: "eq", value: OVERLONG_TRACE_ID }] }
+    const { clauses, params } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("1 = 0")
+    expect(params).toEqual({})
+  })
+
+  it("degrades an over-long neq value to a static always-match clause", () => {
+    const filters: FilterSet = { traceId: [{ op: "neq", value: OVERLONG_TRACE_ID }] }
+    const { clauses, params } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("1 = 1")
+    expect(params).toEqual({})
+  })
+
+  it("degrades an over-long contains value the same way as eq (arrayContains routes contains to has)", () => {
+    const filters: FilterSet = { traceId: [{ op: "contains", value: OVERLONG_TRACE_ID }] }
+    const { clauses } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("1 = 0")
+  })
+
+  it("drops over-long elements from an in value array, keeping well-formed ones", () => {
+    const filters: FilterSet = { traceId: [{ op: "in", value: [VALID_TRACE_ID, OVERLONG_TRACE_ID] }] }
+    const { clauses, params } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("hasAny(trace_ids, {f_0:Array(FixedString(32))})")
+    expect(params.f_0).toEqual([VALID_TRACE_ID])
+  })
+
+  it("emits a valid (always-false) hasAny call when every in value is over-long", () => {
+    const filters: FilterSet = { traceId: [{ op: "in", value: [OVERLONG_TRACE_ID] }] }
+    const { clauses, params } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("hasAny(trace_ids, {f_0:Array(FixedString(32))})")
+    expect(params.f_0).toEqual([])
+  })
+
+  it("makes notIn match everything when every value is over-long (none could ever be excluded)", () => {
+    const filters: FilterSet = { traceId: [{ op: "notIn", value: [OVERLONG_TRACE_ID] }] }
+    const { clauses, params } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("NOT hasAny(trace_ids, {f_0:Array(FixedString(32))})")
+    expect(params.f_0).toEqual([])
+  })
+
+  it("degrades an over-long value on a plain (non-arrayContains) scalar FixedString field too", () => {
+    const filters: FilterSet = { sourceId: [{ op: "eq", value: OVERLONG_TRACE_ID }] }
+    const { clauses, params } = buildClickHouseWhere(filters, scalarRegistry)
+    expect(clauses[0]).toBe("1 = 0")
+    expect(params).toEqual({})
+  })
+
+  it("still binds a correctly-sized value on a plain scalar FixedString field", () => {
+    const filters: FilterSet = { sourceId: [{ op: "eq", value: "b".repeat(24) }] }
+    const { clauses, params } = buildClickHouseWhere(filters, scalarRegistry)
+    expect(clauses[0]).toBe("source_id = {f_0:FixedString(24)}")
+    expect(params.f_0).toBe("b".repeat(24))
+  })
+
+  it("still binds a value shorter than N, which ClickHouse right-pads (not a bug)", () => {
+    const filters: FilterSet = { sourceId: [{ op: "eq", value: "short" }] }
+    const { clauses, params } = buildClickHouseWhere(filters, scalarRegistry)
+    expect(clauses[0]).toBe("source_id = {f_0:FixedString(24)}")
+    expect(params.f_0).toBe("short")
+  })
+})
+
 describe("buildClickHouseWhere with synthetic fields", () => {
   const syntheticRegistry: ChFieldRegistry = {
     status: {

--- a/packages/platform/db-clickhouse/src/filter-builder.ts
+++ b/packages/platform/db-clickhouse/src/filter-builder.ts
@@ -47,6 +47,34 @@ const assertIntegerFilterValue = (field: string, value: FilterCondition["value"]
   }
 }
 
+const FIXED_STRING_CH_TYPE = /^FixedString\((\d+)\)$/
+
+const fixedStringByteLength = (chType: string): number | undefined => {
+  const match = FIXED_STRING_CH_TYPE.exec(chType)
+  return match ? Number(match[1]) : undefined
+}
+
+const utf8ByteLength = (value: string): number => new TextEncoder().encode(value).length
+
+/** Ops whose SQL negates the match, so a value that can never match should make the clause always true. */
+const NEGATED_FIXED_STRING_OPS: ReadonlySet<string> = new Set(["neq", "notContains"])
+
+/**
+ * FixedString(N) columns store up to N bytes, right-padded with '\0' when shorter — ClickHouse only
+ * rejects a value outright ("Too large value for FixedString(N)") when it *exceeds* N bytes, so
+ * binding an over-long id as a query param would 500 instead of returning zero rows. `in`/`notIn`
+ * values are filtered to fit (ClickHouse binds an empty array fine); other ops degrade to a static
+ * clause before an over-long value ever reaches ClickHouse — mirroring how `sessionMembershipClause`
+ * (registries/helpers.ts) drops the mismatched-length trace arm.
+ */
+const sanitizeFixedStringArrayValue = (
+  value: FilterCondition["value"],
+  byteLength: number,
+): FilterCondition["value"] => {
+  const values = Array.isArray(value) ? value : [value]
+  return values.filter((item): item is string => typeof item === "string" && utf8ByteLength(item) <= byteLength)
+}
+
 // ---------------------------------------------------------------------------
 // Operator -> SQL mapping
 // ---------------------------------------------------------------------------
@@ -129,17 +157,11 @@ export function buildClickHouseWhere(
 
     for (const cond of conditions) {
       const p = `${prefix}_${paramIdx++}`
-      let value: FilterCondition["value"] = mapping.mapValue ? mapping.mapValue(cond.value) : cond.value
-      if (isIntegerChType(mapping.chType)) {
-        assertIntegerFilterValue(field, value)
+      const resolved = resolveScalarCondition(field, mapping, cond, p)
+      clauses.push(resolved.clause)
+      if (resolved.param) {
+        params[p] = resolved.value
       }
-      const ilikeWrap =
-        (cond.op === "contains" || cond.op === "notContains") && !(mapping.isArray && mapping.arrayContains)
-      if (ilikeWrap && typeof value === "string") {
-        value = `%${value}%`
-      }
-      params[p] = value
-      clauses.push(buildClause(mapping, p, cond))
     }
   }
 
@@ -159,6 +181,43 @@ export const runFilterBuild = <A>(build: () => A): Effect.Effect<A, ValidationEr
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+type ResolvedCondition =
+  | { readonly clause: string; readonly param: true; readonly value: FilterCondition["value"] }
+  | { readonly clause: string; readonly param: false }
+
+/** Resolves one filter condition on a scalar field mapping to a SQL clause and its param value, if any. */
+function resolveScalarCondition(
+  field: string,
+  mapping: ScalarFieldMapping,
+  cond: FilterCondition,
+  paramName: string,
+): ResolvedCondition {
+  let value: FilterCondition["value"] = mapping.mapValue ? mapping.mapValue(cond.value) : cond.value
+  if (isIntegerChType(mapping.chType)) {
+    assertIntegerFilterValue(field, value)
+  }
+  const ilikeWrap = (cond.op === "contains" || cond.op === "notContains") && !(mapping.isArray && mapping.arrayContains)
+
+  // ILIKE binds its pattern as `:String` regardless of column type, so only the non-ILIKE paths
+  // (which bind `:FixedString(N)` / `:Array(FixedString(N))`) risk the ClickHouse parse error.
+  const fixedStringLength = ilikeWrap ? undefined : fixedStringByteLength(mapping.chType)
+  if (fixedStringLength !== undefined) {
+    if (cond.op === "in" || cond.op === "notIn") {
+      value = sanitizeFixedStringArrayValue(value, fixedStringLength)
+    } else {
+      const scalar = Array.isArray(value) ? value[0] : value
+      if (typeof scalar !== "string" || utf8ByteLength(scalar) > fixedStringLength) {
+        return { clause: NEGATED_FIXED_STRING_OPS.has(cond.op) ? "1 = 1" : "1 = 0", param: false }
+      }
+    }
+  }
+
+  if (ilikeWrap && typeof value === "string") {
+    value = `%${value}%`
+  }
+  return { clause: buildClause(mapping, paramName, cond), param: true, value }
+}
 
 function buildClause(mapping: ScalarFieldMapping, paramName: string, cond: FilterCondition): string {
   const { column, chType, isArray, arrayContains } = mapping


### PR DESCRIPTION
## What does this PR do?

Fixes a Datadog production error: `RepositoryError: Repository countByProjectId failed: ... Too large value for FixedString(32): value 84dc2b84-4aad-444c-9253-49495fd63a5b cannot be parsed as FixedString(32) for query parameter 'f_0'` — [Datadog issue 043834de-a2ca-11f1-b62f-da7ad0900005](https://app.datadoghq.eu/error-tracking/issue/043834de-a2ca-11f1-b62f-da7ad0900005) (service `web`, 38 occurrences on 2026-08-28).

**Root cause:** `SESSION_FIELD_REGISTRY` registers the `traceId` filter as ClickHouse `FixedString(32)` (`packages/platform/db-clickhouse/src/registries/session-fields.ts`), backing `countByProjectId` and other session/trace queries. `FixedString(N)` columns only reject a value that *exceeds* N bytes ("Too large value for FixedString(N)") — a shorter value is silently right-padded — so when a caller passed a 36-char UUID-with-dashes instead of a 32-hex trace id, the malformed value was bound straight into the query and ClickHouse rejected the whole request with a 500, instead of the filter just matching nothing.

This affects every `FixedString(N)` field in the shared filter builder, not just `traceId` — the `score.*` id fields (`score.source`, `score.sourceId`, `score.annotatorId`, `score.signalId`, `score.simulationId` in `registries/score-fields.ts`) share the exact same code path and were equally exposed to the same crash from any over-long filter value.

**Fix:** `buildClickHouseWhere` (`packages/platform/db-clickhouse/src/filter-builder.ts`) now checks any `FixedString(N)`-typed field before binding a value:
- `in`/`notIn`: over-long elements are filtered out of the array (ClickHouse binds an empty array fine — no crash, no special-casing needed).
- All other ops (`eq`, `neq`, `contains`, `notContains`, comparisons): an over-long value degrades the clause to a static `1 = 0` (never matches) or `1 = 1` (for negated ops, since a value that could never match also can never be excluded), instead of reaching ClickHouse at all.

This mirrors the existing `sessionMembershipClause` pattern in `registries/helpers.ts`, which already drops a mismatched-length trace-id arm for the same reason — this PR generalizes that same defensive idea to the shared filter builder so it protects every `FixedString(N)` field, present and future, rather than one call site.

## Related issue (if applicable)

Datadog Error Tracking issue: https://app.datadoghq.eu/error-tracking/issue/043834de-a2ca-11f1-b62f-da7ad0900005

## How was this tested?

- Added unit tests in `filter-builder.test.ts` covering: over-long `eq`/`neq`/`contains` degrading to `1 = 0`/`1 = 1`, over-long elements being dropped from `in`/`notIn` arrays (including the all-invalid case), a non-arrayContains scalar `FixedString` field behaving the same way, and confirming a value *shorter* than N still binds normally (not a bug — ClickHouse right-pads it).
- Confirmed the exact production repro (a 36-char UUID against `FixedString(32)`) now resolves to a static `1 = 0` clause instead of throwing.
- `pnpm --filter @platform/db-clickhouse test`: all runnable tests pass (165/165; the rest are skipped in this sandbox due to a missing native `chdb` binary, unrelated to this change).
- `pnpm --filter @platform/db-clickhouse typecheck` (tsgo): clean.
- `pnpm exec biome check` on changed files: 0 errors (2 pre-existing cognitive-complexity warnings on this file already existed before this change and are non-blocking; this PR's net effect actually lowers `buildClickHouseWhere`'s complexity score).

**Verification after deploy:** occurrences of Datadog issue `043834de-a2ca-11f1-b62f-da7ad0900005` should not recur; a malformed `traceId` filter should now return an empty result set instead of a 500.

**Remaining risk:** low — this only changes behavior for filter values that would previously have crashed the request; well-formed values are unaffected (covered by existing + new tests).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ckwQ8bqpzNCKTtkrs8Geh

---
_Generated by [Claude Code](https://claude.ai/code/session_012ckwQ8bqpzNCKTtkrs8Geh)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791639656&installation_model_id=435055&pr_number=4616&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4616&signature=c59a2386022c49f500777d4be73f15513bc6942a792de2b0ac1942af382567bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->