### PR TITLE
fix(memories,evaluations): don't crash tokenizing literal special-token strings

### DIFF
--- a/packages/domain/evaluations/src/runtime/evaluation-execution.test.ts
+++ b/packages/domain/evaluations/src/runtime/evaluation-execution.test.ts
@@ -68,6 +68,17 @@ describe("fitPromptToJudgeContextWindow", () => {
     expect(countTokens(fitted)).toBeLessThanOrEqual(5)
   })
 
+  it("does not throw when the prompt contains a literal special-token string", () => {
+    const prompt = "Conversation:\n[assistant] some content <|endoftext|> more content"
+    expect(() => fitPromptToJudgeContextWindow(prompt, "amazon-bedrock", "minimax.minimax-m2.5")).not.toThrow()
+    expect(fitPromptToJudgeContextWindow(prompt, "amazon-bedrock", "minimax.minimax-m2.5")).toBe(prompt)
+  })
+
+  it("does not throw when an oversized prompt containing a special-token string must be truncated", () => {
+    const prompt = `<|endoftext|> ${OVERSIZED_FILLER} <|endoftext|>`
+    expect(() => fitPromptToJudgeContextWindow(prompt, "amazon-bedrock", "minimax.minimax-m2.5")).not.toThrow()
+  })
+
   it("splits the retained budget evenly regardless of where the script's own instructions end (known limitation)", () => {
     // fitPromptToJudgeContextWindow only sees an opaque string — there's no delimiter distinguishing
     // an evaluation script's own instructions from the conversation it embeds — so a 50/50 head/tail

--- a/packages/domain/evaluations/src/runtime/evaluation-execution.ts
+++ b/packages/domain/evaluations/src/runtime/evaluation-execution.ts
@@ -48,14 +48,16 @@ export const fitPromptToJudgeContextWindow = (
   const contextLimitTokens = resolveJudgeContextLimitTokens(provider, model)
   const budgetTokens = Math.max(contextLimitTokens - maxOutputTokens - CONTEXT_SAFETY_MARGIN_TOKENS, 0)
 
-  const tokens = tokenizer().encode(prompt)
+  // `prompt` embeds arbitrary session/model content — a literal substring like "<|endoftext|>"
+  // must count as ordinary text, not throw as a disallowed special token.
+  const tokens = tokenizer().encode(prompt, [], [])
   if (tokens.length <= budgetTokens) {
     return prompt
   }
 
   // Cap the notice itself to the budget too — an operator-configured maxOutputTokens close to the
   // context limit can leave less room than the notice needs, and the result must still fit.
-  const noticeTokens = tokenizer().encode(PROMPT_TRUNCATION_NOTICE).slice(0, budgetTokens)
+  const noticeTokens = tokenizer().encode(PROMPT_TRUNCATION_NOTICE, [], []).slice(0, budgetTokens)
   const keepTokens = Math.max(budgetTokens - noticeTokens.length, 0)
   const headTokens = Math.ceil(keepTokens / 2)
   const tailTokens = keepTokens - headTokens

--- a/packages/domain/memories/src/entities/tokenizer.test.ts
+++ b/packages/domain/memories/src/entities/tokenizer.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { countTokens } from "./tokenizer.ts"
+
+describe("countTokens", () => {
+  it("counts tokens for ordinary text", () => {
+    expect(countTokens("hello world")).toBeGreaterThan(0)
+  })
+
+  it("does not throw when the body contains a literal special-token string", () => {
+    expect(() => countTokens("some content <|endoftext|> more content")).not.toThrow()
+  })
+
+  it("counts a body containing a special-token string as ordinary text, not zero", () => {
+    expect(countTokens("<|endoftext|>")).toBeGreaterThan(0)
+  })
+
+  it("does not throw for other reserved special-token strings", () => {
+    expect(() => countTokens("<|fim_prefix|><|fim_suffix|><|fim_middle|><|endofprompt|>")).not.toThrow()
+  })
+})

--- a/packages/domain/memories/src/entities/tokenizer.ts
+++ b/packages/domain/memories/src/entities/tokenizer.ts
@@ -7,5 +7,7 @@ let encoder: Tiktoken | null = null
 /** Approximate token count of a body using the o200k_base encoding ([D5]). */
 export const countTokens = (body: string): number => {
   if (encoder === null) encoder = getEncoding("o200k_base")
-  return encoder.encode(body).length
+  // `body` is arbitrary session content, not a prompt we control — a literal substring like
+  // "<|endoftext|>" must count as ordinary text, not throw as a disallowed special token.
+  return encoder.encode(body, [], []).length
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `js-tiktoken`'s `encode()` when tokenized text happens to contain a literal special-token substring such as `<|endoftext|>`. By default, `encode()` throws on any of these reserved strings unless the caller explicitly allows them. Two production call sites tokenize **arbitrary** session/model content (not a prompt we control), so any session whose conversation, tool output, or LLM completion happens to contain one of these literal strings crashes:

- `countTokens` (`packages/domain/memories/src/entities/tokenizer.ts`) — used by `packages/domain/agent-score`'s cost-evidence reader (`read-session-cost-evidence.ts`), which fully failed for any affected session.
- `fitPromptToJudgeContextWindow` (`packages/domain/evaluations/src/runtime/evaluation-execution.ts`) — used to trim/truncate judge prompts before invoking an evaluation's LLM judge, which would crash the evaluation run.

**Fix:** pass empty `allowedSpecial`/`disallowedSpecial` sets to `encode()` at both call sites, so these strings are BPE-encoded as ordinary text instead of being validated as special tokens (verified against the `js-tiktoken@1.0.21` source: token substrings in neither set fall through to normal encoding rather than throwing).

### Datadog issue addressed

- [`ae74048c-af27-11f1-8252-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/ae74048c-af27-11f1-8252-da7ad0900005) — `workers`, `Error: The text contains a special token that is not allowed: <|endoftext|>`, thrown from `_Tiktoken.encode` via `countTokens` → `content-atom-ledger.ts` → `read-session-cost-evidence.ts`. New issue (first seen today), 5 occurrences in the last 7 days; not yet regressed to a large volume, but it fully fails cost-evidence collection for any session whose content contains that literal string, and the same flaw exists in a second call site (`fitPromptToJudgeContextWindow`) that could crash evaluation judging the same way. No specific introducing commit — this is a longstanding tokenizer-usage gap that only manifests when session content happens to contain one of these literal strings, not a recent regression.

### Root cause

`js-tiktoken`'s `Tiktoken.encode(text, allowedSpecial = [], disallowedSpecial = "all")` throws whenever `text` contains a substring matching one of the encoding's reserved special tokens (`<|endoftext|>`, `<|fim_prefix|>`, etc.) unless it's in `allowedSpecial`. Both call sites pass through user/model-controlled text with no way to guarantee it's free of these substrings — an LLM can echo `<|endoftext|>` verbatim in a completion, or a user can paste it.

### Fix summary

Both call sites now pass `(text, [], [])`, so any such substring is BPE-encoded as ordinary text (matching the intent — approximate token counting / truncation, not literal special-token semantics).

### Verification approach

- Reproduced the exact production crash locally with `js-tiktoken`'s default `encode()` args and confirmed `(text, [], [])` resolves it without throwing.
- Added tests:
  - `packages/domain/memories/src/entities/tokenizer.test.ts` (new): asserts `countTokens` doesn't throw and returns a sane count for text containing `<|endoftext|>` and other reserved special tokens.
  - `packages/domain/evaluations/src/runtime/evaluation-execution.test.ts`: two new cases asserting `fitPromptToJudgeContextWindow` doesn't throw for both a small prompt and an oversized prompt (requiring truncation) containing `<|endoftext|>`.
- `pnpm --filter @domain/memories test` (78 passed) and `pnpm --filter @domain/evaluations test` (194 passed) — all green.
- `pnpm --filter @domain/memories typecheck` / `pnpm --filter @domain/evaluations typecheck` (via `tsgo`) — clean.
- `pnpm exec biome check` on all changed files — clean.

After deploy, occurrences of Datadog issue `ae74048c-af27-11f1-8252-da7ad0900005` should drop to zero.

### Remaining risk

Low — the change is scoped to two `encode()` call sites and only affects how literal special-token-shaped substrings are tokenized (as ordinary text instead of throwing); it doesn't change behavior for any text that doesn't contain those substrings.

## Related issue (if applicable)

Closes #

## How was this tested?

See "Verification approach" above — new unit tests plus full package test/typecheck/lint runs for both affected packages.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hu9zL16AAxt2XtA1GDkyL

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hu9zL16AAxt2XtA1GDkyL)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/latitude-dev/codesmith/latitude-llm/pr/4631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791865368&installation_model_id=435055&pr_number=4631&repository=latitude-dev%2Flatitude-llm&return_to=https%3A%2F%2Fgithub.com%2Flatitude-dev%2Flatitude-llm%2Fpull%2F4631&signature=21a6c951d25b53047406848f3cf1c1f44ca20a769a96426b5b285922893f70ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->