### PR TITLE
fix(models): stop the prefix fallback answering for a model it does not name

### DIFF
--- a/packages/domain/models/src/registry.test.ts
+++ b/packages/domain/models/src/registry.test.ts
@@ -168,6 +168,35 @@ function findGatewaySlugAlsoSoldByItsVendor(): { slug: string; vendor: string; b
   throw new Error("bundled catalog lists no priced Vercel gateway slug whose vendor prices the bare model")
 }
 
+/** Bare ids a provider only implies through its `<vendor>/<model>` keys, mapped to the keys implying them. */
+function slugsByBareId(ids: readonly string[]): Map<string, string[]> {
+  const keyed = new Set(ids.map((id) => id.toLowerCase()))
+  const bare = new Map<string, string[]>()
+  for (const id of ids) {
+    const separator = id.indexOf("/")
+    if (separator <= 0) continue
+    const bareId = id.slice(separator + 1).toLowerCase()
+    // A remainder that still has a separator is a nested vendor slug, not a bare id.
+    if (bareId.includes("/") || keyed.has(bareId)) continue
+    bare.set(bareId, [...(bare.get(bareId) ?? []), id])
+  }
+  return bare
+}
+
+/** Bare ids the provider answers with a catalog entry other than the single slug that implies them. */
+function misresolvedBareIds(provider: string, ids: readonly string[]): string[] {
+  const misresolved: string[] = []
+  for (const [bareId, slugs] of slugsByBareId(ids)) {
+    // Two vendors offering the same bare id is ambiguous; the tests above cover that path.
+    if (slugs.length !== 1) continue
+    const resolved = getModelForProvider(provider, bareId)
+    if (resolved && resolved.id.toLowerCase() !== slugs[0]?.toLowerCase()) {
+      misresolved.push(`${provider}/${bareId} answered with ${resolved.id}, expected ${slugs[0]}`)
+    }
+  }
+  return misresolved
+}
+
 describe("getModelForProvider", () => {
   it("finds a model for a provider", () => {
     const model = getModelForProvider("openai", "gpt-4o")
@@ -274,6 +303,34 @@ describe("getModelForProvider", () => {
   it("does not price a non-Anthropic bare model id assumed to be Anthropic", () => {
     expect(getModelForProvider("anthropic", "qwen3.7-max")).toBeUndefined()
     expect(getCostSpec("anthropic", "qwen3.7-max").costImplemented).toBe(false)
+  })
+
+  // Derived from the catalog, so a models.dev refresh cannot reintroduce the hazard under new ids.
+  it("never answers an unambiguous bare id with a different catalog entry", () => {
+    const idsByProvider = new Map<string, string[]>()
+    for (const model of getAllModels()) {
+      idsByProvider.set(model.provider, [...(idsByProvider.get(model.provider) ?? []), model.id])
+    }
+
+    const misresolved = [...idsByProvider].flatMap(([provider, ids]) => misresolvedBareIds(provider, ids))
+
+    expect(misresolved).toEqual([])
+  })
+
+  // The fallback absorbs a snapshot date or qualifier; a version bump is another model at its own rate.
+  it("does not answer a version bump with the version it is a bump of", () => {
+    const answeredByPreviousVersion: string[] = []
+    for (const model of getAllModels()) {
+      const trailingVersion = /^(.*\D)(\d+)$/.exec(model.id.toLowerCase())
+      if (!trailingVersion) continue
+      const bumped = `${trailingVersion[1]}${trailingVersion[2]}.5`
+      const resolved = getModelForProvider(model.provider, bumped)
+      if (resolved?.id.toLowerCase() === model.id.toLowerCase()) {
+        answeredByPreviousVersion.push(`${model.provider}/${bumped} answered with ${model.id}`)
+      }
+    }
+
+    expect(answeredByPreviousVersion).toEqual([])
   })
 })
 

--- a/packages/domain/models/src/registry.ts
+++ b/packages/domain/models/src/registry.ts
@@ -90,30 +90,46 @@ function normalizeVersionPunctuation(id: string): string {
 }
 
 /**
- * Find a model by ID (case-insensitive) with prefix fallback.
- *
- * First tries an exact match; then a version-punctuation match, so an id that differs from its
- * catalog key only in how a version is separated (`claude-opus-4.8` vs `claude-opus-4-8`) still
- * resolves; then falls back to the model whose ID is the longest prefix of the requested `modelId`.
- * Useful for versioned model names like `gpt-4.1-2025-04-14` matching `gpt-4.1`.
+ * Find a model whose catalog key names the requested `modelId` outright: an exact match, or one that
+ * differs only in how a version is separated (`claude-opus-4.8` vs `claude-opus-4-8`).
  *
  * The punctuation match requires a single candidate: collapsing a dot must never pick between two
- * genuinely different entries. The prefix fallback stops at a `:` modifier (`:free`, `:thinking`, a
- * context size), which selects a variant the catalog lists and prices separately. Matching past one
- * would answer with the unmodified model, and a free tier would come back at the paid rate.
+ * genuinely different entries.
  */
-export function findModel(models: Model[], modelId: string): Model | undefined {
+function findModelExact(models: Model[], modelId: string): Model | undefined {
   const needle = modelId.toLowerCase()
 
   const exact = models.find((m) => m.id.toLowerCase() === needle)
   if (exact) return exact
 
-  // Same version, different punctuation. Match on the normalised form so `claude-opus-4.8` finds the
-  // catalog's `claude-opus-4-8` (and the reverse), but only when exactly one entry normalises to it,
-  // so a punctuation-only collapse can never resolve one model to a different one.
   const normalizedNeedle = normalizeVersionPunctuation(needle)
   const punctuationMatches = models.filter((m) => normalizeVersionPunctuation(m.id.toLowerCase()) === normalizedNeedle)
-  if (punctuationMatches.length === 1) return punctuationMatches[0]
+  return punctuationMatches.length === 1 ? punctuationMatches[0] : undefined
+}
+
+/**
+ * A prefix may absorb a snapshot date or a trailing qualifier, but never a version bump. `minimax-m2`
+ * offered for `minimax-m2.5` is a different, later model at its own rate, so answering with it reports
+ * a confident wrong price where no price is the honest result. The boundary is the same version dot
+ * `normalizeVersionPunctuation` recognises — a `.` between two digits.
+ */
+const VERSION_BOUNDARY_RE = /^\d\.\d/
+
+function crossesVersionBoundary(needle: string, prefixLength: number): boolean {
+  return VERSION_BOUNDARY_RE.test(needle.slice(prefixLength - 1, prefixLength + 2))
+}
+
+/**
+ * Find the model whose ID is the longest prefix of the requested `modelId`, so a versioned name like
+ * `gpt-4.1-2025-04-14` still resolves to `gpt-4.1`.
+ *
+ * This is the loosest match in the registry and answers only once every exact one has declined. It
+ * stops at a `:` modifier (`:free`, `:thinking`, a context size), which selects a variant the catalog
+ * lists and prices separately; matching past one would answer with the unmodified model, and a free
+ * tier would come back at the paid rate.
+ */
+function findModelByPrefix(models: Model[], modelId: string): Model | undefined {
+  const needle = modelId.toLowerCase()
 
   let best: Model | undefined
   let bestLen = 0
@@ -122,12 +138,25 @@ export function findModel(models: Model[], modelId: string): Model | undefined {
     const id = m.id.toLowerCase()
     if (!needle.startsWith(id) || id.length <= bestLen) continue
     if (needle[id.length] === ":") continue
+    if (crossesVersionBoundary(needle, id.length)) continue
 
     best = m
     bestLen = id.length
   }
 
   return best
+}
+
+/**
+ * Find a model by ID (case-insensitive) with prefix fallback.
+ *
+ * First tries an exact match; then a version-punctuation match, so an id that differs from its
+ * catalog key only in how a version is separated (`claude-opus-4.8` vs `claude-opus-4-8`) still
+ * resolves; then falls back to the model whose ID is the longest prefix of the requested `modelId`.
+ * Useful for versioned model names like `gpt-4.1-2025-04-14` matching `gpt-4.1`.
+ */
+export function findModel(models: Model[], modelId: string): Model | undefined {
+  return findModelExact(models, modelId) ?? findModelByPrefix(models, modelId)
 }
 
 /**
@@ -190,33 +219,40 @@ function findModelByVendorPrefix({
 /**
  * Find a specific model within a provider's model list.
  *
+ * Every match that names a catalog entry outright is tried before the prefix fallback, which is the
+ * only one that can answer with a model the requested id does not name. Asking it first let it hijack
+ * ids the catalog spells exactly: `minimax-m2.5` on a provider listing `minimax/minimax-m2.5` came
+ * back as the neighbouring `MiniMax-M2`, at that older model's rate.
+ *
  * For Bedrock models, tries the original model ID first (some models in
  * models.dev include the regional prefix), then falls back to stripping
  * the prefix (`eu.`, `us.`, `apac.`) for models that don't.
  */
 export function getModelForProvider(provider: string, modelId: string): Model | undefined {
   const models = getModelsForProvider(provider)
-  const match = findModel(models, modelId)
-  if (match) return match
-
   const resolvedProvider = resolveProviderName(provider)
+
   if (resolvedProvider === "amazon-bedrock") {
     const stripped = stripBedrockRegionPrefix(modelId)
-    if (stripped !== modelId) {
-      const strippedMatch = findModel(models, stripped)
-      if (strippedMatch) return strippedMatch
-    }
-    return findBedrockModelByBareId(models, stripped)
+    return (
+      findModelExact(models, modelId) ??
+      findModelExact(models, stripped) ??
+      findBedrockModelByBareId(models, stripped) ??
+      findModelByPrefix(models, modelId) ??
+      findModelByPrefix(models, stripped)
+    )
   }
 
-  const bareIdMatch = findModelByBareId(models, modelId)
-  if (bareIdMatch) return bareIdMatch
-
-  return findModelByVendorPrefix({
-    modelId,
-    reportedProvider: resolvedProvider,
-    reportedProviderIsKnown: models.length > 0,
-  })
+  return (
+    findModelExact(models, modelId) ??
+    findModelByBareId(models, modelId) ??
+    findModelByVendorPrefix({
+      modelId,
+      reportedProvider: resolvedProvider,
+      reportedProviderIsKnown: models.length > 0,
+    }) ??
+    findModelByPrefix(models, modelId)
+  )
 }
 
 /**


### PR DESCRIPTION
Closes #4415.

## What was wrong

Two separate ways the longest-prefix fallback answered for a model the requested id does not name. Both produce a confident wrong rate with `costImplemented: true`, which is worse than the honest "unpriced" the registry already supports.

**1. The fallback ran before the exact matches.** `getModelForProvider` called `findModel` first, and `findModel` runs the prefix fallback itself — so the loosest match was tried before `findModelByBareId` and `findModelByVendorPrefix` ever got a turn. Where a provider keys a model as `<vendor>/<id>` and another entry's id is a leading substring of `<id>`, the neighbour won:

| requested | answered with | catalog actually lists |
| --- | --- | --- |
| `nano-gpt/minimax-m2.5` | `minimax-m2` | `minimax/minimax-m2.5` |
| `qiniu-ai/kimi-k2.5` | `kimi-k2` | `moonshotai/kimi-k2.5` |
| `qiniu-ai/deepseek-v3.2-exp` | `deepseek-v3` | `deepseek/deepseek-v3.2-exp` |

Across the bundled catalog: **27 of 3,767** unambiguous bare ids answered with a different entry.

**2. The fallback had no version boundary.** It exists to absorb a snapshot date or a trailing qualifier, but `minimax-m2` offered for `minimax-m2.5` is a later model at its own rate. Probing every catalog id against a version it does not list: **2,567** were answered by an earlier version.

## The fix

Split `findModel` into `findModelExact` and `findModelByPrefix`, and order `getModelForProvider` so every match that names a catalog entry outright runs before the prefix fallback — the only one that can answer with a model the requested id does not name. `findModel` keeps its old behaviour for its other callers.

Then stop the prefix where a version bump begins, using the same digit-dot-digit boundary `normalizeVersionPunctuation` already recognises.

## Measurements

Both counts are from the bundled catalog on this branch's base:

| | before | after |
| --- | --- | --- |
| unambiguous bare ids answered with a different entry | 27 / 3,767 | **0** |
| absent version bumps answered by an earlier version | 2,567 / 2,722 | **215** |

## On the acceptance criteria

- **`minimax-m2.5`** reproduced and is fixed. It now resolves to `minimax/minimax-m2.5` — the entry the catalog actually lists — rather than staying unpriced as the issue asks. Unpriced was right when the id was ambiguous; the catalog refresh in #4589 left `minimax` as the only vendor offering it, so the exact entry is now the correct answer.
- **`glm-4.7`** no longer reproduces on the current catalog: it already resolved to `z-ai/glm-4.7` before this change, for the same reason.
- **Legitimate prefix matches still resolve** — the Bedrock regional-prefix, bare-Bedrock-id, gateway-slug and vendor-precedence tests are unchanged and pass.
- **Property tests derived from catalog contents** — added two, so a models.dev refresh cannot reintroduce either hazard under ids a hardcoded case never covered. Both fail on `development` (the first with all 27 misresolutions listed) and pass here.

## Known limits, not fixed here

- The 215 remaining are longer ids where a *shorter* prefix still matches and its end does not sit at a version boundary, e.g. `gemini-2.5-pro-preview-06-05` answering for a later variant. Narrowing that needs a rule about what a legitimate remainder looks like, which is a larger change than this one.
- Two ids on `edenai` are keyed with a three-segment slug (`tensorx/deepseek/deepseek-v4-pro-0813`). `findModelByBareId` returns early on any id containing `/`, so the exact entry is never reached and the dated snapshot falls back to its base model. The property test excludes nested vendor slugs for that reason; happy to open a follow-up.

## Verification

```
pnpm --filter @domain/models test        # 178 passed
pnpm --filter @domain/models typecheck
pnpm --filter @domain/models check       # same 2 pre-existing warnings as development
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791685852&installation_model_id=435055&pr_number=4620&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4620&signature=8708f174d83698c8d7e44f03b69785c3d4851e5c99dc93eea3edec8c6ced4bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->