### PR TITLE
fix(taxonomy): sanitize lone UTF-16 surrogates in session projection summaries

### DIFF
--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.test.ts
@@ -1360,4 +1360,14 @@ describe("middleTruncate", () => {
     const value = "😀".repeat(10)
     expect(middleTruncateForTesting(value, value.length)).toBe(value)
   })
+
+  it("strips a lone surrogate already present in text short enough to skip truncation", () => {
+    const loneHighSurrogate = "hello \uD800 world"
+    expect(middleTruncateForTesting(loneHighSurrogate, loneHighSurrogate.length)).not.toMatch(LONE_SURROGATE_PATTERN)
+
+    const loneLowSurrogate = "hello \uDC00 world"
+    expect(middleTruncateForTesting(loneLowSurrogate, loneLowSurrogate.length + 100)).not.toMatch(
+      LONE_SURROGATE_PATTERN,
+    )
+  })
 })

--- a/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
+++ b/packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts
@@ -133,7 +133,7 @@ const TAXONOMY_DIRECT_PROJECTION_MAX_LENGTH = CONVERSATION_INTELLIGENCE_LLM_MAX_
 const TRUNCATION_MARKER = "\n[...truncated...]\n"
 
 const middleTruncate = (value: string, maxLength: number): string => {
-  if (value.length <= maxLength) return value
+  if (value.length <= maxLength) return stripLoneSurrogates(value)
   if (maxLength <= TRUNCATION_MARKER.length) return stripLoneSurrogates(value.slice(0, maxLength))
   const head = Math.floor((maxLength - TRUNCATION_MARKER.length) / 2)
   const tail = maxLength - TRUNCATION_MARKER.length - head

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.test.ts
@@ -28,7 +28,7 @@ import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.
 import { TaxonomyObservationRepository } from "../ports/taxonomy-observation-repository.ts"
 import { createFakeTaxonomyClusterRepository } from "../testing/fake-taxonomy-cluster-repository.ts"
 import { createFakeTaxonomyObservationRepository } from "../testing/fake-taxonomy-observation-repository.ts"
-import { nameClusterUseCase } from "./name-taxonomy.ts"
+import { nameClusterUseCase, readableObservationSummaryForTesting } from "./name-taxonomy.ts"
 
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
@@ -702,5 +702,30 @@ describe("nameClusterUseCase", () => {
     expect(prompts.join("\n")).not.toContain("- Order Status")
     expect(prompts).toHaveLength(2)
     expect(clusters.clusters.get(clusterId)?.name).toBe("Order Status")
+  })
+})
+
+describe("readableObservationSummary", () => {
+  const LONE_SURROGATE_PATTERN = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
+
+  it("strips a lone high surrogate so it never reaches the naming prompt", () => {
+    const summary = readableObservationSummaryForTesting("User asked about \uD800 their order.")
+    expect(summary).not.toBeNull()
+    expect(summary).not.toMatch(LONE_SURROGATE_PATTERN)
+  })
+
+  it("strips a lone low surrogate so it never reaches the naming prompt", () => {
+    const summary = readableObservationSummaryForTesting("User asked about \uDC00 their order.")
+    expect(summary).not.toBeNull()
+    expect(summary).not.toMatch(LONE_SURROGATE_PATTERN)
+  })
+
+  it("leaves a well-formed surrogate pair (e.g. an emoji) untouched", () => {
+    expect(readableObservationSummaryForTesting("Order status 😀 check")).toBe("Order status 😀 check")
+  })
+
+  it("returns null for non-string or blank values, as before", () => {
+    expect(readableObservationSummaryForTesting(null)).toBeNull()
+    expect(readableObservationSummaryForTesting("   ")).toBeNull()
   })
 })

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
@@ -126,6 +126,13 @@ const withNamingTimeout = <A, E, R>(effect: Effect.Effect<A, E, R>, durationMs =
 // reads as a tag to the model without being parseable as one.
 const defangTags = (text: string): string => text.replaceAll("<", "‹").replaceAll(">", "›")
 
+// JS strings are UTF-16 and a persisted observation summary can carry an
+// unpaired surrogate (e.g. a code-unit slice that split an emoji). Sent
+// verbatim, it breaks the model provider's JSON request encoding, so strip it
+// before the summary is used as a naming sample.
+const stripLoneSurrogates = (text: string): string =>
+  text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "�")
+
 const truncateSample = (sample: string, maxChars: number): string =>
   sample.length <= maxChars ? sample : `${sample.slice(0, maxChars)}…`
 
@@ -299,8 +306,10 @@ const readableObservationSummary = (value: unknown): string | null => {
   if (typeof value !== "string") return null
   const trimmed = value.trim()
   if (trimmed.length === 0) return null
-  return trimmed
+  return stripLoneSurrogates(trimmed)
 }
+
+export const readableObservationSummaryForTesting = readableObservationSummary
 
 const NAMING_SAMPLE_TRUNCATION_MARKER = "\n[...truncated...]\n"
 


### PR DESCRIPTION
## What does this PR do?

Fixes a production error: Datadog Error Tracking shows recurring `workflows` `Error` occurrences (~42 over the last 7 days, service `workflows`, resource `taxonomy.propose-themes`) with messages like:

> `The model returned the following errors: {"error":{"code":"validation_error","message":"Failed to deserialize the JSON body into the target type: ?[1].content[0].text: Invalid 'messages': lone leading surrogate in hex escape at line 1 column 2156", ...}}`

**Root cause:** `middleTruncate` in `packages/domain/conversation-intelligence/src/use-cases/analyze-session.ts` strips lone UTF-16 surrogates from both halves of a *truncated* string, but returned the *untruncated* case (`value.length <= maxLength`) verbatim:

```ts
const middleTruncate = (value: string, maxLength: number): string => {
  if (value.length <= maxLength) return value // <- not sanitized
  ...
```

Any session conversation short enough to skip truncation could therefore persist a summary with an unpaired UTF-16 surrogate (e.g. from a code-unit slice that split an emoji, or malformed input) into `projectionMetadata.summary` in ClickHouse. That summary is later read back in `packages/domain/taxonomy/src/use-cases/name-taxonomy.ts` and fed straight into the taxonomy-naming AI prompt (`taxonomy.propose-themes` / `taxonomy.name-cluster`). The Bedrock provider's strict JSON request encoding rejects the lone surrogate, crashing the naming job.

This is the same class of bug documented for `record-session-observation.ts` (ClickHouse insert + Voyage embeddings) — this is a **different, more recently added call site** (`analyze-session.ts`'s direct-projection path) with the identical unsanitized-lone-surrogate flaw.

**Fix (two layers, same root cause):**
1. **Source:** `middleTruncate` now sanitizes the untruncated branch too, so no new unsanitized summary is ever persisted.
2. **Defense in depth:** `readableObservationSummary` in `name-taxonomy.ts` now also strips lone surrogates when reading a summary back from ClickHouse, so rows already persisted with the bug before this fix deploys are also protected before they reach the naming prompt.

## Related issue (if applicable)

Datadog Error Tracking issue: `workflows` service, `Error` type, resource `taxonomy.propose-themes`, message containing `lone leading surrogate in hex escape` (~42 occurrences / 7d, `env:production`).

Closes #

## How was this tested?

- Added a regression test in `analyze-session.test.ts` reproducing the exact gap: a lone surrogate in text short enough to skip truncation. Confirmed it **fails** without the fix (`hello \uD800 world"` matches the lone-surrogate pattern) and **passes** with it.
- Added regression tests in `name-taxonomy.test.ts` for `readableObservationSummary` covering a lone high surrogate, a lone low surrogate, a well-formed surrogate pair (emoji, left untouched), and the existing null/blank-string behavior. Confirmed they fail without the fix (the export doesn't exist / summary isn't sanitized) and pass with it.
- `pnpm --filter @domain/conversation-intelligence test` — 46/46 passing.
- `pnpm --filter @domain/taxonomy test` — 322/322 passing.
- `pnpm --filter @domain/conversation-intelligence typecheck` and `pnpm --filter @domain/taxonomy typecheck` — clean (via `tsgo`).
- `pnpm exec biome check` on all changed files — clean (one pre-existing, unrelated complexity warning in `name-taxonomy.ts` verified via `git stash` to predate this change).

**Verification in production:** after this deploys, occurrences of the `taxonomy.propose-themes` "lone leading surrogate" error signature should drop to zero for newly analyzed sessions; the defensive read-side strip also stops it recurring for clusters whose samples include already-persisted affected summaries.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TMnsRjPR8Yyvm4DYxgcjP

---
_Generated by [Claude Code](https://claude.ai/code/session_012TMnsRjPR8Yyvm4DYxgcjP)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791768303&installation_model_id=435055&pr_number=4624&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4624&signature=c04411c01979519d6322bf207bf1eb9849325ffbb380b62b5ad1e909de31f8bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->