### PR TITLE
fix(taxonomy): strip lone UTF-16 surrogates from cluster naming prompts

### DIFF
--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
@@ -300,6 +300,48 @@ describe("nameClusterUseCase", () => {
     }
   })
 
+  it("strips lone UTF-16 surrogates from naming prompts, whether from the raw summary or from truncation splitting a pair", async () => {
+    const prompts: string[] = []
+    const ai: AIShape = {
+      generate: <T>(input: GenerateInput<T>) => {
+        prompts.push(input.prompt)
+        const object = input.prompt.includes("Candidates:")
+          ? { name: "Order Status", description: "Users check on the status of an order they placed." }
+          : { candidates: [{ theme: "order status", examples: [0] }] }
+        return Effect.succeed({ object: object as T, tokens: 10, duration: 1 } satisfies GenerateResult<T>)
+      },
+      embed: () => Effect.die("embed not used"),
+      rerank: () => Effect.die("rerank not used"),
+    }
+
+    // A lone high surrogate (\uD83D) already present in the persisted summary —
+    // Bedrock rejects "lone leading surrogate in hex escape" if this reaches the prompt.
+    const rawLoneSurrogate = "before \uD83D order status after"
+    {
+      const { effect } = runNameCluster({
+        seedObservations: [observation({ projectionMetadata: { summary: rawLoneSurrogate } })],
+        ai,
+      })
+      await Effect.runPromise(effect)
+    }
+
+    // Each "😀" is a surrogate pair (😀 — two UTF-16 code units). Repeating it
+    // past the sample cap forces `middleTruncate`'s head/tail slice to land mid-pair.
+    const emojiOversized = "😀".repeat(TAXONOMY_NAMING_SAMPLE_CHAR_CAP)
+    {
+      const { effect } = runNameCluster({
+        seedObservations: [observation({ projectionMetadata: { summary: emojiOversized } })],
+        ai,
+      })
+      await Effect.runPromise(effect)
+    }
+
+    expect(prompts.length).toBeGreaterThan(0)
+    for (const prompt of prompts) {
+      expect(hasLoneSurrogate(prompt)).toBe(false)
+    }
+  })
+
   // Interior + root modes are named from already-named children (no direct
   // members), and their modeContext is also parameterized/hardcoded — cover them
   // too so an edit to the interior `umbrella` string or the root prompt can't
@@ -704,3 +746,7 @@ describe("nameClusterUseCase", () => {
     expect(clusters.clusters.get(clusterId)?.name).toBe("Order Status")
   })
 })
+
+function hasLoneSurrogate(text: string): boolean {
+  return /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(text)
+}

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
@@ -312,6 +312,14 @@ const middleTruncate = (value: string, maxLength: number): string => {
   return `${value.slice(0, head)}${NAMING_SAMPLE_TRUNCATION_MARKER}${value.slice(value.length - tail)}`
 }
 
+// JS strings are UTF-16 and may contain unpaired surrogates — either from malformed
+// input in the original session summary or from a code-unit slice above splitting a
+// surrogate pair. Bedrock's JSON parser rejects them ("lone leading surrogate in hex
+// escape"), so we replace any lone surrogate with U+FFFD before the sample reaches
+// the naming prompt (mirrors `stripLoneSurrogates` in build-trace-search-document.ts).
+const stripLoneSurrogates = (value: string): string =>
+  value.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "�")
+
 const serializedNamingSamplesLength = (bodies: readonly string[]): number => {
   if (bodies.length === 0) return 0
   return bodies.reduce((sum, body, index) => sum + `${index}: ${body}`.length, 0) + (bodies.length - 1)
@@ -320,13 +328,13 @@ const serializedNamingSamplesLength = (bodies: readonly string[]): number => {
 const boundNamingSamples = (samples: readonly string[]): readonly string[] => {
   const perSample = samples.map((sample) => middleTruncate(sample, TAXONOMY_NAMING_SAMPLE_CHAR_CAP))
   if (serializedNamingSamplesLength(perSample) <= TAXONOMY_NAMING_SAMPLES_TOTAL_CHAR_CAP || perSample.length === 0) {
-    return perSample
+    return perSample.map(stripLoneSurrogates)
   }
 
   const framing = perSample.reduce((sum, _, index) => sum + `${index}: `.length, 0) + Math.max(0, perSample.length - 1)
   const bodyBudget = Math.max(perSample.length, TAXONOMY_NAMING_SAMPLES_TOTAL_CHAR_CAP - framing)
   const perCap = Math.max(1, Math.floor(bodyBudget / perSample.length))
-  return perSample.map((sample) => middleTruncate(sample, perCap))
+  return perSample.map((sample) => stripLoneSurrogates(middleTruncate(sample, perCap)))
 }
 
 const generateWithCollisionGuard = (input: Omit<GenerateInput, "retryForbiddenName">) =>


### PR DESCRIPTION
## What does this PR do?

Fixes a production error in taxonomy cluster naming: Bedrock rejects the naming prompt with `Invalid 'messages': lone leading surrogate in hex escape` whenever a sample fed into the prompt carries an unpaired UTF-16 surrogate, aborting naming for that cluster (both the primary and fallback model fail identically, since both receive the same malformed prompt).

**Datadog issue:** [`469bdd84-87aa-11f1-83a2-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issues/469bdd84-87aa-11f1-83a2-da7ad0900005) — `workflows` service, `taxonomy.propose-themes` resource, `error.type:Error`. ~42 occurrences over the last 7 days, first seen 2026-07-24 (`issue.first_seen_version` `e80aed65f6cb569900c7bd9024f2f5d3362c0ecb`; this repo's shallow clone only reaches back 50 commits, before that SHA, so I could not pin the exact introducing commit — the surrounding code (`middleTruncate`/`boundNamingSamples`) predates the available history).

**Root cause:** `packages/domain/taxonomy/src/use-cases/name-taxonomy.ts`'s `boundNamingSamples` truncates each cluster sample with `middleTruncate`, which does a raw `String#slice` on head/tail character offsets. JS strings are UTF-16, so a slice can land in the middle of a surrogate pair, leaving a lone surrogate in the sample. Lone surrogates can also already be present in the persisted session summary itself (arbitrary LLM/user I/O). Either way, the corrupted sample flows unsanitized into the `taxonomy.propose-themes` / `taxonomy.name-cluster` prompts sent to Bedrock, which rejects the whole request.

This is the same root cause already fixed for ClickHouse/Voyage ingestion in `packages/domain/spans/src/use-cases/build-trace-search-document.ts` (`stripLoneSurrogates`, applied after that module's own middle-truncation) — this PR applies the identical fix at this sibling call site, which the earlier fix didn't cover since it lives in a different package.

**Fix:** `boundNamingSamples` now strips any lone surrogate (replacing it with U+FFFD) after `middleTruncate`, on both its early-return and rebudgeted-truncation paths, before the sample reaches the naming prompt.

## Related issue (if applicable)

Closes #

## How was this tested?

- Added `strips lone UTF-16 surrogates from naming prompts, whether from the raw summary or from truncation splitting a pair` to `packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts`, covering both sources: a raw lone surrogate already in the persisted summary, and an emoji-repeated sample forcing `middleTruncate`'s head/tail slice to land mid-pair.
- Confirmed the new test fails without the fix (reproduces the bug) and passes with it.
- `pnpm --filter @domain/taxonomy exec vitest run --dir src` — 319/319 tests pass.
- `pnpm --filter @domain/taxonomy typecheck` (tsgo) — clean.
- `pnpm exec biome check` on the changed files — no new findings (one pre-existing, unrelated cognitive-complexity warning on a different function in the same file).

**Verification after deploy:** occurrences of Datadog issue `469bdd84-87aa-11f1-83a2-da7ad0900005` (`taxonomy.propose-themes` "lone leading surrogate") should drop to zero for clusters with the previously-corrupting samples.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLnsc7xP4Ct3Y9pcmhWVLw

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLnsc7xP4Ct3Y9pcmhWVLw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791732269&installation_model_id=435055&pr_number=4623&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4623&signature=27c7d5222fb090887df1af3a961568b88f4836d8c9f099da8b93705b2ccdbc35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->