### PR TITLE
fix(workers): stop double-reporting UnpricedSpanError to Datadog

### DIFF
--- a/apps/workers/src/workers/unpriced-spans-report.test.ts
+++ b/apps/workers/src/workers/unpriced-spans-report.test.ts
@@ -76,6 +76,41 @@ describe("reportUnpricedSpans", () => {
     expect(lines).toHaveLength(0)
   })
 
+  // Datadog ingests a span's recorded "exception" event as a second, attribute-less Error Tracking
+  // occurrence alongside the one derived from the span's own error.* attributes, silently doubling
+  // this issue's reported volume. The reporting span must carry error info only via attributes.
+  it("reports the error via span attributes only, never span.recordException", async () => {
+    const setAttributes = vi.fn()
+    const setStatus = vi.fn()
+    const end = vi.fn()
+    const recordException = vi.fn()
+    const startSpan = vi.fn().mockReturnValue({ setAttributes, setStatus, end, recordException })
+
+    vi.resetModules()
+    vi.doMock("@repo/observability", async () => {
+      const actual = await vi.importActual<typeof import("@repo/observability")>("@repo/observability")
+      return { ...actual, trace: { ...actual.trace, getTracer: () => ({ startSpan }) } }
+    })
+
+    const isolated = await import("./unpriced-spans-report.ts")
+    isolated.resetUnpricedSpanReportThrottle()
+    Effect.runSync(isolated.reportUnpricedSpans([group()], organizationId))
+
+    vi.doUnmock("@repo/observability")
+    vi.resetModules()
+
+    expect(recordException).not.toHaveBeenCalled()
+    expect(setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "gen_ai.provider.name": "@some-vendor/unmapped-sdk",
+        "gen_ai.request.model": "mystery-model",
+        "error.type": "UnpricedSpanError",
+        "error.message": "Ingested token usage that no pricing matched; cost recorded as 0",
+      }),
+    )
+    expect(end).toHaveBeenCalledOnce()
+  })
+
   // Overflow used to clear the whole map, which re-opened every pair still inside its window.
   it("keeps throttling a pair when a flood of new pairs overflows the tracked set", () => {
     Effect.runSync(reportUnpricedSpans([group({ model: "evicted-first" })], organizationId))

--- a/apps/workers/src/workers/unpriced-spans-report.ts
+++ b/apps/workers/src/workers/unpriced-spans-report.ts
@@ -1,6 +1,6 @@
 import type { OrganizationId } from "@domain/shared"
 import type { UnpricedSpanGroup } from "@domain/spans"
-import { createLogger, recordSpanExceptionForDatadog, SpanStatusCode, trace } from "@repo/observability"
+import { createLogger, SpanStatusCode, trace } from "@repo/observability"
 import { Effect } from "effect"
 
 const logger = createLogger("unpriced-spans")
@@ -58,18 +58,28 @@ function claimReportSlot(key: string, now: number): boolean {
  * A span of its own, not the ingest span: the batch succeeded and its spans were stored, so marking
  * that span as an error would fail a healthy job and pollute the `status:error` queries used to
  * triage real ingest breakage.
+ *
+ * Sets `error.*` as plain span attributes instead of calling the shared
+ * `recordSpanExceptionForDatadog` helper: that helper also calls `span.recordException(...)`, which
+ * Datadog ingests as a second, independent Error Tracking occurrence for the same span — one that
+ * carries only the exception event's own fields, not this span's `gen_ai.*`/`latitude.*` attributes.
+ * That silently doubled every occurrence count here while stripping the provider/model context this
+ * signal exists to carry. This span is a synthetic monitoring signal, not a caught exception in a
+ * real request flow, so it doesn't need the OTel exception-event convention.
  */
 function recordUnpricedSpanIssue(group: UnpricedSpanGroup, organizationId: OrganizationId): void {
   const span = tracer.startSpan("cost.unpriced_spans")
+  const error = new UnpricedSpanError()
   span.setAttributes({
     "latitude.organization_id": organizationId,
     "latitude.project_id": group.projectId,
     "gen_ai.provider.name": group.provider,
     "gen_ai.request.model": group.model,
     "cost.unpriced_spans": group.spans,
+    "error.type": error.name,
+    "error.message": error.message,
+    "error.stack": error.stack ?? "",
   })
-  const error = new UnpricedSpanError()
-  recordSpanExceptionForDatadog(span, error)
   span.setStatus({ code: SpanStatusCode.ERROR, message: error.message })
   span.end()
 }

--- a/apps/workers/src/workers/unpriced-spans-report.ts
+++ b/apps/workers/src/workers/unpriced-spans-report.ts
@@ -1,6 +1,6 @@
 import type { OrganizationId } from "@domain/shared"
 import type { UnpricedSpanGroup } from "@domain/spans"
-import { createLogger, SpanStatusCode, trace } from "@repo/observability"
+import { createLogger, normalizeStack, SpanStatusCode, trace } from "@repo/observability"
 import { Effect } from "effect"
 
 const logger = createLogger("unpriced-spans")
@@ -59,13 +59,9 @@ function claimReportSlot(key: string, now: number): boolean {
  * that span as an error would fail a healthy job and pollute the `status:error` queries used to
  * triage real ingest breakage.
  *
- * Sets `error.*` as plain span attributes instead of calling the shared
- * `recordSpanExceptionForDatadog` helper: that helper also calls `span.recordException(...)`, which
- * Datadog ingests as a second, independent Error Tracking occurrence for the same span — one that
- * carries only the exception event's own fields, not this span's `gen_ai.*`/`latitude.*` attributes.
- * That silently doubled every occurrence count here while stripping the provider/model context this
- * signal exists to carry. This span is a synthetic monitoring signal, not a caught exception in a
- * real request flow, so it doesn't need the OTel exception-event convention.
+ * Sets `error.*` as plain span attributes rather than also calling `span.recordException(...)` (as
+ * `recordSpanExceptionForDatadog` does): Datadog ingests the recorded exception event as a second,
+ * attribute-less Error Tracking occurrence for the same span, doubling this issue's reported volume.
  */
 function recordUnpricedSpanIssue(group: UnpricedSpanGroup, organizationId: OrganizationId): void {
   const span = tracer.startSpan("cost.unpriced_spans")
@@ -78,7 +74,7 @@ function recordUnpricedSpanIssue(group: UnpricedSpanGroup, organizationId: Organ
     "cost.unpriced_spans": group.spans,
     "error.type": error.name,
     "error.message": error.message,
-    "error.stack": error.stack ?? "",
+    "error.stack": normalizeStack(error.stack ?? ""),
   })
   span.setStatus({ code: SpanStatusCode.ERROR, message: error.message })
   span.end()

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -10,7 +10,7 @@ import { getObservabilityState } from "./state.ts"
 import type { InitializeObservabilityOptions } from "./types.ts"
 
 export { EffectOtelTracerLive, withTracing } from "./effect-tracer.ts"
-export { recordSpanExceptionForDatadog } from "./record-span-exception.ts"
+export { normalizeStack, recordSpanExceptionForDatadog } from "./record-span-exception.ts"
 export { trace, SpanStatusCode }
 export const createLogger = (scope: string) => createLoggerWithState(getObservabilityState(), scope)
 export const serializeError = serializeErrorImpl

--- a/packages/observability/src/record-span-exception.ts
+++ b/packages/observability/src/record-span-exception.ts
@@ -33,7 +33,7 @@ const toError = (value: unknown): Error => {
  * rewrites its Nitro/Vinxi server bundle frames from `.mjs` to `.js` to match
  * the upload-time aliases created during the build.
  */
-const normalizeStack = (stack: string): string =>
+export const normalizeStack = (stack: string): string =>
   stack.replaceAll("file://", "").replaceAll(/(\/app\/apps\/web\/\.output\/server\/[^\s):]+)\.mjs(?=[:)])/g, "$1.js")
 
 export function recordSpanExceptionForDatadog(span: Span, error: unknown): Error {


### PR DESCRIPTION
## What does this PR do?

Fixes a telemetry bug that silently doubled the reported occurrence count of the top production Error Tracking issue, [`UnpricedSpanError` (ET-500)](https://app.datadoghq.eu/error-tracking/issue/aaa3aeac-8b28-11f1-aa14-da7ad0900005) (1184 occurrences over the last 7 days, `workers` service).

**Root cause:** `recordUnpricedSpanIssue` (`apps/workers/src/workers/unpriced-spans-report.ts`) called the shared `recordSpanExceptionForDatadog` helper, which does two things on the same span: sets `error.*` attributes *and* calls `span.recordException(...)`. Datadog ingests the recorded exception event as a **second, independent Error Tracking occurrence** for that span, alongside the one derived from the span's own `error.*` attributes.

I confirmed this directly against Datadog: querying the issue's raw error samples shows pairs of occurrences sharing the exact same `trace_id`/`span_id`/`timestamp` — one carrying the full `gen_ai.provider.name`/`gen_ai.request.model`/`latitude.*` context, the other completely blank. Roughly half of this issue's volume (591 of 1184 occurrences in the last 7 days) is this blank, attribute-less duplicate — not a separate instrumentation gap. This also explains why several rounds of prior automated Datadog triage on this issue (see the issue's comment history) kept concluding "expected, by-design telemetry" without ever noticing the count was inflated ~2x.

**Fix:** `recordUnpricedSpanIssue` now sets `error.type`/`error.message`/`error.stack` directly as span attributes instead of calling `recordSpanExceptionForDatadog` (which also records an OTel exception event). This span is a synthetic monitoring signal, not a caught exception in a real request flow, so it doesn't need the OTel exception-event convention — and dropping it removes the second, context-less extraction path. The shared `recordSpanExceptionForDatadog` helper itself is untouched, since it's used broadly (BullMQ job failures, telemetry SDK error capture) where the exception-event convention may still be wanted; this fix is scoped to the one call site that doesn't need it.

Note: this does **not** fix the underlying "some provider/model pairs have no pricing entry" signal itself — that's an ongoing data-completeness task via the `/backoffice/unpriced-spans` admin view, as prior triage on this issue already noted. This PR only removes the duplicate telemetry noise so the real occurrence count is accurate.

## Related issue (if applicable)

Datadog Error Tracking issue [ET-500 / `UnpricedSpanError`](https://app.datadoghq.eu/error-tracking/issue/aaa3aeac-8b28-11f1-aa14-da7ad0900005) — not a GitHub issue.

## How was this tested?

- Added a test that mocks the OTel tracer/span and asserts `recordUnpricedSpanIssue` never calls `span.recordException`, only `span.setAttributes` (with the `gen_ai.*`/`error.*` fields) + `span.setStatus` + `span.end`.
- Confirmed the new test **fails** against the pre-fix code (`recordException` called once) and **passes** with the fix.
- `pnpm --filter @app/workers exec vitest run --dir src unpriced-spans-report.test.ts` — all 6 tests pass.
- `pnpm --filter @app/workers typecheck` (tsgo) — clean.
- `pnpm exec biome check` on both changed files — clean.

**Verification in production:** after deploy, the total occurrence count for this issue should drop to roughly half its current rate, with no more blank/context-less samples appearing alongside populated ones at identical `trace_id`/`span_id`.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GwWYuKqSAwzbauEwRWf4L

---
_Generated by [Claude Code](https://claude.ai/code/session_014GwWYuKqSAwzbauEwRWf4L)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791650005&installation_model_id=435055&pr_number=4619&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4619&signature=b03fa5ba907c51ea0a11965fc0904f2c68edb3bc1eb06ef671ce0868eaee91de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->