### PR TITLE
fix(flaggers): stop double-generating on instruction-extractor schema mismatch

### DIFF
--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -685,6 +685,51 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(calls.generate[1].prompt).toContain("academic notes assistant")
   })
 
+  it("does not reject a model response missing agentContext during generation, only on local re-validation", async () => {
+    const longSystemPrompt = `
+<identity>
+You are an academic notes assistant that turns course material into high-retention study notes for university students.
+</identity>
+${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.trim()
+    const systemInstructions = [{ type: "text", content: longSystemPrompt }] satisfies TraceDetail["systemInstructions"]
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>(input: GenerateInput<T>) => {
+        if (input.system.includes("You extract agent context")) {
+          return Effect.succeed({ object: { understood: true } as T, tokens: 20, duration: 90_000_000 })
+        }
+
+        return Effect.succeed({ object: { matched: false } as T, tokens: 20, duration: 90_000_000 })
+      },
+    })
+
+    await Effect.runPromise(
+      classifyTraceForFlaggerUseCase({
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        traceId: INPUT.traceId,
+        flaggerSlug: "laziness",
+        trace: makeTraceDetail(
+          [
+            { role: "user", parts: [{ type: "text", content: "Generate notes from the attached PDF." }] },
+            { role: "assistant", parts: [{ type: "text", content: "# Course notes\n\n## 1. Core topic" }] },
+          ],
+          [],
+          systemInstructions,
+        ),
+      }).pipe(Effect.provide(Layer.mergeAll(aiLayer, defaultCacheLayer))),
+    )
+
+    const extractionCall = calls.generate.find((call) => call.system.includes("You extract agent context"))
+    if (!extractionCall) throw new Error("expected an instruction-extraction generate call")
+
+    // The Vercel AI SDK validates the raw provider response against this schema before our own code ever
+    // sees it. `{"understood":true}` with no `agentContext` is exactly what Bedrock's minimax/gpt-oss models
+    // send in production (see ET-243/ET-572): the generation-time schema must accept it, or the SDK fails
+    // the primary model's structured-output validation and burns a second (fallback) model call for nothing.
+    const generationValidation = extractionCall.schema.safeParse({ understood: true })
+    expect(generationValidation.success).toBe(true)
+  })
+
   it("skips long inspected system prompts when the extractor cannot understand the agent", async () => {
     const systemInstructions = [
       { type: "text", content: `Disconnected examples only. ${"example ".repeat(800)}` },

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -355,28 +355,35 @@ function extractInspectedSystemPrompt(conversation: FlaggerConversation): string
   )
 }
 
-const instructionExtractorOutputSchema = z
-  .object({
-    understood: z.boolean(),
-    agentContext: z.string(),
-    reasonIfNotUnderstood: z.string().optional(),
-  })
-  .superRefine((value, ctx) => {
-    if (value.understood && !value.agentContext.trim()) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["agentContext"],
-        message: "agentContext is required when understood=true",
-      })
-    }
-    if (!value.understood && !value.reasonIfNotUnderstood?.trim()) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["reasonIfNotUnderstood"],
-        message: "reasonIfNotUnderstood is required when understood=false",
-      })
-    }
-  })
+const instructionExtractorShape = {
+  understood: z.boolean(),
+  agentContext: z.string().optional(),
+  reasonIfNotUnderstood: z.string().optional(),
+}
+
+// Bedrock's minimax/gpt-oss models routinely emit {"understood":true} with no `agentContext`. Passing the
+// strict (superRefine'd) schema straight to the provider makes that a schema-validation failure at the AI
+// SDK level for both the primary and fallback model, burning two generations per occurrence. This structural
+// schema lets those responses through generation; `instructionExtractorOutputSchema` still enforces the
+// invariant during our own re-parse below, so the fallback-context behavior is unchanged.
+const instructionExtractorGenerationSchema = z.object(instructionExtractorShape)
+
+const instructionExtractorOutputSchema = z.object(instructionExtractorShape).superRefine((value, ctx) => {
+  if (value.understood && !value.agentContext?.trim()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["agentContext"],
+      message: "agentContext is required when understood=true",
+    })
+  }
+  if (!value.understood && !value.reasonIfNotUnderstood?.trim()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["reasonIfNotUnderstood"],
+      message: "reasonIfNotUnderstood is required when understood=false",
+    })
+  }
+})
 
 type InstructionExtractorOutput = z.infer<typeof instructionExtractorOutputSchema>
 
@@ -390,7 +397,7 @@ const maskDisallowedWording = (text: string): string => text.replace(disallowedE
 
 const maskDisallowedExtractionWording = (result: InstructionExtractorOutput): InstructionExtractorOutput => ({
   ...result,
-  agentContext: maskDisallowedWording(result.agentContext),
+  ...(result.agentContext === undefined ? {} : { agentContext: maskDisallowedWording(result.agentContext) }),
   ...(result.reasonIfNotUnderstood === undefined
     ? {}
     : { reasonIfNotUnderstood: maskDisallowedWording(result.reasonIfNotUnderstood) }),
@@ -696,7 +703,7 @@ function runInstructionExtraction(input: {
           ...modelConfig,
           system: INSTRUCTION_EXTRACTOR_SYSTEM_PROMPT,
           prompt: buildInstructionExtractorPrompt(input.systemPrompt),
-          schema: instructionExtractorOutputSchema,
+          schema: instructionExtractorGenerationSchema,
           telemetry: {
             spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.flaggerExtractInstructions,
             project: LATITUDE_TELEMETRY_PROJECT_SLUGS.flaggers,


### PR DESCRIPTION
## What does this PR do?

Fixes a recurring production error cluster in the flagger instruction-extraction step (`packages/domain/flaggers/src/use-cases/run-flagger.ts`).

**Datadog issues addressed** (all `workflows` service, `env:production`, one root cause):
- [ET-243 / `50644324-5de3-11f1-a41b-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/50644324-5de3-11f1-a41b-da7ad0900005) — 37 occurrences
- [ET-572 / `593f095c-5de3-11f1-881c-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/593f095c-5de3-11f1-881c-da7ad0900005) — 18 occurrences
- Siblings `593f0a4c-5de3-11f1-a41b-da7ad0900005` (7) and `50645210-5de3-11f1-881c-da7ad0900005`

Combined, this cluster has fired since June 2026 and is still active as of today (last seen 2026-09-13).

**Root cause:** `runInstructionExtraction`'s `getInspectedAgentContext` call asks the Bedrock primary model (`minimax.minimax-m2.5`) and fallback model (`openai.gpt-oss-120b-1:0`) to extract agent context, structured via a Zod schema (`instructionExtractorOutputSchema`) requiring `agentContext: z.string()`. Both models routinely reply `{"understood":true}` with the `agentContext` field omitted entirely. Since that same strict schema (with a `superRefine` enforcing the invariant) was passed straight to the Vercel AI SDK's `Output.object`, the SDK rejects the response as a structural schema-validation failure — for **both** the primary and the fallback model, wasting two full model generations per occurrence and surfacing as an `AIError`/`Error` in Error Tracking. The call's own downstream code already tolerates a missing `agentContext` gracefully (`Effect.catch` → `renderFallbackAgentContext`, a truncated verbatim excerpt of the system prompt) — so there is no user-facing failure, just wasted latency/cost and error-tracking noise.

This exact root cause and fix were already independently identified by three prior automated Datadog triage passes (see the issues' comment history) but never implemented, each time citing it as "cross-cutting" / a product decision. On inspection the fix is safely scoped to this one file.

**Fix:** split the schema in two —
- `instructionExtractorGenerationSchema`: the same shape, but `agentContext` is optional and there's no `superRefine`. This is what's now passed to `ai.generate({ schema: ... })`, so a response missing `agentContext` no longer fails the SDK's structural validation and no second (fallback) model call is triggered.
- `instructionExtractorOutputSchema`: unchanged in behavior — still requires `agentContext` when `understood: true` via `superRefine` — used only for our own local re-parse of the (now successfully generated) response. When the invariant is violated, this re-parse throws, which is caught by the existing `Effect.catch` and falls back to `renderFallbackAgentContext` exactly as before.

Net effect: identical final behavior (fallback context still used when a model omits `agentContext`), but only one model call is made instead of two, and the AIError/Error stops showing up in Error Tracking for this signature.

## How was this tested?

- Added a unit test (`run-flagger.test.ts`) that inspects the schema actually passed to `ai.generate` for the instruction-extraction call and asserts `schema.safeParse({ understood: true })` succeeds — i.e. the exact malformed-but-common model response no longer fails generation-time validation.
- Verified the new test **fails** against the pre-fix code (reverted the schema change locally, re-ran — failed with `expected false to be true`), then passes with the fix applied.
- Full existing `run-flagger.test.ts` suite (82 tests) and the whole `@domain/flaggers` package test suite (507 tests) pass unchanged, including the existing "falls back to prompt excerpts when the extractor returns understood=true without context" test, confirming the fallback behavior is unchanged.
- `pnpm --filter @domain/flaggers typecheck` (tsgo) — clean.
- `pnpm exec biome check` on the changed files — clean.

**Verification in production:** after deploy, occurrences of Datadog issues `50644324-5de3-11f1-a411-da7ad0900005` / `593f095c-5de3-11f1-881c-da7ad0900005` and siblings should drop to zero (or a new, much lower-volume issue may appear only if a model additionally omits `agentContext` in a way our own re-parse doesn't already tolerate, which would itself be a legitimate case for `renderFallbackAgentContext` to handle).

## Related issue (if applicable)

N/A — found via scheduled Datadog production-error triage, no linked GitHub issue.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sfpHaMo3bHzXERHsafyZV

---
_Generated by [Claude Code](https://claude.ai/code/session_018sfpHaMo3bHzXERHsafyZV)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791858450&installation_model_id=435055&pr_number=4630&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4630&signature=d09e48fdf198af0ed0b7972230a5b731c64dcf382ad9ca5bdbe5c2839e1cf1ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->