### PR TITLE
fix(flaggers): recognize combined primary+fallback AI failures as unclassifiable

### DIFF
--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -2678,6 +2678,64 @@ describe("task-failure verdict classification", () => {
 
     expect(result).toMatchObject({ matched: false, verdict: "indeterminate", classificationOutcome: "indeterminate" })
   })
+
+  // Reproduces a combined primary+fallback failure as thrown by @platform/ai-vercel:
+  // both attempts are formatted into one plain `Error` whose `name` is no longer
+  // `AI_NoObjectGeneratedError`/`AI_NoOutputGeneratedError` on either side, so only
+  // the message text (still carrying each attempt's original prefix) identifies it.
+  it("marks indeterminate when the primary model returns unparseable JSON and the fallback also fails", async () => {
+    const { layer: aiLayer } = createFakeAI({
+      generate: () =>
+        Effect.fail(
+          new AIError({
+            message:
+              'AI generation failed (amazon-bedrock/minimax.minimax-m2.5): Primary model amazon-bedrock/minimax.minimax-m2.5 failed: No object generated: could not parse the response. (finishReason=stop, cause="JSON parsing failed: Unexpected non-whitespace character after JSON"); fallback model amazon-bedrock/openai.gpt-oss-120b-1:0 failed: No output generated.',
+            cause: new Error(
+              'Primary model amazon-bedrock/minimax.minimax-m2.5 failed: No object generated: could not parse the response. (finishReason=stop, cause="JSON parsing failed: Unexpected non-whitespace character after JSON"); fallback model amazon-bedrock/openai.gpt-oss-120b-1:0 failed: No output generated.',
+            ),
+          }),
+        ),
+    })
+
+    const result = await Effect.runPromise(
+      classifyConversationForFlaggerUseCase({
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        flaggerSlug: "task-failure",
+        conversation: TASK_SUCCESS_CONVERSATION,
+        traceId: INPUT.traceId,
+      }).pipe(Effect.provide(Layer.mergeAll(aiLayer, defaultCacheLayer))),
+    )
+
+    expect(result).toMatchObject({ matched: false, verdict: "indeterminate", classificationOutcome: "indeterminate" })
+  })
+
+  it("marks indeterminate when both the primary and fallback model produce no output at all", async () => {
+    const { layer: aiLayer } = createFakeAI({
+      generate: () =>
+        Effect.fail(
+          new AIError({
+            message:
+              "AI generation failed (amazon-bedrock/minimax.minimax-m2.5): Primary model amazon-bedrock/minimax.minimax-m2.5 failed: No output generated.; fallback model amazon-bedrock/openai.gpt-oss-120b-1:0 failed: No output generated.",
+            cause: new Error(
+              "Primary model amazon-bedrock/minimax.minimax-m2.5 failed: No output generated.; fallback model amazon-bedrock/openai.gpt-oss-120b-1:0 failed: No output generated.",
+            ),
+          }),
+        ),
+    })
+
+    const result = await Effect.runPromise(
+      classifyConversationForFlaggerUseCase({
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        flaggerSlug: "task-failure",
+        conversation: TASK_SUCCESS_CONVERSATION,
+        traceId: INPUT.traceId,
+      }).pipe(Effect.provide(Layer.mergeAll(aiLayer, defaultCacheLayer))),
+    )
+
+    expect(result).toMatchObject({ matched: false, verdict: "indeterminate", classificationOutcome: "indeterminate" })
+  })
 })
 
 describe("Safety verdict classification", () => {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -1152,15 +1152,29 @@ const parseSafetyOutput = (
 }
 
 // The Vercel AI SDK raises `NoObjectGeneratedError` / `NoOutputGeneratedError`
-// when the model returns output that does not materialize as the requested schema,
+// when the model returns output that does not materialize as the requested schema
+// (a mismatched shape, unparseable/duplicated JSON, or no output at all),
 // `AI_APICallError` with a "prompt is too long" message when the trace evidence
 // exceeds the model's context window, and Bedrock "Grammar compilation timed out"
 // when structured-output grammar compilation fails. The flagger keeps matched=false
 // for callers while marking the result indeterminate for screening coverage.
+//
+// When both the primary and fallback model fail, @platform/ai-vercel throws a
+// plain `Error` whose message concatenates both attempts' formatted errors, so
+// `cause.name` is no longer `AI_NoObjectGeneratedError`/`AI_NoOutputGeneratedError`
+// on either side — only their original messages survive, still carrying the
+// SDK's stable "No object generated: ..."/"No output generated." prefix. Match
+// on that prefix (not the more specific "did not match schema" reason) so every
+// no-structured-output reason — schema mismatch, unparseable/duplicated JSON,
+// no output — is recognized whether it came from a single failed attempt or a
+// combined primary+fallback failure.
 const isSchemaMismatchCause = (cause: unknown): boolean => {
   if (!(cause instanceof Error)) return false
   if (cause.name === "AI_NoObjectGeneratedError" || cause.name === "AI_NoOutputGeneratedError") return true
-  return typeof cause.message === "string" && cause.message.includes("response did not match schema")
+  return (
+    typeof cause.message === "string" &&
+    (cause.message.includes("No object generated:") || cause.message.includes("No output generated."))
+  )
 }
 
 const isPromptTooLongCause = (cause: unknown): boolean =>


### PR DESCRIPTION
## What does this PR do?

Widens the flagger classification path's "unclassifiable model failure" detection so it recognizes **every** no-structured-output failure reason from `@platform/ai-vercel`, not just "response did not match schema" — including duplicated/unparseable JSON and "no output at all" — when **both** the primary and fallback model fail.

### Datadog issues addressed

Production, `env:production`, `service:workflows`, file `packages/platform/ai-vercel/src/ai.ts` (`execute`/`catch`), primary model `amazon-bedrock/minimax.minimax-m2.5` with fallback `amazon-bedrock/openai.gpt-oss-120b-1:0` — this is the flagger instruction-extractor/classifier's structured-output call (`packages/domain/flaggers/src/use-cases/run-flagger.ts`):

- https://app.datadoghq.eu/error-tracking/issue/bfe17be0-aef1-11f1-b145-da7ad0900005 — "No object generated: could not parse the response" (duplicated JSON) + fallback "No output generated."
- https://app.datadoghq.eu/error-tracking/issue/3ccb57a0-7a60-11f1-989d-da7ad0900005 — same shape, 6 occurrences/7d, recurring since 2026-07-08
- https://app.datadoghq.eu/error-tracking/issue/61af2458-8ce3-11f1-9895-da7ad0900005 — "could not parse the response" / "Unexpected end of JSON input", recurring since 2026-07-31
- https://app.datadoghq.eu/error-tracking/issue/04d0d332-5ce4-11f1-add8-da7ad0900005 and https://app.datadoghq.eu/error-tracking/issue/04d116bc-5ce4-11f1-949d-da7ad0900005 — primary **and** fallback both "No output generated." with no schema-mismatch phrase at all, recurring since 2026-05-31

Combined, these AIError variants recur dozens of times per week against `packages/platform/ai-vercel/src/ai.ts`, alongside a much higher-volume, already-handled sibling (`response did not match schema`, e.g. https://app.datadoghq.eu/error-tracking/issue/50645210-5de3-11f1-881c-da7ad0900005, 72 occurrences/7d) that the existing code already routes to an indeterminate result.

### Root cause

`packages/domain/flaggers/src/use-cases/run-flagger.ts`'s `isUnclassifiableModelFailureCause` decides whether an AI generation failure should degrade the flagger classification to `indeterminate` (safe) or propagate as a real error (breaks the run). When only the **primary** model fails, `@platform/ai-vercel` rethrows the SDK's original error, whose `name` is `AI_NoObjectGeneratedError`/`AI_NoOutputGeneratedError` — already recognized regardless of the specific reason.

But when **both** primary and fallback fail, `ai.ts`'s `execute()` (`packages/platform/ai-vercel/src/ai.ts:445-450`) collapses both attempts into a single plain `Error` (`new Error("Primary model X failed: ...; fallback model Y failed: ...")`). Its `name` is just `"Error"`, so only message-text matching can identify it — and the existing code only matched the substring `"response did not match schema"`. Every other no-structured-output reason (duplicated/malformed JSON, no output generated at all) fell through this check and propagated as an uncaught `AIError` out of `classifyConversationForFlaggerUseCase`, instead of degrading gracefully like the schema-mismatch case already does.

### Fix

Match on the Vercel AI SDK's stable `"No object generated:"` / `"No output generated."` message prefixes (which survive in the composed message for both attempts) instead of the narrower `"did not match schema"` phrase, so every no-structured-output reason is treated consistently — whether it came from a single failed attempt (still caught by `cause.name`) or a combined primary+fallback failure (now caught by the broadened message match). This is a superset of the previous behavior: every case handled before is still handled.

### Tests

Added two cases to `packages/domain/flaggers/src/use-cases/run-flagger.test.ts` reproducing the exact production message shapes seen in Datadog:
- combined failure where the primary model returns unparseable/duplicated JSON and the fallback also fails
- combined failure where both primary and fallback simply produce no output

Both new tests fail against the pre-fix code (confirmed by temporarily reverting the fix and re-running) and pass with it.

## How was this tested?

- `pnpm --filter @domain/flaggers test` — 83/83 passed (full `run-flagger.test.ts` suite, including the 2 new cases)
- Confirmed the 2 new tests fail without the fix and pass with it (reverted/reapplied locally)
- `pnpm exec biome check` on the changed files — clean
- `pnpm --filter @domain/flaggers typecheck` — pre-existing, unrelated failures only (`@latitude-data/telemetry`/`@latitude-data/sdk` module resolution, requires a full monorepo build first); confirmed identical failures exist on `development` without this change

### Verification steps

After deploy, the `AIError`/`Error` issues linked above (duplicated-JSON and no-output-at-all shapes on the flagger classification path) should stop recurring as propagated errors — the classification run instead completes with `classificationOutcome: "indeterminate"`, matching the existing behavior for the schema-mismatch variant.

### Remaining risk / follow-up not included in this PR

- The underlying model-compliance issue (why `amazon-bedrock/minimax.minimax-m2.5` produces malformed/duplicated JSON or empty output on this schema) is not fixed here — this PR only ensures the failure degrades gracefully instead of breaking the classification run, matching already-established behavior for the schema-mismatch case.
- A related, separate cluster (`EvaluationExecutionError`/`LiveEvaluationExecutionError`, "Script exceeded its budget of 120000ms wall clock", https://app.datadoghq.eu/error-tracking/issue/ecf42756-7f5b-11f1-b694-da7ad0900005 and https://app.datadoghq.eu/error-tracking/issue/f2bcc120-7f79-11f1-b285-da7ad0900005) shares the same root model (`minimax.minimax-m2.5` via `EVALUATION_DEFAULT_SCRIPT_RUNTIME_MODEL`) but sits in the evaluation sandbox rather than the flagger, and was deliberately left out of this PR — it needs a product decision (shorten the inner `llm()` timeout so the fallback isn't starved by the wall-clock budget, or move the evaluation judge off `minimax.minimax-m2.5` via the existing `LAT_AI_EVALUATION_JUDGE_MODEL` env override) rather than a pure bug fix.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01W3YWEDqwZswRnUq8qce3Xj)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791844125&installation_model_id=435055&pr_number=4627&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4627&signature=f0cd3c5926c3ffcd25f1952b1e8b22e58a2d63698dc92aa1507a2e494bef0a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->