### PR TITLE
fix(agent-score): correct scoring evidence aggregation

### DIFF
--- a/packages/domain/agent-score/src/entities/agent-score-explanation.ts
+++ b/packages/domain/agent-score/src/entities/agent-score-explanation.ts
@@ -82,7 +82,9 @@ const costWindowGateSchema = z.object({
 
 const speedWindowGateSchema = z.object({
   coverage: z.enum(["measured", "unmeasured"]),
-  unmeasuredReason: z.enum(["completePathFloor", "completePathCoverageFloor", "noObservedTime"]).optional(),
+  unmeasuredReason: z
+    .enum(["completePathFloor", "completePathCoverageFloor", "latencyReferenceCoverage", "noObservedTime"])
+    .optional(),
   completeSessionCount: z.number(),
   incompleteSessionCount: z.number(),
   completeShareOfEligible: z.number(),

--- a/packages/domain/agent-score/src/entities/session-assessment-input.ts
+++ b/packages/domain/agent-score/src/entities/session-assessment-input.ts
@@ -130,10 +130,10 @@ export interface NormalizedSessionCostEvidence {
   /**
    * The workload this session is comparable with, for the matched signal estimator.
    *
-   * Built from provider, model, prompt size and streaming mode because those are what make two
-   * sessions cost and take a similar amount without any signal being involved. Comparison only ever
-   * happens inside one key, so an agent whose signal-bearing sessions are also its biggest sessions
-   * cannot have that difference read as the signal's effect.
+   * Built from provider, model, input and output size, toolset, call scale and streaming mode because
+   * those are what make two sessions cost and take a similar amount without any signal being
+   * involved. Comparison only ever happens inside one key, so an agent whose signal-bearing sessions
+   * are also its biggest sessions cannot have that difference read as the signal's effect.
    */
   readonly workloadStratum: string
   readonly denominators: CostFamilyDenominators

--- a/packages/domain/agent-score/src/readers/read-session-cost-evidence.test.ts
+++ b/packages/domain/agent-score/src/readers/read-session-cost-evidence.test.ts
@@ -148,6 +148,39 @@ describe("readSessionCostEvidence", () => {
       totalCount: 1,
     })
   })
+
+  it("separates workloads by output size", () => {
+    const shortOutput = read([generation()]).workloadStratum
+    const longOutput = read([generation({ tokens: { ...generation().tokens, tokensOutput: 5_000 } })]).workloadStratum
+
+    expect(shortOutput).not.toBe(longOutput)
+  })
+
+  it("separates workloads by the tools offered to the model", () => {
+    const withTools = readSessionCostEvidence({
+      generations: [generation()],
+      toolCalls: [],
+      memoryEvents: [],
+      countTokens: () => 0,
+      completed: true,
+      recoveredIncidents: [],
+      recoveredStructuralDefects: [],
+      toolDefinitions: [
+        {
+          name: "search",
+          estimatedSerializedTokens: 20,
+          requestCount: 1,
+          calledAtLeastOnce: false,
+          observationPeriodComplete: false,
+        },
+      ],
+      unmatchedToolCallNames: [],
+      cacheEvidence: null,
+      latencyArtifact: artifact,
+    }).workloadStratum
+
+    expect(withTools).not.toBe(read([generation()]).workloadStratum)
+  })
 })
 
 describe("latency reader coverage", () => {

--- a/packages/domain/agent-score/src/readers/read-session-cost-evidence.ts
+++ b/packages/domain/agent-score/src/readers/read-session-cost-evidence.ts
@@ -7,6 +7,7 @@ import {
   isLlmCompletionOperation,
   latencyInputBucket,
   latencyInputTokens,
+  latencyOutputBucket,
   latencyOutputTokens,
   marginalCriticalPathNs,
   modelRegistryPricing,
@@ -132,26 +133,36 @@ const usageOperations: ReadonlySet<string> = new Set(USAGE_OPERATIONS)
  * A session with no readable generation gets an explicit unknown key rather than an empty one, so it
  * only ever matches other unknowns.
  */
-const workloadStratumOf = (generations: readonly SessionGenerationFact[]): string => {
+const workloadStratumOf = (
+  generations: readonly SessionGenerationFact[],
+  toolDefinitions: readonly ToolDefinitionSurface[],
+): string => {
   const completions = generations.filter((generation) => isLlmCompletionOperation(generation.operation))
   if (completions.length === 0) return "unknown"
 
   const byCalls = new Map<string, number>()
   let inputTokens = 0
+  let outputTokens = 0
   let streaming = 0
   for (const generation of completions) {
     const pair = `${generation.provider}/${generation.model}`
     byCalls.set(pair, (byCalls.get(pair) ?? 0) + 1)
     inputTokens += latencyInputTokens(generation.tokens)
+    outputTokens += latencyOutputTokens(generation.tokens)
     if (generation.isStreaming) streaming += 1
   }
   const dominant = [...byCalls.entries()].sort(
     (left, right) => right[1] - left[1] || left[0].localeCompare(right[0]),
   )[0]
-  const bucket = latencyInputBucket(Math.round(inputTokens / completions.length))
+  const inputBucket = latencyInputBucket(Math.round(inputTokens / completions.length))
+  const outputBucket = latencyOutputBucket(Math.round(outputTokens / completions.length))
+  const toolset =
+    toolDefinitions.length === 0
+      ? "no-tools"
+      : [...new Set(toolDefinitions.map((definition) => definition.name))].sort().join(",")
   const mode = streaming * 2 >= completions.length ? "streaming" : "buffered"
   const scale = completions.length <= 2 ? "short" : completions.length <= 10 ? "medium" : "long"
-  return `${dominant?.[0] ?? "unknown"}|${bucket}|${mode}|${scale}`
+  return `${dominant?.[0] ?? "unknown"}|${inputBucket}|${outputBucket}|${toolset}|${mode}|${scale}`
 }
 
 /**
@@ -429,7 +440,7 @@ export const readSessionCostEvidence = (input: SessionCostEvidenceInput): Sessio
 
   return {
     readings,
-    workloadStratum: workloadStratumOf(input.generations),
+    workloadStratum: workloadStratumOf(input.generations, input.toolDefinitions),
     denominators: {
       spend: spendCoverage.pricedMicrocents,
       context: ledger.readableInputTokens,

--- a/packages/domain/agent-score/src/scoring/attribute-dimensions.test.ts
+++ b/packages/domain/agent-score/src/scoring/attribute-dimensions.test.ts
@@ -12,6 +12,7 @@ const contribution = (
   families: readonly { family: CostFamily; eligibleUnits: number }[],
 ): SessionWindowContribution => ({
   sessionId: "session",
+  costUsableForDenominator: true,
   families: families.map((entry) => ({ ...entry, penalizedUnits: 0 })),
   speed: { observedNs: 0, avoidableNs: 0, usableForDenominator: true },
 })

--- a/packages/domain/agent-score/src/scoring/attribute-dimensions.ts
+++ b/packages/domain/agent-score/src/scoring/attribute-dimensions.ts
@@ -148,7 +148,10 @@ export const attributeCostWindow = ({
       family,
       fold.contributions.reduce(
         (total, contribution) =>
-          total + (contribution.families.find((entry) => entry.family === family)?.eligibleUnits ?? 0),
+          total +
+          (contribution.costUsableForDenominator
+            ? (contribution.families.find((entry) => entry.family === family)?.eligibleUnits ?? 0)
+            : 0),
         0,
       ),
     ]),
@@ -209,6 +212,9 @@ export const attributeSpeedWindow = ({
   readonly seed?: number
 }): DimensionAttribution => {
   const causeIds = [...fold.speedCauseNs.keys()]
+  const observedSessionCount = fold.contributions.filter(
+    (contribution) => contribution.speed.usableForDenominator,
+  ).length
   const scoreWith = (active: ReadonlySet<string>): number => {
     if (observedNs <= 0) return 100
     const avoidable = [...active].reduce((total, causeId) => total + (fold.speedCauseNs.get(causeId) ?? 0), 0)
@@ -230,7 +236,7 @@ export const attributeSpeedWindow = ({
         label: causeId,
         evidence: "measured",
         nativeEffect: { value: fold.speedCauseNs.get(causeId) ?? 0, unit: "nanoseconds" },
-        observationCount: fold.foldedSessionCount,
+        observationCount: observedSessionCount,
         ...(destination ? { destination } : {}),
       }
     },

--- a/packages/domain/agent-score/src/scoring/bootstrap-window.ts
+++ b/packages/domain/agent-score/src/scoring/bootstrap-window.ts
@@ -11,6 +11,8 @@ import type { CostFamilyResult } from "./aggregate-session-cost.ts"
  */
 export interface SessionWindowContribution {
   readonly sessionId: string
+  /** False when a required Cost family was unreadable; excluded from Cost but retained for Speed. */
+  readonly costUsableForDenominator: boolean
   readonly families: readonly Pick<CostFamilyResult, "family" | "eligibleUnits" | "penalizedUnits">[]
   readonly speed: {
     readonly observedNs: number
@@ -54,9 +56,9 @@ export const aggregateWindowCost = ({
 }): WindowCostAggregate => {
   const familyPenalties = Object.fromEntries(
     COST_FAMILIES.map((family) => {
-      const rows = contributions.flatMap((contribution) =>
-        contribution.families.filter((entry) => entry.family === family),
-      )
+      const rows = contributions
+        .filter((contribution) => contribution.costUsableForDenominator)
+        .flatMap((contribution) => contribution.families.filter((entry) => entry.family === family))
       const eligible = rows.reduce((total, entry) => total + entry.eligibleUnits, 0)
       const penalized = rows.reduce((total, entry) => total + entry.penalizedUnits, 0)
       return [family, Math.min(artifact.familyCaps[family], ratio(penalized, eligible))]

--- a/packages/domain/agent-score/src/scoring/build-window-signal-effects.test.ts
+++ b/packages/domain/agent-score/src/scoring/build-window-signal-effects.test.ts
@@ -232,7 +232,7 @@ describe("buildWindowSignalEffects", () => {
   it("estimates Speed in nanoseconds and shares no cap with Cost", () => {
     const result = build(evidenceFor({ exposed: 30, clean: 30, exposedShare: 0.5, cleanShare: 0.5 }))
 
-    expect(result.avoidableNs).toBeGreaterThan(0)
+    expect(result.avoidableNs).toBeCloseTo(5_400_000, 6)
     expect(result.avoidableNs).toBeGreaterThan(LAUNCH_COST_SCORING_ARTIFACT.residualSignalCap)
   })
 

--- a/packages/domain/agent-score/src/scoring/compose-agent-score.test.ts
+++ b/packages/domain/agent-score/src/scoring/compose-agent-score.test.ts
@@ -10,23 +10,39 @@ import type { ProjectReliabilityEstimate } from "./estimate-reliability.ts"
 import type { ProjectSafetyEstimate } from "./estimate-safety.ts"
 import type { CostWindowGate, SpeedWindowGate } from "./window-gates.ts"
 
-const outcome = (overrides: Partial<ProjectOutcomeEstimate> = {}): ProjectOutcomeEstimate => ({
-  outcome: 80,
-  interval: { lower: 75, upper: 85 },
-  intervalMethod: "exactBinomial",
-  eligibleSessionCount: 1_000,
-  examinedSessionCount: 200,
-  deterministicSessionCount: 0,
-  sampledSessionCount: 200,
-  sampledFailureCount: 40,
-  sampledWeight: 2_000,
-  censusWeight: 0,
-  excluded: { incompatibleJudgmentVersion: 0, unknownInclusionProbability: 0, deterministicEndpoint: 0 },
-  coverage: "measured",
-  judgedSessions: [],
-  deterministicFailureSessionIds: [],
-  ...overrides,
-})
+const outcome = (overrides: Partial<ProjectOutcomeEstimate> = {}): ProjectOutcomeEstimate => {
+  const estimate = {
+    outcome: 80,
+    interval: { lower: 75, upper: 85 },
+    intervalMethod: "exactBinomial" as const,
+    eligibleSessionCount: 1_000,
+    examinedSessionCount: 200,
+    deterministicSessionCount: 0,
+    sampledSessionCount: 200,
+    sampledFailureCount: 40,
+    sampledWeight: 2_000,
+    censusWeight: 0,
+    excluded: { incompatibleJudgmentVersion: 0, unknownInclusionProbability: 0, deterministicEndpoint: 0 },
+    coverage: "measured" as const,
+    ...overrides,
+  }
+  const inclusionProbability =
+    estimate.sampledWeight > 0 ? Math.min(1, estimate.sampledSessionCount / estimate.sampledWeight) : 1
+  return {
+    ...estimate,
+    judgedSessions:
+      overrides.judgedSessions ??
+      Array.from({ length: estimate.sampledSessionCount }, (_, index) => ({
+        sessionId: `outcome-${index}`,
+        succeeded: index >= estimate.sampledFailureCount,
+        inclusionProbability,
+        judgmentVersion: "test",
+      })),
+    deterministicFailureSessionIds:
+      overrides.deterministicFailureSessionIds ??
+      Array.from({ length: estimate.deterministicSessionCount }, (_, index) => `deterministic-${index}`),
+  }
+}
 
 const reliability = (overrides: Partial<ProjectReliabilityEstimate> = {}): ProjectReliabilityEstimate => ({
   reliability: 36,
@@ -41,25 +57,36 @@ const reliability = (overrides: Partial<ProjectReliabilityEstimate> = {}): Proje
   ...overrides,
 })
 
-const safety = (overrides: Partial<ProjectSafetyEstimate> = {}): ProjectSafetyEstimate => ({
-  safety: 90,
-  harmRate: 0.001,
-  interval: { lower: 56, upper: 99 },
-  intervalMethod: "exactBinomial",
-  eligibleSessionCount: 1_000,
-  examinedSessionCount: 1_000,
-  harmedSessionCount: 1,
-  excluded: {
-    incompleteSuite: 0,
-    suiteNotApplicable: 0,
-    unknownInclusionProbability: 0,
-    incompatibleJudgmentVersion: 0,
-  },
-  rateLimitedHintedCount: 0,
-  coverage: "measured",
-  examinedSessions: [],
-  ...overrides,
-})
+const safety = (overrides: Partial<ProjectSafetyEstimate> = {}): ProjectSafetyEstimate => {
+  const estimate = {
+    safety: 90,
+    harmRate: 0.001,
+    interval: { lower: 56, upper: 99 },
+    intervalMethod: "exactBinomial" as const,
+    eligibleSessionCount: 1_000,
+    examinedSessionCount: 1_000,
+    harmedSessionCount: 1,
+    excluded: {
+      incompleteSuite: 0,
+      suiteNotApplicable: 0,
+      unknownInclusionProbability: 0,
+      incompatibleJudgmentVersion: 0,
+    },
+    rateLimitedHintedCount: 0,
+    coverage: "measured" as const,
+    ...overrides,
+  }
+  return {
+    ...estimate,
+    examinedSessions:
+      overrides.examinedSessions ??
+      Array.from({ length: estimate.examinedSessionCount }, (_, index) => ({
+        sessionId: `safety-${index}`,
+        harmed: index < estimate.harmedSessionCount,
+        examinationProbability: 1,
+      })),
+  }
+}
 
 const costGate = (overrides: Partial<CostWindowGate> = {}): CostWindowGate => ({
   coverage: "measured",
@@ -81,6 +108,7 @@ const speedGate = (overrides: Partial<SpeedWindowGate> = {}): SpeedWindowGate =>
 const contributions = (count: number): SessionWindowContribution[] =>
   Array.from({ length: count }, (_, index) => ({
     sessionId: `session-${index}`,
+    costUsableForDenominator: true,
     families: [{ family: "tools" as const, eligibleUnits: 10, penalizedUnits: index % 5 === 0 ? 4 : 1 }],
     speed: { observedNs: 1_000_000, avoidableNs: index % 4 === 0 ? 300_000 : 50_000, usableForDenominator: true },
   }))
@@ -209,6 +237,67 @@ describe("the composite interval", () => {
   it("reproduces itself from the same seed and inputs", () => {
     expect(compose().composite?.interval).toEqual(compose().composite?.interval)
   })
+
+  it("preserves Outcome sampling strata in composite replicates", () => {
+    const judgedSessions = Array.from({ length: 100 }, (_, index) => ({
+      sessionId: `weighted-outcome-${index}`,
+      succeeded: index >= 20,
+      inclusionProbability: index < 20 ? 0.01 : 1,
+      judgmentVersion: "test",
+    }))
+    const outcomeOnly: AgentScoreArtifact = {
+      ...LAUNCH_AGENT_SCORE_ARTIFACT,
+      compositeWeights: { outcome: 1, reliability: 0, cost: 0, speed: 0, safety: 0 },
+    }
+    const weighted = compose({
+      artifact: outcomeOnly,
+      outcome: outcome({
+        outcome: (100 * 80) / 2_080,
+        sampledSessionCount: 100,
+        sampledFailureCount: 20,
+        sampledWeight: 2_080,
+        judgedSessions,
+      }),
+    })
+    const uniform = compose({
+      artifact: outcomeOnly,
+      outcome: outcome({
+        outcome: 80,
+        sampledSessionCount: 100,
+        sampledFailureCount: 20,
+        sampledWeight: 100,
+        judgedSessions: judgedSessions.map((session) => ({ ...session, inclusionProbability: 1 })),
+      }),
+    })
+
+    expect(weighted.composite?.interval.upper).toBeLessThan(uniform.composite?.interval.lower as number)
+  })
+
+  it("preserves Safety sampling strata in composite replicates", () => {
+    const examinedSessions = Array.from({ length: 100 }, (_, index) => ({
+      sessionId: `weighted-safety-${index}`,
+      harmed: index < 20,
+      examinationProbability: index < 20 ? 0.01 : 1,
+    }))
+    const safetyOnly: AgentScoreArtifact = {
+      ...LAUNCH_AGENT_SCORE_ARTIFACT,
+      compositeWeights: { outcome: 0, reliability: 0, cost: 0, speed: 0, safety: 1 },
+    }
+    const weighted = compose({
+      artifact: safetyOnly,
+      safety: safety({ examinedSessionCount: 100, harmedSessionCount: 20, examinedSessions }),
+    })
+    const uniform = compose({
+      artifact: safetyOnly,
+      safety: safety({
+        examinedSessionCount: 100,
+        harmedSessionCount: 20,
+        examinedSessions: examinedSessions.map((session) => ({ ...session, examinationProbability: 1 })),
+      }),
+    })
+
+    expect(weighted.composite?.interval.upper).toBeLessThan(uniform.composite?.interval.lower as number)
+  })
 })
 
 describe("the published dimensions", () => {
@@ -250,6 +339,8 @@ describe("the composite policy cap", () => {
     expect(result.composite?.score).toBe(50)
     expect(result.composite?.policyCap).toMatchObject({ applied: true, cap: 50 })
     expect(result.composite?.policyCap?.removedPoints).toBeCloseTo(uncapped - 50, 9)
+    expect(result.composite?.interval.upper).toBeLessThanOrEqual(50)
+    expect(result.composite?.interval.lower).toBeLessThanOrEqual(result.composite?.score as number)
   })
 
   it("leaves a clean window alone even when the cap is enabled", () => {

--- a/packages/domain/agent-score/src/scoring/compose-agent-score.ts
+++ b/packages/domain/agent-score/src/scoring/compose-agent-score.ts
@@ -97,43 +97,81 @@ const percentile = (sorted: readonly number[], fraction: number): number => {
  * One dimension's endpoint as a distribution rather than a single rate.
  *
  * Outcome, Reliability and Safety each reduce to "how often did the adverse thing happen", so a
- * replicate draws that rate from the Beta its counts imply and pushes it back through the same
- * monotone map that produced the point estimate. Resampling the observed vector instead would make
- * a window with zero observed failures produce zero variation, and the composite would claim a
- * precision the evidence does not have.
+ * replicate draws each selection stratum's rate from the Beta its counts imply, pools the weighted
+ * strata and pushes that rate back through the same monotone map that produced the point estimate.
+ * Resampling the observed vector instead would make a window with zero observed failures produce
+ * zero variation, and the composite would claim a precision the evidence does not have.
  */
-interface EndpointModel {
+interface EndpointStratum {
   readonly adverseEvents: number
   readonly trials: number
+  readonly populationWeight: number
+}
+
+interface EndpointModel {
+  readonly strata: readonly EndpointStratum[]
+  readonly censusWeight: number
+  readonly censusAdverseEvents: number
   readonly scoreAt: (adverseRate: number) => number
 }
 
 const clampScore = (value: number): number => Math.max(0, Math.min(100, value))
 
+const strataOf = (
+  observations: readonly { readonly adverse: boolean; readonly inclusionProbability: number }[],
+): EndpointStratum[] => {
+  const counts = new Map<number, { adverseEvents: number; trials: number }>()
+  for (const observation of observations) {
+    const stratum = counts.get(observation.inclusionProbability) ?? { adverseEvents: 0, trials: 0 }
+    stratum.trials += 1
+    if (observation.adverse) stratum.adverseEvents += 1
+    counts.set(observation.inclusionProbability, stratum)
+  }
+  return [...counts.entries()].map(([inclusionProbability, counts]) => ({
+    ...counts,
+    populationWeight: counts.trials / inclusionProbability,
+  }))
+}
+
 const outcomeModel = (estimate: ProjectOutcomeEstimate): EndpointModel => ({
-  adverseEvents: estimate.sampledFailureCount,
-  trials: estimate.sampledSessionCount,
-  // The census is certain failure at weight one, so only the sampled side moves between replicates.
-  scoreAt: (failureRate) => {
-    const totalWeight = estimate.sampledWeight + estimate.censusWeight
-    return totalWeight <= 0 ? 0 : clampScore((100 * (estimate.sampledWeight * (1 - failureRate))) / totalWeight)
-  },
+  strata: strataOf(
+    estimate.judgedSessions.map((session) => ({
+      adverse: !session.succeeded,
+      inclusionProbability: session.inclusionProbability,
+    })),
+  ),
+  censusWeight: estimate.censusWeight,
+  censusAdverseEvents: estimate.censusWeight,
+  scoreAt: (failureRate) => clampScore(100 * (1 - failureRate)),
 })
 
 const reliabilityModel = (estimate: ProjectReliabilityEstimate, referenceRunSessions: number): EndpointModel => ({
-  adverseEvents: estimate.terminalFailureSessionCount,
-  trials: estimate.readableSessionCount,
+  strata: [
+    {
+      adverseEvents: estimate.terminalFailureSessionCount,
+      trials: estimate.readableSessionCount,
+      populationWeight: estimate.readableSessionCount,
+    },
+  ],
+  censusWeight: 0,
+  censusAdverseEvents: 0,
   scoreAt: (failureRate) => survivalOverReferenceRun({ adverseRate: failureRate, referenceRunSessions }),
 })
 
 const safetyModel = (estimate: ProjectSafetyEstimate, referenceRunSessions: number): EndpointModel => ({
-  adverseEvents: estimate.harmedSessionCount,
-  trials: estimate.examinedSessionCount,
+  strata: strataOf(
+    estimate.examinedSessions.map((session) => ({
+      adverse: session.harmed,
+      inclusionProbability: session.examinationProbability,
+    })),
+  ),
+  censusWeight: 0,
+  censusAdverseEvents: 0,
   scoreAt: (harmRate) => survivalOverReferenceRun({ adverseRate: harmRate, referenceRunSessions }),
 })
 
 /**
- * Draws an adverse rate from the Jeffreys posterior for the observed counts.
+ * Draws an adverse rate from the Jeffreys posterior for each stratum's observed counts.
  *
  * The half-counts are what keep the draw non-degenerate at the boundaries, which is the whole point:
  * a clean window has seen no harm, not proven that none can happen.
@@ -145,10 +183,18 @@ const drawAdverseRate = ({
   readonly model: EndpointModel
   readonly random: () => number
 }): number => {
-  if (model.trials <= 0) return 0
-  const alpha = model.adverseEvents + 0.5
-  const beta = model.trials - model.adverseEvents + 0.5
-  return inverseRegularizedIncompleteBeta(random(), alpha, beta)
+  const sampledWeight = model.strata.reduce((total, stratum) => total + stratum.populationWeight, 0)
+  const totalWeight = model.censusWeight + sampledWeight
+  if (totalWeight <= 0) return 0
+
+  const sampledAdverseWeight = model.strata.reduce((total, stratum) => {
+    if (stratum.trials <= 0) return total
+    const alpha = stratum.adverseEvents + 0.5
+    const beta = stratum.trials - stratum.adverseEvents + 0.5
+    const adverseRate = inverseRegularizedIncompleteBeta(random(), alpha, beta)
+    return total + stratum.populationWeight * adverseRate
+  }, 0)
+  return (model.censusAdverseEvents + sampledAdverseWeight) / totalWeight
 }
 
 const dimensionOf = ({
@@ -308,18 +354,17 @@ const bootstrapWindow = (input: ComposeAgentScoreInput): WindowBootstrap => {
     const speed = aggregateWindowSpeed(resampled, residualAvoidableNs).speed
     costs.push(cost)
     speeds.push(speed)
-    composites.push(
-      weightedComposite({
-        artifact: input.artifact,
-        scores: {
-          outcome: models.outcome.scoreAt(drawAdverseRate({ model: models.outcome, random })),
-          reliability: models.reliability.scoreAt(drawAdverseRate({ model: models.reliability, random })),
-          cost,
-          speed,
-          safety: models.safety.scoreAt(drawAdverseRate({ model: models.safety, random })),
-        },
-      }),
-    )
+    const composite = weightedComposite({
+      artifact: input.artifact,
+      scores: {
+        outcome: models.outcome.scoreAt(drawAdverseRate({ model: models.outcome, random })),
+        reliability: models.reliability.scoreAt(drawAdverseRate({ model: models.reliability, random })),
+        cost,
+        speed,
+        safety: models.safety.scoreAt(drawAdverseRate({ model: models.safety, random })),
+      },
+    })
+    composites.push(applyPolicyCap({ artifact: input.artifact, composite, safety: input.safety }).score)
   }
 
   return {

--- a/packages/domain/agent-score/src/scoring/coverage-never-helps.test.ts
+++ b/packages/domain/agent-score/src/scoring/coverage-never-helps.test.ts
@@ -68,6 +68,7 @@ describe("unreconstructable critical paths", () => {
         excludedSessionCount: 9_980,
       },
       eligibleSessionCount: 10_000,
+      latencyReaderCoverage: [],
       floors: LAUNCH_AGENT_SCORE_ARTIFACT.dimensionFloors.speed,
     })
 

--- a/packages/domain/agent-score/src/scoring/estimate-residual-effect.ts
+++ b/packages/domain/agent-score/src/scoring/estimate-residual-effect.ts
@@ -50,6 +50,8 @@ export type ResidualEffect =
       readonly effect: number
       readonly rawEffect: number
       readonly exposedSessions: number
+      /** Selection-corrected number of exposed sessions represented by the observed sample. */
+      readonly exposedWeight: number
       readonly unexposedSessions: number
       readonly usedStrata: number
       readonly droppedStrata: number
@@ -164,6 +166,7 @@ export const estimateResidualEffect = ({
     effect: Math.max(0, rawEffect) * shrinkage,
     rawEffect,
     exposedSessions: exposed.length,
+    exposedWeight: exposed.reduce((total, session) => total + weightOf(session, groupId), 0),
     unexposedSessions: unexposed.length,
     usedStrata: usable.reduce((total, fold) => total + fold.used.length, 0),
     droppedStrata,

--- a/packages/domain/agent-score/src/scoring/estimate-signal-residuals.ts
+++ b/packages/domain/agent-score/src/scoring/estimate-signal-residuals.ts
@@ -155,7 +155,8 @@ export const estimateSpeedSignalResiduals = ({
       for (const signalId of group.signalIds) gaps.push({ signalId, groupId: group.groupId, support })
       continue
     }
-    for (const [signalId, avoidableNs] of splitAcrossMembers({ group, effect: support.effect })) {
+    const windowAvoidableNs = support.effect * support.exposedWeight
+    for (const [signalId, avoidableNs] of splitAcrossMembers({ group, effect: windowAvoidableNs })) {
       residuals.push({ signalId, groupId: group.groupId, avoidableNs, support })
     }
   }

--- a/packages/domain/agent-score/src/scoring/fold-window-contributions.test.ts
+++ b/packages/domain/agent-score/src/scoring/fold-window-contributions.test.ts
@@ -1,0 +1,62 @@
+import { SessionId } from "@domain/shared"
+import { describe, expect, it } from "vitest"
+import { LAUNCH_COST_SCORING_ARTIFACT } from "../artifacts/launch-cost-scoring-artifact.ts"
+import { PROVISIONAL_COST_METRIC_CATALOG } from "../entities/cost-metric-catalog.ts"
+import { unreadableReading } from "../entities/cost-metric-reading.ts"
+import type { NormalizedSessionAssessmentInput } from "../entities/session-assessment-input.ts"
+import { aggregateWindowCost, aggregateWindowSpeed } from "./bootstrap-window.ts"
+import { EMPTY_WINDOW_FOLD, foldWindowBatch } from "./fold-window-contributions.ts"
+
+describe("foldWindowBatch", () => {
+  it("retains readable Speed evidence when Cost is unpublishable", () => {
+    const session: NormalizedSessionAssessmentInput = {
+      sessionId: SessionId("session-1"),
+      hasReadableUserTask: true,
+      observedMicrocents: 0,
+      observedDurationNs: 1_000,
+      findings: [],
+      readers: [],
+      screeningDecisions: [],
+      scoringEligibleSignalIds: [],
+      costEvidence: {
+        readings: [
+          unreadableReading(
+            {
+              metricId: "cost.recoverable_spend_share",
+              family: "spend",
+              rawUnit: "microcents",
+              aggregation: "resourceRatio",
+            },
+            ["missingPricing"],
+            1_000,
+          ),
+        ],
+        workloadStratum: "test",
+        denominators: { spend: 1_000, context: 0, tools: 0, memory: 0, recovery: 0 },
+        observedCriticalPathNs: 1_000,
+        criticalPathComplete: true,
+        measuredAvoidableNs: 250,
+        estimatedAvoidableNs: 0,
+        measuredAvoidableMicrocents: 0,
+        estimatedAvoidableMicrocents: 0,
+        avoidableNsByCause: { "latency:throughput": 250 },
+      },
+    }
+    const fold = foldWindowBatch({
+      fold: EMPTY_WINDOW_FOLD,
+      sessions: [session],
+      denominatorsFor: () => ({ spend: 1_000, context: 0, tools: 0, memory: 0, recovery: 0 }),
+      artifact: LAUNCH_COST_SCORING_ARTIFACT,
+      catalog: PROVISIONAL_COST_METRIC_CATALOG,
+    })
+
+    expect(fold).toMatchObject({ foldedSessionCount: 0, withheldSessionCount: 1 })
+    expect(fold.contributions).toHaveLength(1)
+    expect(fold.contributions[0]?.costUsableForDenominator).toBe(false)
+    expect(
+      aggregateWindowCost({ contributions: fold.contributions, artifact: LAUNCH_COST_SCORING_ARTIFACT }).cost,
+    ).toBe(100)
+    expect(aggregateWindowSpeed(fold.contributions)).toMatchObject({ observedNs: 1_000, avoidableNs: 250, speed: 75 })
+    expect(fold.speedCauseNs.get("latency:throughput")).toBe(250)
+  })
+})

--- a/packages/domain/agent-score/src/scoring/fold-window-contributions.ts
+++ b/packages/domain/agent-score/src/scoring/fold-window-contributions.ts
@@ -33,6 +33,7 @@ export const foldSessionContribution = ({
 
   return {
     sessionId: session.sessionId,
+    costUsableForDenominator: aggregate.publishable,
     families: aggregate.families.map((family) => ({
       family: family.family,
       eligibleUnits: family.eligibleUnits,
@@ -92,9 +93,8 @@ export const EMPTY_WINDOW_FOLD: WindowFold = {
 /**
  * Adds one batch's contributions to a running fold.
  *
- * Sessions whose required families could not be read are counted but not contributed: they are the
- * window's coverage story, and letting their unreadable families into the denominator would treat
- * unknown resources as necessary ones.
+ * Sessions whose required Cost families could not be read are retained for Speed but excluded from
+ * Cost: one dimension's missing evidence must not erase another dimension's readable evidence.
  */
 export const foldWindowBatch = ({
   fold,
@@ -117,6 +117,7 @@ export const foldWindowBatch = ({
     familyCoverage[family] = { ...fold.familyCoverage[family] }
   }
   let withheld = 0
+  let published = 0
 
   for (const session of sessions) {
     // Coverage counts every session's readings, including a session whose required family could not
@@ -139,18 +140,19 @@ export const foldWindowBatch = ({
     })
     if (!aggregate.publishable) {
       withheld += 1
-      continue
-    }
-    const familyOf = new Map((session.costEvidence?.readings ?? []).map((reading) => [reading.metricId, reading]))
-    for (const [metricId, penalty] of aggregate.penaltiesByMetric) {
-      const reading = familyOf.get(metricId)
-      if (!reading) continue
-      const eligibleUnits = denominators[reading.family]
-      const existing = costCauseUnits.get(metricId)
-      costCauseUnits.set(metricId, {
-        family: reading.family,
-        penalizedUnits: (existing?.penalizedUnits ?? 0) + penalty * eligibleUnits,
-      })
+    } else {
+      published += 1
+      const familyOf = new Map((session.costEvidence?.readings ?? []).map((reading) => [reading.metricId, reading]))
+      for (const [metricId, penalty] of aggregate.penaltiesByMetric) {
+        const reading = familyOf.get(metricId)
+        if (!reading) continue
+        const eligibleUnits = denominators[reading.family]
+        const existing = costCauseUnits.get(metricId)
+        costCauseUnits.set(metricId, {
+          family: reading.family,
+          penalizedUnits: (existing?.penalizedUnits ?? 0) + penalty * eligibleUnits,
+        })
+      }
     }
     if (session.costEvidence?.criticalPathComplete) {
       for (const [cause, avoidableNs] of Object.entries(session.costEvidence.avoidableNsByCause)) {
@@ -162,7 +164,7 @@ export const foldWindowBatch = ({
 
   return {
     contributions: [...fold.contributions, ...added],
-    foldedSessionCount: fold.foldedSessionCount + added.length,
+    foldedSessionCount: fold.foldedSessionCount + published,
     withheldSessionCount: fold.withheldSessionCount + withheld,
     familyCoverage,
     costCauseUnits,

--- a/packages/domain/agent-score/src/scoring/signal-residuals.test.ts
+++ b/packages/domain/agent-score/src/scoring/signal-residuals.test.ts
@@ -141,6 +141,7 @@ describe("estimateResidualEffect", () => {
     if (result.measured) {
       expect(result.rawEffect).toBeCloseTo(0.4, 6)
       expect(result.effect).toBeCloseTo(0.4 * (20 / 40), 6)
+      expect(result.exposedWeight).toBe(20)
       expect(result.effect).toBeLessThan(result.rawEffect)
     }
   })
@@ -182,6 +183,7 @@ describe("estimateResidualEffect", () => {
     const result = estimateResidualEffect({ sessions, groupId: "group-a" })
 
     expect(result.measured && result.rawEffect).toBeCloseTo(1, 6)
+    expect(result.measured && result.exposedWeight).toBe(100)
   })
 
   it("does not apply one group's sampling probability to another group", () => {
@@ -384,7 +386,23 @@ describe("estimateSpeedSignalResiduals", () => {
     })
     const { residuals } = estimateSpeedSignalResiduals({ sessions, groups: [group] })
 
-    expect(residuals[0]?.avoidableNs).toBeCloseTo(800_000_000 * (20 / 40), 3)
+    expect(residuals[0]?.avoidableNs).toBeCloseTo(800_000_000 * (20 / 40) * 20, 3)
+  })
+
+  it("scales the per-session effect to the selection-corrected exposed population", () => {
+    const sessions = cohort({
+      exposedCount: 20,
+      cleanCount: 20,
+      exposedOutcome: 900_000_000,
+      cleanOutcome: 100_000_000,
+    }).map((entry) =>
+      entry.exposedGroupIds.includes("group-a")
+        ? { ...entry, inclusionProbabilityByGroupId: new Map([["group-a", 0.25]]) }
+        : entry,
+    )
+    const { residuals } = estimateSpeedSignalResiduals({ sessions, groups: [group] })
+
+    expect(residuals[0]?.avoidableNs).toBeCloseTo(800_000_000 * (20 / 40) * 80, 3)
   })
 
   it("reports a gap when the comparison fails", () => {

--- a/packages/domain/agent-score/src/scoring/speed-scoring.test.ts
+++ b/packages/domain/agent-score/src/scoring/speed-scoring.test.ts
@@ -80,6 +80,7 @@ const contribution = (
   speed: { readonly observedNs: number; readonly avoidableNs: number; readonly usableForDenominator?: boolean },
 ): SessionWindowContribution => ({
   sessionId,
+  costUsableForDenominator: true,
   families: COST_FAMILIES.map((family) =>
     family === "spend" ? { family, ...spend } : { family, eligibleUnits: 0, penalizedUnits: 0 },
   ),

--- a/packages/domain/agent-score/src/scoring/window-gates.test.ts
+++ b/packages/domain/agent-score/src/scoring/window-gates.test.ts
@@ -5,6 +5,7 @@ import { COST_FAMILIES, type CostFamily } from "../entities/cost-evidence.ts"
 import type { CostScoringArtifact } from "../entities/cost-scoring-artifact.ts"
 import type { WindowSpeedAggregate } from "./bootstrap-window.ts"
 import type { FamilyReadingCoverage, WindowFold } from "./fold-window-contributions.ts"
+import type { WindowReaderCoverage } from "./tally-reader-coverage.ts"
 import { gateCostWindow, gateSpeedWindow } from "./window-gates.ts"
 
 const COST_FLOORS = LAUNCH_AGENT_SCORE_ARTIFACT.dimensionFloors.cost
@@ -97,16 +98,33 @@ const speedAggregate = (overrides: Partial<WindowSpeedAggregate> = {}): WindowSp
   ...overrides,
 })
 
+const latencyReader = (overrides: Partial<WindowReaderCoverage> = {}): WindowReaderCoverage => ({
+  readerId: "spans.throughput",
+  label: "Generation throughput",
+  scoreDimensions: ["speed"],
+  applicableSessions: 800,
+  fullyReadSessions: 800,
+  readableUnits: 800,
+  applicableUnits: 800,
+  coverage: 1,
+  limitations: {},
+  ...overrides,
+})
+
+const gateSpeed = (overrides: Omit<Parameters<typeof gateSpeedWindow>[0], "latencyReaderCoverage">) =>
+  gateSpeedWindow({ latencyReaderCoverage: [latencyReader()], ...overrides })
+
 describe("gateSpeedWindow", () => {
   it("publishes when enough critical paths reconstructed", () => {
-    expect(
-      gateSpeedWindow({ speed: speedAggregate(), eligibleSessionCount: 1_000, floors: SPEED_FLOORS }),
-    ).toMatchObject({ coverage: "measured", completeSessionCount: 800 })
+    expect(gateSpeed({ speed: speedAggregate(), eligibleSessionCount: 1_000, floors: SPEED_FLOORS })).toMatchObject({
+      coverage: "measured",
+      completeSessionCount: 800,
+    })
   })
 
   it("withholds below the complete-path session floor", () => {
     expect(
-      gateSpeedWindow({
+      gateSpeed({
         speed: speedAggregate({ includedSessionCount: 50 }),
         eligibleSessionCount: 1_000,
         floors: SPEED_FLOORS,
@@ -116,7 +134,7 @@ describe("gateSpeedWindow", () => {
 
   it("withholds when the reconstructed sessions describe too little of the base", () => {
     expect(
-      gateSpeedWindow({
+      gateSpeed({
         speed: speedAggregate({ includedSessionCount: 300, excludedSessionCount: 9_700 }),
         eligibleSessionCount: 10_000,
         floors: SPEED_FLOORS,
@@ -126,11 +144,22 @@ describe("gateSpeedWindow", () => {
 
   it("withholds when there is no observed time to divide by", () => {
     expect(
-      gateSpeedWindow({
+      gateSpeed({
         speed: speedAggregate({ observedNs: 0, avoidableNs: 0 }),
         eligibleSessionCount: 1_000,
         floors: SPEED_FLOORS,
       }),
     ).toMatchObject({ coverage: "unmeasured", unmeasuredReason: "noObservedTime" })
+  })
+
+  it("withholds when a latency reference was missing for an applicable generation", () => {
+    expect(
+      gateSpeedWindow({
+        speed: speedAggregate(),
+        eligibleSessionCount: 1_000,
+        latencyReaderCoverage: [latencyReader({ applicableUnits: 800, readableUnits: 799, coverage: 799 / 800 })],
+        floors: SPEED_FLOORS,
+      }),
+    ).toMatchObject({ coverage: "unmeasured", unmeasuredReason: "latencyReferenceCoverage" })
   })
 })

--- a/packages/domain/agent-score/src/scoring/window-gates.ts
+++ b/packages/domain/agent-score/src/scoring/window-gates.ts
@@ -3,6 +3,7 @@ import { COST_FAMILIES, type CostFamily } from "../entities/cost-evidence.ts"
 import type { CostScoringArtifact } from "../entities/cost-scoring-artifact.ts"
 import type { WindowSpeedAggregate } from "./bootstrap-window.ts"
 import type { WindowFold } from "./fold-window-contributions.ts"
+import type { WindowReaderCoverage } from "./tally-reader-coverage.ts"
 
 export type CostUnmeasuredReason = "requiredFamilyUnreadable" | "publishableSessionFloor" | "noReadableSessions"
 
@@ -83,7 +84,11 @@ export const gateCostWindow = ({
   return { ...base, coverage: "measured" }
 }
 
-export type SpeedUnmeasuredReason = "completePathFloor" | "completePathCoverageFloor" | "noObservedTime"
+export type SpeedUnmeasuredReason =
+  | "completePathFloor"
+  | "completePathCoverageFloor"
+  | "latencyReferenceCoverage"
+  | "noObservedTime"
 
 export interface SpeedWindowGate {
   readonly coverage: "measured" | "unmeasured"
@@ -104,10 +109,12 @@ export interface SpeedWindowGate {
 export const gateSpeedWindow = ({
   speed,
   eligibleSessionCount,
+  latencyReaderCoverage,
   floors,
 }: {
   readonly speed: WindowSpeedAggregate
   readonly eligibleSessionCount: number
+  readonly latencyReaderCoverage: readonly WindowReaderCoverage[]
   readonly floors: SpeedCoverageFloors
 }): SpeedWindowGate => {
   const completeShareOfEligible = eligibleSessionCount > 0 ? speed.includedSessionCount / eligibleSessionCount : 0
@@ -122,6 +129,9 @@ export const gateSpeedWindow = ({
   }
   if (completeShareOfEligible < floors.completeCriticalPathShareOfEligible) {
     return { ...base, coverage: "unmeasured", unmeasuredReason: "completePathCoverageFloor" }
+  }
+  if (latencyReaderCoverage.some((reader) => reader.readableUnits < reader.applicableUnits)) {
+    return { ...base, coverage: "unmeasured", unmeasuredReason: "latencyReferenceCoverage" }
   }
   if (speed.observedNs <= 0) {
     return { ...base, coverage: "unmeasured", unmeasuredReason: "noObservedTime" }

--- a/packages/domain/agent-score/src/scoring/window-invariance.test.ts
+++ b/packages/domain/agent-score/src/scoring/window-invariance.test.ts
@@ -17,6 +17,7 @@ import type { ReliabilitySessionEndpoint } from "./select-reliability-endpoints.
 
 const contribution = (index: number, penalized: number): SessionWindowContribution => ({
   sessionId: `session-${index}`,
+  costUsableForDenominator: true,
   families: [{ family: "tools", eligibleUnits: 20, penalizedUnits: penalized }],
   speed: { observedNs: 1_000_000, avoidableNs: penalized * 10_000, usableForDenominator: true },
 })

--- a/packages/domain/agent-score/src/use-cases/compute-agent-score.ts
+++ b/packages/domain/agent-score/src/use-cases/compute-agent-score.ts
@@ -242,6 +242,9 @@ export const computeAgentScore = Effect.fn("agentScore.computeAgentScore")(funct
     gate: gateSpeedWindow({
       speed: aggregateWindowSpeed(pass.fold.contributions, signalEffects.avoidableNs),
       eligibleSessionCount: selection.eligibleSessionCount,
+      latencyReaderCoverage: [...pass.readers.values()].filter(
+        (reader) => reader.readerId === "spans.ttft" || reader.readerId === "spans.throughput",
+      ),
       floors: input.artifact.dimensionFloors.speed,
     }),
   }

--- a/packages/domain/agent-score/src/use-cases/run-cost-speed-shadow.ts
+++ b/packages/domain/agent-score/src/use-cases/run-cost-speed-shadow.ts
@@ -163,11 +163,13 @@ const decilesOf = (values: readonly number[]): number[] => {
  */
 const familyDistributionsOf = (contributions: readonly SessionWindowContribution[]): ShadowFamilyDistribution[] =>
   COST_FAMILIES.map((family) => {
-    const shares = contributions.flatMap((contribution) =>
-      contribution.families.flatMap((entry) =>
-        entry.family === family && entry.eligibleUnits > 0 ? [entry.penalizedUnits / entry.eligibleUnits] : [],
-      ),
-    )
+    const shares = contributions
+      .filter((contribution) => contribution.costUsableForDenominator)
+      .flatMap((contribution) =>
+        contribution.families.flatMap((entry) =>
+          entry.family === family && entry.eligibleUnits > 0 ? [entry.penalizedUnits / entry.eligibleUnits] : [],
+        ),
+      )
     return { family, sessionCount: shares.length, deciles: decilesOf(shares) }
   })
 

--- a/packages/platform/db-postgres/src/repositories/wrapped-report-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/wrapped-report-repository.test.ts
@@ -317,7 +317,7 @@ describe("WrappedReportRepositoryLive", () => {
   })
 
   it("findLeaderboardRankForReport deduplicates by project — older report for same project is excluded", async () => {
-    const today = new Date()
+    const today = new Date("2026-01-15T12:00:00.000Z")
     const earlier = new Date(today.getTime() - 60 * 60 * 1000) // 1h earlier, still same day
     const dedupProj = ProjectId("dedup".padEnd(24, "a"))
     // Two reports for the same project — "new" and "old" on the same day.


### PR DESCRIPTION
Follow-up to #4626. The merged implementation could discard valid Speed evidence when Cost coverage failed, treat missing latency references as zero avoidable time, and publish composite intervals using different weighting or cap rules from their point estimates.

Cost and Speed now fold independently. Sessions with unreadable Cost evidence remain available to Speed, while Cost aggregates and attribution exclude them. Speed publication also requires complete TTFT and throughput reference coverage.

Composite bootstrap draws now preserve the inverse-probability strata used by Outcome and Safety. Confirmed-harm caps apply inside each replicate, so capped intervals describe the published score.

Residual Speed effects are scaled from a per-exposed-session estimate to the selection-corrected exposed population. Workload strata now include output size and the offered toolset, preventing unmatched workloads from becoming controls.

## validation

- `pnpm --filter @domain/agent-score test` (596 tests)
- `pnpm --filter @domain/agent-score typecheck`
- `pnpm typecheck` (94 packages)
- commit hook: `pnpm format` and `pnpm knip`

Refs #4626.